### PR TITLE
NET-400: Add welcome message with mnemonic and node explorer url upon config wizard and broker startup

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -73,7 +73,8 @@
     "terminal-kit": "^2.1.5",
     "utf8-binary-cutter": "^0.9.2",
     "uuid": "^8.3.2",
-    "ws": "^7.4.5"
+    "ws": "^7.4.5",
+    "streamr-client-protocol": "^8.2.0"
   },
   "devDependencies": {
     "@streamr/dev-config": "^1.0.0",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -73,8 +73,7 @@
     "terminal-kit": "^2.1.5",
     "utf8-binary-cutter": "^0.9.2",
     "uuid": "^8.3.2",
-    "ws": "^7.4.5",
-    "streamr-client-protocol": "^8.2.0"
+    "ws": "^7.4.5"
   },
   "devDependencies": {
     "@streamr/dev-config": "^1.0.0",

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -5,7 +5,7 @@ import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import * as os from 'os'
 import chalk from "chalk"
 
-import { generateMnemonicFromAddress } from 'streamr-client-protocol'
+import { Protocol } from 'streamr-network'
 
 import * as WebsocketConfigSchema from './plugins/websocket/config.schema.json'
 import * as MqttConfigSchema from './plugins/mqtt/config.schema.json'
@@ -253,7 +253,7 @@ export async function startBrokerConfigWizard(): Promise<void> {
         const answers = await inquirer.prompt(prompts)
         const config = getConfigFromAnswers(answers)
         const nodeAddress = new Wallet(config.ethereumPrivateKey).address
-        const mnemonic = generateMnemonicFromAddress(nodeAddress)
+        const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
         logger.info('Welcome to the Streamr Network')
         logger.print(`Your node's generated name is ${mnemonic}.`)
         logger.print('View your node in the Network Explorer:')

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -7,7 +7,6 @@ import chalk from "chalk"
 
 import { generateMnemonicFromAddress } from 'streamr-client-protocol'
 
-
 import * as WebsocketConfigSchema from './plugins/websocket/config.schema.json'
 import * as MqttConfigSchema from './plugins/mqtt/config.schema.json'
 import * as BrokerConfigSchema from './helpers/config.schema.json'

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -5,6 +5,9 @@ import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import * as os from 'os'
 import chalk from "chalk"
 
+import { generateMnemonicFromAddress } from 'streamr-client-protocol'
+
+
 import * as WebsocketConfigSchema from './plugins/websocket/config.schema.json'
 import * as MqttConfigSchema from './plugins/mqtt/config.schema.json'
 import * as BrokerConfigSchema from './helpers/config.schema.json'
@@ -249,14 +252,19 @@ export async function startBrokerConfigWizard(): Promise<void> {
     try {
         const answers = await inquirer.prompt(prompts)
         const config = getConfigFromAnswers(answers)
-        logger.info(`This will be your node's address: ${new Wallet(config.ethereumPrivateKey).address}`)
+        const nodeAddress = new Wallet(config.ethereumPrivateKey).address
+        const mnemonic = generateMnemonicFromAddress(nodeAddress)
+        logger.info('Welcome to the Streamr Network')
+        logger.print(`Your node's generated name is ${mnemonic}.`)
+        logger.print('View your node in the Network Explorer:')
+        logger.print(`https://streamr.network/network-explorer/nodes/${nodeAddress}`)
         logger.info('This is your node\'s private key. Please store it in a secure location:')
         logger.alert(config.ethereumPrivateKey)
         const storageAnswers = await selectValidDestinationPath()
         const destinationPath = createStorageFile(config, storageAnswers)
         logger.info('Broker Config Wizard ran succesfully')
         logger.print(`Stored config under ${destinationPath}`)
-        logger.print(`You can start the broker now with`)
+        logger.print('You can start the broker now with')
         logger.info(`streamr-broker ${destinationPath}`)
     } catch (e) {
         logger.warn('Broker Config Wizard encountered an error:')

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -16,7 +16,6 @@ import BROKER_CONFIG_SCHEMA from './helpers/config.schema.json'
 import { createLocalStreamrClient } from './localStreamrClient'
 import { createApiAuthenticator } from './apiAuthenticator'
 import { StorageNodeRegistry } from "./StorageNodeRegistry"
-import { generateMnemonicFromAddress } from 'streamr-client-protocol'
 import { v4 as uuidv4 } from 'uuid'
 const { Utils } = Protocol
 
@@ -150,7 +149,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
                 httpServer = await startHttpServer(httpServerRoutes, config.httpServer, apiAuthenticator)
             }
 
-            logger.info(`Welcome to the Streamr Network. Your node's generated name is ${generateMnemonicFromAddress(brokerAddress)}.`)
+            logger.info(`Welcome to the Streamr Network. Your node's generated name is ${Protocol.generateMnemonicFromAddress(brokerAddress)}.`)
             logger.info(`View your node in the Network Explorer: https://streamr.network/network-explorer/nodes/${brokerAddress}`)
 
             logger.info(`Network node '${networkNodeName}' (id=${nodeId}) running`)

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -16,6 +16,7 @@ import BROKER_CONFIG_SCHEMA from './helpers/config.schema.json'
 import { createLocalStreamrClient } from './localStreamrClient'
 import { createApiAuthenticator } from './apiAuthenticator'
 import { StorageNodeRegistry } from "./StorageNodeRegistry"
+import { generateMnemonicFromAddress } from 'streamr-client-protocol'
 import { v4 as uuidv4 } from 'uuid'
 const { Utils } = Protocol
 
@@ -148,6 +149,10 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             if (httpServerRoutes.length > 0) {
                 httpServer = await startHttpServer(httpServerRoutes, config.httpServer, apiAuthenticator)
             }
+
+            logger.info(`Welcome to the Streamr Network. Your node's generated name is ${generateMnemonicFromAddress(brokerAddress)}.`)
+            logger.info(`View your node in the Network Explorer: https://streamr.network/network-explorer/nodes/${brokerAddress}`)
+
             logger.info(`Network node '${networkNodeName}' (id=${nodeId}) running`)
             logger.info(`Ethereum address ${brokerAddress}`)
             logger.info(`Configured with trackers: ${trackers.join(', ')}`)


### PR DESCRIPTION
This PR adds the following message to the startup process of the config wizard and the broker via `createBroker` method:
```
Your node's generated name is Gown Senior Head.
View your node in the Network Explorer:
https://streamr.network/network-explorer/nodes/0x653875a86CFAF8aE1fb20a53C705dE47CeDEeb43
```
