### PR TITLE
CLI-tools: remove msgChainId parameter from "resend from" command

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add permission commands: `stream grant-permission` and `stream revoke-permission`
 - Remove `typescript` and `ts-node` as run-time dependencies
+- Remove `--msg-chain-id` parameter from `stream resend from`
 
 ## [5.0.0] - 2021-05-05
 ### Added


### PR DESCRIPTION
Resend from requests don't support `msgChainId` parameter. Removed that parameter from that cli tool command. Also refactored `publisherId`+`msgChainId` parameter handling.