### PR TITLE
fix: start parity-sidechain-node0

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "broker-node-no-storage-1 parity-node0"
+          services-to-start: "broker-node-no-storage-1 parity-node0 parity-sidechain-node0"
       - run: |
           for (( i=0; i < 5; i=i+1 )); do
               curl -s http://localhost:8791/api/v1/volume;


### PR DESCRIPTION
Updated `Start Streamr Docker Stack` task to start also `parity-sidechain-node0` service. 

This may fix the issue of a failing`Build, the test, and publish Docker images` github action (which is run on `main` commits).

The `parity-sidechain-node0` is needed because Broker (`configs/docker-1.env.json`) reads the storage node registry from a sidechain contract:
```
"storageNodeConfig": {
  "registry": {
    "contractAddress": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
    "jsonRpcProvider": "http://10.200.10.1:8546"
  }
}, 
```

**Note:** if this doesn't fix the issue, it may be because Broker starts before `parity-sidechain-node0`. The broker reads the registry during the startup, and if `parity-sidechain-node0` has not yet started, the reading fails . We could refactor it to read the storage registry information only when it is needed (see also https://linear.app/streamr/issue/NET-363/refresh-the-storage-node-registry-information-from-contract, https://github.com/streamr-dev/network-monorepo/pull/116)