### PR TITLE
No longer send "full" status messages to reduce the size of WS payloads

### DIFF
--- a/packages/network/bin/subscriber.js
+++ b/packages/network/bin/subscriber.js
@@ -49,10 +49,6 @@ subscriber.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, (streamMessage) => {
 })
 
 setInterval(() => {
-    console.log(Object.keys(subscriber.nodeToNode.endpoint.connections).length)
-}, 2000)
-
-setInterval(() => {
     const newMessages = messageNo - lastReported
     logger.info('%s received %d (%d)', id, messageNo, newMessages)
     lastReported = messageNo

--- a/packages/network/bin/subscriber.js
+++ b/packages/network/bin/subscriber.js
@@ -49,6 +49,10 @@ subscriber.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, (streamMessage) => {
 })
 
 setInterval(() => {
+    console.log(Object.keys(subscriber.nodeToNode.endpoint.connections).length)
+}, 2000)
+
+setInterval(() => {
     const newMessages = messageNo - lastReported
     logger.info('%s received %d (%d)', id, messageNo, newMessages)
     lastReported = messageNo

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -54,7 +54,8 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     newWebrtcConnectionTimeout?: number,
     webrtcDatachannelBufferThresholdLow?: number,
     webrtcDatachannelBufferThresholdHigh?: number,
-    stunUrls?: string[]
+    stunUrls?: string[],
+    rttUpdateTimeout?: number
 }
 
 export const startTracker = async ({
@@ -100,6 +101,7 @@ export const createNetworkNode = ({
     trackerPingInterval,
     disconnectionWaitTime,
     newWebrtcConnectionTimeout,
+    rttUpdateTimeout,
     webrtcDatachannelBufferThresholdLow,
     webrtcDatachannelBufferThresholdHigh,
     stunUrls = ['stun:stun.l.google.com:19302']
@@ -131,6 +133,7 @@ export const createNetworkNode = ({
             nodeToNode
         },
         metricsContext,
-        disconnectionWaitTime
+        disconnectionWaitTime,
+        rttUpdateTimeout
     })
 }

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -60,7 +60,7 @@ export interface StatusStreams {
 
 export interface Status {
     streams: StatusStreams
-    rtts: Rtts
+    rtts: Rtts | null
     location: Location
     started: string
     singleStream: boolean // indicate whether this is a status update for only a single stream

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -445,7 +445,7 @@ export class Node extends EventEmitter {
 
     private prepareAndSendMultipleStatuses(tracker: string, streams?: StreamIdAndPartition[]): void {
         const statusMessages = this.getMultipleStatusMessages(tracker, streams)
-        statusMessages.map((status) => {
+        statusMessages.forEach((status) => {
             this.sendStatus(tracker, status)
         })
     }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -411,13 +411,8 @@ export class Node extends EventEmitter {
     }
 
     // Gets statuses of all streams assigned to a tracker by default
-    private getMultipleStatusMessages(tracker: string, predefinedStreams: StreamIdAndPartition[]): Status[] {
-        let streams
-        if (predefinedStreams.length === 0) {
-            streams = this.streams.getStreams()
-        } else {
-            streams = predefinedStreams
-        }
+    private getMultipleStatusMessages(tracker: string, explicitStreams?: StreamIdAndPartition[]): Status[] {
+        const streams = explicitStreams || this.streams.getStreams()
         const statusMessages = streams
             .filter((streamId) => this.getTrackerId(streamId) === tracker)
             .map((streamId) => this.getStreamStatus(streamId))
@@ -448,7 +443,7 @@ export class Node extends EventEmitter {
         }
     }
 
-    private prepareAndSendMultipleStatuses(tracker: string, streams: StreamIdAndPartition[] = []): void {
+    private prepareAndSendMultipleStatuses(tracker: string, streams?: StreamIdAndPartition[]): void {
         const statusMessages = this.getMultipleStatusMessages(tracker, streams)
         statusMessages.map((status) => {
             this.sendStatus(tracker, status)

--- a/packages/network/src/logic/Tracker.ts
+++ b/packages/network/src/logic/Tracker.ts
@@ -105,7 +105,9 @@ export class Tracker extends EventEmitter {
         const filteredStreams = this.instructionCounter.filterStatus(status, source)
 
         // update RTTs and location
-        this.overlayConnectionRtts[source] = rtts
+        if (rtts) {
+            this.overlayConnectionRtts[source] = rtts
+        }
         this.locationManager.updateLocation({
             nodeId: source,
             location,

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -61,25 +61,9 @@ describe('multi trackers', () => {
             trackers: trackerAddresses
         })
 
-        nodeOne.start()
-        await Promise.all([
-            // @ts-expect-error private field
-            waitForEvent(trackerOne.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED),
-            // @ts-expect-error private field
-            waitForEvent(trackerTwo.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED),
-            // @ts-expect-error private field
-            waitForEvent(trackerThree.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        ])
+        await nodeOne.start()
+        await nodeTwo.start()
 
-        nodeTwo.start()
-        await Promise.all([
-            // @ts-expect-error private field
-            waitForEvent(trackerOne.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED),
-            // @ts-expect-error private field
-            waitForEvent(trackerTwo.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED),
-            // @ts-expect-error private field
-            waitForEvent(trackerThree.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        ])
     })
 
     afterEach(async () => {
@@ -156,10 +140,10 @@ describe('multi trackers', () => {
             waitForEvent(nodeTwo, NodeEvent.NODE_SUBSCRIBED)
         ])
 
-        expect(nodeOneEvents).toHaveLength(1)
-        expect(nodeTwoEvents).toHaveLength(1)
-        expect(nodeTwoEvents[0][0]).toEqual(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
-        expect(nodeTwoEvents[0][2]).toEqual('trackerOne')
+        expect(nodeOneEvents).toHaveLength(4)
+        expect(nodeTwoEvents).toHaveLength(4)
+        expect(nodeTwoEvents[3][0]).toEqual(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
+        expect(nodeTwoEvents[3][2]).toEqual('trackerOne')
 
         // second stream, second tracker
         nodeOne.subscribe(SECOND_STREAM_2, 0)

--- a/packages/network/test/integration/tracker-endpoints.test.ts
+++ b/packages/network/test/integration/tracker-endpoints.test.ts
@@ -246,17 +246,17 @@ describe('tracker endpoint', () => {
         expect(jsonResult).toEqual([
             {
                 "partition": 0,
+                "streamId": "sandbox/test/stream-3",
+                "topologySize": 1
+            },
+            {
+                "partition": 0,
                 "streamId": "stream-1",
                 "topologySize": 2
             },
             {
                 "partition": 0,
                 "streamId": "stream-2",
-                "topologySize": 1
-            },
-            {
-                "partition": 0,
-                "streamId": "sandbox/test/stream-3",
                 "topologySize": 1
             }
         ])

--- a/packages/network/test/integration/tracker-node-status.test.ts
+++ b/packages/network/test/integration/tracker-node-status.test.ts
@@ -55,11 +55,10 @@ describe('check status message flow between tracker and two nodes', () => {
     })
 
     it('tracker should receive status message from node', (done) => {
+        nodeOne.subscribe(streamId, 0)
         // @ts-expect-error private field
         tracker.trackerServer.once(TrackerServerEvent.NODE_STATUS_RECEIVED, (statusMessage, peerInfo) => {
             expect(peerInfo).toEqual('node-1')
-            // @ts-expect-error private field
-            expect(statusMessage.status).toEqual(nodeOne.getFullStatus(TRACKER_ID))
             done()
         })
 
@@ -67,11 +66,10 @@ describe('check status message flow between tracker and two nodes', () => {
     })
 
     it('tracker should receive status from second node', (done) => {
+        nodeTwo.subscribe(streamId, 0)
         // @ts-expect-error private field
         tracker.trackerServer.once(TrackerServerEvent.NODE_STATUS_RECEIVED, (statusMessage, peerInfo) => {
             expect(peerInfo).toEqual('node-2')
-            // @ts-expect-error private field
-            expect(statusMessage.status).toEqual(nodeTwo.getFullStatus(TRACKER_ID))
             done()
         })
         nodeTwo.start()
@@ -80,28 +78,26 @@ describe('check status message flow between tracker and two nodes', () => {
     it('tracker should receive from both nodes new statuses', (done) => {
         nodeOne.start()
         nodeTwo.start()
+        nodeOne.subscribe(streamId, 0)
+        nodeTwo.subscribe(streamId, 0)
 
         let receivedTotal = 0
-        let nodeOneStatus: any = null
-        let nodeTwoStatus: any = null
+        let nodeOneStatusReceived = false
+        let nodeTwoStatusReceived = false
 
         // @ts-expect-error private field
         tracker.trackerServer.on(TrackerServerEvent.NODE_STATUS_RECEIVED, (statusMessage, nodeId) => {
-            if (nodeId === 'node-1') {
-                nodeOneStatus = statusMessage.status
+            if (nodeId === 'node-1' && !nodeOneStatusReceived) {
+                nodeOneStatusReceived = true
                 receivedTotal += 1
             }
 
-            if (nodeId === 'node-2') {
-                nodeTwoStatus = statusMessage.status
+            if (nodeId === 'node-2' && !nodeTwoStatusReceived) {
+                nodeTwoStatusReceived = true
                 receivedTotal += 1
             }
 
             if (receivedTotal === 2) {
-                // @ts-expect-error private field
-                expect(nodeOneStatus).toEqual(nodeOne.getFullStatus())
-                // @ts-expect-error private field
-                expect(nodeTwoStatus).toEqual(nodeTwo.getFullStatus())
                 done()
             }
         })

--- a/packages/network/test/integration/tracker-node-status.test.ts
+++ b/packages/network/test/integration/tracker-node-status.test.ts
@@ -39,6 +39,7 @@ describe('check status message flow between tracker and two nodes', () => {
             trackers: [trackerInfo],
             peerPingInterval: 100,
             trackerPingInterval: 100,
+            rttUpdateTimeout: 10
         })
         
         nodeTwo = createNetworkNode({
@@ -47,6 +48,7 @@ describe('check status message flow between tracker and two nodes', () => {
             location,
             peerPingInterval: 100,
             trackerPingInterval: 100,
+            rttUpdateTimeout: 10
         })
     })
 


### PR DESCRIPTION
- Instead of sending a single large JSON status message send multiple small per stream status messages

- A node sends multiple status messages when:

 - the node first connects to the tracker and is subscribed to streams or wants to subscribe
 - a peer disconnects from the node

- This change is backwards compatible with previous versions where nodes still send full status messages as the logic to handle such messages is not been removed from the tracker's side

- Removed unused variable sendStatusToAllTrackersInterval from Node.ts

- Rtts are no longer sent on each status message, instead there is a default 15 second timeout for updating rtts to the tracker.

- Default interval for retrying instruction messages increased 1 -> 3 minutes to reduce status message traffic