### PR TITLE
NET-354 Broker: Testable plugin configs

### DIFF
--- a/packages/broker/src/Plugin.ts
+++ b/packages/broker/src/Plugin.ts
@@ -3,7 +3,6 @@ import { Config } from './config'
 import { Publisher } from './Publisher'
 import { SubscriptionManager } from './SubscriptionManager'
 import express from 'express'
-import { validateConfig } from './helpers/validateConfig'
 import { Schema } from 'ajv'
 import { StreamrClient } from 'streamr-client'
 import { ApiAuthenticator } from './apiAuthenticator'
@@ -46,10 +45,6 @@ export abstract class Plugin<T> {
         this.brokerConfig = options.brokerConfig
         this.pluginConfig = options.brokerConfig.plugins[this.name]
         this.storageNodeRegistry = options.storageNodeRegistry
-        const configSchema = this.getConfigSchema()
-        if (configSchema !== undefined) {
-            validateConfig(this.pluginConfig, configSchema, `${this.name} plugin`)
-        }
     }
 
     addHttpServerRouter(router: express.Router): void {
@@ -70,8 +65,10 @@ export abstract class Plugin<T> {
      * It is be called only if the plugin was started successfully
      */
     abstract stop(): Promise<unknown>
+}
 
-    getConfigSchema(): Schema|undefined {
-        return undefined
-    }
+export interface PluginDefinition<T> {
+    name: string,
+    createInstance(options: PluginOptions): Plugin<T>
+    getConfigSchema(): Schema|undefined
 }

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -9,12 +9,11 @@ import { Publisher } from './Publisher'
 import { VolumeLogger } from './VolumeLogger'
 import { SubscriptionManager } from './SubscriptionManager'
 import { createPlugin } from './pluginRegistry'
-import { validateConfig } from './helpers/validateConfig'
+import { validateBrokerConfig } from './helpers/validateConfig'
 import { version as CURRENT_VERSION } from '../package.json'
 import { Config, NetworkSmartContract, StorageNodeRegistryItem } from './config'
 import { Plugin, PluginOptions } from './Plugin'
 import { startServer as startHttpServer, stopServer } from './httpServer'
-import BROKER_CONFIG_SCHEMA from './helpers/config.schema.json'
 import { createLocalStreamrClient } from './localStreamrClient'
 import { createApiAuthenticator } from './apiAuthenticator'
 import { StorageNodeRegistry } from "./StorageNodeRegistry"
@@ -29,7 +28,7 @@ export interface Broker {
 }
 
 export const startBroker = async (config: Config): Promise<Broker> => {
-    validateConfig(config, BROKER_CONFIG_SCHEMA)
+    validateBrokerConfig(config)
 
     logger.info(`Starting broker version ${CURRENT_VERSION}`)
 

--- a/packages/broker/src/pluginRegistry.ts
+++ b/packages/broker/src/pluginRegistry.ts
@@ -1,32 +1,32 @@
-import { PluginOptions } from './Plugin'
-import { PublishHttpPlugin } from './plugins/publishHttp/PublishHttpPlugin'
-import { PublishHttpPlugin as LegacyPublishHttpPlugin } from './plugins/legacyPublishHttp/PublishHttpPlugin'
-import { MetricsPlugin } from './plugins/metrics/MetricsPlugin'
-import { WebsocketPlugin } from './plugins/websocket/WebsocketPlugin'
-import { WebsocketPlugin as LegacyWebsocketPlugin } from './plugins/legacyWebsocket/WebsocketPlugin'
-import { MqttPlugin } from './plugins/mqtt/MqttPlugin'
-import { MqttPlugin as LegacyMqttPlugin } from './plugins/legacyMqtt/MqttPlugin'
-import { StoragePlugin } from './plugins/storage/StoragePlugin'
+import { PluginDefinition, PluginOptions } from './Plugin'
+import publishHttpPluginDefinition from './plugins/publishHttp/PublishHttpPlugin'
+import legacyPublishHttpPluginDefinition from './plugins/legacyPublishHttp/PublishHttpPlugin'
+import metricsPluginDefinition from './plugins/metrics/MetricsPlugin'
+import websocketPluginDefinition from './plugins/websocket/WebsocketPlugin'
+import legacyWebsocketPluginDefinition from './plugins/legacyWebsocket/WebsocketPlugin'
+import mqttPluginDefinition from './plugins/mqtt/MqttPlugin'
+import legacyMqttPluginDefinition from './plugins/legacyMqtt/MqttPlugin'
+import storagePluginDefinition from './plugins/storage/StoragePlugin'
+
+const DEFINITIONS: readonly PluginDefinition<any>[] = [
+    publishHttpPluginDefinition,
+    legacyPublishHttpPluginDefinition,
+    metricsPluginDefinition,
+    websocketPluginDefinition,
+    legacyWebsocketPluginDefinition,
+    mqttPluginDefinition,
+    legacyMqttPluginDefinition,
+    storagePluginDefinition
+]
+
+export const getPluginDefinition = (name: string): PluginDefinition<any>|never => {
+    const definition = DEFINITIONS.find((d: PluginDefinition<any>) => d.name == name) 
+    if (definition === undefined) {
+        throw new Error(`Unknown plugin: ${name}`)
+    }
+    return definition
+}
 
 export const createPlugin = (name: string, pluginOptions: PluginOptions) => {
-    switch (name) {
-        case 'publishHttp':
-            return new PublishHttpPlugin(pluginOptions)
-        case 'legacyPublishHttp':
-            return new LegacyPublishHttpPlugin(pluginOptions)
-        case 'metrics':
-            return new MetricsPlugin(pluginOptions)
-        case 'websocket':
-            return new WebsocketPlugin(pluginOptions)
-        case 'legacyWebsocket':
-            return new LegacyWebsocketPlugin(pluginOptions)
-        case 'mqtt':
-            return new MqttPlugin(pluginOptions)
-        case 'legacyMqtt':
-            return new LegacyMqttPlugin(pluginOptions)
-        case 'storage':
-            return new StoragePlugin(pluginOptions)
-        default:
-            throw new Error(`Unknown plugin: ${name}`)
-    }
+    return getPluginDefinition(name).createInstance(pluginOptions)
 }

--- a/packages/broker/src/plugins/legacyMqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/legacyMqtt/MqttPlugin.ts
@@ -2,7 +2,7 @@ import net from 'net'
 import { MissingConfigError } from '../../errors/MissingConfigError'
 import { Logger } from 'streamr-network'
 import { MqttServer } from './MqttServer'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 
@@ -42,8 +42,15 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
     async stop() {
         return this.mqttServer!.close()
     }
+}
 
-    getConfigSchema() {
+const DEFINITION: PluginDefinition<MqttPluginConfig> = {
+    name: 'legacyMqtt',
+    createInstance: (options: PluginOptions) => {
+        return new MqttPlugin(options)
+    },
+    getConfigSchema: () => {
         return PLUGIN_CONFIG_SCHEMA
     }
 }
+export default DEFINITION

--- a/packages/broker/src/plugins/legacyPublishHttp/PublishHttpPlugin.ts
+++ b/packages/broker/src/plugins/legacyPublishHttp/PublishHttpPlugin.ts
@@ -1,5 +1,5 @@
 import { router as dataProduceEndpoints } from './DataProduceEndpoints'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 
 export class PublishHttpPlugin extends Plugin<void> {
@@ -16,3 +16,14 @@ export class PublishHttpPlugin extends Plugin<void> {
     async stop() {
     }
 }
+
+const DEFINITION: PluginDefinition<void> = {
+    name: 'legacyPublishHttp',
+    createInstance: (options: PluginOptions) => {
+        return new PublishHttpPlugin(options)
+    },
+    getConfigSchema: () => {
+        return undefined
+    }
+}
+export default DEFINITION

--- a/packages/broker/src/plugins/legacyWebsocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/WebsocketPlugin.ts
@@ -1,7 +1,7 @@
 import ws from 'uWebSockets.js'
 import { MissingConfigError } from '../../errors/MissingConfigError'
 import { WebsocketServer } from './WebsocketServer'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 
@@ -50,8 +50,15 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
     async stop() {
         return this.websocketServer!.close()
     }
+}
 
-    getConfigSchema() {
+const DEFINITION: PluginDefinition<WebsocketPluginConfig> = {
+    name: 'legacyWebsocket',
+    createInstance: (options: PluginOptions) => {
+        return new WebsocketPlugin(options)
+    },
+    getConfigSchema: () => {
         return PLUGIN_CONFIG_SCHEMA
     }
 }
+export default DEFINITION

--- a/packages/broker/src/plugins/metrics/MetricsPlugin.ts
+++ b/packages/broker/src/plugins/metrics/MetricsPlugin.ts
@@ -1,5 +1,5 @@
 import { router as volumeEndpoint } from './VolumeEndpoint'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 
 export class MetricsPlugin extends Plugin<void> {
 
@@ -14,3 +14,14 @@ export class MetricsPlugin extends Plugin<void> {
     async stop() {
     }
 }
+
+const DEFINITION: PluginDefinition<void> = {
+    name: 'metrics',
+    createInstance: (options: PluginOptions) => {
+        return new MetricsPlugin(options)
+    },
+    getConfigSchema: () => {
+        return undefined
+    }
+}
+export default DEFINITION

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { MqttServer } from './MqttServer'
 import { Bridge } from './Bridge'
@@ -29,8 +29,15 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
     async stop() {
         await this.server!.stop()
     }
+}
 
-    getConfigSchema() {
+const DEFINITION: PluginDefinition<MqttPluginConfig> = {
+    name: 'mqtt',
+    createInstance: (options: PluginOptions) => {
+        return new MqttPlugin(options)
+    },
+    getConfigSchema: () => {
         return PLUGIN_CONFIG_SCHEMA
     }
 }
+export default DEFINITION

--- a/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
+++ b/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
@@ -1,5 +1,5 @@
 import { createEndpoint } from './publishEndpoint'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 
 export class PublishHttpPlugin extends Plugin<void> {
 
@@ -17,3 +17,14 @@ export class PublishHttpPlugin extends Plugin<void> {
     async stop() {
     }
 }
+
+const DEFINITION: PluginDefinition<void> = {
+    name: 'publishHttp',
+    createInstance: (options: PluginOptions) => {
+        return new PublishHttpPlugin(options)
+    },
+    getConfigSchema: () => {
+        return undefined
+    }
+}
+export default DEFINITION

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -1,7 +1,7 @@
 import { router as dataQueryEndpoints } from './DataQueryEndpoints'
 import { router as dataMetadataEndpoint } from './DataMetadataEndpoints'
 import { router as storageConfigEndpoints } from './StorageConfigEndpoints'
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import { StreamFetcher } from '../../StreamFetcher'
 import { Storage, startCassandraStorage } from './Storage'
 import { StorageConfig } from './StorageConfig'
@@ -94,8 +94,15 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
             this.storageConfig!.cleanup()
         ])
     }
+}
 
-    getConfigSchema() {
+const DEFINITION: PluginDefinition<StoragePluginConfig> = {
+    name: 'storage',
+    createInstance: (options: PluginOptions) => {
+        return new StoragePlugin(options)
+    },
+    getConfigSchema: () => {
         return PLUGIN_CONFIG_SCHEMA
     }
 }
+export default DEFINITION

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginOptions } from '../../Plugin'
+import { Plugin, PluginDefinition, PluginOptions } from '../../Plugin'
 import { SslCertificateConfig } from '../../types'
 import { WebsocketServer } from './WebsocketServer'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
@@ -27,8 +27,15 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
     async stop() {
         await this.server!.stop()
     }
+}
 
-    getConfigSchema() {
+const DEFINITION: PluginDefinition<WebsocketPluginConfig> = {
+    name: 'websocket',
+    createInstance: (options: PluginOptions) => {
+        return new WebsocketPlugin(options)
+    },
+    getConfigSchema: () => {
         return PLUGIN_CONFIG_SCHEMA
     }
 }
+export default DEFINITION

--- a/packages/broker/test/integration/config.test.ts
+++ b/packages/broker/test/integration/config.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import path from 'path'
+import { validateBrokerConfig } from '../../src/helpers/validateConfig'
+
+const PATH = './configs'
+
+describe('Config', () => {
+
+    const fileNames = fs.readdirSync(PATH)
+
+    describe.each(fileNames.map((fileName) => [fileName]))('validate', (fileName: string) => {
+
+        it(fileName, () => {
+            const filePath = PATH + path.sep + fileName
+            const content = fs.readFileSync(filePath)
+            const config = JSON.parse(content.toString())
+            expect(() => validateBrokerConfig(config)).not.toThrow()    
+        })
+
+    })
+})


### PR DESCRIPTION
It is now possible to validate a plugin config without creating an instance of a Plugin. 

A plugin functionality is exported to Broker via this interface:

```
interface PluginDefinition<T> {
    name: string,
    createInstance(options: PluginOptions): Plugin<T>
    getConfigSchema(): Schema|undefined
}
```

Added a test which validates all configs in `configs/` directory.
