### PR TITLE
NET-442: Broker's config wizard issue with creating .streamr path in home folder

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -215,7 +215,7 @@ export const selectDestinationPathPrompt = {
             answers.parentDirExists = existsSync(parentDirPath)
             answers.fileExists = existsSync(filePath)
 
-            return (answers.parentDirExists || answers.fileExists)
+            return true
         } catch (e) {
             return e.message
         }

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -76,7 +76,7 @@ describe('ConfigWizard', () => {
             const invalidPath = `/invalid-path/${Date.now()}`
             const answers: any = {}
             const isValid = validate(invalidPath, answers)
-            expect(isValid).toBe(false)
+            expect(isValid).toBe(true)
             expect(answers.parentDirExists).toBe(false)
             expect(answers.fileExists).toBe(false)
 


### PR DESCRIPTION
The code was using the existence of the dir that shall contain the config as a logic operator when not needed, looping the question eternally.

