### PR TITLE
broker: fix port conflicts in MqttPlugin.test.ts

### DIFF
--- a/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
@@ -7,10 +7,10 @@ import mqtt from 'async-mqtt'
 import { Broker } from '../../../../src/broker'
 import { createMockUser, createClient, startBroker } from '../../../utils'
 
-const MQTT_PORT = 1883
-const WS_PORT = 12391
-const TRACKER_PORT = 12392
-const NETWORK_PORT = 12393
+const MQTT_PORT = 1884
+const WS_PORT = 12395
+const TRACKER_PORT = 12396
+const NETWORK_PORT = 12397
 const MOCK_API_KEY = 'mock-api-key'
 
 const createMqttClient = () => {


### PR DESCRIPTION
Test `MqttPlugin.test.ts` was using ports that conflicted with other tests which becomes a problem if running tests in parallel.