### PR TITLE
Fix long resend test.

### DIFF
--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -345,7 +345,7 @@ describe('StreamrClient resends', () => {
                 published = await publishTestMessages(LONG_RESEND, {
                     waitForLast: true,
                     // get all messages in case of bad disordering
-                    waitForLastCount: LONG_RESEND,
+                    waitForLastCount: LONG_RESEND * 2,
                     // speed up publish time
                     batchSize: 10,
                     delay: 1,

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -344,6 +344,11 @@ describe('StreamrClient resends', () => {
                 client.debug(`Publishing ${LONG_RESEND} messages...`)
                 published = await publishTestMessages(LONG_RESEND, {
                     waitForLast: true,
+                    // get all messages in case of bad disordering
+                    waitForLastCount: LONG_RESEND,
+                    // speed up publish time
+                    batchSize: 10,
+                    delay: 1,
                 })
                 client.debug(`Published ${LONG_RESEND} messages`)
                 await client.disconnect()


### PR DESCRIPTION
I think this "works" (update: it doesn't) because when it asks for say, the "last X" items, if the very last item isn't in that last X because the last messages logic is broken, (perhaps due to storing messages out of order, then it will never find the last item because it's (mysteriously) at some position > X. Changing it to always fetch "everything" might work around this bug.

Update: ugh, didn't seem to fix it in CI.