### PR TITLE
Fix InstructionRetryManager test

### DIFF
--- a/packages/network/test/unit/InstructionRetryManager.test.ts
+++ b/packages/network/test/unit/InstructionRetryManager.test.ts
@@ -12,6 +12,10 @@ describe('InstructionRetryManager', () => {
         instructionRetryManager = new InstructionRetryManager(handlerCb, 100)
     })
 
+    afterEach(() => {
+        instructionRetryManager.reset()
+    })
+
     function createInstruction(streamId: string, counter: number) {
         return new TrackerLayer.InstructionMessage({
             requestId: 'requestId',


### PR DESCRIPTION
Added afterEach() that stops the retrying. Before the fix the test kept on running 100 times per second in the background.