### PR TITLE
NET-430: default STUN addresses

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -57,7 +57,7 @@ export const DEFAULT_CONFIG: any = {
             id: "0x49D45c17bCA1Caf692001D21c38aDECCB4c08504"
         }],
         location: null,
-        stun: "stun:turn.streamr.network:5349",
+        stun: "stun:stun.streamr.network:5349",
         turn: null
     },
     generateSessionId: false,
@@ -73,7 +73,8 @@ export const DEFAULT_CONFIG: any = {
         legacyWebsocket: {},
         testnetMiner: {
             rewardStreamId: "streamr.eth/brubeck-testnet/rewards",
-            claimServerUrl: "http://testnet1.streamr.network:3011"
+            claimServerUrl: "http://testnet1.streamr.network:3011",
+            stunServerHost: "stun.sipgate.net"
         },
         metrics: {
             consoleAndPM2IntervalInSeconds: 0,

--- a/packages/broker/src/plugins/testnetMiner/config.schema.json
+++ b/packages/broker/src/plugins/testnetMiner/config.schema.json
@@ -23,7 +23,7 @@
                 "string",
                 "null"
             ],
-            "default": "TODO: Streamr's STUN server host"
+            "default": "stun.streamr.network:5349"
         }
     }
 }


### PR DESCRIPTION
- Point network STUN to appropriate address
- NAT-type-identifier only seems to work with the sipgate URL. Even google's servers fail