### PR TITLE
CLI-tools: "stream create" argument is streamId, not name

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add permission commands: `stream grant-permission` and `stream revoke-permission`
 - Remove `typescript` and `ts-node` as run-time dependencies
 - Remove `--msg-chain-id` parameter from `stream resend from`
+- (Breaking) `streamr stream create` argument is `streamId`, not `name`
 
 ## [5.0.0] - 2021-05-05
 ### Added

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -79,8 +79,15 @@ streamr stream show <streamId> --private-key <key>
 ### create
 Create a new stream
 ```
-streamr stream create <name> --private-key <key>
+streamr stream create <id> --private-key <key>
 ```
+The id can be a full id or a path. If only path is specified, it is prefixed with your Ethereum address.
+```
+streamr stream create /foo/bar
+streamr stream create 0x1234567890123456789012345678901234567890/foobar
+streamr stream create yourdomain.ens/foobar
+```
+
 
 ### resend
 Request a resend of historical data printed as JSON objects to stdout line-by-line.

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -12,8 +12,8 @@ import pkg from '../package.json'
 
 const program = new Command()
 program
-    .arguments('<name>')
-    .description('create a new stream')
+    .arguments('<id>')
+    .description('create a new stream: the id can be a full streamId or a path')
     .option('-d, --description <description>', 'define a description')
     .option('-c, --config <config>', 'define a configuration as JSON', (s: string) => JSON.parse(s))
     .option('-p, --partitions <count>', 'define a partition count',
@@ -21,9 +21,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((name: string, options: any) => {
+    .action((id: string, options: any) => {
         const body: any = {
-            name,
+            id,
             description: options.description,
             config: options.config,
             partitions: options.partitions


### PR DESCRIPTION
**Breaking change:** the argument of `stream create` changed from `name` to `streamId`,

See https://linear.app/streamr/issue/BACK-141/do-not-allow-empty-streamid-remove-support-for-streamid-generation