### PR TITLE
NET-438: Log improvements on WebRTCConnection timeout

### DIFF
--- a/packages/network/src/connection/WebRtcConnection.ts
+++ b/packages/network/src/connection/WebRtcConnection.ts
@@ -162,7 +162,6 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         this.doConnect()
         this.connectionTimeoutRef = setTimeout(() => {
             if (this.isFinished) { return }
-            this.baseLogger.warn(`connection timed out after ${this.newConnectionTimeout}ms`)
             this.close(new Error(`timed out after ${this.newConnectionTimeout}ms`))
         }, this.newConnectionTimeout)
     }
@@ -481,7 +480,6 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         clearTimeout(this.connectionTimeoutRef!)
         this.connectionTimeoutRef = setTimeout(() => {
             if (this.isFinished) { return }
-            this.baseLogger.warn(`connection timed out after ${this.newConnectionTimeout}ms`)
             this.close(new Error(`timed out after ${this.newConnectionTimeout}ms`))
         }, this.newConnectionTimeout)
     }

--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -124,7 +124,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     }
 
     private startConnectionStatusReport(): void {
-        const STATUS_REPORT_TIMER_MS = 5 * 60 * 1000
+        const STATUS_REPORT_INTERVAL_MS = 5 * 60 * 1000
         this.statusReportTimer = setInterval(() => {
             let connectedPeerCount = 0
             const pendingPeerIds = []
@@ -137,7 +137,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 }
             }
             this.logger.info(`Successfully connected to ${connectedPeerCount} peers. Still trying to connect to the following peers: [${pendingPeerIds.join(', ')}]`)
-        }, STATUS_REPORT_TIMER_MS)
+        }, STATUS_REPORT_INTERVAL_MS)
     }
 
     private createConnection(

--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -49,8 +49,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private readonly bufferThresholdHigh: number
     private readonly maxMessageSize
 
-    private statusReportTimeout?: NodeJS.Timeout
-    private statusReportIntervalMs: number
+    private statusReportInterval?: NodeJS.Timeout
 
     constructor(
         peerInfo: PeerInfo,
@@ -121,28 +120,24 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 return Object.values(this.connections).reduce((total, c) => total + c.getQueueSize(), 0)
             })
 
-        this.statusReportIntervalMs = 5 * 60 * 1000
         this.startConnectionStatusReport()
     }
 
     private startConnectionStatusReport(): void {
-        if (this.statusReportTimeout) {
-            clearTimeout(this.statusReportTimeout)
-        }
-        this.statusReportTimeout = setTimeout(() => {
+        const statusReportIntervalMs = 5 * 60 * 1000
+        this.statusReportInterval = setInterval(() => {
             let connectedPeerCount = 0
-            const pendingConnectionIds = []
+            const pendingPeerIds = []
             for (const peerId of Object.keys(this.connections)) {
                 const lastState = this.connections[peerId].getLastState()
                 if (lastState === 'open') {
                     connectedPeerCount += 1
                 } else if (lastState === 'connecting') {
-                    pendingConnectionIds.push(peerId)
+                    pendingPeerIds.push(peerId)
                 }
             }
-            this.logger.info(`Successfully connected to ${connectedPeerCount} peers. Still trying to connect to the following peers: [${pendingConnectionIds.join(', ')}]`)
-            this.startConnectionStatusReport()
-        }, this.statusReportIntervalMs)
+            this.logger.info(`Successfully connected to ${connectedPeerCount} peers. Still trying to connect to the following peers: [${pendingPeerIds.join(', ')}]`)
+        }, statusReportIntervalMs)
     }
 
     private createConnection(
@@ -457,7 +452,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.rtcSignaller.setIceCandidateListener(() => {})
         this.rtcSignaller.setErrorListener(() => {})
         this.rtcSignaller.setConnectListener(() => {})
-        clearTimeout(this.statusReportTimeout!)
+        clearInterval(this.statusReportInterval!)
         this.removeAllListeners()
         Object.values(connections).forEach((connection) => connection.close())
         Object.values(messageQueues).forEach((queue) => queue.clear())

--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -49,7 +49,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private readonly bufferThresholdHigh: number
     private readonly maxMessageSize
 
-    private statusReportInterval?: NodeJS.Timeout
+    private statusReportTimer?: NodeJS.Timeout
 
     constructor(
         peerInfo: PeerInfo,
@@ -124,8 +124,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     }
 
     private startConnectionStatusReport(): void {
-        const statusReportIntervalMs = 5 * 60 * 1000
-        this.statusReportInterval = setInterval(() => {
+        const STATUS_REPORT_TIMER_MS = 5 * 60 * 1000
+        this.statusReportTimer = setInterval(() => {
             let connectedPeerCount = 0
             const pendingPeerIds = []
             for (const peerId of Object.keys(this.connections)) {
@@ -137,7 +137,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 }
             }
             this.logger.info(`Successfully connected to ${connectedPeerCount} peers. Still trying to connect to the following peers: [${pendingPeerIds.join(', ')}]`)
-        }, statusReportIntervalMs)
+        }, STATUS_REPORT_TIMER_MS)
     }
 
     private createConnection(
@@ -452,7 +452,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.rtcSignaller.setIceCandidateListener(() => {})
         this.rtcSignaller.setErrorListener(() => {})
         this.rtcSignaller.setConnectListener(() => {})
-        clearInterval(this.statusReportInterval!)
+        clearInterval(this.statusReportTimer!)
         this.removeAllListeners()
         Object.values(connections).forEach((connection) => connection.close())
         Object.values(messageQueues).forEach((queue) => queue.clear())


### PR DESCRIPTION
Silences the  connection time-out `logger.warn` on every individual connection and adds a periodic reporting `logger.info` for 'open' and 'connecting' peer states every 5 minutes