### PR TITLE
NET-399: Update Package.json metadata for all monorepo packages

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -4,7 +4,8 @@
   "description": "A full-featured broker node implementation for the Streamr Network.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/streamr-dev/broker.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/broker"
   },
   "bin": {
     "streamr-broker": "bin/broker.js",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:streamr-dev/cli-tools.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/cli-tools"
   },
   "keywords": [
     "streamr",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/streamr-dev/streamr-client.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/client"
   },
   "types": "./dist/types/src/index.d.ts",
   "main": "./dist/src/index-commonjs.js",

--- a/packages/cross-client-testing/package.json
+++ b/packages/cross-client-testing/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/streamr-dev/streamr-client-testing.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/cross-client-testing"
   },
   "keywords": [],
   "type": "module",

--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -4,7 +4,8 @@
   "description": "Streamr Development Environment Configs",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/streamr-dev/network-monorepo.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/dev-config"
   },
   "main": "index.js",
   "author": "Streamr Network AG <contact@streamr.network>",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -4,7 +4,8 @@
   "description": "Minimal and extendable implementation of the Streamr Network network node.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/streamr-dev/network.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/network"
   },
   "bin": {
     "network": "bin/network.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",
-    "url": "git://github.com/streamr-dev/streamr-client-protocol-js.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/streamr-client-protocol"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/streamr-dev/network-monorepo.git",
-    "directory": "packages/streamr-client-protocol"
+    "directory": "packages/protocol"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:streamr-dev/streamr-test-utils.git"
+    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "directory": "packages/streamr-test-utils"
   },
   "author": "Streamr <contact@streamr.com>",
   "license": "Apache-2.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -23,7 +23,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/streamr-dev/network-monorepo.git",
-    "directory": "packages/streamr-test-utils"
+    "directory": "packages/test-utils"
   },
   "author": "Streamr <contact@streamr.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Update the `repository` field in the `package.json` of every monorepo package from their old locations, ie:
```json
"repository": {
    "type": "git",
    "url": "git+https://github.com/streamr-dev/broker.git"
},
```
So it reflects the monorepo package and their actual location, ie:
```json
"repository": {
    "type": "git",
    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
    "directory": "packages/broker"
},
```