### PR TITLE
Reduce storage refresh interval from 10s to 1s in dev + docker configs.

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -56,7 +56,7 @@
         "datacenter": "datacenter1"
       },
       "storageConfig": {
-        "refreshInterval": 10000
+        "refreshInterval": 1000
       }
     }
   }

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -54,8 +54,8 @@
         "datacenter": "datacenter1"
       },
       "storageConfig": {
-        "refreshInterval": 10000
-      }    
+        "refreshInterval": 1000
+      }
     }
   }
 }


### PR DESCRIPTION
The 10s limit means tests that need storage can run at most 1 per 10s. This substantially increases test time. Can bump this back up to 10s in production I guess.
Ideally we wouldn't have to poll at all, if only we had a way of sending messages in real-time, like… a stream or something.

To demonstrate speedup:

## Before: 55.5s
```
 PASS  test/integration/SubscriberResends.test.ts (55.502 s)
  resends
    test repeat 1 of 1
      no data
        ✓ throws error if bad stream id (345 ms)
        ✓ throws error if no resend config (9918 ms)
        ✓ handles nothing to resend (10147 ms)
        ✓ resendSubscribe with nothing to resend (10656 ms)
      with resend data
        ✓ requests resend (345 ms)
        ✓ requests resend number (563 ms)
        ✓ closes stream (576 ms)
        ✓ closes connection with autoDisconnect (1474 ms)
        resendSubscribe
          ✓ sees resends and realtime (920 ms)
          ✓ sees resends when no realtime (1343 ms)
          ✓ ends resend if unsubscribed (920 ms)
          ✓ can return before start (894 ms)
          ✓ can end asynchronously (1687 ms)
          ✓ can end inside resend (1174 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        55.564 s
```

## After: 21s (62% less time!)

```
PASS  test/integration/SubscriberResends.test.ts (20.984 s)
  resends
    test repeat 1 of 1
      no data
        ✓ throws error if bad stream id (345 ms)
        ✓ throws error if no resend config (765 ms)
        ✓ handles nothing to resend (1167 ms)
        ✓ resendSubscribe with nothing to resend (1777 ms)
      with resend data
        ✓ requests resend (346 ms)
        ✓ requests resend number (516 ms)
        ✓ closes stream (527 ms)
        ✓ closes connection with autoDisconnect (1497 ms)
        resendSubscribe
          ✓ sees resends and realtime (842 ms)
          ✓ sees resends when no realtime (1343 ms)
          ✓ ends resend if unsubscribed (874 ms)
          ✓ can return before start (908 ms)
          ✓ can end asynchronously (1731 ms)
          ✓ can end inside resend (1169 ms) 
```

----

In addition, these batch/bucket timers should probably be made configurable and lowered for the test env:

https://github.com/streamr-dev/network-monorepo/blob/86922c91c73b53cbe0dc8dc4b80e5583777a286f/packages/broker/src/plugins/storage/BatchManager.ts#L46

https://github.com/streamr-dev/network-monorepo/blob/86922c91c73b53cbe0dc8dc4b80e5583777a286f/packages/broker/src/plugins/storage/BucketManager.ts#L46-L47 