### PR TITLE
Broker NET-333!: Configurable payload format for WebSocket and MQTT plugin

### DIFF
--- a/packages/broker/src/helpers/PayloadFormat.ts
+++ b/packages/broker/src/helpers/PayloadFormat.ts
@@ -1,6 +1,6 @@
 export interface PayloadFormat {
-    createMessage: (payload: string) => Message
-    createPayload: (content: any, metadata?: Metadata) => string
+    createMessage: (payload: string) => Message|never
+    createPayload: (content: any, metadata?: Metadata) => string|never
 }
 
 export interface Message {
@@ -15,13 +15,15 @@ export interface Metadata {
     msgChainId?: string
 }
 
-const pickProperties = (fields: string[], from: any) => {
+const METADATA_FIELDS = [ 'timestamp', 'sequenceNumber', 'publisherId', 'msgChainId' ]
+
+const pickProperties = (fields: string[], from: Record<string,unknown>): Record<string,unknown> => {
     const result: any = {}
     fields.forEach((field) => result[field] = from[field])
     return result
 }
 
-const assertContent = (content: any) => {
+const assertContent = (content: any): void|never => {
     if ((content === undefined) || (content === null)) {
         throw new Error('Content missing')
     }
@@ -30,7 +32,7 @@ const assertContent = (content: any) => {
     }
 }
 
-const assertMetadata = (metadata: any) => {
+const assertMetadata = (metadata: any): void|never => {
     if (!(metadata instanceof Object)) {
         throw new Error('Metadata is not an object')
     }
@@ -45,14 +47,14 @@ const parsePayloadJson = (payload: string) => {
 }
 
 export class PlainPayloadFormat implements PayloadFormat {
-    createMessage(payload: string): Message {
+    createMessage(payload: string): Message|never {
         return {
             content: parsePayloadJson(payload),
             metadata: {}
         }
     }
 
-    createPayload(content: any): string {
+    createPayload(content: any): string|never {
         assertContent(content)
         return JSON.stringify(content)
     }
@@ -60,30 +62,28 @@ export class PlainPayloadFormat implements PayloadFormat {
 
 export class MetadataPayloadFormat implements PayloadFormat {
 
-    private static FIELDS = [ 'timestamp', 'sequenceNumber', 'publisherId', 'msgChainId' ]
-
-    createMessage(payload: string): Message {
+    createMessage(payload: string): Message|never {
         const json = parsePayloadJson(payload)
         const content = json.content
         assertContent(content)
         let metadata
         if (json.metadata !== undefined) {
             assertMetadata(json.metadata)
-            metadata = pickProperties(MetadataPayloadFormat.FIELDS, json.metadata)
+            metadata = pickProperties(METADATA_FIELDS, json.metadata)
         } else {
             metadata = {}
         }
         return { content, metadata }
     }
 
-    createPayload(content: any, metadata?: Metadata): string {
+    createPayload(content: any, metadata?: Metadata): string|never {
         assertContent(content)
         const payload: any = {
             content
         }
         if (metadata !== undefined) {
             assertMetadata(metadata)
-            payload.metadata = pickProperties(MetadataPayloadFormat.FIELDS, metadata)
+            payload.metadata = pickProperties(METADATA_FIELDS, metadata as Record<string,unknown>)
         }
         return JSON.stringify(payload)
     }

--- a/packages/broker/src/helpers/PayloadFormat.ts
+++ b/packages/broker/src/helpers/PayloadFormat.ts
@@ -1,0 +1,94 @@
+export interface PayloadFormat {
+    createMessage: (payload: string) => Message
+    createPayload: (content: any, metadata?: Metadata) => string
+}
+
+export interface Message {
+    content: any
+    metadata: Metadata
+}
+
+export interface Metadata {
+    timestamp?: number
+    sequenceNumber?: number
+    publisherId?: string
+    msgChainId?: string
+}
+
+const pickProperties = (fields: string[], from: any) => {
+    const result: any = {}
+    fields.forEach((field) => result[field] = from[field])
+    return result
+}
+
+const assertContent = (content: any) => {
+    if ((content === undefined) || (content === null)) {
+        throw new Error('Content missing')
+    }
+    if (!(content instanceof Array || content instanceof Object)) {
+        throw new Error('Content is not an object or an array')
+    }
+}
+
+const assertMetadata = (metadata: any) => {
+    if (!(metadata instanceof Object)) {
+        throw new Error('Metadata is not an object')
+    }
+}
+
+const parsePayloadJson = (payload: string) => {
+    try {
+        return JSON.parse(payload)
+    } catch (e) {
+        throw new Error(`Payload is not a JSON string: ${e.message}`)
+    }
+}
+
+export class PlainPayloadFormat implements PayloadFormat {
+    createMessage(payload: string): Message {
+        return {
+            content: parsePayloadJson(payload),
+            metadata: {}
+        }
+    }
+
+    createPayload(content: any): string {
+        assertContent(content)
+        return JSON.stringify(content)
+    }
+}
+
+export class MetadataPayloadFormat implements PayloadFormat {
+
+    private static FIELDS = [ 'timestamp', 'sequenceNumber', 'publisherId', 'msgChainId' ]
+
+    createMessage(payload: string): Message {
+        const json = parsePayloadJson(payload)
+        const content = json.content
+        assertContent(content)
+        let metadata
+        if (json.metadata !== undefined) {
+            assertMetadata(json.metadata)
+            metadata = pickProperties(MetadataPayloadFormat.FIELDS, json.metadata)
+        } else {
+            metadata = {}
+        }
+        return { content, metadata }
+    }
+
+    createPayload(content: any, metadata?: Metadata): string {
+        assertContent(content)
+        const payload: any = {
+            content
+        }
+        if (metadata !== undefined) {
+            assertMetadata(metadata)
+            payload.metadata = pickProperties(MetadataPayloadFormat.FIELDS, metadata)
+        }
+        return JSON.stringify(payload)
+    }
+}
+
+export const getPayloadFormat = (metadata: boolean) => {
+    return metadata ? new MetadataPayloadFormat() : new PlainPayloadFormat()
+}

--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -1,5 +1,6 @@
 import { StreamrClient, Subscription } from 'streamr-client'
 import { Logger } from 'streamr-network'
+import { PayloadFormat } from '../../helpers/PayloadFormat'
 import { MqttServer, MqttServerListener } from './MqttServer'
 
 const logger = new Logger(module)
@@ -8,39 +9,32 @@ export class Bridge implements MqttServerListener {
 
     private readonly streamrClient: StreamrClient
     private readonly mqttServer: MqttServer
+    private readonly payloadFormat: PayloadFormat
     private readonly streamIdDomain?: string
 
-    constructor(streamrClient: StreamrClient, mqttServer: MqttServer, streamIdDomain?: string) {
+    constructor(streamrClient: StreamrClient, mqttServer: MqttServer, payloadFormat: PayloadFormat, streamIdDomain?: string) {
         this.streamrClient = streamrClient
         this.mqttServer = mqttServer
+        this.payloadFormat = payloadFormat
         this.streamIdDomain = streamIdDomain
     }
 
     onMessageReceived(topic: string, payload: string): void {
-        let json
+        let message
         try {
-            json = JSON.parse(payload)
-        } catch (e) {
-            logger.warn('Unable to publish message: JSON syntax error')
+            message = this.payloadFormat.createMessage(payload)
+        } catch (err) {
+            logger.warn(`Unable to publish message: ${err.message}`)
             return
         }
-        const { message, metadata } = json
-        if (message === undefined) {
-            logger.warn('Unable to publish message: no "message" field in JSON')
-            return
-        }
-        this.streamrClient.publish(this.getStreamId(topic), message, metadata?.timestamp)
+        const { content, metadata } = message
+        this.streamrClient.publish(this.getStreamId(topic), content, metadata.timestamp)
     }
     
     onSubscribed(topic: string): void {
         logger.info('Client subscribed: ' + topic)
-        this.streamrClient.subscribe(this.getStreamId(topic), (message: any, metadata: any) => {
-            const payload = JSON.stringify({
-                message,
-                metadata: {
-                    timestamp: metadata.messageId.timestamp
-                }
-            })
+        this.streamrClient.subscribe(this.getStreamId(topic), (content: any, metadata: any) => {
+            const payload = this.payloadFormat.createPayload(content, metadata.messageId)
             this.mqttServer.publish(topic, payload)
         })
     }

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -1,4 +1,5 @@
 import { Plugin, PluginOptions } from '../../Plugin'
+import { getPayloadFormat } from '../../helpers/PayloadFormat'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { MqttServer } from './MqttServer'
 import { Bridge } from './Bridge'
@@ -6,6 +7,7 @@ import { Bridge } from './Bridge'
 export interface MqttPluginConfig {
     port: number
     streamIdDomain: string|null
+    payloadMetadata: boolean
 }
 
 export class MqttPlugin extends Plugin<MqttPluginConfig> {
@@ -21,7 +23,12 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
 
     async start() {
         this.server = new MqttServer(this.pluginConfig.port, this.apiAuthenticator)
-        const bridge = new Bridge(this.streamrClient!, this.server, this.pluginConfig.streamIdDomain ?? undefined)
+        const bridge = new Bridge(
+            this.streamrClient!, 
+            this.server, 
+            getPayloadFormat(this.pluginConfig.payloadMetadata),
+            this.pluginConfig.streamIdDomain ?? undefined
+        )
         this.server.setListener(bridge)
         return this.server.start()
     }

--- a/packages/broker/src/plugins/mqtt/config.schema.json
+++ b/packages/broker/src/plugins/mqtt/config.schema.json
@@ -4,7 +4,8 @@
     "type": "object",
     "description": "MQTT plugin configuration",
     "required": [
-        "port"
+        "port",
+        "payloadMetadata"
     ],
     "additionalProperties": false,
     "properties": {
@@ -15,6 +16,10 @@
         "streamIdDomain": {
             "type": "string",
             "description": "All topics are mapped to streamIds by prepending the domain to the topic: streamIdDomain + '/' + topic"
+        },
+        "payloadMetadata": {
+            "type": "boolean",
+            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON"
         }
     }
 }

--- a/packages/broker/src/plugins/websocket/Connection.ts
+++ b/packages/broker/src/plugins/websocket/Connection.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws'
 import { StreamrClient } from 'streamr-client'
+import { PayloadFormat } from '../../helpers/PayloadFormat'
 
 export interface Connection {
-    init: (ws: WebSocket, streamrClient: StreamrClient) => void
+    init: (ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) => void
 }

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -31,7 +31,7 @@ export class PublishConnection implements Connection {
         ws.on('message', (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)
-                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
+                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? content[this.partitionKeyField] : undefined)
                 streamrClient.publish({
                     id: this.streamId,
                     partition: this.partition

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -31,7 +31,7 @@ export class PublishConnection implements Connection {
         ws.on('message', (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)
-                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? content[this.partitionKeyField] : undefined)
+                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
                 streamrClient.publish({
                     id: this.streamId,
                     partition: this.partition

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -5,16 +5,9 @@ import { ParsedQs } from 'qs'
 import { parsePositiveInteger, parseQueryParameter } from '../../helpers/parser'
 import { Connection } from './Connection'
 import { closeWithError } from '../../helpers/closeWebsocket'
+import { PayloadFormat } from '../../helpers/PayloadFormat'
 
 const logger = new Logger(module)
-
-const parsePayloadJson = (contentAsString: string) => {
-    try {
-        return JSON.parse(contentAsString)
-    } catch (e) {
-        throw new Error(`Payload is not a JSON string: ${e.message}`)
-    }
-}
 
 export class PublishConnection implements Connection {
 
@@ -34,15 +27,15 @@ export class PublishConnection implements Connection {
         }
     }
     
-    init(ws: WebSocket, streamrClient: StreamrClient) {
-        ws.on('message', (contentPayload: string) => {
+    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) {
+        ws.on('message', (payload: string) => {
             try {
-                const content = parsePayloadJson(contentPayload)
-                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? content[this.partitionKeyField] : undefined)
+                const { content, metadata } = payloadFormat.createMessage(payload)
+                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content as any)[this.partitionKeyField] : undefined)
                 streamrClient.publish({
                     id: this.streamId,
                     partition: this.partition
-                }, content, undefined, partitionKey)
+                }, content, metadata.timestamp, partitionKey)
             } catch (err: any) {
                 closeWithError(err, 'Unable to publish', ws, logger)
             }

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -31,7 +31,7 @@ export class PublishConnection implements Connection {
         ws.on('message', (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)
-                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content as any)[this.partitionKeyField] : undefined)
+                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
                 streamrClient.publish({
                     id: this.streamId,
                     partition: this.partition

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -1,10 +1,12 @@
 import { Plugin, PluginOptions } from '../../Plugin'
 import { SslCertificateConfig } from '../../types'
+import { getPayloadFormat } from '../../helpers/PayloadFormat'
 import { WebsocketServer } from './WebsocketServer'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 
 export interface WebsocketPluginConfig {
     port: number
+    payloadMetadata: boolean
     sslCertificate: SslCertificateConfig|null
 }
 
@@ -21,7 +23,12 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
 
     async start() {
         this.server = new WebsocketServer(this.streamrClient!)
-        await this.server.start(this.pluginConfig.port, this.apiAuthenticator, this.pluginConfig.sslCertificate ?? undefined)
+        await this.server.start(
+            this.pluginConfig.port, 
+            getPayloadFormat(this.pluginConfig.payloadMetadata),
+            this.apiAuthenticator, 
+            this.pluginConfig.sslCertificate ?? undefined
+        )
     }
 
     async stop() {

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -13,6 +13,7 @@ import { ApiAuthenticator } from '../../apiAuthenticator'
 import { SslCertificateConfig } from '../../types'
 import { PublishConnection } from './PublishConnection'
 import { SubscribeConnection } from './SubscribeConnection'
+import { PayloadFormat } from '../../helpers/PayloadFormat'
 
 const logger = new Logger(module)
 
@@ -42,7 +43,12 @@ export class WebsocketServer {
         this.streamrClient = streamrClient
     }
 
-    async start(port: number, apiAuthenticator: ApiAuthenticator, sslCertificateConfig?: SslCertificateConfig): Promise<void> {
+    async start(
+        port: number, 
+        payloadFormat: PayloadFormat,
+        apiAuthenticator: ApiAuthenticator, 
+        sslCertificateConfig?: SslCertificateConfig
+    ): Promise<void> {
         this.httpServer = (sslCertificateConfig !== undefined) 
             ? https.createServer({
                 key: fs.readFileSync(sslCertificateConfig.privateKeyFileName),
@@ -73,7 +79,7 @@ export class WebsocketServer {
         })
 
         this.wss.on('connection', (ws: WebSocket, _request: http.IncomingMessage, connection: Connection) => {
-            connection.init(ws, this.streamrClient)
+            connection.init(ws, this.streamrClient, payloadFormat)
         })
 
         this.httpServer.listen(port)

--- a/packages/broker/src/plugins/websocket/config.schema.json
+++ b/packages/broker/src/plugins/websocket/config.schema.json
@@ -5,6 +5,7 @@
     "description": "WebSocket plugin configuration",
     "required": [
         "port",
+        "payloadMetadata",
         "sslCertificate"
     ],
     "additionalProperties": false,
@@ -12,6 +13,10 @@
         "port": {
             "type": "integer",
             "description": "Port to start plugin on"
+        },
+        "payloadMetadata": {
+            "type": "boolean",
+            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON"
         },
         "sslCertificate": {
             "description": "Files to use for SSL",

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -1,0 +1,124 @@
+import { Stream, StreamrClient } from 'streamr-client'
+import { startTracker, Tracker } from 'streamr-network'
+import { Broker } from '../../src/broker'
+import { Message } from '../helpers/PayloadFormat'
+import { createClient, startBroker, createTestStream, createMockUser, Queue } from '../utils'
+
+interface MessagingPluginApi<T> {
+    createClient: (action: 'publish'|'subscribe', streamId: string, apiKey: string) => Promise<T>
+    closeClient: (client: T) => Promise<void>
+    publish: (message: Message, streamId: string, client: T) => Promise<void>,
+    subscribe: (messageQueue: Queue<Message>, streamId: string, client: T) => Promise<void>
+}
+
+const MOCK_MESSAGE = { 
+    content: { 
+        foo: 'bar' 
+    }, 
+    metadata: {
+        timestamp: 11111111
+    } 
+}
+const MOCK_API_KEY = 'mock-api-key'
+
+const brokerUser = createMockUser()
+
+const assertReceivedMessage = (message: Message) => {
+    const { content, metadata } = message
+    expect(content).toEqual(MOCK_MESSAGE.content)
+    expect(metadata.timestamp).toEqual(MOCK_MESSAGE.metadata.timestamp)
+    expect(metadata.sequenceNumber).toEqual(0)
+    expect(metadata.publisherId).toEqual(brokerUser.address.toLocaleLowerCase())
+    expect(metadata.msgChainId).toBeDefined()
+}
+
+export const createMessagingPluginTest = <T>(
+    pluginName: string, 
+    api: MessagingPluginApi<T>, 
+    pluginPort: number, 
+    testModule: NodeJS.Module,
+    pluginConfig: any = {}
+) => {
+
+    // some free ports
+    const LEGACY_WEBSOCKET_PORT = pluginPort + 1
+    const TRACKER_PORT = pluginPort + 2
+    const NETWORK_PORT = pluginPort + 3
+
+    describe(`Plugin: ${pluginName}`, () => {
+
+        let stream: Stream
+        let streamrClient: StreamrClient
+        let pluginClient: T
+        let tracker: Tracker
+        let broker: Broker
+        let messageQueue: Queue<Message>
+
+        beforeAll(async () => {
+            tracker = await startTracker({
+                id: 'tracker',
+                host: '127.0.0.1',
+                port: TRACKER_PORT,
+            })
+            broker = await startBroker({
+                name: 'broker',
+                privateKey: brokerUser.privateKey,
+                networkPort: NETWORK_PORT,
+                trackerPort: TRACKER_PORT,
+                wsPort: LEGACY_WEBSOCKET_PORT,
+                apiAuthentication: {
+                    keys: [MOCK_API_KEY]
+                },
+                extraPlugins: {
+                    [pluginName]: {
+                        port: pluginPort,
+                        payloadMetadata: true,
+                        ...pluginConfig
+                    }
+                }
+            })
+        })
+
+        afterAll(async () => {
+            await Promise.allSettled([
+                broker.close(),
+                tracker.stop()
+            ])
+        })
+
+        beforeEach(async () => {
+            streamrClient = createClient(LEGACY_WEBSOCKET_PORT, brokerUser.privateKey, {
+                autoDisconnect: false
+            })
+            stream = await createTestStream(streamrClient, testModule)
+            messageQueue = new Queue<Message>()
+        })
+
+        afterEach(async () => {
+            if (pluginClient !== undefined) {
+                api.closeClient(pluginClient)
+            }
+            await streamrClient?.ensureDisconnected()
+        })
+
+        test('publish', async () => {
+            streamrClient.subscribe(stream.id, (content: any, metadata: any) => {
+                messageQueue.push({ content, metadata: metadata.messageId })
+            })
+            pluginClient = await api.createClient('publish', stream.id, MOCK_API_KEY)
+            await api.publish(MOCK_MESSAGE, stream.id, pluginClient)
+            const message = await messageQueue.pop()
+            assertReceivedMessage(message)
+        })
+
+        test('subscribe', async () => {
+            pluginClient = await api.createClient('subscribe', stream.id, MOCK_API_KEY)
+            await api.subscribe(messageQueue, stream.id, pluginClient)
+            await streamrClient.publish(stream.id, MOCK_MESSAGE.content, MOCK_MESSAGE.metadata.timestamp)
+            const message = await messageQueue.pop()
+            assertReceivedMessage(message)
+        })
+
+    })
+
+}

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -98,7 +98,7 @@ export const createMessagingPluginTest = <T>(
 
         afterEach(async () => {
             if (pluginClient !== undefined) {
-                api.closeClient(pluginClient)
+                await api.closeClient(pluginClient)
             }
             await streamrClient?.ensureDisconnected()
         })

--- a/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
@@ -5,6 +5,9 @@ import { createMessagingPluginTest } from '../../createMessagingPluginTest'
 import { Queue } from '../../../utils'
 
 const MQTT_PORT = 12430
+const LEGACY_WEBSOCKET_PORT = 12431
+const TRACKER_PORT = 12432
+const NETWORK_PORT = 12433
 
 createMessagingPluginTest('mqtt',
     {
@@ -29,6 +32,11 @@ createMessagingPluginTest('mqtt',
             await client.subscribe(streamId)
         }
     },
-    MQTT_PORT,
+    {
+        plugin: MQTT_PORT,
+        legacyWebsocket: LEGACY_WEBSOCKET_PORT,
+        tracker: TRACKER_PORT,
+        network: NETWORK_PORT
+    },
     module
 )

--- a/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
@@ -1,120 +1,34 @@
-import { StreamrClient } from 'streamr-client'
 import { AsyncMqttClient } from 'async-mqtt'
-import { Wallet } from 'ethers'
-import { waitForCondition } from 'streamr-test-utils'
-import { startTracker, Tracker } from 'streamr-network'
 import mqtt from 'async-mqtt'
-import { Broker } from '../../../../src/broker'
-import { createMockUser, createClient, startBroker } from '../../../utils'
+import { Message } from '../../../../src/helpers/PayloadFormat'
+import { createMessagingPluginTest } from '../../createMessagingPluginTest'
+import { Queue } from '../../../utils'
 
-const MQTT_PORT = 1884
-const WS_PORT = 12395
-const TRACKER_PORT = 12396
-const NETWORK_PORT = 12397
-const MOCK_API_KEY = 'mock-api-key'
+const MQTT_PORT = 12430
 
-const createMqttClient = () => {
-    return mqtt.connectAsync('mqtt://localhost:' + MQTT_PORT, {
-        username: '',
-        password: MOCK_API_KEY,
-    })
-}
-
-describe('MQTT plugin', () => {
-
-    let streamrClient: StreamrClient
-    let mqttClient: AsyncMqttClient
-    let user: Wallet
-    let topic: string
-    let tracker: Tracker
-    let broker: Broker
-
-    const getStreamId = () => user.address + '/' + topic
-
-    beforeAll(async () => {
-        user = createMockUser()
-        tracker = await startTracker({
-            id: 'tracker',
-            host: '127.0.0.1',
-            port: TRACKER_PORT,
-        })
-        broker = await startBroker({
-            name: 'broker',
-            privateKey: user.privateKey,
-            networkPort: NETWORK_PORT,
-            trackerPort: TRACKER_PORT,
-            wsPort: WS_PORT,
-            extraPlugins: {
-                mqtt: {
-                    port: MQTT_PORT,
-                    streamIdDomain: user.address
-                }
-            },
-            apiAuthentication: {
-                keys: [MOCK_API_KEY]
-            }
-        })
-    })
-
-    afterAll(async () => {
-        await Promise.allSettled([
-            broker.close(),
-            tracker.stop()
-        ])
-    })
-
-    beforeEach(async () => {
-        streamrClient = createClient(WS_PORT, user.privateKey, {
-            autoDisconnect: false
-        })
-        mqttClient = await createMqttClient()
-        topic = 'topic-' + Date.now()
-        await streamrClient.createStream({
-            id: getStreamId()
-        })
-    })
-
-    afterEach(async () => {
-        await Promise.allSettled([
-            mqttClient.end(true),
-            streamrClient.ensureDisconnected()
-        ])
-    })
-
-    test('publish on MQTT client', async () => {
-        const createPayload = () => {
-            const message = {
-                foo: 'from-client'
-            }
-            return JSON.stringify({
-                message
+createMessagingPluginTest('mqtt',
+    {
+        createClient: async (_action: 'publish'|'subscribe', _streamId: string, apiKey: string): Promise<AsyncMqttClient> => {
+            return mqtt.connectAsync('mqtt://localhost:' + MQTT_PORT, {
+                username: '',
+                password: apiKey,
             })
+        },
+        closeClient: async (client: AsyncMqttClient): Promise<void> => {
+            await client.end(true)
+        },
+        publish: async (msg: Message, streamId: string, client: AsyncMqttClient): Promise<void> => {
+            await client.publish(streamId, JSON.stringify(msg))
+        },
+        subscribe: async (messageQueue: Queue<Message>, streamId: string, client: AsyncMqttClient): Promise<void> => {
+            client.once('message', (topic: string, message: Buffer) => {
+                if (topic === streamId) {
+                    messageQueue.push(JSON.parse(message.toString()))
+                }
+            })
+            await client.subscribe(streamId)
         }
-        let receivedMessage: any
-        await streamrClient.subscribe({
-            stream: getStreamId()
-        }, (message: any) => {
-            receivedMessage = message
-        })
-        mqttClient.publish(topic, createPayload())
-        await waitForCondition(() => receivedMessage !== undefined)
-        expect(receivedMessage.foo).toBe('from-client')
-    })
-
-    test('subscribe on MQTT client', async () => {
-        let receivedTopic: string|undefined
-        let receivedJson: any
-        mqttClient.once('message', (topic: string, payload: Buffer) => {
-            receivedTopic = topic
-            receivedJson = JSON.parse(payload.toString())
-        })
-        await mqttClient.subscribe(topic)
-        await streamrClient.publish(getStreamId(), {
-            foo: 'to-client'
-        })
-        await waitForCondition(() => receivedJson !== undefined, 7000)
-        expect(receivedTopic).toBe(topic)
-        expect(receivedJson.message.foo).toBe('to-client')
-        expect(receivedJson.metadata.timestamp).toBeDefined()
-    }, 15000)
-})
+    },
+    MQTT_PORT,
+    module
+)

--- a/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
@@ -5,6 +5,9 @@ import { createMessagingPluginTest } from '../../createMessagingPluginTest'
 import { Queue } from '../../../utils'
 
 const WEBSOCKET_PORT = 12400
+const LEGACY_WEBSOCKET_PORT = 12401
+const TRACKER_PORT = 12402
+const NETWORK_PORT = 12403
 
 createMessagingPluginTest('websocket', 
     {
@@ -23,7 +26,12 @@ createMessagingPluginTest('websocket',
             client.on('message', (payload: string) => messageQueue.push(JSON.parse(payload)))
         }
     },
-    WEBSOCKET_PORT,
+    {
+        plugin: WEBSOCKET_PORT,
+        legacyWebsocket: LEGACY_WEBSOCKET_PORT,
+        tracker: TRACKER_PORT,
+        network: NETWORK_PORT
+    },
     module,
     {
         sslCertificate: null

--- a/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
@@ -1,86 +1,31 @@
 import WebSocket from 'ws'
-import { Stream, StreamrClient } from 'streamr-client'
 import { waitForEvent } from 'streamr-test-utils'
-import { startTracker, Tracker } from 'streamr-network'
-import { Broker } from '../../../../src/broker'
-import { createClient, startBroker, fastPrivateKey, createTestStream, createQueue } from '../../../utils'
+import { Message } from '../../../../src/helpers/PayloadFormat'
+import { createMessagingPluginTest } from '../../createMessagingPluginTest'
+import { Queue } from '../../../utils'
 
 const WEBSOCKET_PORT = 12400
-const LEGACY_WEBSOCKET_PORT = 12401
-const TRACKER_PORT = 12402
-const NETWORK_PORT = 12403
 
-const privateKey = fastPrivateKey()
-
-describe('Websocket plugin', () => {
-
-    let stream: Stream
-    let streamrClient: StreamrClient
-    let wsClient: WebSocket
-    let tracker: Tracker
-    let broker: Broker
-
-    const createWebsocketClient = async (action: string): Promise<WebSocket> => {
-        const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(stream.id)}/${action}`)
-        await waitForEvent(client, 'open')
-        return client
+createMessagingPluginTest('websocket', 
+    {
+        createClient: async (action: 'publish'|'subscribe', streamId: string, apiKey: string): Promise<WebSocket> => {
+            const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(streamId)}/${action}?apiKey=${apiKey}`)
+            await waitForEvent(client, 'open')
+            return client
+        },
+        closeClient: async (client: WebSocket): Promise<void> => {
+            client.close()
+        },
+        publish: async (msg: Message, _streamId: string, client: WebSocket): Promise<void> => {
+            client.send(JSON.stringify(msg))
+        },
+        subscribe: async (messageQueue: Queue<Message>, _streamId: string, client: WebSocket): Promise<void> => {
+            client.on('message', (payload: string) => messageQueue.push(JSON.parse(payload)))
+        }
+    },
+    WEBSOCKET_PORT,
+    module,
+    {
+        sslCertificate: null
     }
-
-    beforeAll(async () => {
-        tracker = await startTracker({
-            id: 'tracker',
-            host: '127.0.0.1',
-            port: TRACKER_PORT,
-        })
-        broker = await startBroker({
-            name: 'broker',
-            privateKey,
-            networkPort: NETWORK_PORT,
-            trackerPort: TRACKER_PORT,
-            wsPort: LEGACY_WEBSOCKET_PORT,
-            extraPlugins: {
-                websocket: {
-                    port: WEBSOCKET_PORT,
-                    sslCertificate: null
-                }
-            }
-        })
-    })
-
-    afterAll(async () => {
-        await Promise.allSettled([
-            broker.close(),
-            tracker.stop()
-        ])
-    })
-
-    beforeEach(async () => {
-        streamrClient = createClient(LEGACY_WEBSOCKET_PORT, privateKey, {
-            autoDisconnect: false
-        })
-        stream = await createTestStream(streamrClient, module)
-    })
-
-    afterEach(async () => {
-        wsClient?.close()
-        await streamrClient?.ensureDisconnected()
-    })
-
-    test('publish', async () => {
-        const MOCK_MESSAGE = { foo: 'from-client' }
-        const messageQueue = createQueue()
-        streamrClient.subscribe(stream.id, messageQueue.push)
-        wsClient = await createWebsocketClient('publish')
-        wsClient.send(JSON.stringify(MOCK_MESSAGE))
-        expect(await messageQueue.pop()).toEqual(MOCK_MESSAGE)
-    })
-
-    test('subscribe', async () => {
-        const MOCK_MESSAGE = { foo: 'to-client' }
-        const messageQueue = createQueue()
-        wsClient = await createWebsocketClient('subscribe')
-        wsClient.on('message', messageQueue.push)
-        await streamrClient.publish(stream.id, MOCK_MESSAGE)
-        expect(await messageQueue.pop()).toEqual(JSON.stringify(MOCK_MESSAGE))
-    })
-})
+)

--- a/packages/broker/test/unit/helpers/PayloadFormat.test.ts
+++ b/packages/broker/test/unit/helpers/PayloadFormat.test.ts
@@ -1,0 +1,134 @@
+import { MetadataPayloadFormat, PlainPayloadFormat } from '../../../src/helpers/PayloadFormat'
+
+const MOCK_OBJECT = {
+    foo: 'bar'
+}
+const MOCK_ARRAY = [
+    'foo',
+    'bar'
+]
+const MOCK_METADATA = {
+    timestamp: 123,
+    sequenceNumber: 456,
+    publisherId: 'p',
+    msgChainId: 'm'
+}
+
+describe('PayloadFormat', () => {
+
+    describe('plain', () => {
+
+        const format = new PlainPayloadFormat()
+
+        describe('createMessage', () => {
+
+            it('object', () => {
+                expect(format.createMessage(JSON.stringify(MOCK_OBJECT))).toEqual({
+                    content: MOCK_OBJECT,
+                    metadata: {}
+                })
+            })
+
+            it('array', () => {
+                expect(format.createMessage(JSON.stringify(MOCK_ARRAY))).toEqual({
+                    content: MOCK_ARRAY,
+                    metadata: {}
+                })
+            })
+
+            it.each([
+                ['foobar'],
+                [undefined]
+            ])('invalid: %p', (payload: any) => {
+                expect(() => format.createMessage(payload)).toThrow()
+            })
+
+        })
+
+        describe('createPayload', () => {
+
+            it('object', () => {
+                expect(JSON.parse(format.createPayload(MOCK_OBJECT))).toEqual(MOCK_OBJECT)
+            })
+
+            it('array', () => {
+                expect(JSON.parse(format.createPayload(MOCK_ARRAY))).toEqual(MOCK_ARRAY)
+            })
+
+            it.each([
+                ['foobar'],
+                [undefined]
+            ])('invalid: %p', (content: any) => {
+                expect(() => format.createPayload(content)).toThrow()
+            })
+
+        })
+
+    })
+
+    describe('metadata', () => {
+
+        const format = new MetadataPayloadFormat()
+
+        describe('createMessage', () => {
+
+            it('object', () => {
+                expect(format.createMessage(JSON.stringify({
+                    content: MOCK_OBJECT,
+                    metadata: MOCK_METADATA
+                }))).toEqual({
+                    content: MOCK_OBJECT,
+                    metadata: MOCK_METADATA
+                })
+            })
+
+            it('array', () => {
+                expect(format.createMessage(JSON.stringify({
+                    content: MOCK_ARRAY,
+                    metadata: MOCK_METADATA
+                }))).toEqual({
+                    content: MOCK_ARRAY,
+                    metadata: MOCK_METADATA
+                })
+            })
+
+            it.each([
+                ['foobar'],
+                [undefined],
+                [JSON.stringify({ content: 'foobar' })],
+                [JSON.stringify({ content: undefined })],
+                [JSON.stringify({ content: {}, metadata: 'foobar' })]
+            ])('invalid: %p', (payload: any) => {
+                expect(() => format.createMessage(payload)).toThrow()
+            })
+
+        })
+
+        describe('createPayload', () => {
+
+            it('object', () => {
+                expect(JSON.parse(format.createPayload(MOCK_OBJECT, MOCK_METADATA))).toEqual({
+                    content: MOCK_OBJECT,
+                    metadata: MOCK_METADATA
+                })
+            })
+
+            it('array', () => {
+                expect(JSON.parse(format.createPayload(MOCK_ARRAY, MOCK_METADATA))).toEqual({
+                    content: MOCK_ARRAY,
+                    metadata: MOCK_METADATA
+                })
+            })
+
+            it.each([
+                ['foobar', {}],
+                [undefined, {}],
+                [{}, 'foobar']
+            ])('invalid: %p %p', (content: any, metadata: any) => {
+                expect(() => format.createPayload(content, metadata)).toThrow()
+            })
+
+        })
+
+    })
+})

--- a/packages/broker/test/unit/helpers/PayloadFormat.test.ts
+++ b/packages/broker/test/unit/helpers/PayloadFormat.test.ts
@@ -1,12 +1,8 @@
 import { MetadataPayloadFormat, PlainPayloadFormat } from '../../../src/helpers/PayloadFormat'
 
-const MOCK_OBJECT = {
+const MOCK_CONTENT = {
     foo: 'bar'
 }
-const MOCK_ARRAY = [
-    'foo',
-    'bar'
-]
 const MOCK_METADATA = {
     timestamp: 123,
     sequenceNumber: 456,
@@ -22,23 +18,18 @@ describe('PayloadFormat', () => {
 
         describe('createMessage', () => {
 
-            it('object', () => {
-                expect(format.createMessage(JSON.stringify(MOCK_OBJECT))).toEqual({
-                    content: MOCK_OBJECT,
-                    metadata: {}
-                })
-            })
-
-            it('array', () => {
-                expect(format.createMessage(JSON.stringify(MOCK_ARRAY))).toEqual({
-                    content: MOCK_ARRAY,
+            it('happy path', () => {
+                expect(format.createMessage(JSON.stringify(MOCK_CONTENT))).toEqual({
+                    content: MOCK_CONTENT,
                     metadata: {}
                 })
             })
 
             it.each([
+                [''],
                 ['foobar'],
-                [undefined]
+                [undefined],
+                [[]]
             ])('invalid: %p', (payload: any) => {
                 expect(() => format.createMessage(payload)).toThrow()
             })
@@ -47,17 +38,15 @@ describe('PayloadFormat', () => {
 
         describe('createPayload', () => {
 
-            it('object', () => {
-                expect(JSON.parse(format.createPayload(MOCK_OBJECT))).toEqual(MOCK_OBJECT)
-            })
-
-            it('array', () => {
-                expect(JSON.parse(format.createPayload(MOCK_ARRAY))).toEqual(MOCK_ARRAY)
+            it('happy path', () => {
+                expect(JSON.parse(format.createPayload(MOCK_CONTENT))).toEqual(MOCK_CONTENT)
             })
 
             it.each([
+                [''],
                 ['foobar'],
-                [undefined]
+                [undefined],
+                [[]],
             ])('invalid: %p', (content: any) => {
                 expect(() => format.createPayload(content)).toThrow()
             })
@@ -72,31 +61,23 @@ describe('PayloadFormat', () => {
 
         describe('createMessage', () => {
 
-            it('object', () => {
+            it('happy path', () => {
                 expect(format.createMessage(JSON.stringify({
-                    content: MOCK_OBJECT,
+                    content: MOCK_CONTENT,
                     metadata: MOCK_METADATA
                 }))).toEqual({
-                    content: MOCK_OBJECT,
-                    metadata: MOCK_METADATA
-                })
-            })
-
-            it('array', () => {
-                expect(format.createMessage(JSON.stringify({
-                    content: MOCK_ARRAY,
-                    metadata: MOCK_METADATA
-                }))).toEqual({
-                    content: MOCK_ARRAY,
+                    content: MOCK_CONTENT,
                     metadata: MOCK_METADATA
                 })
             })
 
             it.each([
+                [''],
                 ['foobar'],
                 [undefined],
                 [JSON.stringify({ content: 'foobar' })],
                 [JSON.stringify({ content: undefined })],
+                [JSON.stringify({ content: [] })],
                 [JSON.stringify({ content: {}, metadata: 'foobar' })]
             ])('invalid: %p', (payload: any) => {
                 expect(() => format.createMessage(payload)).toThrow()
@@ -106,24 +87,21 @@ describe('PayloadFormat', () => {
 
         describe('createPayload', () => {
 
-            it('object', () => {
-                expect(JSON.parse(format.createPayload(MOCK_OBJECT, MOCK_METADATA))).toEqual({
-                    content: MOCK_OBJECT,
-                    metadata: MOCK_METADATA
-                })
-            })
-
-            it('array', () => {
-                expect(JSON.parse(format.createPayload(MOCK_ARRAY, MOCK_METADATA))).toEqual({
-                    content: MOCK_ARRAY,
+            it('happy path', () => {
+                expect(JSON.parse(format.createPayload(MOCK_CONTENT, MOCK_METADATA))).toEqual({
+                    content: MOCK_CONTENT,
                     metadata: MOCK_METADATA
                 })
             })
 
             it.each([
+                ['', {}],
                 ['foobar', {}],
                 [undefined, {}],
-                [{}, 'foobar']
+                [[], {}],
+                [{}, ''],
+                [{}, 'foobar'],
+                [{}, []]
             ])('invalid: %p %p', (content: any, metadata: any) => {
                 expect(() => format.createPayload(content, metadata)).toThrow()
             })

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -1,0 +1,49 @@
+import { StreamrClient } from 'streamr-client'
+import { Bridge } from '../../../../src/plugins/mqtt/Bridge'
+import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
+
+const MOCK_TOPIC = 'mock-topic'
+const MOCK_STREAM_ID_DOMAIN = 'mock.ens'
+const MOCK_STREAM_ID = `${MOCK_STREAM_ID_DOMAIN}/${MOCK_TOPIC}`
+const MOCK_CONTENT = { foo: 'bar' }
+
+describe('MQTT Bridge', () => {
+
+    describe.each([
+        [MOCK_STREAM_ID_DOMAIN, MOCK_TOPIC],
+        [undefined, MOCK_STREAM_ID]
+    ])('streamIdDomain: %p', (streamIdDomain: string|undefined, topic: string) => {
+
+        let bridge: Bridge
+        let streamrClient: Partial<StreamrClient>
+
+        beforeEach(() => {
+            streamrClient = {
+                publish: jest.fn().mockResolvedValue(undefined),
+                subscribe: jest.fn().mockResolvedValue(undefined),
+                unsubscribe: jest.fn().mockResolvedValue(undefined)
+            }
+            bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), streamIdDomain)
+        })
+
+        it('onMessageReceived', () => {
+            bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT))
+            expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, undefined)
+        })
+
+        it('onSubscribed', () => {
+            bridge.onSubscribed(topic)
+            expect(streamrClient.subscribe).toBeCalledWith(MOCK_STREAM_ID, expect.anything())
+        })
+
+        it('onUnsubscribed', () => {
+            const subscription = {
+                streamId: MOCK_STREAM_ID
+            }
+            streamrClient.getSubscriptions = jest.fn().mockReturnValue([subscription])
+            bridge.onUnsubscribed(topic)
+            expect(streamrClient.unsubscribe).toBeCalledWith(subscription)
+        })
+    
+    })
+})

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -3,6 +3,7 @@ import qs from 'qs'
 import StreamrClient from 'streamr-client'
 import { waitForCondition, waitForEvent } from 'streamr-test-utils'
 import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
+import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
 
 const PORT = 12398
 const MOCK_STREAM_ID = '0x1234567890123456789012345678901234567890/mock-path'
@@ -38,7 +39,7 @@ describe('WebsocketServer', () => {
             subscribe: jest.fn().mockResolvedValue(undefined),
         } as Partial<StreamrClient>
         wsServer = new WebsocketServer(streamrClient as StreamrClient)
-        await wsServer.start(PORT, {
+        await wsServer.start(PORT, new PlainPayloadFormat(), {
             isValidAuthentication: (apiKey?: string) => (apiKey === REQUIRED_API_KEY)
         })
     })
@@ -163,7 +164,7 @@ describe('WebsocketServer', () => {
             await waitForEvent(wsClient, 'open')
             const payloadPromise = waitForEvent(wsClient, 'message')
             const onMessageCallback = (streamrClient.subscribe as any).mock.calls[0][1]
-            onMessageCallback(MOCK_MESSAGE)
+            onMessageCallback(MOCK_MESSAGE, {})
             const firstPayload = (await payloadPromise)[0] as string
             expect(JSON.parse(firstPayload)).toEqual(MOCK_MESSAGE)
         })

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -226,15 +226,15 @@ export const createTestStream = (streamrClient: StreamrClient, module: NodeModul
     })
 }
 
-export const createQueue = () => {
-    const items: any[] = []
-    return {
-        push: (item: any) => {
-            items.push(item)
-        },
-        pop: async () => {
-            await waitForCondition(() => items.length > 0)
-            return items.shift()
-        }
+export class Queue<T> {
+    items: T[] = []
+
+    push(item: T) {
+        this.items.push(item)
+    }
+
+    async pop(): Promise<T> {
+        await waitForCondition(() => this.items.length > 0)
+        return this.items.shift()!
     }
 }


### PR DESCRIPTION
Unified the payload handling of `websocket` plugin and `mqtt` plugin. Added a new setting `payloadMetadata` (a boolean value) to both plugin configs. 

If `payloadMetadata` is `true`, the publish and subscription payloads are JSONs which have a structure of
```
{
    content: ...,
    metadata: ...
}
```

For publish requests, it is possible to set an optional `timestamp` value in the metadata. For subscription requests, the metadata contains `timestamp`, `sequenceNumber`, `publisherId` and `msgChainId` fields of the message.

If `payloadMetadata` setting is `false`, the payloads are plain content JSONs (and therefore it is not possible to define the timestamp  or read the metadata of the message).

**Test refactoring:** As the payload handling of `websocket` and `mqtt` plugins are similar, the plugin integration tests now use a shared helper method `createMessagePluginTest`. MQTT-specific test of `streamIdDomain` has been refactored to a separate unit test.

**Breaking change:** As the `payloadFormat` setting is a required parameter, this is be a breaking change.