### PR TITLE
Simplify running broker in docker: Run broker with no args as default Dockerfile command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:16-buster as build
 WORKDIR /usr/src/monorepo
 COPY . .
 RUN npm set unsafe-perm true
+RUN npm install -g npm@6 # explicitly use npm v6
 RUN npm ci
 RUN npm run bootstrap-pkg streamr-broker
 RUN npx lerna exec -- npm prune --production # image contains all packages, remove devDeps to keep image size down

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,6 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl 
 COPY --from=build /usr/src/monorepo /usr/src/monorepo
 WORKDIR /usr/src/monorepo
 
-# Make ports available to the world outside this container
-EXPOSE 30315
-# WebSocket
-EXPOSE 8890
-# HTTP
-EXPOSE 8891
-# MQTT
-EXPOSE 9000
-
 ENV LOG_LEVEL=info
 ENV CONFIG_FILE configs/docker-1.env.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY --from=build /usr/src/monorepo /usr/src/monorepo
 WORKDIR /usr/src/monorepo
 
 ENV LOG_LEVEL=info
-ENV CONFIG_FILE configs/docker-1.env.json
 
 RUN ln -s packages/broker/tracker.js tracker.js
-CMD node packages/broker/bin/broker.js packages/broker/${CONFIG_FILE}
+
+WORKDIR /usr/src/monorepo/packages/broker
+CMD ./bin/broker.js # start broker from default config


### PR DESCRIPTION
Needs this to land first: https://github.com/streamr-dev/streamr-docker-dev/pull/139

* Run brokers with no args as default command. Removes `CONFIG_FILE` env var. This simplifies running broker in docker for testnet users.
* Removes unneeded EXPOSE statements from Dockerfile.
* Uses npm v6 instead of npm v7. Installs with npm v7 do not seem to succeed reliably. 🤷  Our package-locks are set up for v6 anyway.
