### PR TITLE
cli-tools: permission command execution engine

### DIFF
--- a/packages/cli-tools/bin/streamr-stream-grant-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-grant-permission.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander'
 import {
     envOptions,

--- a/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register
+#!/usr/bin/env node
 import { Command } from 'commander'
 import {
     envOptions,

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -43,7 +43,6 @@
     "eslint": "^7.26.0",
     "eslint-config-streamr-ts": "^3.0.1",
     "eslint-plugin-promise": "^5.1.0",
-    "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
Fix `grant-permission` and `revoke-permission` commands to run on `node` instead of `ts-node`. Remove `ts-node` as obsolete dependency.
