### PR TITLE
NET-404 broker: config defaults

### DIFF
--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -218,16 +218,11 @@ plugins: {
 }
 ```
 
-The plugin  uses the Broker's global `httpServer`. It is configured in the root level:
+The default HTTP server port is `8080`. You can change it by specifying a `port` value for the root level `httpServer` option:
+
 ```
 "network": ...
 "plugins": ...
-"httpServer": {}
-```
-
-The default httpServer port is `8080`. You can change it with `port` config option:
-
-```
 "httpServer": {
     "port": 1234
 }

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -237,7 +237,7 @@ If you provide a SSL certificate it will support use SSL/TLS connections:
 }
 ```
 
-The plugin provides a single endpoint: `/streams/:streamId/` with the following optional query parameters:
+The plugin provides a single endpoint: `/streams/:streamId` with the following optional query parameters:
 
 - `timestamp` in ISO-8601 format e.g. 2001-02-03T04:05:06Z, or as a number 1234567890000
 - `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams)) **TODO**: define which partition is used when neither parameter is given

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -12,9 +12,7 @@ Currently many plugins use `legacyWebsocket` plugin as an internal communication
 
 ```
 plugins: {
-    "legacyWebsocket": {
-        port: 9999 // any available port
-    }
+    "legacyWebsocket": {}
 }
 ```
 
@@ -28,11 +26,7 @@ To enable the plugin, add the plugin definition to the Broker configuration JSON
 
 ```
 plugins: {
-    "websocket": {
-        "port": 7170,  // any available port
-        "payloadMetadata": false,
-        "sslCertificate": null
-    }
+    "websocket": {}
 }
 ```
 
@@ -55,6 +49,18 @@ socket.addEventListener('open', () => {
 ```
 
 ### Advanced usage
+
+#### Port
+
+The default port is `8081`. You can change it by specifying a `port` value:
+
+```
+plugins: {
+    "websocket": {
+        "port": 1234
+    }
+}
+```
 
 #### Explicit metadata
 
@@ -144,10 +150,7 @@ As an alternative to Websockets, it is possible to publish and subscribe to a st
 
 ```
 plugins: {
-    "mqtt": {
-        "port": 7171,  // any available port,
-        "payloadMetadata": false
-    }
+    "mqtt": {}
 }
 ```
 
@@ -171,6 +174,8 @@ await client.publish(streamId, JSON.stringify(msg))
 ```
 
 ### Advanced usage
+
+The default port is `1883`. You can change it with `port` config option. 
 
 Explicit metadata can be provided the same way it is provided to the `websocket` plugin ([see above](#explicit-metadata)).
 
@@ -213,14 +218,18 @@ plugins: {
 }
 ```
 
-The plugin doesn't need any configuration options as it uses the Broker's global `httpServer`.
-
-The `httpServer` is configured in the root level:
+The plugin  uses the Broker's global `httpServer`. It is configured in the root level:
 ```
 "network": ...
 "plugins": ...
+"httpServer": {}
+```
+
+The default httpServer port is `8080`. You can change it with `port` config option:
+
+```
 "httpServer": {
-    "port": 8080
+    "port": 1234
 }
 ```
 

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -201,9 +201,6 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             await Promise.all(plugins.map((plugin) => plugin.start()))
             const httpServerRoutes = plugins.flatMap((plugin) => plugin.getHttpServerRoutes())
             if (httpServerRoutes.length > 0) {
-                if (config.httpServer === null) {
-                    throw new Error('HTTP server config not defined')
-                }
                 httpServer = await startHttpServer(httpServerRoutes, config.httpServer, apiAuthenticator)
             }
             await volumeLogger.start()

--- a/packages/broker/src/config.ts
+++ b/packages/broker/src/config.ts
@@ -68,7 +68,7 @@ export interface Config {
     streamrUrl: string,
     streamrAddress: string,
     storageNodeConfig: StorageNodeConfig,
-    httpServer: HttpServerConfig | null
+    httpServer: HttpServerConfig
     plugins: Record<string,any>
     apiAuthentication: {
         keys: string[]

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -18,11 +18,10 @@
     },
     "httpServer": {
       "type": [
-        "object",
-        "null"
+        "object"
       ],
       "description": "HTTP server configuration",
-      "default": null,
+      "default": {},
       "additionalProperties": false,
       "properties": {
         "port": {

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -5,22 +5,15 @@
   "type": "object",
   "required": [
     "plugins",
-    "httpServer",
     "ethereumPrivateKey",
-    "generateSessionId",
     "network",
-    "reporting",
-    "streamrUrl",
-    "streamrAddress",
-    "storageNodeConfig",
-    "apiAuthentication"
+    "reporting"
   ],
   "additionalProperties": false,
   "properties": {
     "plugins": {
       "type": "object",
       "description": "Pluging configurations",
-      "required": [],
       "additionalProperties": true
     },
     "httpServer": {
@@ -29,28 +22,29 @@
         "null"
       ],
       "description": "HTTP server configuration",
-      "required": [
-        "port"
-      ],
+      "default": null,
       "additionalProperties": false,
       "properties": {
         "port": {
           "$ref": "#/definitions/port",
-          "description": "Port to start HTTP server on"
+          "description": "Port to start HTTP server on",
+          "default": 8080
         },
         "certFileName": {
           "type": [
             "string",
             "null"
           ],
-          "description": "Path of certificate file to use for SSL"
+          "description": "Path of certificate file to use for SSL",
+          "default": null
         },
         "privateKeyFileName": {
           "type": [
             "string",
             "null"
           ],
-          "description": "Path of private key file to use for SSL"
+          "description": "Path of private key file to use for SSL",
+          "default": null
         }
       }
     },
@@ -61,14 +55,14 @@
     },
     "generateSessionId": {
       "type": "boolean",
-      "description": "Whether to generate a session id that gets attached to node id (or not). Disable for consistent node id."
+      "description": "Whether to generate a session id that gets attached to node id (or not). Disable for consistent node id.",
+      "default": true
     },
     "network": {
       "type": "object",
       "description": "Network node settings",
       "required": [
         "name",
-        "trackers",
         "location"
       ],
       "additionalProperties": false,
@@ -78,6 +72,18 @@
           "description": "Human-readable name for network node"
         },
         "trackers": {
+          "default": [
+            {
+              "id": "0x7b9ad7B9E377dFd17fb4fF8F946956BDa1572849",
+              "ws": "wss://corea1.streamr.network:30300",
+              "http": "https://corea1.streamr.network:30300"
+            },
+            {
+              "id": "0xeC3471C25f47FD62D181Af7fd5cB82D4520E26BC",
+              "ws": "wss://corea2.streamr.network:30300",
+              "http": "https://corea2.streamr.network:30300"
+            }
+          ],
           "oneOf": [
             {
               "type": "array",
@@ -110,6 +116,7 @@
         },
         "location": {
           "description": "Location of node",
+          "default": null,
           "oneOf": [
             {
               "type": "null",
@@ -276,16 +283,24 @@
     "streamrUrl": {
       "type": "string",
       "description": "Base URL of Core (E&E) API to use",
+      "default": "https://streamr.network",
       "format": "uri"
     },
     "streamrAddress": {
       "type": "string",
       "description": "Ethereum address Core (E&E)",
+      "default": "0xf3E5A65851C3779f468c9EcB32E6f25D9D68601a",
       "pattern": "^0x[a-fA-F0-9]{40}$"
     },
     "storageNodeConfig": {
       "type": "object",
       "description": "Storage node settings",
+      "default": {
+        "registry": [{
+          "address": "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916",
+          "url": "https://corea1.streamr.network:8001"
+        }]
+      },
       "required": [
         "registry"
       ],
@@ -314,6 +329,7 @@
         "null"
       ],
       "description": "Plugins should restrict the API access: if an endpoint requires authentication, the user must provide one of the API keys e.g. in a request header",
+      "default": null,
       "required": [
         "keys"
       ],

--- a/packages/broker/src/helpers/validateConfig.ts
+++ b/packages/broker/src/helpers/validateConfig.ts
@@ -3,7 +3,9 @@ import addFormats from 'ajv-formats'
 import { Todo } from '../types'
 
 export const validateConfig = (data: unknown, schema: Schema, contextName?: string) => {
-    const ajv = new Ajv()
+    const ajv = new Ajv({
+        useDefaults: true
+    })
     addFormats(ajv)
     if (!ajv.validate(schema, data)) {
         const prefix = (contextName !== undefined) ? (contextName + ': ') : ''

--- a/packages/broker/src/plugins/legacyWebsocket/config.schema.json
+++ b/packages/broker/src/plugins/legacyWebsocket/config.schema.json
@@ -3,18 +3,17 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "description": "WebSocket plugin configuration",
-    "required": [
-        "port"
-    ],
     "additionalProperties": false,
     "properties": {
         "port": {
             "type": "integer",
-            "description": "Port to start plugin on"
+            "description": "Port to start plugin on",
+            "default": 8082
         },
         "pingInterval": {
             "type": "integer",
             "description": "How often to ping client connections (in milliseconds)",
+            "default": 60000,
             "minimum": 0
         },
         "certFileName": {
@@ -22,14 +21,16 @@
                 "string",
                 "null"
             ],
-            "description": "Path of certificate file to use for SSL"
+            "description": "Path of certificate file to use for SSL",
+            "default": null
         },
         "privateKeyFileName": {
             "type": [
                 "string",
                 "null"
             ],
-            "description": "Path of private key file to use for SSL"
+            "description": "Path of private key file to use for SSL",
+            "default": null
         }
     }
 }

--- a/packages/broker/src/plugins/mqtt/config.schema.json
+++ b/packages/broker/src/plugins/mqtt/config.schema.json
@@ -3,23 +3,25 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "description": "MQTT plugin configuration",
-    "required": [
-        "port",
-        "payloadMetadata"
-    ],
     "additionalProperties": false,
     "properties": {
         "port": {
             "type": "integer",
-            "description": "Port to start plugin on"
+            "description": "Port to start plugin on",
+            "default": 1883
         },
         "streamIdDomain": {
-            "type": "string",
-            "description": "All topics are mapped to streamIds by prepending the domain to the topic: streamIdDomain + '/' + topic"
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "All topics are mapped to streamIds by prepending the domain to the topic: streamIdDomain + '/' + topic",
+            "default": null
         },
         "payloadMetadata": {
             "type": "boolean",
-            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON"
+            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON",
+            "default": false
         }
     }
 }

--- a/packages/broker/src/plugins/storage/config.schema.json
+++ b/packages/broker/src/plugins/storage/config.schema.json
@@ -52,7 +52,10 @@
                     "description": "Interval (in milliseconds) in which to refresh storage config from Core API (0 = disable)"
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "default": {
+                "refreshInterval": 600000
+            }
         }  
     }
 }

--- a/packages/broker/src/plugins/testnetMiner/config.schema.json
+++ b/packages/broker/src/plugins/testnetMiner/config.schema.json
@@ -3,11 +3,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "description": "Testnet miner plugin configuration",
-    "required": [
-        "rewardStreamId",
-        "claimServerUrl",
-        "maxClaimDelay"
-    ],
     "additionalProperties": false,
     "properties": {
         "rewardStreamId": {
@@ -20,7 +15,8 @@
         },
         "maxClaimDelay": {
             "type": "number",
-            "description": "Maximum time for delaying the claim in milliseconds"
+            "description": "Maximum time for delaying the claim in milliseconds",
+            "default": 60000
         },
         "stunServerHost": {
             "type": [

--- a/packages/broker/src/plugins/websocket/config.schema.json
+++ b/packages/broker/src/plugins/websocket/config.schema.json
@@ -3,20 +3,17 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "description": "WebSocket plugin configuration",
-    "required": [
-        "port",
-        "payloadMetadata",
-        "sslCertificate"
-    ],
     "additionalProperties": false,
     "properties": {
         "port": {
             "type": "integer",
-            "description": "Port to start plugin on"
+            "description": "Port to start plugin on",
+            "default": 8081
         },
         "payloadMetadata": {
             "type": "boolean",
-            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON"
+            "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON",
+            "default": false
         },
         "sslCertificate": {
             "description": "Files to use for SSL",
@@ -24,6 +21,7 @@
                 "object",
                 "null"
             ],
+            "default": null,
             "required": [
                 "certFileName",
                 "privateKeyFileName"

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -106,11 +106,11 @@ export function formConfig({
         streamrUrl,
         streamrAddress,
         storageNodeConfig,
-        httpServer: httpPort ? {
-            port: httpPort,
+        httpServer: {
+            port: httpPort ? httpPort : 8080,
             privateKeyFileName: null,
             certFileName: null
-        } : null,
+        },
         apiAuthentication,
         plugins
     }


### PR DESCRIPTION
Many config options for Broker and plugins have now some default values. 

Most of the defaults are not environment specific. If a default value is environment specific, the value is for the production environment.

The minimal config is currently like this:
```
{
    "ethereumPrivateKey": "foo",
    "network": {
        "name": "bar"
    },
    "reporting": {
        "intervalInSeconds": 0,
        "streamr": null,
        "perNodeMetrics": null
    },
    "plugins": {}
}
```

Most of the plugins can be initialized with empty setup:
```
    "plugins": {
        "websocket": {},
        "mqtt": {},
        "publishHttp": {},
        "legacyWebsocket": {},
        "testnetMiner": {},
        "metrics": {},
        "storage": {
            "cassandra": {
                "hosts": ["127.0.0.1"],
                "username": "",
                "password": "",
                "keyspace": "streamr_dev_v2",
                "datacenter": "datacenter1"
              }
        }
    }
}
```

**TODO:**
- Reporting config has yet not been modified as it will be moved into a plugin (https://github.com/streamr-dev/network-monorepo/pull/143)
- Config wizard config template has not yet been simplified as there is a pending refactor PR (https://github.com/streamr-dev/network-monorepo/pull/144)

**Future improvements:**
- The `websocket` plugin could use Broker's `httpServer`. That would simplify maintenance as there is be one port less to configure, and possible SSL certificates could be shared.