### PR TITLE
[JS Client] React native persistent store proposal

### DIFF
--- a/packages/client/copy-package.js
+++ b/packages/client/copy-package.js
@@ -10,6 +10,7 @@ pkg.types = `./${path.relative('./dist', pkg.types)}`
 pkg.main = `./${path.relative('./dist', pkg.main)}`
 pkg.browser = `./${path.relative('./dist', pkg.browser)}`
 pkg.exports['.'].browser = `./${path.relative('./dist', pkg.exports['.'].browser)}`
+pkg.exports['.']['react-native'] = `./${path.relative('./dist', pkg.exports['.']['react-native'])}`
 pkg.exports['.'].default.import = `./${path.relative('./dist', pkg.exports['.'].default.import)}`
 pkg.exports['.'].default.require = `./${path.relative('./dist', pkg.exports['.'].default.require)}`
 

--- a/packages/client/copy-package.js
+++ b/packages/client/copy-package.js
@@ -9,9 +9,9 @@ delete pkg.private
 pkg.types = `./${path.relative('./dist', pkg.types)}`
 pkg.main = `./${path.relative('./dist', pkg.main)}`
 pkg.browser = `./${path.relative('./dist', pkg.browser)}`
-pkg.exports.browser = `./${path.relative('./dist', pkg.exports.browser)}`
-pkg.exports.default.import = `./${path.relative('./dist', pkg.exports.default.import)}`
-pkg.exports.default.require = `./${path.relative('./dist', pkg.exports.default.require)}`
+pkg.exports['.'].browser = `./${path.relative('./dist', pkg.exports['.'].browser)}`
+pkg.exports['.'].default.import = `./${path.relative('./dist', pkg.exports['.'].default.import)}`
+pkg.exports['.'].default.require = `./${path.relative('./dist', pkg.exports['.'].default.require)}`
 
 try {
     fs.mkdirSync('./dist/')

--- a/packages/client/copy-package.js
+++ b/packages/client/copy-package.js
@@ -9,6 +9,7 @@ delete pkg.private
 pkg.types = `./${path.relative('./dist', pkg.types)}`
 pkg.main = `./${path.relative('./dist', pkg.main)}`
 pkg.browser = `./${path.relative('./dist', pkg.browser)}`
+pkg['react-native'] = `./${path.relative('./dist', pkg['react-native'])}`
 pkg.exports['.'].browser = `./${path.relative('./dist', pkg.exports['.'].browser)}`
 pkg.exports['.']['react-native'] = `./${path.relative('./dist', pkg.exports['.']['react-native'])}`
 pkg.exports['.'].default.import = `./${path.relative('./dist', pkg.exports['.'].default.import)}`

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,11 +11,14 @@
   "main": "./dist/src/index-commonjs.js",
   "browser": "./dist/streamr-client.web.js",
   "exports": {
-    "browser": "./dist/streamr-client.web.js",
-    "default": {
-      "import": "./dist/src/index-esm.mjs",
-      "require": "./dist/src/index-commonjs.js"
-    }
+    ".": {
+      "browser": "./streamr-client.web.js",
+      "default": {
+        "import": "./src/index-esm.mjs",
+        "require": "./src/index-commonjs.js"
+      }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "clean": "rm -rf dist; rm -rf vendor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/types/src/index.d.ts",
   "main": "./dist/src/index-commonjs.js",
   "browser": "./dist/streamr-client.web.js",
+  "react-native": "./dist/streamr-client.rn.js",
   "exports": {
     ".": {
       "browser": "./streamr-client.web.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": {
       "browser": "./streamr-client.web.js",
+      "react-native": "./streamr-client.rn.js",
       "default": {
         "import": "./src/index-esm.mjs",
         "require": "./src/index-commonjs.js"
@@ -154,6 +155,7 @@
     "@ethersproject/transactions": "^5.1.1",
     "@ethersproject/wallet": "^5.1.0",
     "@ethersproject/web": "^5.1.0",
+    "@react-native-async-storage/async-storage": "^1.15.5",
     "debug": "^4.3.2",
     "env-paths": "^2.2.1",
     "eventemitter3": "^4.0.7",

--- a/packages/client/src/stream/encryption/ReactNativePersistentStore.ts
+++ b/packages/client/src/stream/encryption/ReactNativePersistentStore.ts
@@ -1,15 +1,14 @@
 import { PersistentStore } from './GroupKeyStore'
-import AsyncStorage from '@react-native-async-storage/async-storage'
-
-const { setItem, getItem, removeItem, clear, getAllKeys } = AsyncStorage
+// @ts-ignore
+import AsyncStorage from '@react-native-async-storage/async-storage/src/AsyncStorage.native'
 
 export default class ReactNativePersistentStore implements PersistentStore<string, string> {
     readonly clientId: string
     readonly streamId: string
 
     constructor({ clientId, streamId }: { clientId: string, streamId: string }) {
-        this.streamId = encodeURIComponent(streamId)
-        this.clientId = encodeURIComponent(clientId)
+        this.streamId = streamId
+        this.clientId = clientId
     }
 
     async has(key: string) {
@@ -19,13 +18,13 @@ export default class ReactNativePersistentStore implements PersistentStore<strin
 
     // eslint-disable-next-line class-methods-use-this
     async get(key: string) {
-        const value = await getItem(key)
+        const value = await AsyncStorage.getItem(key)
         return value || undefined
     }
 
     async set(key: string, value: string) {
         const had = await this.has(key)
-        await setItem(key, value,)
+        await AsyncStorage.setItem(key, value,)
         return had
     }
 
@@ -34,19 +33,19 @@ export default class ReactNativePersistentStore implements PersistentStore<strin
             return false
         }
 
-        await removeItem(key,)
+        await AsyncStorage.removeItem(key,)
         return true
     }
 
     // eslint-disable-next-line class-methods-use-this
     async clear() {
-        await clear()
+        await AsyncStorage.clear()
         return !!await this.size()
     }
 
     // eslint-disable-next-line class-methods-use-this
     async size() {
-        const allKeys = await getAllKeys()
+        const allKeys = await AsyncStorage.getAllKeys()
         return allKeys.length
     }
 

--- a/packages/client/src/stream/encryption/ReactNativePersistentStore.ts
+++ b/packages/client/src/stream/encryption/ReactNativePersistentStore.ts
@@ -1,0 +1,70 @@
+import { PersistentStore } from './GroupKeyStore'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+const { setItem, getItem, removeItem, clear, getAllKeys } = AsyncStorage
+
+export default class ReactNativePersistentStore implements PersistentStore<string, string> {
+    readonly clientId: string
+    readonly streamId: string
+
+    constructor({ clientId, streamId }: { clientId: string, streamId: string }) {
+        this.streamId = encodeURIComponent(streamId)
+        this.clientId = encodeURIComponent(clientId)
+    }
+
+    async has(key: string) {
+        const val = await this.get(key)
+        return val == null
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async get(key: string) {
+        const value = await getItem(key)
+        return value || undefined
+    }
+
+    async set(key: string, value: string) {
+        const had = await this.has(key)
+        await setItem(key, value,)
+        return had
+    }
+
+    async delete(key: string) {
+        if (!await this.has(key)) {
+            return false
+        }
+
+        await removeItem(key,)
+        return true
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async clear() {
+        await clear()
+        return !!await this.size()
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async size() {
+        const allKeys = await getAllKeys()
+        return allKeys.length
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async close() {
+        // noop
+    }
+
+    async destroy() {
+        await this.clear()
+        await this.close()
+    }
+
+    async exists() { // eslint-disable-line class-methods-use-this
+        return !!AsyncStorage
+    }
+
+    get [Symbol.toStringTag]() {
+        return this.constructor.name
+    }
+}

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -157,10 +157,18 @@ module.exports = (env, argv) => {
         name: 'react-native-lib',
         target: 'web',
         output: {
-            libraryTarget: 'umd2',
+            library: {
+                type: 'umd2',
+                name: 'StreamrClient'
+            },
             filename: libraryName + '.rn.js',
-            library: 'StreamrClient',
         },
+        externals: [
+            {
+                'react-native': true,
+                '@react-native-async-storage/async-storage/src/AsyncStorage.native': '@react-native-async-storage/async-storage/src/AsyncStorage.native',
+            }
+        ],
         resolve: {
             modules: [
                 'node_modules', // without this symlinked protocol won't find own dependencies
@@ -176,11 +184,13 @@ module.exports = (env, argv) => {
                 'node-fetch': path.resolve(__dirname, './src/shim/node-fetch.js'),
                 'node-webcrypto-ossl': path.resolve(__dirname, 'src/shim/crypto.js'),
                 'streamr-client-protocol': path.resolve(__dirname, 'node_modules/streamr-client-protocol/dist/src'),
-                // swap out ServerPersistentStore for BrowserPersistentStore
+                // swap out ServerPersistentStore for ReactNativePersistentStore
                 [path.resolve(__dirname, 'src/stream/encryption/ServerPersistentStore')]: (
                     path.resolve(__dirname, 'src/stream/encryption/ReactNativePersistentStore')
                 ),
-            }
+            },
+            conditionNames: ['react-native'],
+            mainFields: ['react-native', 'browser', 'main']
         },
         plugins: [
             new LodashWebpackPlugin(),

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -153,5 +153,50 @@ module.exports = (env, argv) => {
         })
     }
 
-    return [clientConfig, clientMinifiedConfig].filter(Boolean)
+    const reactNativeConfig = merge({}, commonConfig, {
+        name: 'react-native-lib',
+        target: 'web',
+        output: {
+            libraryTarget: 'umd2',
+            filename: libraryName + '.rn.js',
+            library: 'StreamrClient',
+        },
+        resolve: {
+            modules: [
+                'node_modules', // without this symlinked protocol won't find own dependencies
+            ],
+            alias: {
+                stream: 'readable-stream',
+                util: 'util',
+                http: path.resolve(__dirname, './src/shim/http-https.js'),
+                https: path.resolve(__dirname, './src/shim/http-https.js'),
+                ws: path.resolve(__dirname, './src/shim/ws.js'),
+                crypto: path.resolve(__dirname, 'node_modules', 'crypto-browserify'),
+                buffer: path.resolve(__dirname, 'node_modules', 'buffer'),
+                'node-fetch': path.resolve(__dirname, './src/shim/node-fetch.js'),
+                'node-webcrypto-ossl': path.resolve(__dirname, 'src/shim/crypto.js'),
+                'streamr-client-protocol': path.resolve(__dirname, 'node_modules/streamr-client-protocol/dist/src'),
+                // swap out ServerPersistentStore for BrowserPersistentStore
+                [path.resolve(__dirname, 'src/stream/encryption/ServerPersistentStore')]: (
+                    path.resolve(__dirname, 'src/stream/encryption/ReactNativePersistentStore')
+                ),
+            }
+        },
+        plugins: [
+            new LodashWebpackPlugin(),
+            new webpack.ProvidePlugin({
+                process: 'process/browser',
+                Buffer: ['buffer', 'Buffer'],
+            }),
+            ...(analyze ? [
+                new BundleAnalyzerPlugin({
+                    analyzerMode: 'static',
+                    openAnalyzer: false,
+                    generateStatsFile: true,
+                }),
+            ] : [])
+        ]
+    })
+
+    return [clientConfig, clientMinifiedConfig, reactNativeConfig].filter(Boolean)
 }


### PR DESCRIPTION
Hi @timoxley, the issue this attempts to solve is that neither BrowserPersistentStore or ServerPersistentStore works in React Native when encrypting and signing data for publishing to a stream. At least according to my testing and analysis (might be wrong!).

This isn't complete yet, but I wanted to check in to see what you think of the approach. I tried to follow the pattern of how the client handles the differences between the BrowserPersistentStore and ServerPersistentStore.

After implementing ReactNativePersistentStore with `@react-native-async-storage/async-storage`, I'm still running into issues, but I wanted to check in on the approach to see if it's even worth fixing those bugs.

Thanks for looking!