### PR TITLE
NET-342: ConfigWizard generation of apiAuthentication.keys

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -50,7 +50,7 @@ const logger = {
 
 function generateApiKey(){
     const hex = uuid().split('-').join('')
-    return Buffer.from(hex).toString('base64')
+    return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
 }
 
 export const DEFAULT_CONFIG: any = {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -48,7 +48,7 @@ const logger = {
     }
 }
 
-const generateApiKey = ():string => {
+const generateApiKey = (): string => {
     const hex = uuid().split('-').join('')
     return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
 }
@@ -248,7 +248,7 @@ const selectValidDestinationPath = async (): Promise<inquirer.Answers> => {
     return answers
 }
 
-export const createStorageFile = (config: any, answers: inquirer.Answers): string => {
+export const createStorageFile = async (config: any, answers: inquirer.Answers): Promise<string> => {
     if (!answers.parentDirExists) {
         mkdirSync(answers.parentDirPath)
     }
@@ -270,7 +270,7 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         logger.info('This is your node\'s private key. Please store it in a secure location:')
         logger.alert(config.ethereumPrivateKey)
         const storageAnswers = await selectValidDestinationPath()
-        const destinationPath = createStorageFile(config, storageAnswers)
+        const destinationPath = await createStorageFile(config, storageAnswers)
         logger.info('Broker Config Wizard ran succesfully')
         logger.print(`Stored config under ${destinationPath}`)
         logger.print('You can start the broker now with')

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import * as os from 'os'
 import chalk from "chalk"
-
+import { v4 as uuid } from 'uuid'
 import { Protocol } from 'streamr-network'
 
 import * as WebsocketConfigSchema from './plugins/websocket/config.schema.json'
@@ -46,6 +46,11 @@ const logger = {
     error: (...args: any[]) => {
         console.log(chalk.bgRed.black('!'), ...args)
     }
+}
+
+function generateApiKey(){
+    const hex = uuid().split('-').join('')
+    return Buffer.from(hex).toString('base64')
 }
 
 export const DEFAULT_CONFIG: any = {
@@ -92,6 +97,9 @@ export const DEFAULT_CONFIG: any = {
             }
         },
     },
+    apiAuthentication: {
+        keys: [generateApiKey()]
+    }
 }
 
 let prompts: Array<inquirer.Question | inquirer.ListQuestion | inquirer.CheckboxQuestion> = [

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -53,7 +53,7 @@ const generateApiKey = ():string => {
     return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
 }
 
-export const DEFAULT_CONFIG: any = {
+export const CONFIG_TEMPLATE: any = {
     network: {
         name: 'miner-node',
         trackers: [{
@@ -179,7 +179,7 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
 prompts = prompts.concat(pluginSelectorPrompt).concat(pluginPrompts)
 
 export const getConfigFromAnswers = (answers: inquirer.Answers): any => {
-    const config = { ... DEFAULT_CONFIG, plugins: { ... DEFAULT_CONFIG.plugins } }
+    const config = { ... CONFIG_TEMPLATE, plugins: { ... CONFIG_TEMPLATE.plugins } }
 
     const pluginNames = Object.values(PLUGIN_NAMES)
     pluginNames.forEach((pluginName) => {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -48,7 +48,7 @@ const logger = {
     }
 }
 
-function generateApiKey(){
+const generateApiKey = ():string => {
     const hex = uuid().split('-').join('')
     return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
 }
@@ -257,7 +257,7 @@ export const createStorageFile = (config: any, answers: inquirer.Answers): strin
     return answers.selectDestinationPath
 }
 
-export async function startBrokerConfigWizard(): Promise<void> {
+export const startBrokerConfigWizard = async(): Promise<void> => {
     try {
         const answers = await inquirer.prompt(prompts)
         const config = getConfigFromAnswers(answers)

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -91,10 +91,10 @@ describe('ConfigWizard', () => {
             tmpDataDir = mkdtempSync(path.join(os.tmpdir(), 'broker-test-config-wizard'))
         })
 
-        it ('happy path; create parent dir when doesn\'t exist', () => {
+        it ('happy path; create parent dir when doesn\'t exist', async () => {
             const parentDirPath = tmpDataDir + '/newdir/'
             const selectDestinationPath = parentDirPath + 'test-config.json'
-            const configFileLocation: string = createStorageFile(CONFIG, {
+            const configFileLocation: string = await createStorageFile(CONFIG, {
                 selectDestinationPath,
                 parentDirPath,
                 fileExists: false,
@@ -104,23 +104,23 @@ describe('ConfigWizard', () => {
             expect(existsSync(configFileLocation)).toBe(true)
         })
 
-        it ('should throw when attempting to mkdir on existing path', () => {
+        it ('should throw when attempting to mkdir on existing path', async () => {
             const parentDirPath = '/home/'
-            expect(createStorageFile(CONFIG, {
+            await expect(createStorageFile(CONFIG, {
                 parentDirPath,
                 parentDirExists: false,
-            })).toThrow()
+            })).rejects.toThrow()
         })
 
-        it ('should throw when no permissions on path', () => {
+        it ('should throw when no permissions on path', async () => {
             const parentDirPath = '/home/'
             const selectDestinationPath = parentDirPath + 'test-config.json'
-            expect(createStorageFile(CONFIG, {
+            await expect(createStorageFile(CONFIG, {
                 selectDestinationPath,
                 parentDirPath,
                 fileExists: false,
                 parentDirExists: true,
-            })).toThrow()
+            })).rejects.toThrow()
         })
 
     })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -111,9 +111,8 @@ describe('ConfigWizard', () => {
                     parentDirPath,
                     parentDirExists: false,
                 })
-            } catch(e){
-                expect(e.code).toBe('EEXIST')
-                expect(e.syscall).toBe('mkdir')
+            } catch(e) {
+                expect(e).not.toBeUndefined()
             }
         })
 
@@ -127,9 +126,8 @@ describe('ConfigWizard', () => {
                     fileExists: false,
                     parentDirExists: true,
                 })
-            } catch(e){
-                expect(e.code).toBe('EACCES')
-                expect(e.syscall).toBe('open')
+            } catch (e) {
+                expect(e).not.toBeUndefined()
             }
         })
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -105,30 +105,22 @@ describe('ConfigWizard', () => {
         })
 
         it ('should throw when attempting to mkdir on existing path', () => {
-            try {
-                const parentDirPath = '/home/'
-                createStorageFile(CONFIG, {
-                    parentDirPath,
-                    parentDirExists: false,
-                })
-            } catch(e) {
-                expect(e).not.toBeUndefined()
-            }
+            const parentDirPath = '/home/'
+            expect(createStorageFile(CONFIG, {
+                parentDirPath,
+                parentDirExists: false,
+            })).toThrow()
         })
 
         it ('should throw when no permissions on path', () => {
-            try {
-                const parentDirPath = '/home/'
-                const selectDestinationPath = parentDirPath + 'test-config.json'
-                createStorageFile(CONFIG, {
-                    selectDestinationPath,
-                    parentDirPath,
-                    fileExists: false,
-                    parentDirExists: true,
-                })
-            } catch (e) {
-                expect(e).not.toBeUndefined()
-            }
+            const parentDirPath = '/home/'
+            const selectDestinationPath = parentDirPath + 'test-config.json'
+            expect(createStorageFile(CONFIG, {
+                selectDestinationPath,
+                parentDirPath,
+                fileExists: false,
+                parentDirExists: true,
+            })).toThrow()
         })
 
     })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -180,6 +180,9 @@ describe('ConfigWizard', () => {
             expect(config.plugins.publishHttp).toMatchObject({})
             expect(config.ethereumPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
             expect(config.httpServer).toBe(undefined)
+            expect(config.apiAuthentication).toBeDefined()
+            expect(config.apiAuthentication.keys).toBeDefined()
+            expect(config.apiAuthentication.keys.length).toBe(1)
         })
 
         it('should exercise the happy path with user input', () => {


### PR DESCRIPTION
Added `apiAuthentication` field with the following structure to the DEFAULT_CONFIG:
```typescript
"apiAuthentication": {
    "keys": [
      "MTEzNzFkMDQ4Mjg3NDhlNTk4M2FhMGFhOGNhMDI1MjQ"
    ]
  },
```

The value of the keys comes from the `generateApiKey` method, an alphanumeric string encoded in base64:
```typescript
function generateApiKey(){
    const hex = uuid().split('-').join('')
    return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
}
```

___ 

Modified tests to be system-agnostic, as the `fs` error codes for Ubuntu and Mac are not the same, and the error code irrelevant for our testing purposes:
```typescript
// before
 } catch(e){
    expect(e.code).toBe('EEXIST')
    expect(e.syscall).toBe('mkdir')
// now
} catch(e) {
    expect(e).not.toBeUndefined()
}
```