### PR TITLE
Network: Logger.error supports Error object

### DIFF
--- a/packages/network/src/helpers/Logger.ts
+++ b/packages/network/src/helpers/Logger.ts
@@ -54,7 +54,7 @@ export class Logger {
     }
 
     error(msg: string, ...args: any[]): void {
-        const errorInstance = args.find(arg => (arg instanceof Error))
+        const errorInstance = args.find((arg) => (arg instanceof Error))
         if (errorInstance !== undefined) {
             this.logger.error({ err: errorInstance }, msg, ...args)
         } else {

--- a/packages/network/test/unit/Logger.test.ts
+++ b/packages/network/test/unit/Logger.test.ts
@@ -88,11 +88,12 @@ describe(Logger, () => {
         let lines: string[]
         const logger = new Logger(module, '', {
             write: (msg: string) => {
-                lines = msg.split('\n').map(line => line.trim())
+                lines = msg.split('\n').map((line) => line.trim())
             }
         })
         logger.error('log message', new SyntaxError('error message'))
         expect(lines!.length >= 7)
+        // eslint-disable-next-line
         const [ main, _errorTag, errorType, errorMessage, _stackTag, _errorDescription, firstStackFrame ] = lines!
         expect(main.includes('ERROR')).toBeTruthy()
         expect(main.includes('log message')).toBeTruthy()


### PR DESCRIPTION
Improved `error()` method of `Logger.ts`: if the caller provides an `Error` instance as a method parameter,  the details of the error instance are written to the output.

E.g. call to `logger.error('log message', new SyntaxError('error message'))`

produces output:

```
ERROR [2001-02-03T04:04:06.000] (Logger.test:        ): log message
        err: {
          "type": "SyntaxError",
          "message": "error message",
          "stack":
              SyntaxError: error message
                  at Object.<anonymous> (filepath:123:45)
                  ...
        }
```

Added also optional `destinationStream` parameter to `Logger` constructor to support unit testing.