### PR TITLE
NET-444: Config wizard; user-provided ports written as strings instead of numbers

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -164,10 +164,9 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
             if (portNumber < MIN_PORT_VALUE || portNumber > MAX_PORT_VALUE) {
                 return `Out of range port ${portNumber} provided (valid range ${MIN_PORT_VALUE}-${MAX_PORT_VALUE})`
             }
-
             return true
         },
-        default: defaultPluginPort
+        default: defaultPluginPort.toString()
     })
 })
 
@@ -181,15 +180,15 @@ export const getConfigFromAnswers = (answers: inquirer.Answers): any => {
         const defaultPluginPort = PLUGIN_DEFAULT_PORTS[pluginName]
         if (answers.selectPlugins && answers.selectPlugins.includes(pluginName)){
             let pluginConfig = {}
-            if (answers[`${pluginName}Port`] !== defaultPluginPort){
+            if (answers[`${pluginName}Port`] !== defaultPluginPort.toString()){
                 if (pluginName === PLUGIN_NAMES.PUBLISH_HTTP) {
                     // the publishHttp plugin is special, it needs to be added to the config after the other plugins
                     config.httpServer = {
-                        port: answers[`${pluginName}Port`]
+                        port: parseInt(answers[`${pluginName}Port`])
                     }
                 } else {
                     // user provided a custom value, fill in
-                    pluginConfig = { port: answers[`${pluginName}Port`] }
+                    pluginConfig = { port: parseInt(answers[`${pluginName}Port`]) }
                 }
             }
             config.plugins![pluginName] = pluginConfig

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -155,8 +155,8 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
         when: (answers: inquirer.Answers) => {
             return answers.selectPlugins.includes(pluginName)
         },
-        validate: (input: any): string | boolean => {
-            const portNumber = parseInt(input)
+        validate: (input: string | number): string | boolean => {
+            const portNumber = (typeof input === 'string')  ? parseInt(input) : input
             if (!Number.isInteger(portNumber)) {
                 return `Non-numeric value provided`
             }
@@ -207,7 +207,7 @@ export const selectDestinationPathPrompt = {
     default: path.join(os.homedir(), '.streamr/broker-config.json'),
     validate: (input: string, answers: inquirer.Answers = {}): string | boolean => {
         try {
-            const filePath = input || answers.selectDestinationPath
+            const filePath = input
             const parentDirPath = path.dirname(filePath)
 
             answers.parentDirPath = parentDirPath

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -181,14 +181,13 @@ export const getConfigFromAnswers = (answers: inquirer.Answers): any => {
         if (answers.selectPlugins && answers.selectPlugins.includes(pluginName)){
             let pluginConfig = {}
             if (answers[`${pluginName}Port`] !== defaultPluginPort){
+                const portObject = { port: parseInt(answers[`${pluginName}Port`]) }
                 if (pluginName === PLUGIN_NAMES.PUBLISH_HTTP) {
                     // the publishHttp plugin is special, it needs to be added to the config after the other plugins
-                    config.httpServer = {
-                        port: parseInt(answers[`${pluginName}Port`])
-                    }
+                    config.httpServer = portObject
                 } else {
                     // user provided a custom value, fill in
-                    pluginConfig = { port: parseInt(answers[`${pluginName}Port`]) }
+                    pluginConfig = portObject
                 }
             }
             config.plugins![pluginName] = pluginConfig

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -155,8 +155,11 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
         when: (answers: inquirer.Answers) => {
             return answers.selectPlugins.includes(pluginName)
         },
-        validate: (input: number, answers: inquirer.Answers): string | boolean => {
-            const portNumber = parseInt(input || answers[`${pluginName}Port`])
+        filter: (input: any, answers: inquirer.Answers) => {
+            return parseInt(input || answers[`${pluginName}Port`])
+        },
+        validate: (input: number): string | boolean => {
+            const portNumber = input
             if (!Number.isInteger(portNumber)) {
                 return `Non-numeric value provided`
             }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -155,7 +155,7 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
         when: (answers: inquirer.Answers) => {
             return answers.selectPlugins.includes(pluginName)
         },
-        validate: (input: string, answers: inquirer.Answers): string | boolean => {
+        validate: (input: number, answers: inquirer.Answers): string | boolean => {
             const portNumber = parseInt(input || answers[`${pluginName}Port`])
             if (!Number.isInteger(portNumber)) {
                 return `Non-numeric value provided`
@@ -166,7 +166,7 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
             }
             return true
         },
-        default: defaultPluginPort.toString()
+        default: defaultPluginPort
     })
 })
 
@@ -180,7 +180,7 @@ export const getConfigFromAnswers = (answers: inquirer.Answers): any => {
         const defaultPluginPort = PLUGIN_DEFAULT_PORTS[pluginName]
         if (answers.selectPlugins && answers.selectPlugins.includes(pluginName)){
             let pluginConfig = {}
-            if (answers[`${pluginName}Port`] !== defaultPluginPort.toString()){
+            if (answers[`${pluginName}Port`] !== defaultPluginPort){
                 if (pluginName === PLUGIN_NAMES.PUBLISH_HTTP) {
                     // the publishHttp plugin is special, it needs to be added to the config after the other plugins
                     config.httpServer = {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -155,11 +155,8 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
         when: (answers: inquirer.Answers) => {
             return answers.selectPlugins.includes(pluginName)
         },
-        filter: (input: any, answers: inquirer.Answers) => {
-            return parseInt(input || answers[`${pluginName}Port`])
-        },
-        validate: (input: number): string | boolean => {
-            const portNumber = input
+        validate: (input: any): string | boolean => {
+            const portNumber = parseInt(input)
             if (!Number.isInteger(portNumber)) {
                 return `Non-numeric value provided`
             }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -156,7 +156,7 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
             return answers.selectPlugins.includes(pluginName)
         },
         validate: (input: string | number): string | boolean => {
-            const portNumber = (typeof input === 'string')  ? parseInt(input) : input
+            const portNumber = (typeof input === 'string') ? Number(input) : input
             if (!Number.isInteger(portNumber)) {
                 return `Non-numeric value provided`
             }

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -157,8 +157,13 @@ Object.keys(PLUGIN_DEFAULT_PORTS).map((pluginName) => {
         },
         validate: (input: string | number): string | boolean => {
             const portNumber = (typeof input === 'string') ? Number(input) : input
-            if (!Number.isInteger(portNumber)) {
+
+            if (Number.isNaN(portNumber)) {
                 return `Non-numeric value provided`
+            }
+
+            if (!Number.isInteger(portNumber)) {
+                return `Non-integer value provided`
             }
 
             if (portNumber < MIN_PORT_VALUE || portNumber > MAX_PORT_VALUE) {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -180,8 +180,9 @@ export const getConfigFromAnswers = (answers: inquirer.Answers): any => {
         const defaultPluginPort = PLUGIN_DEFAULT_PORTS[pluginName]
         if (answers.selectPlugins && answers.selectPlugins.includes(pluginName)){
             let pluginConfig = {}
-            if (answers[`${pluginName}Port`] !== defaultPluginPort){
-                const portObject = { port: parseInt(answers[`${pluginName}Port`]) }
+            const portNumber = parseInt(answers[`${pluginName}Port`])
+            if (portNumber !== defaultPluginPort){
+                const portObject = { port: portNumber }
                 if (pluginName === PLUGIN_NAMES.PUBLISH_HTTP) {
                     // the publishHttp plugin is special, it needs to be added to the config after the other plugins
                     config.httpServer = portObject
@@ -206,12 +207,11 @@ export const selectDestinationPathPrompt = {
     default: path.join(os.homedir(), '.streamr/broker-config.json'),
     validate: (input: string, answers: inquirer.Answers = {}): string | boolean => {
         try {
-            const filePath = input
-            const parentDirPath = path.dirname(filePath)
+            const parentDirPath = path.dirname(input)
 
             answers.parentDirPath = parentDirPath
             answers.parentDirExists = existsSync(parentDirPath)
-            answers.fileExists = existsSync(filePath)
+            answers.fileExists = existsSync(input)
 
             return true
         } catch (e) {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -150,7 +150,7 @@ describe('ConfigWizard', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 selectPlugins:['websocket'],
-                websocketPort: port.toString(),
+                websocketPort: port,
             }
             const config = getConfigFromAnswers(answers)
             expect(config.plugins.websocket.port).toBe(port)
@@ -160,9 +160,9 @@ describe('ConfigWizard', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
-                websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT.toString(),
-                mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT.toString(),
-                publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT.toString(),
+                websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT,
+                mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
+                publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT,
             }
             const config = getConfigFromAnswers(answers)
             expect(config.plugins.websocket).toMatchObject({})

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -40,6 +40,12 @@ describe('ConfigWizard', () => {
             expect(validate(port)).toBe(`Out of range port ${port} provided (valid range 1024-49151)`)
         })
 
+        it ('invalid data: float-point number', () => {
+            const validate = portPrompt.validate!
+            const port = 55.55
+            expect(validate(port)).toBe(`Non-numeric value provided`)
+        })
+
         it ('invalid data: non-numeric', () => {
             const validate = portPrompt.validate!
             const port = 'Not A Number!'
@@ -145,12 +151,23 @@ describe('ConfigWizard', () => {
             expect(config.ethereumPrivateKey).toBe(privateKey)
         })
 
-        it ('should exercise the plugin port assignation path', () => {
+        it ('should exercise the plugin port assignation path with a number', () => {
             const port = 3737
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 selectPlugins:['websocket'],
                 websocketPort: port,
+            }
+            const config = getConfigFromAnswers(answers)
+            expect(config.plugins.websocket.port).toBe(port)
+        })
+
+        it ('should exercise the plugin port assignation path with a stringified number', () => {
+            const port = 3737
+            const answers = {
+                generateOrImportEthereumPrivateKey: 'Generate',
+                selectPlugins:['websocket'],
+                websocketPort: port.toString(),
             }
             const config = getConfigFromAnswers(answers)
             expect(config.plugins.websocket.port).toBe(port)

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -29,9 +29,14 @@ describe('ConfigWizard', () => {
     })
 
     describe('plugin port validation', () => {
-        it ('happy path', () => {
+        it ('happy path: numeric value', () => {
             const validate = portPrompt.validate!
             expect(validate(7070)).toBe(true)
+        })
+
+        it ('happy path: string value', () => {
+            const validate = portPrompt.validate!
+            expect(validate('7070')).toBe(true)
         })
 
         it ('invalid data: out-of-range number', () => {
@@ -43,7 +48,7 @@ describe('ConfigWizard', () => {
         it ('invalid data: float-point number', () => {
             const validate = portPrompt.validate!
             const port = 55.55
-            expect(validate(port)).toBe(`Non-numeric value provided`)
+            expect(validate(port)).toBe(`Non-integer value provided`)
         })
 
         it ('invalid data: non-numeric', () => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -146,11 +146,11 @@ describe('ConfigWizard', () => {
         })
 
         it ('should exercise the plugin port assignation path', () => {
-            const port = '3737'
+            const port = 3737
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 selectPlugins:['websocket'],
-                websocketPort: port,
+                websocketPort: port.toString(),
             }
             const config = getConfigFromAnswers(answers)
             expect(config.plugins.websocket.port).toBe(port)
@@ -160,9 +160,9 @@ describe('ConfigWizard', () => {
             const answers = {
                 generateOrImportEthereumPrivateKey: 'Generate',
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
-                websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT,
-                mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT,
-                publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT,
+                websocketPort: DEFAULT_CONFIG_PORTS.DEFAULT_WS_PORT.toString(),
+                mqttPort: DEFAULT_CONFIG_PORTS.DEFAULT_MQTT_PORT.toString(),
+                publishHttpPort: DEFAULT_CONFIG_PORTS.DEFAULT_HTTP_PORT.toString(),
             }
             const config = getConfigFromAnswers(answers)
             expect(config.plugins.websocket).toMatchObject({})
@@ -181,14 +181,15 @@ describe('ConfigWizard', () => {
                 generateOrImportEthereumPrivateKey: 'Import',
                 importPrivateKey: privateKey,
                 selectPlugins: [ 'websocket', 'mqtt', 'publishHttp' ],
-                websocketPort: 3170,
-                mqttPort: 3171,
-                publishHttpPort: 3172
+                websocketPort: '3170',
+                mqttPort: '3171',
+                publishHttpPort: '3172'
             }
+
             const config = getConfigFromAnswers(answers)
-            expect(config.plugins.websocket.port).toBe(answers.websocketPort)
-            expect(config.plugins.mqtt.port).toBe(answers.mqttPort)
-            expect(config.httpServer.port).toBe(answers.publishHttpPort)
+            expect(config.plugins.websocket.port).toBe(parseInt(answers.websocketPort))
+            expect(config.plugins.mqtt.port).toBe(parseInt(answers.mqttPort))
+            expect(config.httpServer.port).toBe(parseInt(answers.publishHttpPort))
             expect(config.plugins.publishHttp).toMatchObject({})
             expect(config.ethereumPrivateKey).toBe(privateKey)
         })

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -4,6 +4,17 @@ import os from 'os'
 import path from 'path'
 import { CONFIG_WIZARD_PROMPTS, DEFAULT_CONFIG_PORTS, selectDestinationPathPrompt, createStorageFile, getConfigFromAnswers } from '../../src/ConfigWizard'
 
+const assertValidPort = (port: number | string, pluginName = 'websocket') => {
+    const numericPort = (typeof port === 'string') ? parseInt(port) : port
+    const answers = {
+        generateOrImportEthereumPrivateKey: 'Generate',
+        selectPlugins:[pluginName],
+        websocketPort: port,
+    }
+    const config = getConfigFromAnswers(answers)
+    expect(config.plugins[pluginName].port).toBe(numericPort)
+}
+
 describe('ConfigWizard', () => {
     const importPrivateKeyPrompt = CONFIG_WIZARD_PROMPTS[1]
     const portPrompt = CONFIG_WIZARD_PROMPTS[3]
@@ -157,25 +168,11 @@ describe('ConfigWizard', () => {
         })
 
         it ('should exercise the plugin port assignation path with a number', () => {
-            const port = 3737
-            const answers = {
-                generateOrImportEthereumPrivateKey: 'Generate',
-                selectPlugins:['websocket'],
-                websocketPort: port,
-            }
-            const config = getConfigFromAnswers(answers)
-            expect(config.plugins.websocket.port).toBe(port)
+            assertValidPort(3737)
         })
 
         it ('should exercise the plugin port assignation path with a stringified number', () => {
-            const port = 3737
-            const answers = {
-                generateOrImportEthereumPrivateKey: 'Generate',
-                selectPlugins:['websocket'],
-                websocketPort: port.toString(),
-            }
-            const config = getConfigFromAnswers(answers)
-            expect(config.plugins.websocket.port).toBe(port)
+            assertValidPort('3737')
         })
 
         it ('should exercise the happy path with default answers', () => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -31,12 +31,12 @@ describe('ConfigWizard', () => {
     describe('plugin port validation', () => {
         it ('happy path', () => {
             const validate = portPrompt.validate!
-            expect(validate('7070')).toBe(true)
+            expect(validate(7070)).toBe(true)
         })
 
         it ('invalid data: out-of-range number', () => {
             const validate = portPrompt.validate!
-            const port = '10000000000'
+            const port = 10000000000
             expect(validate(port)).toBe(`Out of range port ${port} provided (valid range 1024-49151)`)
         })
 


### PR DESCRIPTION
The wizard's lack of type structure on the temporary configs allowed for the ports on the plugins to be provided as either strings or numbers. 

This PR assumes all given inputs will be strings for the ports and modifies the tests accordingly

**Enhancement:** Located and patched a bug that allowed floats to be provided as port numbers, with the according tests