### PR TITLE
network [NET-417]: add HTTP endpoint to tracker to query the streams of a node

### DIFF
--- a/packages/network/src/logic/trackerSummaryUtils.ts
+++ b/packages/network/src/logic/trackerSummaryUtils.ts
@@ -66,6 +66,22 @@ export function addRttsToNodeConnections(
     }
 }
 
+export function findStreamsForNode(
+    overlayPerStream: OverlayPerStream,
+    nodeId: string
+): Array<{ streamId: string, partition: number, topologySize: number}> {
+    return Object.entries(overlayPerStream)
+        .filter(([_, overlayTopology]) => overlayTopology.hasNode(nodeId))
+        .map(([streamKey, overlayTopology]) => {
+            const streamIdAndPartition = StreamIdAndPartition.fromKey(streamKey)
+            return {
+                streamId: streamIdAndPartition.id,
+                partition: streamIdAndPartition.partition,
+                topologySize: overlayTopology.getNumberOfNodes()
+            }
+        })
+}
+
 function getNodeToNodeConnectionRtts(
     nodeOne: string,
     nodeTwo: string,

--- a/packages/network/test/integration/tracker-endpoints.test.ts
+++ b/packages/network/test/integration/tracker-endpoints.test.ts
@@ -240,6 +240,46 @@ describe('tracker endpoint', () => {
         })
     })
 
+    it('/nodes/node-1/streams', async () => {
+        const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/nodes/node-1/streams/`)
+        expect(status).toEqual(200)
+        expect(jsonResult).toEqual([
+            {
+                "partition": 0,
+                "streamId": "stream-1",
+                "topologySize": 2
+            },
+            {
+                "partition": 0,
+                "streamId": "stream-2",
+                "topologySize": 1
+            },
+            {
+                "partition": 0,
+                "streamId": "sandbox/test/stream-3",
+                "topologySize": 1
+            }
+        ])
+    })
+
+    it('/nodes/node-2/streams', async () => {
+        const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/nodes/node-2/streams/`)
+        expect(status).toEqual(200)
+        expect(jsonResult).toEqual([
+            {
+                "partition": 0,
+                "streamId": "stream-1",
+                "topologySize": 2
+            }
+        ])
+    })
+
+    it('/nodes/non-existing-node/streams', async () => {
+        const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/nodes/non-existing-node/streams/`)
+        expect(status).toEqual(200)
+        expect(jsonResult).toEqual([])
+    })
+
     it('/location/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/location/`)
         expect(status).toEqual(200)


### PR DESCRIPTION
As specified in the ticket https://linear.app/streamr/issue/NET-417/endpoint-to-query-streams-carried-by-a-node