### PR TITLE
NET-437: Broker's config wizard UX/UI polishing

### DIFF
--- a/packages/broker/bin/config-wizard.js
+++ b/packages/broker/bin/config-wizard.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const startBrokerConfigWizard = require('../dist/src/ConfigWizard').startBrokerConfigWizard
+const startBrokerConfigWizard = require('../dist/src/ConfigWizard').start
 
 const program = require('commander')
 

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -149,11 +149,10 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
         choices: Object.values(PLUGIN_NAMES)
     }
 
-    const MIN_PORT_VALUE = 1024
-    const MAX_PORT_VALUE = 49151
-
     const portPrompts: Array<inquirer.Question> = Object.keys(PLUGIN_DEFAULT_PORTS).map((name) => {
         const defaultPort = PLUGIN_DEFAULT_PORTS[name]
+        const MIN_PORT_VALUE = 1024
+        const MAX_PORT_VALUE = 49151
         return {
             type: 'input',
             name: `${name}Port`,

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -282,8 +282,7 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         if (privateKeyAnswers.revealGeneratedPrivateKey) {
             logger.info(`This is your node\'s private key: ${privateKey}`)
         }
-        const pluginPrompts = createPluginPrompts()
-        const pluginsAnswers = await inquirer.prompt(pluginPrompts)
+        const pluginsAnswers = await inquirer.prompt(createPluginPrompts())
         const config = getConfig(privateKey, pluginsAnswers)
         const storageAnswers = await selectStoragePath()
         const destinationPath = await createStorageFile(config, storageAnswers)

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -138,8 +138,9 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
         choices: Object.values(PLUGIN_NAMES)
     }
 
-    const portPrompts: Array<inquirer.Question> = Object.keys(DEFAULT_CONFIG_PORTS).map((name) => {
-        const defaultPort = DEFAULT_CONFIG_PORTS[name]
+    const portPrompts: Array<inquirer.Question> = Object.keys(DEFAULT_CONFIG_PORTS).map((key) => {
+        const name = PLUGIN_NAMES[key]
+        const defaultPort = DEFAULT_CONFIG_PORTS[key]
         return {
             type: 'input',
             name: `${name}Port`,

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -12,6 +12,17 @@ import * as MqttConfigSchema from './plugins/mqtt/config.schema.json'
 import * as BrokerConfigSchema from './helpers/config.schema.json'
 import * as LegacyWebsocketConfigSchema from './plugins/legacyWebsocket/config.schema.json'
 
+const createLogger = () => {
+    return {
+        info: (...args: any[]) => {
+            console.log(chalk.bgWhite.black(':'), ...args)
+        },
+        error: (...args: any[]) => {
+            console.error(chalk.bgRed.black('!'), ...args)
+        }
+    }
+}
+
 const generateApiKey = (): string => {
     const hex = uuid().split('-').join('')
     return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
@@ -259,17 +270,7 @@ export const start = async (
     getPrivateKeyAnswers = () => inquirer.prompt(PRIVATE_KEY_PROMPTS),
     getPluginAnswers = () => inquirer.prompt(createPluginPrompts()),
     getStorageAnswers = selectStoragePath,
-    logger = {
-        info: (...args: any[]) => {
-            console.log(chalk.bgWhite.black(':'), ...args)
-        },
-        warn: (...args: any[]) => {
-            console.warn(chalk.bgYellow.black('!'), ...args)
-        },
-        error: (...args: any[]) => {
-            console.error(chalk.bgRed.black('!'), ...args)
-        }
-    }
+    logger = createLogger()
 ): Promise<void> => {
     try {
         const privateKeyAnswers = await getPrivateKeyAnswers()
@@ -289,7 +290,6 @@ export const start = async (
         logger.info('You can start the broker now with')
         logger.info(`streamr-broker ${storagePath}`)
     } catch (e: any) {
-        logger.warn('Broker Config Wizard encountered an error:')
-        logger.error(e.message)
+        logger.error('Broker Config Wizard encountered an error:' + e.message)
     }
 }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -290,6 +290,6 @@ export const start = async (
         logger.info('You can start the broker now with')
         logger.info(`streamr-broker ${storagePath}`)
     } catch (e: any) {
-        logger.error('Broker Config Wizard encountered an error:' + e.message)
+        logger.error("Broker Config Wizard encountered an error:\n" + e.message)
     }
 }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -261,15 +261,12 @@ export const start = async (
     getStorageAnswers = selectStoragePath,
     logger = {
         info: (...args: any[]) => {
-            // eslint-disable-next-line no-console
             console.log(chalk.bgWhite.black(':'), ...args)
         },
         warn: (...args: any[]) => {
-            // eslint-disable-next-line no-console
             console.warn(chalk.bgYellow.black('!'), ...args)
         },
         error: (...args: any[]) => {
-            // eslint-disable-next-line no-console
             console.error(chalk.bgRed.black('!'), ...args)
         }
     }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -275,7 +275,7 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         const pluginPrompts = createPluginPrompts()
         const pluginsAnswers = await inquirer.prompt(pluginPrompts)
         const config = getConfigFromAnswers(privateKey, pluginsAnswers)
-        const nodeAddress = new Wallet(config.privateKey).address
+        const nodeAddress = new Wallet(privateKey).address
         const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
         const storageAnswers = await selectValidDestinationPath()
         const destinationPath = await createStorageFile(config, storageAnswers)

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -93,7 +93,7 @@ export const CONFIG_TEMPLATE: any = {
     }
 }
 
-const privateKeyPrompts: Array<inquirer.Question | inquirer.ListQuestion | inquirer.CheckboxQuestion> = [
+const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inquirer.CheckboxQuestion> = [
     {
         type: 'list',
         name:'generateOrImportPrivateKey',
@@ -279,7 +279,7 @@ export const getNodeIdentity = (privateKey: string) => {
 
 export const start = async(): Promise<void> => {
     try {
-        const privateKeyAnswers = await inquirer.prompt(privateKeyPrompts)
+        const privateKeyAnswers = await inquirer.prompt(PRIVATE_KEY_PROMPTS)
         const privateKey = getPrivateKey(privateKeyAnswers)
         if (privateKeyAnswers.revealGeneratedPrivateKey) {
             logger.info(`This is your node\'s private key: ${privateKey}`)
@@ -302,6 +302,6 @@ export const start = async(): Promise<void> => {
 }
 
 export const PROMPTS = {
-    privateKey: privateKeyPrompts,
+    privateKey: PRIVATE_KEY_PROMPTS,
     plugins: createPluginPrompts(),
 }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -285,21 +285,21 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         const pluginsAnswers = await inquirer.prompt(createPluginPrompts())
         const config = getConfig(privateKey, pluginsAnswers)
         const storageAnswers = await selectStoragePath()
-        const destinationPath = await createStorageFile(config, storageAnswers)
+        const storagePath = await createStorageFile(config, storageAnswers)
         logger.info('Welcome to the Streamr Network')
         const {mnemonic, networkExplorerUrl} = getNodeIdentity(config)
         logger.info(`Your node's generated name is ${mnemonic}.`)
         logger.info('View your node in the Network Explorer:')
         logger.info(networkExplorerUrl)
         logger.info('You can start the broker now with')
-        logger.info(`streamr-broker ${destinationPath}`)
+        logger.info(`streamr-broker ${storagePath}`)
     } catch (e) {
         logger.warn('Broker Config Wizard encountered an error:')
         logger.error(e.message)
     }
 }
 
-export const CONFIG_WIZARD_PROMPTS = {
+export const PROMPTS = {
     privateKey: privateKeyPrompts,
     plugins: createPluginPrompts(),
 }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -282,7 +282,7 @@ export const start = async(): Promise<void> => {
         const storageAnswers = await selectStoragePath()
         const storagePath = await createStorageFile(config, storageAnswers)
         logger.info('Welcome to the Streamr Network')
-        const {mnemonic, networkExplorerUrl} = getNodeIdentity(config)
+        const {mnemonic, networkExplorerUrl} = getNodeIdentity(privateKey)
         logger.info(`Your node's generated name is ${mnemonic}.`)
         logger.info('View your node in the Network Explorer:')
         logger.info(networkExplorerUrl)

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -228,7 +228,7 @@ const selectStoragePath = async (): Promise<inquirer.Answers> => {
 }
 
 export const getPrivateKey = (answers: inquirer.Answers): string => {
-    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT && answers.importPrivateKey) ? answers.importPrivateKey : Wallet.createRandom().privateKey
+    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT) ? answers.importPrivateKey : Wallet.createRandom().privateKey
 }
 
 export const getConfig = (privateKey: string, pluginsAnswers: inquirer.Answers): any => {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -161,7 +161,7 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
         return {
             type: 'input',
             name: `${name}Port`,
-            message: `Select a port for the ${name} Plugin [Enter for default: ${defaultPort}]`,
+            message: `Provide a port for the ${name} Plugin [Enter for default: ${defaultPort}]`,
             when: (answers: inquirer.Answers) => {
                 return answers.selectPlugins.includes(name)
             },

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -12,7 +12,6 @@ import * as MqttConfigSchema from './plugins/mqtt/config.schema.json'
 import * as BrokerConfigSchema from './helpers/config.schema.json'
 import * as LegacyWebsocketConfigSchema from './plugins/legacyWebsocket/config.schema.json'
 
-
 const logger = {
     info: (...args: any[]) => {
         // eslint-disable-next-line no-console
@@ -130,7 +129,6 @@ const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inq
     }
 ]
 
-
 const PLUGIN_DEFAULT_PORTS: {[pluginName: string]: number} = {
     websocket: DEFAULT_WS_PORT,
     mqtt: DEFAULT_MQTT_PORT,
@@ -184,7 +182,6 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
 
     return [selectPrompt, ...portPrompts]
 }
-
 
 export const selectStoragePathPrompt = {
     type: 'input',

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -265,8 +265,8 @@ export const createStorageFile = async (config: any, answers: inquirer.Answers):
     return answers.selectStoragePath
 }
 
-export const getNodeIdentity = (config: any) => {
-    const nodeAddress = new Wallet(config.ethereumPrivateKey).address
+export const getNodeIdentity = (privateKey: string) => {
+    const nodeAddress = new Wallet(privateKey).address
     const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
     const networkExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`
     return {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -275,7 +275,7 @@ export const getNodeIdentity = (config: any) => {
     }
 }
 
-export const startBrokerConfigWizard = async(): Promise<void> => {
+export const start = async(): Promise<void> => {
     try {
         const privateKeyAnswers = await inquirer.prompt(privateKeyPrompts)
         const privateKey = getPrivateKey(privateKeyAnswers)

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -268,10 +268,10 @@ export const createStorageFile = async (config: any, answers: inquirer.Answers):
 export const generateMiscFromConfig = (config: any) => {
     const nodeAddress = new Wallet(config.ethereumPrivateKey).address
     const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
-    const nodeExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`
+    const networkExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`
     return {
         mnemonic,
-        nodeExplorerUrl
+        networkExplorerUrl
     }
 }
 
@@ -288,10 +288,10 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         const storageAnswers = await selectValidDestinationPath()
         const destinationPath = await createStorageFile(config, storageAnswers)
         logger.info('Welcome to the Streamr Network')
-        const {mnemonic, nodeExplorerUrl} = generateMiscFromConfig(config)
+        const {mnemonic, networkExplorerUrl} = generateMiscFromConfig(config)
         logger.info(`Your node's generated name is ${mnemonic}.`)
         logger.info('View your node in the Network Explorer:')
-        logger.info(nodeExplorerUrl)
+        logger.info(networkExplorerUrl)
         logger.info('You can start the broker now with')
         logger.info(`streamr-broker ${destinationPath}`)
     } catch (e) {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -24,8 +24,7 @@ export const DEFAULT_CONFIG_PORTS = {
     LEGACY_WS: DEFAULT_LEGACY_WS_PORT
 }
 
-const MIN_PORT_VALUE = 1024
-const MAX_PORT_VALUE = 49151
+
 
 const PRIVATE_KEY_SOURCE_GENERATE = 'Generate'
 const PRIVATE_KEY_SOURCE_IMPORT = 'Import'
@@ -155,6 +154,9 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
         message: 'Select the plugins to enable',
         choices: Object.values(PLUGIN_NAMES)
     }
+
+    const MIN_PORT_VALUE = 1024
+    const MAX_PORT_VALUE = 49151
 
     const portPrompts: Array<inquirer.Question> = Object.keys(PLUGIN_DEFAULT_PORTS).map((name) => {
         const defaultPort = PLUGIN_DEFAULT_PORTS[name]

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -107,11 +107,7 @@ const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inq
                 new Wallet(input)
                 return true
             } catch (e: any) {
-                if (e.message.includes('invalid hexlify value')){
-                    return `Invalid privateKey provided for import: ${input}`
-                } else {
-                    return e.message
-                }
+                return 'Invalid private key provided.'
             }
         }
     },

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -32,16 +32,11 @@ const generateApiKey = (): string => {
     return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
 }
 
-const DEFAULT_WS_PORT = WebsocketConfigSchema.properties.port.default
-const DEFAULT_MQTT_PORT = MqttConfigSchema.properties.port.default
-const DEFAULT_HTTP_PORT = BrokerConfigSchema.properties.httpServer.properties.port.default
-const DEFAULT_LEGACY_WS_PORT = LegacyWebsocketConfigSchema.properties.port.default
-
 export const DEFAULT_CONFIG_PORTS = {
-    WS: DEFAULT_WS_PORT,
-    MQTT: DEFAULT_MQTT_PORT,
-    HTTP: DEFAULT_HTTP_PORT,
-    LEGACY_WS: DEFAULT_LEGACY_WS_PORT
+    WS: WebsocketConfigSchema.properties.port.default,
+    MQTT: MqttConfigSchema.properties.port.default,
+    HTTP: BrokerConfigSchema.properties.httpServer.properties.port.default,
+    LEGACY_WS: LegacyWebsocketConfigSchema.properties.port.default,
 }
 
 const PRIVATE_KEY_SOURCE_GENERATE = 'Generate'
@@ -80,7 +75,7 @@ export const CONFIG_TEMPLATE: any = {
             nodeMetrics: {
                 storageNode: "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916",
                 client: {
-                    wsUrl: `ws://127.0.0.1:${DEFAULT_LEGACY_WS_PORT}/api/v1/ws`,
+                    wsUrl: `ws://127.0.0.1:${DEFAULT_CONFIG_PORTS.LEGACY_WS}/api/v1/ws`,
                     httpUrl: "https://streamr.network/api/v1",
                 }
             }
@@ -130,9 +125,9 @@ const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inq
 ]
 
 const PLUGIN_DEFAULT_PORTS: {[pluginName: string]: number} = {
-    websocket: DEFAULT_WS_PORT,
-    mqtt: DEFAULT_MQTT_PORT,
-    publishHttp: DEFAULT_HTTP_PORT
+    websocket: DEFAULT_CONFIG_PORTS.WS,
+    mqtt: DEFAULT_CONFIG_PORTS.MQTT,
+    publishHttp: DEFAULT_CONFIG_PORTS.HTTP,
 }
 
 const PLUGIN_NAMES: {[pluginName: string]: string} = {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -133,7 +133,7 @@ const privateKeyPrompts: Array<inquirer.Question | inquirer.ListQuestion | inqui
 ]
 
 export const getPrivateKey = (answers: inquirer.Answers): string => {
-    return (answers.importPrivateKey) ? answers.importPrivateKey : Wallet.createRandom().privateKey
+    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT && answers.importPrivateKey) ? answers.importPrivateKey : Wallet.createRandom().privateKey
 }
 
 const PLUGIN_DEFAULT_PORTS: {[pluginName: string]: number} = {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -132,7 +132,7 @@ const privateKeyPrompts: Array<inquirer.Question | inquirer.ListQuestion | inqui
     }
 ]
 
-export const getPrivateKeyFromAnswers = (answers: inquirer.Answers): string => {
+export const getPrivateKey = (answers: inquirer.Answers): string => {
     return (answers.importPrivateKey) ? answers.importPrivateKey : Wallet.createRandom().privateKey
 }
 
@@ -187,7 +187,7 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
     return [selectPluginsPrompt, ...pluginPortPrompts]
 }
 
-export const getConfigFromAnswers = (privateKey: string, pluginsAnswers: inquirer.Answers): any => {
+export const getConfig = (privateKey: string, pluginsAnswers: inquirer.Answers): any => {
     const config = { ... CONFIG_TEMPLATE, plugins: { ... CONFIG_TEMPLATE.plugins } }
     config.ethereumPrivateKey = privateKey
 
@@ -234,7 +234,7 @@ export const selectDestinationPathPrompt = {
     }
 }
 
-const selectValidDestinationPath = async (): Promise<inquirer.Answers> => {
+const selectStoragePath = async (): Promise<inquirer.Answers> => {
     const answers = await inquirer.prompt([selectDestinationPathPrompt])
 
     if (answers.fileExists) {
@@ -248,7 +248,7 @@ const selectValidDestinationPath = async (): Promise<inquirer.Answers> => {
         ])
 
         if (!overwriteAnswers.confirmOverwrite) {
-            return selectValidDestinationPath()
+            return selectStoragePath()
         }
     }
 
@@ -265,7 +265,7 @@ export const createStorageFile = async (config: any, answers: inquirer.Answers):
     return answers.selectDestinationPath
 }
 
-export const generateMiscFromConfig = (config: any) => {
+export const getNodeIdentity = (config: any) => {
     const nodeAddress = new Wallet(config.ethereumPrivateKey).address
     const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
     const networkExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`
@@ -278,17 +278,17 @@ export const generateMiscFromConfig = (config: any) => {
 export const startBrokerConfigWizard = async(): Promise<void> => {
     try {
         const privateKeyAnswers = await inquirer.prompt(privateKeyPrompts)
-        const privateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
+        const privateKey = getPrivateKey(privateKeyAnswers)
         if (privateKeyAnswers.revealGeneratedPrivateKey) {
             logger.info(`This is your node\'s private key: ${privateKey}`)
         }
         const pluginPrompts = createPluginPrompts()
         const pluginsAnswers = await inquirer.prompt(pluginPrompts)
-        const config = getConfigFromAnswers(privateKey, pluginsAnswers)
-        const storageAnswers = await selectValidDestinationPath()
+        const config = getConfig(privateKey, pluginsAnswers)
+        const storageAnswers = await selectStoragePath()
         const destinationPath = await createStorageFile(config, storageAnswers)
         logger.info('Welcome to the Streamr Network')
-        const {mnemonic, networkExplorerUrl} = generateMiscFromConfig(config)
+        const {mnemonic, networkExplorerUrl} = getNodeIdentity(config)
         logger.info(`Your node's generated name is ${mnemonic}.`)
         logger.info('View your node in the Network Explorer:')
         logger.info(networkExplorerUrl)

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -32,12 +32,15 @@ const PRIVATE_KEY_SOURCE_IMPORT = 'Import'
 
 const logger = {
     info: (...args: any[]) => {
+        // eslint-disable-next-line no-console
         console.log(chalk.bgWhite.black(':'), ...args)
     },
     warn: (...args: any[]) => {
+        // eslint-disable-next-line no-console
         console.warn(chalk.bgYellow.black('!'), ...args)
     },
     error: (...args: any[]) => {
+        // eslint-disable-next-line no-console
         console.error(chalk.bgRed.black('!'), ...args)
     }
 }
@@ -168,8 +171,8 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
 const revealGeneratedPrivateKeyPrompt = {
     type: 'confirm',
     name: 'revealGeneratedPrivateKey',
-    message: 'We strongly recommend backing up your private key. It will be written into the config file, but would you also like to see it on screen now?',
-    default: true,
+    message: 'We strongly recommend backing up your private key. It will be written into the config file, but would you also like to see this sensitive information on screen now?',
+    default: false,
     when: (answers: inquirer.Answers) => {
         return answers.generateOrImportEthereumPrivateKey === PRIVATE_KEY_SOURCE_GENERATE
     }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -140,8 +140,6 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
 
     const portPrompts: Array<inquirer.Question> = Object.keys(DEFAULT_CONFIG_PORTS).map((name) => {
         const defaultPort = DEFAULT_CONFIG_PORTS[name]
-        const MIN_PORT_VALUE = 1024
-        const MAX_PORT_VALUE = 49151
         return {
             type: 'input',
             name: `${name}Port`,
@@ -150,6 +148,8 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
                 return answers.selectPlugins.includes(name)
             },
             validate: (input: string | number): string | boolean => {
+                const MIN_PORT_VALUE = 1024
+                const MAX_PORT_VALUE = 49151
                 const portNumber = (typeof input === 'string') ? Number(input) : input
                 if (Number.isNaN(portNumber)) {
                     return `Non-numeric value provided`

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -265,6 +265,16 @@ export const createStorageFile = async (config: any, answers: inquirer.Answers):
     return answers.selectDestinationPath
 }
 
+export const generateMiscFromConfig = (config: any) => {
+    const nodeAddress = new Wallet(config.ethereumPrivateKey).address
+    const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
+    const nodeExplorerUrl = `https://streamr.network/network-explorer/nodes/${nodeAddress}`
+    return {
+        mnemonic,
+        nodeExplorerUrl
+    }
+}
+
 export const startBrokerConfigWizard = async(): Promise<void> => {
     try {
         const privateKeyAnswers = await inquirer.prompt(privateKeyPrompts)
@@ -275,14 +285,13 @@ export const startBrokerConfigWizard = async(): Promise<void> => {
         const pluginPrompts = createPluginPrompts()
         const pluginsAnswers = await inquirer.prompt(pluginPrompts)
         const config = getConfigFromAnswers(privateKey, pluginsAnswers)
-        const nodeAddress = new Wallet(privateKey).address
-        const mnemonic = Protocol.generateMnemonicFromAddress(nodeAddress)
         const storageAnswers = await selectValidDestinationPath()
         const destinationPath = await createStorageFile(config, storageAnswers)
         logger.info('Welcome to the Streamr Network')
+        const {mnemonic, nodeExplorerUrl} = generateMiscFromConfig(config)
         logger.info(`Your node's generated name is ${mnemonic}.`)
         logger.info('View your node in the Network Explorer:')
-        logger.info(`https://streamr.network/network-explorer/nodes/${nodeAddress}`)
+        logger.info(nodeExplorerUrl)
         logger.info('You can start the broker now with')
         logger.info(`streamr-broker ${destinationPath}`)
     } catch (e) {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { writeFileSync, mkdtempSync, existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers, getEthereumPrivateKeyFromAnswers } from '../../src/ConfigWizard'
+import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers, getPrivateKeyFromAnswers } from '../../src/ConfigWizard'
 
 const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const numericPort = (typeof port === 'string') ? parseInt(port) : port
@@ -13,13 +13,13 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
         selectPlugins:[pluginName],
         websocketPort: port,
     }
-    const ethereumPrivateKey = getEthereumPrivateKeyFromAnswers(privateKeyAnswers)
+    const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
     const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
     expect(config.plugins[pluginName].port).toBe(numericPort)
 }
 
 describe('ConfigWizard', () => {
-    const importPrivateKeyPrompt = CONFIG_WIZARD_PROMPTS.ethereum[1]
+    const importPrivateKeyPrompt = CONFIG_WIZARD_PROMPTS.privateKey[1]
     const portPrompt = CONFIG_WIZARD_PROMPTS.plugins[1]
 
     describe('importPrivateKey validate', () => {
@@ -156,7 +156,7 @@ describe('ConfigWizard', () => {
                 generateOrImportEthereumPrivateKey: 'Generate',
             }
 
-            const ethereumPrivateKey = getEthereumPrivateKeyFromAnswers(answers)
+            const ethereumPrivateKey = getPrivateKeyFromAnswers(answers)
             expect(ethereumPrivateKey).toBeDefined()
             expect(ethereumPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
         })
@@ -167,7 +167,7 @@ describe('ConfigWizard', () => {
                 generateOrImportEthereumPrivateKey: 'Import',
                 importPrivateKey: privateKey,
             }
-            const ethereumPrivateKey = getEthereumPrivateKeyFromAnswers(answers)
+            const ethereumPrivateKey = getPrivateKeyFromAnswers(answers)
             expect(ethereumPrivateKey).toBe(privateKey)
         })
 
@@ -186,14 +186,13 @@ describe('ConfigWizard', () => {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 revealGeneratedPrivateKey: false
             }
-
             const pluginsAnswers = {
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT,
                 mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
                 publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT,
             }
-            const ethereumPrivateKey = getEthereumPrivateKeyFromAnswers(privateKeyAnswers)
+            const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
             const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
             expect(config.plugins.websocket).toMatchObject({})
             expect(config.plugins.mqtt).toMatchObject({})
@@ -218,7 +217,7 @@ describe('ConfigWizard', () => {
                 mqttPort: '3171',
                 publishHttpPort: '3172'
             }
-            const ethereumPrivateKey = getEthereumPrivateKeyFromAnswers(privateKeyAnswers)
+            const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
             const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
             expect(config.plugins.websocket.port).toBe(parseInt(pluginsAnswers.websocketPort))
             expect(config.plugins.mqtt.port).toBe(parseInt(pluginsAnswers.mqttPort))

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -159,7 +159,7 @@ describe('ConfigWizard', () => {
         it ('should exercise the happy path with default answers', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
-                revealGeneratedPrivateKey: true,
+                revealGeneratedPrivateKey: false,
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT,
                 mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
@@ -180,7 +180,7 @@ describe('ConfigWizard', () => {
             const privateKey = Wallet.createRandom().privateKey
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Import',
-                revealGeneratedPrivateKey: false,
+                revealGeneratedPrivateKey: true,
                 importPrivateKey: privateKey,
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: 3170,

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -203,10 +203,9 @@ describe('ConfigWizard', () => {
         })
 
         it('should exercise the happy path with user input', () => {
-            const importPrivateKey = Wallet.createRandom().privateKey
             const privateKeyAnswers = {
                 generateOrImportPrivateKey: 'Import',
-                importPrivateKey
+                importPrivateKey: Wallet.createRandom().privateKey
             }
             const pluginsAnswers = {
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
@@ -216,7 +215,7 @@ describe('ConfigWizard', () => {
             }
             const privateKey = getPrivateKey(privateKeyAnswers)
             const config = getConfig(privateKey, pluginsAnswers)
-            expect(config.ethereumPrivateKey).toBe(importPrivateKey)
+            expect(config.ethereumPrivateKey).toBe(privateKeyAnswers.importPrivateKey)
             expect(config.plugins.websocket.port).toBe(parseInt(pluginsAnswers.websocketPort))
             expect(config.plugins.mqtt.port).toBe(parseInt(pluginsAnswers.mqttPort))
             expect(config.httpServer.port).toBe(parseInt(pluginsAnswers.publishHttpPort))

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -21,7 +21,7 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
 const assertValidMisc = (config: any) => {
     const misc = generateMiscFromConfig(config)
     expect(misc.mnemonic).toBeDefined()
-    expect(misc.nodeExplorerUrl).toBeDefined()
+    expect(misc.networkExplorerUrl).toBeDefined()
 }
 
 describe('ConfigWizard', () => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { writeFileSync, mkdtempSync, existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers, getPrivateKeyFromAnswers, generateMiscFromConfig } from '../../src/ConfigWizard'
+import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfig, getPrivateKey, getNodeIdentity } from '../../src/ConfigWizard'
 
 const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const numericPort = (typeof port === 'string') ? parseInt(port) : port
@@ -13,13 +13,13 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
         selectPlugins:[pluginName],
         websocketPort: port,
     }
-    const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
-    const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
+    const ethereumPrivateKey = getPrivateKey(privateKeyAnswers)
+    const config = getConfig(ethereumPrivateKey, pluginsAnswers)
     expect(config.plugins[pluginName].port).toBe(numericPort)
 }
 
 const assertValidMisc = (config: any) => {
-    const misc = generateMiscFromConfig(config)
+    const misc = getNodeIdentity(config)
     expect(misc.mnemonic).toBeDefined()
     expect(misc.networkExplorerUrl).toBeDefined()
 }
@@ -156,13 +156,13 @@ describe('ConfigWizard', () => {
 
     })
 
-    describe('getEthereumConfigFromAnswers', () => {
+    describe('getEthereumConfig', () => {
         it ('should exercise the `generate` path', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
             }
 
-            const ethereumPrivateKey = getPrivateKeyFromAnswers(answers)
+            const ethereumPrivateKey = getPrivateKey(answers)
             expect(ethereumPrivateKey).toBeDefined()
             expect(ethereumPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
         })
@@ -173,7 +173,7 @@ describe('ConfigWizard', () => {
                 generateOrImportEthereumPrivateKey: 'Import',
                 importPrivateKey: privateKey,
             }
-            const ethereumPrivateKey = getPrivateKeyFromAnswers(answers)
+            const ethereumPrivateKey = getPrivateKey(answers)
             expect(ethereumPrivateKey).toBe(privateKey)
         })
 
@@ -198,8 +198,8 @@ describe('ConfigWizard', () => {
                 mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
                 publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT,
             }
-            const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
-            const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
+            const ethereumPrivateKey = getPrivateKey(privateKeyAnswers)
+            const config = getConfig(ethereumPrivateKey, pluginsAnswers)
             expect(config.plugins.websocket).toMatchObject({})
             expect(config.plugins.mqtt).toMatchObject({})
             expect(config.plugins.publishHttp).toMatchObject({})
@@ -224,8 +224,8 @@ describe('ConfigWizard', () => {
                 mqttPort: '3171',
                 publishHttpPort: '3172'
             }
-            const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
-            const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
+            const ethereumPrivateKey = getPrivateKey(privateKeyAnswers)
+            const config = getConfig(ethereumPrivateKey, pluginsAnswers)
             expect(config.plugins.websocket.port).toBe(parseInt(pluginsAnswers.websocketPort))
             expect(config.plugins.mqtt.port).toBe(parseInt(pluginsAnswers.mqttPort))
             expect(config.httpServer.port).toBe(parseInt(pluginsAnswers.publishHttpPort))

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -6,14 +6,11 @@ import { PROMPTS, DEFAULT_CONFIG_PORTS, selectStoragePathPrompt, createStorageFi
 
 const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const numericPort = (typeof port === 'string') ? parseInt(port) : port
-    const privateKeyAnswers = {
-        generateOrImportPrivateKey: 'Generate',
-    }
     const pluginsAnswers = {
         selectPlugins:[pluginName],
         websocketPort: port,
     }
-    const privateKey = getPrivateKey(privateKeyAnswers)
+    const privateKey = getPrivateKey({})
     const config = getConfig(privateKey, pluginsAnswers)
     expect(config.plugins[pluginName].port).toBe(numericPort)
 }
@@ -125,7 +122,6 @@ describe('ConfigWizard', () => {
                 fileExists: false,
                 parentDirExists: false,
             })
-            console.log(configFileLocation)
             expect(configFileLocation).toBe(selectStoragePath)
             expect(existsSync(configFileLocation)).toBe(true)
         })
@@ -153,11 +149,7 @@ describe('ConfigWizard', () => {
 
     describe('getEthereumConfig', () => {
         it ('should exercise the `generate` path', () => {
-            const answers = {
-                generateOrImportPrivateKey: 'Generate',
-            }
-
-            const privateKey = getPrivateKey(answers)
+            const privateKey = getPrivateKey({})
             expect(privateKey).toBeDefined()
             expect(privateKey).toMatch(/^0x[0-9a-f]{64}$/)
         })
@@ -192,10 +184,7 @@ describe('ConfigWizard', () => {
 
     describe('end-to-end', () => {
         it ('should exercise the happy path with default answers', () => {
-            const privateKeyAnswers = {
-                generateOrImportPrivateKey: 'Generate',
-                revealGeneratedPrivateKey: false
-            }
+            const privateKeyAnswers = {}
             const pluginsAnswers = {
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: DEFAULT_CONFIG_PORTS.WS,
@@ -218,7 +207,6 @@ describe('ConfigWizard', () => {
             const importPrivateKey = Wallet.createRandom().privateKey
             const privateKeyAnswers = {
                 generateOrImportPrivateKey: 'Import',
-                revealGeneratedPrivateKey: true,
                 importPrivateKey
             }
             const pluginsAnswers = {
@@ -229,11 +217,11 @@ describe('ConfigWizard', () => {
             }
             const privateKey = getPrivateKey(privateKeyAnswers)
             const config = getConfig(privateKey, pluginsAnswers)
+            expect(config.ethereumPrivateKey).toBe(importPrivateKey)
             expect(config.plugins.websocket.port).toBe(parseInt(pluginsAnswers.websocketPort))
             expect(config.plugins.mqtt.port).toBe(parseInt(pluginsAnswers.mqttPort))
             expect(config.httpServer.port).toBe(parseInt(pluginsAnswers.publishHttpPort))
             expect(config.plugins.publishHttp).toMatchObject({})
-            expect(config.ethereumPrivateKey).toBe(privateKey)
         })
     })
 })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -18,12 +18,6 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     expect(config.plugins[pluginName].port).toBe(numericPort)
 }
 
-const assertValidIdentity = (config: any) => {
-    const misc = getNodeIdentity(config)
-    expect(misc.mnemonic).toBeDefined()
-    expect(misc.networkExplorerUrl).toBeDefined()
-}
-
 describe('ConfigWizard', () => {
     const importPrivateKeyPrompt = PROMPTS.privateKey[1]
     const portPrompt = PROMPTS.plugins[1]
@@ -187,6 +181,15 @@ describe('ConfigWizard', () => {
         })
     })
 
+    describe('identity', () => {
+        it ('happy path', () => {
+            const privateKey = '0x9a2f3b058b9b457f9f954e62ea9fd2cefe2978736ffb3ef2c1782ccfad9c411d'
+            const identity = getNodeIdentity(privateKey)
+            expect(identity.mnemonic).toBe('Mountain Until Gun')
+            expect(identity.networkExplorerUrl).toBe('https://streamr.network/network-explorer/nodes/0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc')
+        })
+    })
+
     describe('end-to-end', () => {
         it ('should exercise the happy path with default answers', () => {
             const privateKeyAnswers = {
@@ -209,7 +212,6 @@ describe('ConfigWizard', () => {
             expect(config.apiAuthentication).toBeDefined()
             expect(config.apiAuthentication.keys).toBeDefined()
             expect(config.apiAuthentication.keys.length).toBe(1)
-            assertValidIdentity(config)
         })
 
         it('should exercise the happy path with user input', () => {
@@ -232,7 +234,6 @@ describe('ConfigWizard', () => {
             expect(config.httpServer.port).toBe(parseInt(pluginsAnswers.publishHttpPort))
             expect(config.plugins.publishHttp).toMatchObject({})
             expect(config.ethereumPrivateKey).toBe(privateKey)
-            assertValidIdentity(config)
         })
     })
 })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { writeFileSync, mkdtempSync, existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers, getPrivateKeyFromAnswers } from '../../src/ConfigWizard'
+import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers, getPrivateKeyFromAnswers, generateMiscFromConfig } from '../../src/ConfigWizard'
 
 const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const numericPort = (typeof port === 'string') ? parseInt(port) : port
@@ -16,6 +16,12 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const ethereumPrivateKey = getPrivateKeyFromAnswers(privateKeyAnswers)
     const config = getConfigFromAnswers(ethereumPrivateKey, pluginsAnswers)
     expect(config.plugins[pluginName].port).toBe(numericPort)
+}
+
+const assertValidMisc = (config: any) => {
+    const misc = generateMiscFromConfig(config)
+    expect(misc.mnemonic).toBeDefined()
+    expect(misc.nodeExplorerUrl).toBeDefined()
 }
 
 describe('ConfigWizard', () => {
@@ -202,6 +208,7 @@ describe('ConfigWizard', () => {
             expect(config.apiAuthentication).toBeDefined()
             expect(config.apiAuthentication.keys).toBeDefined()
             expect(config.apiAuthentication.keys.length).toBe(1)
+            assertValidMisc(config)
         })
 
         it('should exercise the happy path with user input', () => {
@@ -224,6 +231,7 @@ describe('ConfigWizard', () => {
             expect(config.httpServer.port).toBe(parseInt(pluginsAnswers.publishHttpPort))
             expect(config.plugins.publishHttp).toMatchObject({})
             expect(config.ethereumPrivateKey).toBe(privateKey)
+            assertValidMisc(config)
         })
     })
 })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -4,16 +4,6 @@ import os from 'os'
 import path from 'path'
 import { PROMPTS, DEFAULT_CONFIG_PORTS, selectStoragePathPrompt, createStorageFile, getConfig, getPrivateKey, getNodeIdentity } from '../../src/ConfigWizard'
 
-const assertValidPort = (port: number | string, pluginName = 'websocket') => {
-    const numericPort = (typeof port === 'string') ? parseInt(port) : port
-    const pluginsAnswers = {
-        selectPlugins:[pluginName],
-        websocketPort: port,
-    }
-    const config = getConfig(undefined as any, pluginsAnswers)
-    expect(config.plugins[pluginName].port).toBe(numericPort)
-}
-
 describe('ConfigWizard', () => {
     const importPrivateKeyPrompt = PROMPTS.privateKey[1]
     const portPrompt = PROMPTS.plugins[1]
@@ -166,6 +156,16 @@ describe('ConfigWizard', () => {
     })
 
     describe('getConfig', () => {
+        const assertValidPort = (port: number | string, pluginName = 'websocket') => {
+            const numericPort = (typeof port === 'string') ? parseInt(port) : port
+            const pluginsAnswers = {
+                selectPlugins:[pluginName],
+                websocketPort: port,
+            }
+            const config = getConfig(undefined as any, pluginsAnswers)
+            expect(config.plugins[pluginName].port).toBe(numericPort)
+        }
+
         it ('should exercise the plugin port assignation path with a number', () => {
             assertValidPort(3737)
         })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -159,6 +159,7 @@ describe('ConfigWizard', () => {
         it ('should exercise the happy path with default answers', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
+                revealGeneratedPrivateKey: true,
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT,
                 mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
@@ -179,6 +180,7 @@ describe('ConfigWizard', () => {
             const privateKey = Wallet.createRandom().privateKey
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Import',
+                revealGeneratedPrivateKey: false,
                 importPrivateKey: privateKey,
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
                 websocketPort: 3170,

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -115,14 +115,14 @@ describe('ConfigWizard', () => {
 
         it ('happy path; create parent dir when doesn\'t exist', async () => {
             const parentDirPath = tmpDataDir + '/newdir/'
-            const selectStoragePath = parentDirPath + 'test-config.json'
+            const configPath = parentDirPath + 'test-config.json'
             const configFileLocation: string = await createStorageFile(CONFIG, {
-                selectStoragePath,
+                selectStoragePath: configPath,
                 parentDirPath,
                 fileExists: false,
                 parentDirExists: false,
             })
-            expect(configFileLocation).toBe(selectStoragePath)
+            expect(configFileLocation).toBe(configPath)
             expect(existsSync(configFileLocation)).toBe(true)
         })
 
@@ -136,9 +136,9 @@ describe('ConfigWizard', () => {
 
         it ('should throw when no permissions on path', async () => {
             const parentDirPath = '/home/'
-            const selectStoragePath = parentDirPath + 'test-config.json'
+            const configPath = parentDirPath + 'test-config.json'
             await expect(createStorageFile(CONFIG, {
-                selectStoragePath,
+                selectStoragePath: configPath,
                 parentDirPath,
                 fileExists: false,
                 parentDirExists: true,
@@ -226,7 +226,7 @@ describe('ConfigWizard', () => {
     describe('user flow', () => {
         it ('should exercise the happy path', async () => {
             const tmpDataDir = mkdtempSync(path.join(os.tmpdir(), 'broker-test-config-wizard'))
-            const selectStoragePath = tmpDataDir + 'test-config.json'
+            const configPath = tmpDataDir + 'test-config.json'
             const privateKey = '0x1234567890123456789012345678901234567890123456789012345678901234'
             const websocketPort = '3170'
             const mqttPort = '3171'
@@ -245,7 +245,7 @@ describe('ConfigWizard', () => {
                 }),
                 jest.fn().mockResolvedValue({
                     parentDirExists: true,
-                    selectStoragePath
+                    selectStoragePath: configPath
                 }),
                 logger
             )
@@ -255,9 +255,9 @@ describe('ConfigWizard', () => {
                 'View your node in the Network Explorer:',
                 'https://streamr.network/network-explorer/nodes/0x2e988A386a799F506693793c6A5AF6B54dfAaBfB',
                 'You can start the broker now with',
-                `streamr-broker ${selectStoragePath}`,
+                `streamr-broker ${configPath}`,
             ])
-            const fileContent = readFileSync(selectStoragePath).toString()
+            const fileContent = readFileSync(configPath).toString()
             const config = JSON.parse(fileContent)
             expect(config.ethereumPrivateKey).toBe(privateKey)
             expect(config.plugins.websocket.port).toBe(parseInt(websocketPort))

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -35,7 +35,7 @@ describe('ConfigWizard', () => {
         it ('invalid data', () => {
             const validate = importPrivateKeyPrompt.validate!
             const privateKey = '0xInvalidPrivateKey'
-            expect(validate(privateKey)).toBe(`Invalid privateKey provided for import: ${privateKey}`)
+            expect(validate(privateKey)).toBe(`Invalid private key provided.`)
         })
     })
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -10,8 +10,7 @@ const assertValidPort = (port: number | string, pluginName = 'websocket') => {
         selectPlugins:[pluginName],
         websocketPort: port,
     }
-    const privateKey = getPrivateKey({})
-    const config = getConfig(privateKey, pluginsAnswers)
+    const config = getConfig(undefined as any, pluginsAnswers)
     expect(config.plugins[pluginName].port).toBe(numericPort)
 }
 
@@ -147,7 +146,7 @@ describe('ConfigWizard', () => {
 
     })
 
-    describe('getEthereumConfig', () => {
+    describe('getPrivateKey and getConfig', () => {
         it ('should exercise the `generate` path', () => {
             const privateKey = getPrivateKey({})
             expect(privateKey).toBeDefined()

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { writeFileSync, mkdtempSync, existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfig, getPrivateKey, getNodeIdentity } from '../../src/ConfigWizard'
+import { PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfig, getPrivateKey, getNodeIdentity } from '../../src/ConfigWizard'
 
 const assertValidPort = (port: number | string, pluginName = 'websocket') => {
     const numericPort = (typeof port === 'string') ? parseInt(port) : port
@@ -25,8 +25,8 @@ const assertValidMisc = (config: any) => {
 }
 
 describe('ConfigWizard', () => {
-    const importPrivateKeyPrompt = CONFIG_WIZARD_PROMPTS.privateKey[1]
-    const portPrompt = CONFIG_WIZARD_PROMPTS.plugins[1]
+    const importPrivateKeyPrompt = PROMPTS.privateKey[1]
+    const portPrompt = PROMPTS.plugins[1]
 
     describe('importPrivateKey validate', () => {
         it ('happy path, prefixed', () => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -146,7 +146,7 @@ describe('ConfigWizard', () => {
 
     })
 
-    describe('getPrivateKey and getConfig', () => {
+    describe('getPrivateKey', () => {
         it ('should exercise the `generate` path', () => {
             const privateKey = getPrivateKey({})
             expect(privateKey).toBeDefined()
@@ -163,6 +163,9 @@ describe('ConfigWizard', () => {
             expect(privateKey).toBe(privateKey)
         })
 
+    })
+
+    describe('getConfig', () => {
         it ('should exercise the plugin port assignation path with a number', () => {
             assertValidPort(3737)
         })


### PR DESCRIPTION
- The wizard now asks the user if they want their generated private key displayed. 
- The logger has been simplified and colors reduced to the minimal.
- Import of private keys is now executed as a `password` input rather than plaintext.
- The ordering of the flow has changed for a better user experience.