### PR TITLE
NET-416: pass nat type and broker version metadata to tracker

### DIFF
--- a/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
+++ b/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
@@ -7,6 +7,7 @@ import { Metrics } from '../../../../network/dist/helpers/MetricsContext'
 import { scheduleAtInterval } from '../../helpers/scheduler'
 import { withTimeout } from '../../helpers/withTimeout'
 import { fetchOrThrow } from '../../helpers/fetch'
+import { version as CURRENT_VERSION } from '../../../package.json'
 
 const REWARD_STREAM_PARTITION = 0
 const LATENCY_POLL_INTERVAL = 30 * 60 * 1000
@@ -57,6 +58,10 @@ export class TestnetMinerPlugin extends Plugin<TestnetMinerPluginConfig> {
         if (this.pluginConfig.stunServerHost !== null) {
             this.natType = await this.getNatType()
         }
+        this.networkNode.setExtraMetadata({
+            natType: this.natType || null,
+            brokerVersion: CURRENT_VERSION,
+        })
         await this.streamrClient!.subscribe(this.pluginConfig.rewardStreamId, (message: any) => {
             if (message.rewardCode) {
                 this.onRewardCodeReceived(message.rewardCode)

--- a/packages/network/src/NetworkNode.ts
+++ b/packages/network/src/NetworkNode.ts
@@ -13,6 +13,10 @@ export class NetworkNode extends Node {
         super(networkOpts)
     }
 
+    setExtraMetadata(metadata: Record<string, unknown>): void {
+        this.extraMetadata = metadata
+    }
+
     publish(streamMessage: MessageLayer.StreamMessage): void {
         this.onDataReceived(streamMessage)
     }

--- a/packages/network/src/helpers/trackerHttpEndpoints.ts
+++ b/packages/network/src/helpers/trackerHttpEndpoints.ts
@@ -110,6 +110,10 @@ export function trackerHttpEndpoints(
         staticLogger.debug(`request to /location/${nodeId}/`)
         res.json(location || {})
     })
+    app.get('/metadata/', (req: express.Request, res: express.Response) => {
+        staticLogger.debug('request to /metadata/')
+        res.json(tracker.getAllExtraMetadatas())
+    })
     app.get('/metrics/', async (req: express.Request, res: express.Response) => {
         const metrics = await metricsContext.report()
         staticLogger.debug('request to /metrics/')

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -64,6 +64,7 @@ export interface Status {
     location: Location
     started: string
     singleStream: boolean // indicate whether this is a status update for only a single stream
+    extra: Record<string, unknown>
 }
 
 export type RtcIceCandidateMessage = {

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -85,6 +85,7 @@ export class Node extends EventEmitter {
     private readonly metrics: Metrics
     private connectToBoostrapTrackersInterval?: NodeJS.Timeout | null
     private handleBufferedMessagesTimeoutRef?: NodeJS.Timeout | null
+    protected extraMetadata: Record<string, unknown> = {}
 
     constructor(opts: NodeOptions) {
         super()
@@ -417,7 +418,8 @@ export class Node extends EventEmitter {
             started: this.started,
             rtts: this.nodeToNode.getRtts(),
             location: this.peerInfo.location,
-            singleStream: false
+            singleStream: false,
+            extra: this.extraMetadata
         }
     }
 
@@ -427,7 +429,8 @@ export class Node extends EventEmitter {
             started: this.started,
             rtts: this.nodeToNode.getRtts(),
             location: this.peerInfo.location,
-            singleStream: true
+            singleStream: true,
+            extra: this.extraMetadata
         }
     }
 

--- a/packages/network/test/integration/tracker-endpoints.test.ts
+++ b/packages/network/test/integration/tracker-endpoints.test.ts
@@ -65,6 +65,9 @@ describe('tracker endpoint', () => {
                 longitude: null
             }
         })
+        nodeTwo.setExtraMetadata({
+            foo: 'bar'
+        })
 
         nodeOne.subscribe('stream-1', 0)
         nodeTwo.subscribe('stream-1', 0)
@@ -279,5 +282,16 @@ describe('tracker endpoint', () => {
         expect(jsonResult.peerId).toEqual('tracker')
         expect(jsonResult.startTime).toBeGreaterThan(1600000000000)
         expect(jsonResult.metrics).not.toBeUndefined()
+    })
+
+    it('/metadata/', async () => {
+        const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/metadata/`)
+        expect(status).toEqual(200)
+        expect(jsonResult).toEqual({
+            'node-1': {},
+            'node-2': {
+                foo: 'bar'
+            }
+        })
     })
 })


### PR DESCRIPTION
- Package `network` now provides a way to share metadata with the tracker. The latest metadata gets shared with tracker(s) via status messages. The tracker will store the metadata (per node) in memory and provide it to the outside world via HTTP endpoint `/tracker/`.
- `TestnetMinerPlugin` in package `broker` uses the new metadata sharing feature to share `natType` and `brokerVersion` fields with tracker (and the rest of the world).