### PR TITLE
NET-384: Config should accept ethereumPrivateKey with and without 0x prefix

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -1,5 +1,5 @@
 {
-  "ethereumPrivateKey": "0xaa7a3b3bb9b4a662e756e978ad8c6464412e7eef1b871f19e5120d4747bce966",
+  "ethereumPrivateKey": "aa7a3b3bb9b4a662e756e978ad8c6464412e7eef1b871f19e5120d4747bce966",
   "generateSessionId": false,
   "network": {
     "name": "S1",

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -57,7 +57,7 @@
     "ethereumPrivateKey": {
       "type": "string",
       "description": "Ethereum private key to establish broker identity",
-      "pattern": "^0x[a-f0-9]{64}$"
+      "pattern": "^(0x)?[a-f0-9]{64}$"
     },
     "generateSessionId": {
       "type": "boolean",


### PR DESCRIPTION
Currently the config requires the ethereumPrivateKey to have the 0x prefix, although this is not customary in the Ethereum space. Versions with and without the prefix should be accepted.

Currently, when attempting to give a private key without the prefix, the following error is printed:

Error: /ethereumPrivateKey must match pattern "^0x[a-f0-9]{64}$"