### PR TITLE
CLI-tools NET-360: Support path notation when defining a stream ID

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add permission commands: `stream grant-permission` and `stream revoke-permission`
 - Remove `typescript` and `ts-node` as run-time dependencies
 - Remove `--msg-chain-id` parameter from `stream resend from`
-- (Breaking) `streamr stream create` argument is `streamId`, not `name`
+- (Breaking) `streamr stream create` argument is a stream ID, not a name
+- Support path notation when defining a stream ID
 
 ## [5.0.0] - 2021-05-05
 ### Added

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -28,6 +28,8 @@ To get a list of all commands simply run `streamr`. To list subcommands run e.g.
 
 Run `streamr <command> <subcommand> --help` to get more information about a a command, its options, and so forth.
 
+If there is a stream parameter in a command, it can be defined as a full id (e.g. `0x1234567890123456789012345678901234567890/foo/bar`) or a path (e.g. `/foo/bar`). If path notation is used, the stream ID is made by prefixing the authenticated Ethereum address (`--private-key <key>`) to the path.
+
 ### subscribe
 Used to subscribe to a stream and output real-time JSON objects to stdout line-by-line.
 
@@ -79,9 +81,9 @@ streamr stream show <streamId> --private-key <key>
 ### create
 Create a new stream
 ```
-streamr stream create <id> --private-key <key>
+streamr stream create <streamId> --private-key <key>
 ```
-The id can be a full id or a path. If only path is specified, it is prefixed with your Ethereum address.
+E.g.
 ```
 streamr stream create /foo/bar
 streamr stream create 0x1234567890123456789012345678901234567890/foobar

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -35,7 +35,7 @@ Used to subscribe to a stream and output real-time JSON objects to stdout line-b
 
 For example, to subscribe to a public stream such as the tram demo do
 ```
-streamr stream subscribe 7wa7APtlTq6EC5iTCBy6dw
+streamr stream subscribe streamr.eth/demos/helsinki-trams
 ```
 
 To subscribe to a private stream and authenticate with an Ethereum private key:
@@ -96,7 +96,7 @@ Request a resend of historical data printed as JSON objects to stdout line-by-li
 
 For example, to fetch the 10 latest messages of a public stream such as the tram demo do
 ```
-streamr stream resend last 10 7wa7APtlTq6EC5iTCBy6dw
+streamr stream resend last 10 streamr.eth/demos/helsinki-trams
 ```
 
 
@@ -123,7 +123,7 @@ You can pipe the line-by-line JSON objects output by `subscribe` to
 your program written in any language. Just make the program read JSON objects
 from stdin.
 ```
-streamr stream subscribe 7wa7APtlTq6EC5iTCBy6dw | ruby calculate-average-speed.rb
+streamr stream subscribe streamr.eth/demos/helsinki-trams | ruby calculate-average-speed.rb
 ```
 
 #### Publishing to a stream from any programming language
@@ -148,12 +148,12 @@ If you have a working stream in production that you'd also like to use in your
 development environment, you can combine the `subscribe` and `publish` commands to effectively copy
 the real-time events.
 ```
-streamr stream subscribe 7wa7APtlTq6EC5iTCBy6dw | streamr stream publish --dev <streamId> --private-key <key>
+streamr stream subscribe streamr.eth/demos/helsinki-trams | streamr stream publish --dev <streamId> --private-key <key>
 ```
 
 And the same for staging environment:
 ```
-streamr stream subscribe 7wa7APtlTq6EC5iTCBy6dw | streamr stream publish --stg <streamId> --private-key <key>
+streamr stream subscribe streamr.eth/demos/helsinki-trams | streamr stream publish --stg <streamId> --private-key <key>
 ```
 
 ## Develop

--- a/packages/cli-tools/bin/common.ts
+++ b/packages/cli-tools/bin/common.ts
@@ -1,4 +1,5 @@
 import * as commander from 'commander'
+import { Wallet } from 'ethers'
 import { StreamrClientOptions } from 'streamr-client'
 
 export interface EnvironmentOptions {
@@ -90,4 +91,20 @@ export function createFnParseInt(name: string): (s: string) => number {
         }
         return n
     }
+}
+
+export const createStreamId = (streamIdOrPath: string|undefined, options: any) => {
+    if (streamIdOrPath === undefined) {
+        return undefined
+    }
+    const PATH_PREFIX = '/'
+    if (!streamIdOrPath.startsWith(PATH_PREFIX)) {
+        return streamIdOrPath
+    }
+    const privateKey = options.privateKey
+    if (privateKey === undefined) {
+        console.error(`relative stream id ${streamIdOrPath} requires authentication`)
+        process.exit(1)
+    }
+    return new Wallet(privateKey).address.toLowerCase() + streamIdOrPath
 }

--- a/packages/cli-tools/bin/common.ts
+++ b/packages/cli-tools/bin/common.ts
@@ -93,7 +93,7 @@ export function createFnParseInt(name: string): (s: string) => number {
     }
 }
 
-export const createStreamId = (streamIdOrPath: string|undefined, options: any) => {
+export const getStreamId = (streamIdOrPath: string|undefined, options: any) => {
     if (streamIdOrPath === undefined) {
         return undefined
     }

--- a/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
@@ -6,6 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
+    createStreamId,
 } from './common'
 import pkg from '../package.json'
 
@@ -16,8 +17,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((storageNodeAddress: string, streamId: string, options: any) => {
+    .action((storageNodeAddress: string, streamIdOrPath: string, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const streamId = createStreamId(streamIdOrPath, options)!
         client.getStream(streamId)
             .then((stream: Stream) => stream.addToStorageNode(storageNodeAddress))
             .catch((err) => {

--- a/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
@@ -6,7 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
-    createStreamId,
+    getStreamId,
 } from './common'
 import pkg from '../package.json'
 
@@ -19,7 +19,7 @@ envOptions(program)
     .version(pkg.version)
     .action((storageNodeAddress: string, streamIdOrPath: string, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         client.getStream(streamId)
             .then((stream: Stream) => stream.addToStorageNode(storageNodeAddress))
             .catch((err) => {

--- a/packages/cli-tools/bin/streamr-storage-node-list.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list.ts
@@ -6,7 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
-    createStreamId,
+    getStreamId,
 } from './common'
 import pkg from '../package.json'
 import EasyTable from 'easy-table'
@@ -31,7 +31,7 @@ envOptions(program)
     .version(pkg.version)
     .action((options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        const streamId = createStreamId(options.stream, options)
+        const streamId = getStreamId(options.stream, options)
         getStorageNodes(streamId, client).then((addresses: string[]) => {
             if (addresses.length > 0) {
                 console.info(EasyTable.print(addresses.map((address: string) => ({

--- a/packages/cli-tools/bin/streamr-storage-node-list.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list.ts
@@ -6,6 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
+    createStreamId,
 } from './common'
 import pkg from '../package.json'
 import EasyTable from 'easy-table'
@@ -30,7 +31,8 @@ envOptions(program)
     .version(pkg.version)
     .action((options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        getStorageNodes(options.stream, client).then((addresses: string[]) => {
+        const streamId = createStreamId(options.stream, options)
+        getStorageNodes(streamId, client).then((addresses: string[]) => {
             if (addresses.length > 0) {
                 console.info(EasyTable.print(addresses.map((address: string) => ({
                     address

--- a/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
@@ -6,7 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
-    createStreamId,
+    getStreamId,
 } from './common'
 import pkg from '../package.json'
 
@@ -19,7 +19,7 @@ envOptions(program)
     .version(pkg.version)
     .action((storageNodeAddress: string, streamIdOrPath: string, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         client.getStream(streamId)
             .then((stream: Stream) => stream.removeFromStorageNode(storageNodeAddress))
             .catch((err) => {

--- a/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
@@ -6,6 +6,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
+    createStreamId,
 } from './common'
 import pkg from '../package.json'
 
@@ -16,8 +17,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((storageNodeAddress: string, streamId: string, options: any) => {
+    .action((storageNodeAddress: string, streamIdOrPath: string, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const streamId = createStreamId(streamIdOrPath, options)!
         client.getStream(streamId)
             .then((stream: Stream) => stream.removeFromStorageNode(storageNodeAddress))
             .catch((err) => {

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -12,8 +12,8 @@ import pkg from '../package.json'
 
 const program = new Command()
 program
-    .arguments('<id>')
-    .description('create a new stream: the id can be a full streamId or a path')
+    .arguments('<streamId>')
+    .description('create a new stream')
     .option('-d, --description <description>', 'define a description')
     .option('-c, --config <config>', 'define a configuration as JSON', (s: string) => JSON.parse(s))
     .option('-p, --partitions <count>', 'define a partition count',
@@ -21,9 +21,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((id: string, options: any) => {
+    .action((streamIdOrPath: string, options: any) => {
         const body: any = {
-            id,
+            id: streamIdOrPath,
             description: options.description,
             config: options.config,
             partitions: options.partitions

--- a/packages/cli-tools/bin/streamr-stream-grant-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-grant-permission.ts
@@ -4,7 +4,7 @@ import {
     envOptions,
     authOptions,
     formStreamrOptionsWithEnv,
-    createStreamId
+    getStreamId
 } from './common'
 import pkg from '../package.json'
 import { AnonymousStreamPermisson, StreamOperation, StreamrClient, UserStreamPermission } from 'streamr-client'
@@ -52,7 +52,7 @@ envOptions(program)
         const operations = operationIds.map((o: string) => getOperation(o))
         const target = getTarget(user)
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         const stream = await client.getStream(streamId)
         const tasks = operations.map((operation: StreamOperation) => stream.grantPermission(operation, target))
         const permissions = await Promise.all(tasks)

--- a/packages/cli-tools/bin/streamr-stream-grant-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-grant-permission.ts
@@ -3,7 +3,8 @@ import { Command } from 'commander'
 import {
     envOptions,
     authOptions,
-    formStreamrOptionsWithEnv
+    formStreamrOptionsWithEnv,
+    createStreamId
 } from './common'
 import pkg from '../package.json'
 import { AnonymousStreamPermisson, StreamOperation, StreamrClient, UserStreamPermission } from 'streamr-client'
@@ -47,10 +48,11 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action(async (streamId: string, user: string, operationIds: string[], options: any) => {
+    .action(async (streamIdOrPath: string, user: string, operationIds: string[], options: any) => {
         const operations = operationIds.map((o: string) => getOperation(o))
         const target = getTarget(user)
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const streamId = createStreamId(streamIdOrPath, options)!
         const stream = await client.getStream(streamId)
         const tasks = operations.map((operation: StreamOperation) => stream.grantPermission(operation, target))
         const permissions = await Promise.all(tasks)

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -2,7 +2,7 @@
 import { Command } from 'commander'
 import es from 'event-stream'
 import { publishStream } from '../src/publish'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -13,7 +13,8 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((streamId: string, options: any) => {
+    .action((streamIdOrPath: string, options: any) => {
+        const streamId = createStreamId(streamIdOrPath, options)!
         const ps = publishStream(streamId, options.partitionKey, formStreamrOptionsWithEnv(options))
         process.stdin
             .pipe(es.split())

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -2,7 +2,7 @@
 import { Command } from 'commander'
 import es from 'event-stream'
 import { publishStream } from '../src/publish'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, getStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -14,7 +14,7 @@ authOptions(program)
 envOptions(program)
     .version(pkg.version)
     .action((streamIdOrPath: string, options: any) => {
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         const ps = publishStream(streamId, options.partitionKey, formStreamrOptionsWithEnv(options))
         process.stdin
             .pipe(es.split())

--- a/packages/cli-tools/bin/streamr-stream-resend.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend.ts
@@ -2,7 +2,7 @@
 import { Command } from 'commander'
 import { StreamrClientOptions } from 'streamr-client'
 import { resend } from '../src/resend'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
 import pkg from '../package.json'
 
 function assertBothOrNoneDefined(option1: string, option2: string, errorMessage: string, commandOptions: any) {
@@ -23,7 +23,7 @@ program
     .description('request last N messages')
     .option('-d, --disable-ordering', 'disable ordering of messages by OrderingUtil', false)
     .option('-s, --subscribe', 'subscribe in addition to resend', false)
-    .action((n: string, streamId: string, options: any, command: Command) => {
+    .action((n: string, streamIdOrPath: string, options: any, command: Command) => {
         if (isNaN(n as any)) {
             console.error('argument n is not a number')
             process.exit(1)
@@ -34,6 +34,7 @@ program
         const clientOptions: StreamrClientOptions & { subscribe?: boolean } = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
         clientOptions.subscribe = options.subscribe
+        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 
@@ -43,7 +44,7 @@ program
     .option('--publisher-id <string>', 'filter results by publisher')
     .option('-d, --disable-ordering', 'disable ordering of messages by OrderingUtil', false)
     .option('-s, --subscribe', 'subscribe in addition to resend', false)
-    .action((from: string, streamId: string, options: any, command: Command) => {
+    .action((from: string, streamIdOrPath: string, options: any, command: Command) => {
         const resendOptions = {
             from: {
                 timestamp: Date.parse(from),
@@ -54,6 +55,7 @@ program
         const clientOptions: StreamrClientOptions & { subscribe?: boolean } = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
         clientOptions.subscribe = options.subscribe
+        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 
@@ -63,7 +65,7 @@ program
     .option('--publisher-id <string>', 'filter results by publisher')
     .option('--msg-chain-id <string>', 'filter results by message chain')
     .option('-d, --disable-ordering', 'disable ordering of messages by OrderingUtil', false)
-    .action((from: string, to: string, streamId: string, options: any, command: Command) => {
+    .action((from: string, to: string, streamIdOrPath: string, options: any, command: Command) => {
         const resendOptions = {
             from: {
                 timestamp: Date.parse(from),
@@ -79,6 +81,7 @@ program
         assertBothOrNoneDefined('publisherId', 'msgChainId', '--publisher-id must be accompanied by option --msg-chain-id', options)
         const clientOptions = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
+        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 

--- a/packages/cli-tools/bin/streamr-stream-resend.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend.ts
@@ -2,7 +2,7 @@
 import { Command } from 'commander'
 import { StreamrClientOptions } from 'streamr-client'
 import { resend } from '../src/resend'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, getStreamId } from './common'
 import pkg from '../package.json'
 
 function assertBothOrNoneDefined(option1: string, option2: string, errorMessage: string, commandOptions: any) {
@@ -34,7 +34,7 @@ program
         const clientOptions: StreamrClientOptions & { subscribe?: boolean } = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
         clientOptions.subscribe = options.subscribe
-        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
+        const streamId = getStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 
@@ -55,7 +55,7 @@ program
         const clientOptions: StreamrClientOptions & { subscribe?: boolean } = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
         clientOptions.subscribe = options.subscribe
-        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
+        const streamId = getStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 
@@ -81,7 +81,7 @@ program
         assertBothOrNoneDefined('publisherId', 'msgChainId', '--publisher-id must be accompanied by option --msg-chain-id', options)
         const clientOptions = formStreamrOptionsWithEnv(command.parent!.opts())
         clientOptions.orderMessages = !options.disableOrdering
-        const streamId = createStreamId(streamIdOrPath, command.parent!.opts())!
+        const streamId = getStreamId(streamIdOrPath, command.parent!.opts())!
         resend(streamId, resendOptions, clientOptions)
     })
 

--- a/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
@@ -5,7 +5,7 @@ import {
     authOptions,
     exitWithHelpIfArgsNotBetween,
     formStreamrOptionsWithEnv,
-    createStreamId
+    getStreamId
 } from './common'
 import pkg from '../package.json'
 import { StreamrClient } from 'streamr-client'
@@ -19,7 +19,7 @@ envOptions(program)
     .version(pkg.version)
     .action(async (streamIdOrPath: string, permissionId: number, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         const stream = await client.getStream(streamId)
         stream.revokePermission(permissionId)
     })

--- a/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
@@ -4,7 +4,8 @@ import {
     envOptions,
     authOptions,
     exitWithHelpIfArgsNotBetween,
-    formStreamrOptionsWithEnv
+    formStreamrOptionsWithEnv,
+    createStreamId
 } from './common'
 import pkg from '../package.json'
 import { StreamrClient } from 'streamr-client'
@@ -16,8 +17,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action(async (streamId: string, permissionId: number, options: any) => {
+    .action(async (streamIdOrPath: string, permissionId: number, options: any) => {
         const client = new StreamrClient(formStreamrOptionsWithEnv(options))
+        const streamId = createStreamId(streamIdOrPath, options)!
         const stream = await client.getStream(streamId)
         stream.revokePermission(permissionId)
     })

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import { show } from '../src/show'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, getStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -13,7 +13,7 @@ authOptions(program)
 envOptions(program)
     .version(pkg.version)
     .action((streamIdOrPath: string, options: any) => {
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         show(streamId, options.includePermissions, formStreamrOptionsWithEnv(options))
     })
     .parse(process.argv)

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import { show } from '../src/show'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -12,7 +12,8 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((streamId: string, options: any) => {
+    .action((streamIdOrPath: string, options: any) => {
+        const streamId = createStreamId(streamIdOrPath, options)!
         show(streamId, options.includePermissions, formStreamrOptionsWithEnv(options))
     })
     .parse(process.argv)

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import { subscribe } from '../src/subscribe'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt, createStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -13,8 +13,9 @@ program
 authOptions(program)
 envOptions(program)
     .version(pkg.version)
-    .action((streamId: string, options: any) => {
+    .action((streamIdOrPath: string, options: any) => {
         options.orderMessages = !options.disableOrdering
+        const streamId = createStreamId(streamIdOrPath, options)!
         subscribe(streamId, options.partition, formStreamrOptionsWithEnv(options))
     })
     .parse(process.argv)

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import { subscribe } from '../src/subscribe'
-import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt, createStreamId } from './common'
+import { envOptions, authOptions, exitWithHelpIfArgsNotBetween, formStreamrOptionsWithEnv, createFnParseInt, getStreamId } from './common'
 import pkg from '../package.json'
 
 const program = new Command()
@@ -15,7 +15,7 @@ envOptions(program)
     .version(pkg.version)
     .action((streamIdOrPath: string, options: any) => {
         options.orderMessages = !options.disableOrdering
-        const streamId = createStreamId(streamIdOrPath, options)!
+        const streamId = getStreamId(streamIdOrPath, options)!
         subscribe(streamId, options.partition, formStreamrOptionsWithEnv(options))
     })
     .parse(process.argv)

--- a/packages/cli-tools/package-lock.json
+++ b/packages/cli-tools/package-lock.json
@@ -113,6 +113,374 @@
 				}
 			}
 		},
+		"@ethersproject/abi": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.3.1.tgz",
+			"integrity": "sha512-F98FWTJG7nWWAQ4DcV6R0cSlrj67MWK3ylahuFbzkumem5cLWg1p7fZ3vIdRoS1c7TEf55Lvyx0w7ICR47IImw==",
+			"requires": {
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/hash": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0"
+			}
+		},
+		"@ethersproject/abstract-provider": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.3.0.tgz",
+			"integrity": "sha512-1+MLhGP1GwxBDBNwMWVmhCsvKwh4gK7oIfOrmlmePNeskg1NhIrYssraJBieaFNHUYfKEd/1DjiVZMw8Qu5Cxw==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/networks": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0",
+				"@ethersproject/web": "^5.3.0"
+			}
+		},
+		"@ethersproject/abstract-signer": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.3.0.tgz",
+			"integrity": "sha512-w8IFwOYqiPrtvosPuArZ3+QPR2nmdVTRrVY8uJYL3NNfMmQfTy3V3l2wbzX47UUlNbPJY+gKvzJAyvK1onZxJg==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0"
+			}
+		},
+		"@ethersproject/address": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.3.0.tgz",
+			"integrity": "sha512-29TgjzEBK+gUEUAOfWCG7s9IxLNLCqvr+oDSk6L9TXD0VLvZJKhJV479tKQqheVA81OeGxfpdxYtUVH8hqlCvA==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/rlp": "^5.3.0"
+			}
+		},
+		"@ethersproject/base64": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.3.0.tgz",
+			"integrity": "sha512-JIqgtOmgKcbc2sjGWTXyXktqUhvFUDte8fPVsAaOrcPiJf6YotNF+nsrOYGC9pbHBEGSuSBp3QR0varkO8JHEw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0"
+			}
+		},
+		"@ethersproject/basex": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.3.0.tgz",
+			"integrity": "sha512-8J4nS6t/SOnoCgr3DF5WCSRLC5YwTKYpZWJqeyYQLX+86TwPhtzvHXacODzcDII9tWKhVg6g0Bka8JCBWXsCiQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0"
+			}
+		},
+		"@ethersproject/bignumber": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.3.0.tgz",
+			"integrity": "sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"bn.js": "^4.11.9"
+			}
+		},
+		"@ethersproject/bytes": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.3.0.tgz",
+			"integrity": "sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==",
+			"requires": {
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/constants": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.3.0.tgz",
+			"integrity": "sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.3.0"
+			}
+		},
+		"@ethersproject/contracts": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.3.0.tgz",
+			"integrity": "sha512-eDyQ8ltykvyQqnGZxb/c1e0OnEtzqXhNNC4BX8nhYBCaoBrYYuK/1fLmyEvc5+XUMoxNhwpYkoSSwvPLci7/Zg==",
+			"requires": {
+				"@ethersproject/abi": "^5.3.0",
+				"@ethersproject/abstract-provider": "^5.3.0",
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0"
+			}
+		},
+		"@ethersproject/hash": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.3.0.tgz",
+			"integrity": "sha512-gAFZSjUPQ32CIfoKSMtMEQ+IO0kQxqhwz9fCIFt2DtAq2u4pWt8mL9Z5P0r6KkLcQU8LE9FmuPPyd+JvBzmr1w==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0"
+			}
+		},
+		"@ethersproject/hdnode": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.3.0.tgz",
+			"integrity": "sha512-zLmmtLNoDMGoYRdjOab01Zqkvp+TmZyCGDAMQF1Bs3yZyBs/kzTNi1qJjR1jVUcPP5CWGtjFwY8iNG8oNV9J8g==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/basex": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/pbkdf2": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/sha2": "^5.3.0",
+				"@ethersproject/signing-key": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0",
+				"@ethersproject/wordlists": "^5.3.0"
+			}
+		},
+		"@ethersproject/json-wallets": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.3.0.tgz",
+			"integrity": "sha512-/xwbqaIb5grUIGNmeEaz8GdcpmDr++X8WT4Jqcclnxow8PXCUHFeDxjf3O+nSuoqOYG/Ds0+BI5xuQKbva6Xkw==",
+			"requires": {
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/hdnode": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/pbkdf2": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/random": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0",
+				"aes-js": "3.0.0",
+				"scrypt-js": "3.0.1"
+			}
+		},
+		"@ethersproject/keccak256": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.3.0.tgz",
+			"integrity": "sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"js-sha3": "0.5.7"
+			}
+		},
+		"@ethersproject/logger": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.3.0.tgz",
+			"integrity": "sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA=="
+		},
+		"@ethersproject/networks": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.3.1.tgz",
+			"integrity": "sha512-6uQKHkYChlsfeiZhQ8IHIqGE/sQsf25o9ZxAYpMxi15dLPzz3IxOEF5KiSD32aHwsjXVBKBSlo+teAXLlYJybw==",
+			"requires": {
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/pbkdf2": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.3.0.tgz",
+			"integrity": "sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/sha2": "^5.3.0"
+			}
+		},
+		"@ethersproject/properties": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.3.0.tgz",
+			"integrity": "sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==",
+			"requires": {
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/providers": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.3.1.tgz",
+			"integrity": "sha512-HC63vENTrur6/JKEhcQbA8PRDj1FAesdpX98IW+xAAo3EAkf70ou5fMIA3KCGzJDLNTeYA4C2Bonz849tVLekg==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.3.0",
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/basex": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/hash": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/networks": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/random": "^5.3.0",
+				"@ethersproject/rlp": "^5.3.0",
+				"@ethersproject/sha2": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0",
+				"@ethersproject/web": "^5.3.0",
+				"bech32": "1.1.4",
+				"ws": "7.4.6"
+			}
+		},
+		"@ethersproject/random": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.3.0.tgz",
+			"integrity": "sha512-A5SL/4inutSwt3Fh2OD0x2gz+x6GHmuUnIPkR7zAiTidMD2N8F6tZdMF1hlQKWVCcVMWhEQg8mWijhEzm6BBYw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/rlp": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.3.0.tgz",
+			"integrity": "sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/sha2": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
+			"integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"hash.js": "1.1.7"
+			}
+		},
+		"@ethersproject/signing-key": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.3.0.tgz",
+			"integrity": "sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"bn.js": "^4.11.9",
+				"elliptic": "6.5.4",
+				"hash.js": "1.1.7"
+			}
+		},
+		"@ethersproject/solidity": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.3.0.tgz",
+			"integrity": "sha512-uLRBaNUiISHbut94XKewJgQh6UmydWTBp71I7I21pkjVXfZO2dJ5EOo3jCnumJc01M4LOm79dlNNmF3oGIvweQ==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/sha2": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0"
+			}
+		},
+		"@ethersproject/strings": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.3.0.tgz",
+			"integrity": "sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/transactions": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.3.0.tgz",
+			"integrity": "sha512-cdfK8VVyW2oEBCXhURG0WQ6AICL/r6Gmjh0e4Bvbv6MCn/GBd8FeBH3rtl7ho+AW50csMKeGv3m3K1HSHB2jMQ==",
+			"requires": {
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/rlp": "^5.3.0",
+				"@ethersproject/signing-key": "^5.3.0"
+			}
+		},
+		"@ethersproject/units": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.3.0.tgz",
+			"integrity": "sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==",
+			"requires": {
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/constants": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0"
+			}
+		},
+		"@ethersproject/wallet": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.3.0.tgz",
+			"integrity": "sha512-boYBLydG6671p9QoG6EinNnNzbm7DNOjVT20eV8J6HQEq4aUaGiA2CytF2vK+2rOEWbzhZqoNDt6AlkE1LlsTg==",
+			"requires": {
+				"@ethersproject/abstract-provider": "^5.3.0",
+				"@ethersproject/abstract-signer": "^5.3.0",
+				"@ethersproject/address": "^5.3.0",
+				"@ethersproject/bignumber": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/hash": "^5.3.0",
+				"@ethersproject/hdnode": "^5.3.0",
+				"@ethersproject/json-wallets": "^5.3.0",
+				"@ethersproject/keccak256": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/random": "^5.3.0",
+				"@ethersproject/signing-key": "^5.3.0",
+				"@ethersproject/transactions": "^5.3.0",
+				"@ethersproject/wordlists": "^5.3.0"
+			}
+		},
+		"@ethersproject/web": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.3.0.tgz",
+			"integrity": "sha512-Ni6/DHnY6k/TD41LEkv0RQDx4jqWz5e/RZvrSecsxGYycF+MFy2z++T/yGc2peRunLOTIFwEksgEGGlbwfYmhQ==",
+			"requires": {
+				"@ethersproject/base64": "^5.3.0",
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0"
+			}
+		},
+		"@ethersproject/wordlists": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.3.0.tgz",
+			"integrity": "sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==",
+			"requires": {
+				"@ethersproject/bytes": "^5.3.0",
+				"@ethersproject/hash": "^5.3.0",
+				"@ethersproject/logger": "^5.3.0",
+				"@ethersproject/properties": "^5.3.0",
+				"@ethersproject/strings": "^5.3.0"
+			}
+		},
 		"@jest/types": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -323,6 +691,11 @@
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
+		"aes-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -382,6 +755,16 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"bech32": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+		},
+		"bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -400,6 +783,11 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -520,6 +908,20 @@
 			"requires": {
 				"ansi-regex": "^3.0.0",
 				"wcwidth": ">=1.0.1"
+			}
+		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"emoji-regex": {
@@ -723,6 +1125,43 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"ethers": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.3.1.tgz",
+			"integrity": "sha512-xCKmC0gsZ9gks89ZfK3B1y6LlPdvX5fxDtu9SytnpdDJR1M7pmJI+4H0AxQPMgUYr7GtQdmECLR0gWdJQ+lZYw==",
+			"requires": {
+				"@ethersproject/abi": "5.3.1",
+				"@ethersproject/abstract-provider": "5.3.0",
+				"@ethersproject/abstract-signer": "5.3.0",
+				"@ethersproject/address": "5.3.0",
+				"@ethersproject/base64": "5.3.0",
+				"@ethersproject/basex": "5.3.0",
+				"@ethersproject/bignumber": "5.3.0",
+				"@ethersproject/bytes": "5.3.0",
+				"@ethersproject/constants": "5.3.0",
+				"@ethersproject/contracts": "5.3.0",
+				"@ethersproject/hash": "5.3.0",
+				"@ethersproject/hdnode": "5.3.0",
+				"@ethersproject/json-wallets": "5.3.0",
+				"@ethersproject/keccak256": "5.3.0",
+				"@ethersproject/logger": "5.3.0",
+				"@ethersproject/networks": "5.3.1",
+				"@ethersproject/pbkdf2": "5.3.0",
+				"@ethersproject/properties": "5.3.0",
+				"@ethersproject/providers": "5.3.1",
+				"@ethersproject/random": "5.3.0",
+				"@ethersproject/rlp": "5.3.0",
+				"@ethersproject/sha2": "5.3.0",
+				"@ethersproject/signing-key": "5.3.0",
+				"@ethersproject/solidity": "5.3.0",
+				"@ethersproject/strings": "5.3.0",
+				"@ethersproject/transactions": "5.3.0",
+				"@ethersproject/units": "5.3.0",
+				"@ethersproject/wallet": "5.3.0",
+				"@ethersproject/web": "5.3.0",
+				"@ethersproject/wordlists": "5.3.0"
+			}
+		},
 		"event-stream": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
@@ -881,6 +1320,25 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
 		"ignore": {
 			"version": "5.1.8",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -916,8 +1374,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -969,6 +1426,11 @@
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
 			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 			"dev": true
+		},
+		"js-sha3": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -1061,6 +1523,16 @@
 				"braces": "^3.0.1",
 				"picomatch": "^2.2.3"
 			}
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -1238,6 +1710,11 @@
 			"requires": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"semver": {
 			"version": "7.3.5",
@@ -1480,6 +1957,11 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"ws": {
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "commander": "^7.2.0",
     "easy-table": "^1.1.1",
+    "ethers": "^5.3.1",
     "event-stream": "^4.0.1",
     "streamr-client": "^5.4.4"
   },


### PR DESCRIPTION
f there is a stream parameter in a command, it can be defined as a full id (e.g. `0x1234567890123456789012345678901234567890/foo/bar`) or a path (e.g. `/foo/bar`). Using path notation requires authentication (`--private-key <key>`).

Updated also the example stream ID in the `README.md`.