### PR TITLE
NET-403: Increase default maxClaimDelay in broker-node configuration

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -70,7 +70,7 @@ export const DEFAULT_CONFIG: any = {
         testnetMiner: {
             rewardStreamId: "streamr.eth/brubeck-testnet/rewards",
             claimServerUrl: "http://testnet2.streamr.network:3011",
-            maxClaimDelay: 5000
+            maxClaimDelay: 60000
         },
         metrics: {
             consoleAndPM2IntervalInSeconds: 0,

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -71,8 +71,7 @@ export const DEFAULT_CONFIG: any = {
         legacyWebsocket: {},
         testnetMiner: {
             rewardStreamId: "streamr.eth/brubeck-testnet/rewards",
-            claimServerUrl: "http://testnet1.streamr.network:3011",
-            maxClaimDelay: 60000
+            claimServerUrl: "http://testnet1.streamr.network:3011"
         },
         metrics: {
             consoleAndPM2IntervalInSeconds: 0,


### PR DESCRIPTION
When running the broker-node-init we generate default value for maxClaimDelay in the json configuration file to be 5000ms. It should be one minute, as discussed in the Network call on 2021-08-10.

```typescript
testnetMiner: {
            rewardStreamId: "streamr.eth/brubeck-testnet/rewards",
            claimServerUrl: "http://testnet2.streamr.network:3011",
            // maxClaimDelay: 5000
            maxClaimDelay: 60000
}
```