### PR TITLE
avoid "null" string in authorization header

### DIFF
--- a/packages/broker/src/StreamFetcher.ts
+++ b/packages/broker/src/StreamFetcher.ts
@@ -1,23 +1,16 @@
-import fetch, { Headers, Response } from 'node-fetch'
+import fetch, { Response } from 'node-fetch'
 import memoize from 'memoizee'
 import { Logger } from 'streamr-network'
 import { HttpError } from './errors/HttpError'
 // TODO do all REST operations to E&E via StreamrClient
 import StreamrClient from 'streamr-client'
 import { Todo } from './types'
+import { formAuthorizationHeader } from './helpers/authentication'
 
 const logger = new Logger(module)
 
 const MAX_AGE = 15 * 60 * 1000 // 15 minutes
 const MAX_AGE_MINUTE = 1000 // 1 minutes
-
-function formHeaders(sessionToken?: string) {
-    const headers: Headers = new Headers()
-    if (sessionToken) {
-        headers.set('Authorization', `Bearer ${sessionToken}`)
-    }
-    return headers
-}
 
 async function fetchWithErrorLogging(...args: Parameters<typeof fetch>) {
     try {
@@ -99,7 +92,7 @@ export class StreamFetcher {
      */
     private async _fetch(streamId: string, sessionToken?: string): Promise<Todo> {
         const url = `${this.apiUrl}/streams/${encodeURIComponent(streamId)}`
-        const headers = formHeaders(sessionToken)
+        const headers = formAuthorizationHeader(sessionToken)
 
         const response = await fetchWithErrorLogging(url, {
             headers,
@@ -132,7 +125,7 @@ export class StreamFetcher {
         sessionToken = sessionToken || undefined
 
         const url = `${this.apiUrl}/streams/${encodeURIComponent(streamId)}/permissions/me`
-        const headers = formHeaders(sessionToken)
+        const headers = formAuthorizationHeader(sessionToken)
 
         const response = await fetchWithErrorLogging(url, {
             headers,

--- a/packages/broker/src/helpers/authentication.ts
+++ b/packages/broker/src/helpers/authentication.ts
@@ -1,0 +1,9 @@
+import { Headers } from 'node-fetch'
+
+export function formAuthorizationHeader(sessionToken: string | null | undefined): Headers {
+    const headers: Headers = new Headers()
+    if (sessionToken) {
+        headers.set('Authorization', `Bearer ${sessionToken}`)
+    }
+    return headers
+}

--- a/packages/broker/src/websocket/historicalData.ts
+++ b/packages/broker/src/websocket/historicalData.ts
@@ -7,6 +7,7 @@ const { ControlLayer } = Protocol
 import { MAX_SEQUENCE_NUMBER_VALUE, MIN_SEQUENCE_NUMBER_VALUE } from '../storage/DataQueryEndpoints'
 import { StorageNodeRegistry } from '../StorageNodeRegistry'
 import { GenericError } from '../errors/GenericError'
+import { formAuthorizationHeader } from '../helpers/authentication'
 
 type ResendLastRequest = Protocol.ControlLayer.ResendLastRequest
 type ResendFromRequest = Protocol.ControlLayer.ResendFromRequest
@@ -64,10 +65,9 @@ export const createResponse = async (
     const storageNodeUrl = await storageNodeRegistry.getUrlByStreamId(request.streamId)
     const url = getDataQueryEndpointUrl(request, `${storageNodeUrl}/api/v1`)
     const abortController = new AbortController()
+    const headers = formAuthorizationHeader(request.sessionToken)
     const response = await fetch(url, {
-        headers: {
-            Authorization: 'Bearer ' + request.sessionToken
-        },
+        headers,
         signal: abortController.signal
     })
     if (response.status === 200) {


### PR DESCRIPTION
When doing a resend request as an anonymous user, the authorization header was set with `Bearer null` even though no authorization header should be set.