### PR TITLE
NET-429: Fix broker's startup logging message

### DIFF
--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -154,7 +154,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
 
             logger.info(`Network node '${networkNodeName}' (id=${nodeId}) running`)
             logger.info(`Ethereum address ${brokerAddress}`)
-            logger.info(`Configured with trackers: ${trackers.join(', ')}`)
+            logger.info(`Configured with trackers: [${trackers.map((tracker) => tracker.http).join(', ')}]`)
             logger.info(`Configured with Streamr: ${config.streamrUrl}`)
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
         },


### PR DESCRIPTION
Replace current uninformative log:
```
Configured with trackers: [object Object]
```

Instead, display the `http` access point for each tracker, as it used to:
```
Configured with trackers: [https://testnet1.streamr.network:30300]
```
