### PR TITLE
fix: broker default ports

### DIFF
--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -52,7 +52,7 @@ socket.addEventListener('open', () => {
 
 #### Port
 
-The default port is `8081`. You can change it by specifying a `port` value:
+The default websocket port is `7170`. You can change it by specifying a `port` value:
 
 ```
 plugins: {
@@ -218,7 +218,7 @@ plugins: {
 }
 ```
 
-The default HTTP server port is `8080`. You can change it by specifying a `port` value for the root level `httpServer` option:
+The default HTTP server port is `7171`. You can change it by specifying a `port` value for the root level `httpServer` option:
 
 ```
 "network": ...
@@ -248,7 +248,7 @@ To publish a message to a stream, send the data as a POST payload:
 curl \
 --header 'Content-Type: application/json' \
 --data '{"foo":"bar"}' \
-http://localhost:8080/streams/foo.eth%2fbar
+http://localhost:7171/streams/foo.eth%2fbar
 ```
 
 The endpoint returns HTTP 200 status if the message was published successfully. 

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -26,7 +26,7 @@
         "port": {
           "$ref": "#/definitions/port",
           "description": "Port to start HTTP server on",
-          "default": 8080
+          "default": 7171
         },
         "certFileName": {
           "type": [

--- a/packages/broker/src/plugins/websocket/config.schema.json
+++ b/packages/broker/src/plugins/websocket/config.schema.json
@@ -8,7 +8,7 @@
         "port": {
             "type": "integer",
             "description": "Port to start plugin on",
-            "default": 8081
+            "default": 7170
         },
         "payloadMetadata": {
             "type": "boolean",

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -89,7 +89,7 @@ export function formConfig({
         streamrAddress,
         storageNodeConfig,
         httpServer: {
-            port: httpPort ? httpPort : 8080,
+            port: httpPort ? httpPort : 7171,
             privateKeyFileName: null,
             certFileName: null
         },


### PR DESCRIPTION
Let's use the following default ports for the plugins. This was changed already once, but the chosen ports (such as 8080) unfortunately clash with commonly used http servers (such as the tomcat we run in our own dev env).

- websocket: 7170
- http: 7171
- mqtt: 1883