### PR TITLE
fix Broker: Cassandra query for resendFrom with publisher

### DIFF
--- a/packages/broker/src/plugins/storage/Storage.ts
+++ b/packages/broker/src/plugins/storage/Storage.ts
@@ -281,19 +281,11 @@ export class Storage extends EventEmitter {
         return resultStream
     }
 
-    _fetchFromMessageRefForPublisher(streamId: string, partition: number, fromTimestamp: number, fromSequenceNo: number|null, publisherId?: string|null, msgChainId: string|null = null) {
+    _fetchFromMessageRefForPublisher(streamId: string, partition: number, fromTimestamp: number, fromSequenceNo: number|null, publisherId?: string|null) {
         const resultStream = this._createResultStream()
 
-        let query1 = 'SELECT payload FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id IN ? AND ts = ? AND sequence_no >= ? AND publisher_id = ? '
-        let query2 = 'SELECT payload FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id IN ? AND ts = ? AND sequence_no >= ? AND publisher_id = ? '
-
-        if (msgChainId !== null){
-            query1 += 'AND msg_chain_id = ? '
-            query2 += 'AND msg_chain_id = ? '
-        }
-
-        query1 +=  'ALLOW FILTERING'
-        query2 +=  'ALLOW FILTERING'
+        const query1 = 'SELECT payload FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id IN ? AND ts = ? AND sequence_no >= ? AND publisher_id = ? ALLOW FILTERING'
+        const query2 = 'SELECT payload FROM stream_data WHERE stream_id = ? AND partition = ? AND bucket_id IN ? AND ts > ? AND publisher_id = ? ALLOW FILTERING'
 
         this.bucketManager.getBucketsByTimestamp(streamId, partition, fromTimestamp).then((buckets: Bucket[]) => {
             if (buckets.length === 0) { // TODO not an error as there is no data: do not throw
@@ -304,10 +296,6 @@ export class Storage extends EventEmitter {
 
             const queryParams1 = [streamId, partition, bucketsForQuery, fromTimestamp, fromSequenceNo, publisherId]
             const queryParams2 = [streamId, partition, bucketsForQuery, fromTimestamp, publisherId]
-            if (msgChainId !== null) {
-                queryParams1.push(msgChainId)
-                queryParams2.push(msgChainId)
-            }
             const stream1 = this._queryWithStreamingResults(query1, queryParams1)
             const stream2 = this._queryWithStreamingResults(query2, queryParams2)
 


### PR DESCRIPTION
Provided query parameters in`Storage._fetchFromMessageRefForPublisher` don't match the CQL query parameter types. All "from" type resend fail, if there is a publisher specified.

The query was modified in this PR one week ago:  https://github.com/streamr-dev/network-monorepo/pull/38


To reproduce the bug, run e.g.:

```
streamr stream resend from '2021-01-01T00:00:00Z' testStreamId --publisher-id testPublisher --msg-chain-id testMsgChainId 
```

Throws an exception and prints error in Broker:

```
E 2001-02-03T04:05:06.000   S1:broker              uncaughtException
    TypeError: Expected Number, obtained 'testPublisher'
        at Encoder.encodeInt (/Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/encoder.js:719:13)
        at Encoder.encode (/Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/encoder.js:1571:18)
        at ExecuteRequest.writeQueryParameters (/Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/requests.js:209:40)
        at ExecuteRequest.write (/Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/requests.js:153:10)
        at WriteQueue.process (/Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/writers.js:247:44)
        at /Users/teogeb/workspace/network-monorepo/packages/broker/node_modules/cassandra-driver/lib/writers.js:224:35
        at processTicksAndRejections (internal/process/task_queues.js:75:11)
```