### PR TITLE
NET-496: select a random stream from a configured list (single tracker)

### DIFF
--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -38,20 +38,6 @@
     "legacyMqtt": {
       "port": 9000,
       "streamsTimeout": 300000
-    },
-    "storage": {
-      "cassandra": {
-        "hosts": [
-          "cassandra"
-        ],
-        "username": "",
-        "password": "",
-        "keyspace": "streamr_dev_v2",
-        "datacenter": "datacenter1"
-      },
-      "storageConfig": {
-        "refreshInterval": 10000
-      }    
     }
   }
 }

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -38,6 +38,20 @@
     "legacyMqtt": {
       "port": 9000,
       "streamsTimeout": 300000
+    },
+    "storage": {
+      "cassandra": {
+        "hosts": [
+          "cassandra"
+        ],
+        "username": "",
+        "password": "",
+        "keyspace": "streamr_dev_v2",
+        "datacenter": "datacenter1"
+      },
+      "storageConfig": {
+        "refreshInterval": 10000
+      }
     }
   }
 }

--- a/packages/broker/src/plugins/testnetMiner/config.schema.json
+++ b/packages/broker/src/plugins/testnetMiner/config.schema.json
@@ -5,9 +5,11 @@
     "description": "Testnet miner plugin configuration",
     "additionalProperties": false,
     "properties": {
-        "rewardStreamId": {
-            "type": "string",
-            "default": "streamr.eth/testnets/brubeck-rewards"
+        "rewardStreamIds": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": ["streamr.eth/testnets/brubeck-rewards"]
         },
         "claimServerUrl": {
             "type": "string",

--- a/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/testnetMiner/TestnetMinerPlugin.test.ts
@@ -92,7 +92,7 @@ describe('TestnetMinerPlugin', () => {
             wsPort: LEGACY_WEBSOCKET_PORT,
             extraPlugins: {
                 testnetMiner: {
-                    rewardStreamId,
+                    rewardStreamIds: [rewardStreamId],
                     claimServerUrl: `http://127.0.0.1:${CLAIM_SERVER_PORT}`,
                     stunServerHost: null,
                     maxClaimDelay: 100


### PR DESCRIPTION
- Subscribe to a random stream from a given list
- Add selected the stream id to the claim request
- [NET-499](https://linear.app/streamr/issue/NET-499/use-multiple-trackers-on-miner-plugin) for using multiple trackers