### PR TITLE
NET-358: re-enable and fix broker docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/node_modules
+**/npm-debug.log
+**/test
+**/.idea/
+**/*.iml
+.*
+**/*.png
+**/*.md
+**/*.xml
+**/LICENSE
+**/jest.config.js

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,9 +3,4 @@
 **/test
 **/.idea/
 **/*.iml
-.*
-**/*.png
-**/*.md
-**/*.xml
-**/LICENSE
 **/jest.config.js

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # run job only for main and tags
-    if: false && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: true && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Cache Docker layers

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # run job only for main and tags
-    if: true || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Cache Docker layers

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # run job only for main and tags
-    if: true && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: true || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Cache Docker layers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM node:14-buster as build
-WORKDIR /usr/src/broker
+WORKDIR /usr/src/monorepo
 COPY . .
-RUN npm ci --only=production
+RUN npm ci
+RUN npm run bootstrap-pkg streamr-broker
 # Build TypeScript files ("npm ci" doesn't trigger the build automatically: https://github.com/npm/npm/issues/17346)
-RUN npm run build 
+RUN (cd packages/broker && npm run build)
 
 FROM node:14-buster-slim
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-COPY --from=build /usr/src/broker /usr/src/broker
+COPY --from=build /usr/src/monorepo/packages/broker /usr/src/broker
 WORKDIR /usr/src/broker
 
 # Make ports available to the world outside this container

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-buster as build
 WORKDIR /usr/src/monorepo
 COPY . .
 RUN npm ci
-RUN npm run bootstrap-pkg streamr-broker
+RUN npm run bootstrap
 # Build TypeScript files ("npm ci" doesn't trigger the build automatically: https://github.com/npm/npm/issues/17346)
 RUN (cd packages/broker && npm run build)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm set unsafe-perm true
 RUN npm ci
 RUN npm run bootstrap-pkg streamr-broker
 RUN npx lerna exec -- npm prune --production
-RUN npx lerna link
+RUN npx lerna link # restore inter-package symlinks removed by npm prune
 
 FROM node:14-buster-slim
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ENV LOG_LEVEL=info
 ENV CONFIG_FILE configs/docker-1.env.json
 ENV STREAMR_URL http://10.200.10.1
 
+RUN ln -s packages/broker/tracker.js tracker.js
 CMD node packages/broker/bin/broker.js packages/broker/${CONFIG_FILE} --streamrUrl=${STREAMR_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 FROM node:14-buster as build
 WORKDIR /usr/src/monorepo
 COPY . .
+RUN npm set unsafe-perm true
 RUN npm ci
-RUN npm run bootstrap
-# Build TypeScript files ("npm ci" doesn't trigger the build automatically: https://github.com/npm/npm/issues/17346)
-RUN (cd packages/broker && npm run build)
+RUN npm run bootstrap-pkg streamr-broker
 
 FROM node:14-buster-slim
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-COPY --from=build /usr/src/monorepo/packages/broker /usr/src/broker
-WORKDIR /usr/src/broker
+COPY --from=build /usr/src/monorepo /usr/src/monorepo
+WORKDIR /usr/src/monorepo
 
 # Make ports available to the world outside this container
 EXPOSE 30315
@@ -26,4 +25,4 @@ ENV LOG_LEVEL=info
 ENV CONFIG_FILE configs/docker-1.env.json
 ENV STREAMR_URL http://10.200.10.1
 
-CMD node bin/broker.js ${CONFIG_FILE} --streamrUrl=${STREAMR_URL}
+CMD node packages/broker/bin/broker.js packages/broker/${CONFIG_FILE} --streamrUrl=${STREAMR_URL}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ COPY . .
 RUN npm set unsafe-perm true
 RUN npm ci
 RUN npm run bootstrap-pkg streamr-broker
+RUN npx lerna exec -- npm prune --production
+RUN npx lerna link
 
 FROM node:14-buster-slim
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN npm set unsafe-perm true
 RUN npm ci
 RUN npm run bootstrap-pkg streamr-broker
-RUN npx lerna exec -- npm prune --production
+RUN npx lerna exec -- npm prune --production # image contains all packages, remove devDeps to keep image size down
 RUN npx lerna link # restore inter-package symlinks removed by npm prune
 
 FROM node:14-buster-slim

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -25,10 +25,10 @@
   "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": [{
-      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
-      "url": "http://10.200.10.1:8891"
-    }]
+    "registry": {
+      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "jsonRpcProvider": "http://10.200.10.1:8546"
+    }
   },
   "httpServer": {
     "port": 8791

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -25,10 +25,10 @@
   "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": [{
-      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
-      "url": "http://10.200.10.1:8891"
-    }]
+    "registry": {
+      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "jsonRpcProvider": "http://10.200.10.1:8546"
+    }
   },
   "httpServer": {
     "port": 8691

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -6,7 +6,7 @@
     "port": 30315,
     "advertisedWsUrl": "ws://10.200.10.1:30315",
     "trackers": {
-      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "contractAddress": "0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF",
       "jsonRpcProvider": "http://10.200.10.1:8545"
     },
     "location": {
@@ -24,10 +24,10 @@
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": {
-      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
-      "jsonRpcProvider": "http://10.200.10.1:8546"
-    }
+    "registry": [{
+      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
+      "url": "http://10.200.10.1:8891"
+    }]
   }, 
   "httpServer": {
     "port": 8891

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -24,10 +24,10 @@
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": [{
-      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
-      "url": "http://10.200.10.1:8891"
-    }]
+    "registry": {
+      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "jsonRpcProvider": "http://10.200.10.1:8546"
+    }
   }, 
   "httpServer": {
     "port": 8891

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -24,10 +24,10 @@
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": [{
-      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
-      "url": "http://10.200.10.1:8891"
-    }]
+    "registry": {
+      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "jsonRpcProvider": "http://10.200.10.1:8546"
+    }
   },
   "httpServer": {
     "port": 8791

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -24,10 +24,10 @@
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",
   "storageNodeConfig": {
-    "registry": [{
-      "address": "0xde1112f631486CfC759A50196853011528bC5FA0",
-      "url": "http://10.200.10.1:8891"
-    }]
+    "registry": {
+      "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
+      "jsonRpcProvider": "http://10.200.10.1:8546"
+    }
   },
   "httpServer": {
     "port": 8691


### PR DESCRIPTION
Few points

- `**/node_modules` in .dockerignore very important. Otherwise the context that needs to be sent to the Docker image becomes 1.5GB (compared to 70MB).
- Dockerfile had to be moved to project root as it is not allowed to walk up the directory structure from "base".
- Add symlink to base directory for `tracker.js` to avoid having to update streamr-docker-dev 