### PR TITLE
NET-493: Don't assign 'sec' metrics streams to storage

### DIFF
--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -72,21 +72,24 @@ export class MetricsPublisher {
         const stream = await this.client.getOrCreateStream({
             id: this.getStreamId(periodLegth)
         })
-        // TODO: pretify this error handler
-        // https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
-        try {
-            await stream.addToStorageNode(this.storageNodeAddress)
-        } catch (e) {
-            if (!e.body) { throw e }
-            let parsedBody
+
+        if (periodLegth > PERIOD_LENGTHS.FIVE_SECONDS) {
+            // TODO: pretify this error handler
+            // https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
             try {
-                parsedBody = JSON.parse(e.body)
-            } catch (jsonError) {
-                throw e // original error, not parsing one
-            }
-            // expected error when re-adding storage node
-            if (parsedBody.code !== 'DUPLICATE_NOT_ALLOWED') {
-                throw e
+                await stream.addToStorageNode(this.storageNodeAddress)
+            } catch (e) {
+                if (!e.body) { throw e }
+                let parsedBody
+                try {
+                    parsedBody = JSON.parse(e.body)
+                } catch (jsonError) {
+                    throw e // original error, not parsing one
+                }
+                // expected error when re-adding storage node
+                if (parsedBody.code !== 'DUPLICATE_NOT_ALLOWED') {
+                    throw e
+                }
             }
         }
         await stream.grantPermission('stream_get' as StreamOperation, undefined)

--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -73,7 +73,7 @@ export class MetricsPublisher {
             id: this.getStreamId(periodLegth)
         })
 
-        if (periodLegth > PERIOD_LENGTHS.FIVE_SECONDS) {
+        if (periodLegth !== PERIOD_LENGTHS.FIVE_SECONDS) {
             // TODO: pretify this error handler
             // https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
             try {


### PR DESCRIPTION
Avoid storing the 'sec' metric on any storage node.