### PR TITLE
Overlay topology optimizations

### DIFF
--- a/packages/network/test/benchmarks/join-leave-performance.ts
+++ b/packages/network/test/benchmarks/join-leave-performance.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { OverlayTopology } from '../../src/logic/OverlayTopology'
 
 const NODE_DEGREE = 4

--- a/packages/network/test/benchmarks/join-leave-performance.ts
+++ b/packages/network/test/benchmarks/join-leave-performance.ts
@@ -27,5 +27,4 @@ nodeIdxPicks.forEach((nodeId) => {
     topology.formInstructions(nodeId)
 })
 const diff = Date.now() - startTime
-// @ts-expect-error console identifier not found?
 console.info(`took ${diff / NUM_OF_ROUNDS} ms per node`)

--- a/packages/network/test/benchmarks/join-leave-performance.ts
+++ b/packages/network/test/benchmarks/join-leave-performance.ts
@@ -1,0 +1,31 @@
+import { OverlayTopology } from '../../src/logic/OverlayTopology'
+
+const NODE_DEGREE = 4
+const NUM_OF_NODES = 4000
+const NUM_OF_ROUNDS = 200
+
+// Built up topology of NUM_OF_NODES nodes
+const topology = new OverlayTopology(NODE_DEGREE)
+for (let j = 0; j < NUM_OF_NODES; ++j) {
+    const nodeId = `node-${j}`
+    topology.update(nodeId, [])
+    topology.formInstructions(nodeId)
+}
+
+const nodeIdxPicks: string[] = new Array(NUM_OF_ROUNDS)
+for (let i = 0; i < nodeIdxPicks.length; ++i) {
+    const idx = Math.floor(Math.random() * NUM_OF_NODES)
+    nodeIdxPicks[i] = `node-${idx}`
+}
+
+const startTime = Date.now()
+nodeIdxPicks.forEach((nodeId) => {
+    topology.leave(nodeId).forEach((neighborId) => {
+        topology.formInstructions(neighborId, true)
+    })
+    topology.update(nodeId, [])
+    topology.formInstructions(nodeId)
+})
+const diff = Date.now() - startTime
+// @ts-expect-error console identifier not found?
+console.info(`took ${diff / NUM_OF_ROUNDS} ms per node`)


### PR DESCRIPTION
> Made a performance test where I setup a topology of 4000 nodes. I then repeatedly randomly pick one of the nodes, make it leave and then rejoin. Idea is to try to approximate what is happening in test net.
> 
> With the original algorithm leaving and rejoining (of a single node) took around 9.65ms on average.With the first optimization (avoiding the O(n) scan in update) the same took 7.46ms.Adding the set of nodes with less than max neighbors on top brought this down to 3.55ms. (edited) 

This PR contains the performance test and the above mentioned optimizations. 