### PR TITLE
[JS Client] Fix for build error in React Native

### DIFF
--- a/packages/client/copy-package.js
+++ b/packages/client/copy-package.js
@@ -9,9 +9,9 @@ delete pkg.private
 pkg.types = `./${path.relative('./dist', pkg.types)}`
 pkg.main = `./${path.relative('./dist', pkg.main)}`
 pkg.browser = `./${path.relative('./dist', pkg.browser)}`
-pkg.exports.browser = `./${path.relative('./dist', pkg.exports.browser)}`
-pkg.exports.default.import = `./${path.relative('./dist', pkg.exports.default.import)}`
-pkg.exports.default.require = `./${path.relative('./dist', pkg.exports.default.require)}`
+pkg.exports['.'].browser = `./${path.relative('./dist', pkg.exports['.'].browser)}`
+pkg.exports['.'].default.import = `./${path.relative('./dist', pkg.exports['.'].default.import)}`
+pkg.exports['.'].default.require = `./${path.relative('./dist', pkg.exports['.'].default.require)}`
 
 try {
     fs.mkdirSync('./dist/')

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,11 +11,14 @@
   "main": "./dist/src/index-commonjs.js",
   "browser": "./dist/streamr-client.web.js",
   "exports": {
-    "browser": "./dist/streamr-client.web.js",
-    "default": {
-      "import": "./dist/src/index-esm.mjs",
-      "require": "./dist/src/index-commonjs.js"
-    }
+    ".": {
+      "browser": "./streamr-client.web.js",
+      "default": {
+        "import": "./src/index-esm.mjs",
+        "require": "./src/index-commonjs.js"
+      }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "clean": "rm -rf dist; rm -rf vendor",


### PR DESCRIPTION
There is an issue when adding `streamr-client` to a React Native project, where the build throws a warning:

```
warn Package streamr-client has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in {ProjectRoot}/node_modules/streamr-client/package.json
```

Which is a problem with the `react-native cli` discussed a bit here:

https://github.com/react-native-community/cli/issues/1168

I found a fix for it here, which seems like a light fix that could preempt a lot of confusion and FUD by new adopters adding `streamr-client` to React Native:

https://github.com/infctr/eslint-plugin-typescript-sort-keys/pull/28/files

This PR applies the changes to `package.json` "exports" that should resolve the error/warning.

Let me know what you think!