### PR TITLE
NET-354: Test for validating Broker configs

### DIFF
--- a/packages/broker/test/integration/config.test.ts
+++ b/packages/broker/test/integration/config.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import path from 'path'
+import { createBroker } from '../../src/broker'
+
+const PATH = './configs'
+
+describe('Config', () => {
+
+    const fileNames = fs.readdirSync(PATH)
+
+    describe.each(fileNames.map((fileName) => [fileName]))('validate', (fileName: string) => {
+
+        it(fileName, () => {
+            const filePath = PATH + path.sep + fileName
+            const content = fs.readFileSync(filePath)
+            const config = JSON.parse(content.toString())
+            return expect(createBroker(config)).resolves.toBeDefined()
+        })
+
+    })
+})


### PR DESCRIPTION
New test which validates all configs in `configs/` directory.

Based on https://github.com/streamr-dev/network-monorepo/pull/116. Merge this PR separately to main after that PR has been merged.