### PR TITLE
network: rename TrackerNode -> NodeToTracker

### DIFF
--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -7,7 +7,7 @@ import { ServerWsEndpoint, startHttpServer } from './connection/ws/ServerWsEndpo
 import { Tracker } from './logic/Tracker'
 import { TrackerServer } from './protocol/TrackerServer'
 import { trackerHttpEndpoints } from './helpers/trackerHttpEndpoints'
-import { TrackerNode } from './protocol/TrackerNode'
+import { NodeToTracker } from './protocol/NodeToTracker'
 import { RtcSignaller } from './logic/RtcSignaller'
 import { NodeToNode } from './protocol/NodeToNode'
 import { NetworkNode } from './NetworkNode'
@@ -108,9 +108,9 @@ export const createNetworkNode = ({
 }: NetworkNodeOptions): NetworkNode => {
     const peerInfo = PeerInfo.newNode(id, name, undefined, undefined, location)
     const endpoint = new NodeClientWsEndpoint(peerInfo, metricsContext, trackerPingInterval)
-    const trackerNode = new TrackerNode(endpoint)
+    const nodeToTracker = new NodeToTracker(endpoint)
 
-    const webRtcSignaller = new RtcSignaller(peerInfo, trackerNode)
+    const webRtcSignaller = new RtcSignaller(peerInfo, nodeToTracker)
     const negotiatedProtocolVersions = new NegotiatedProtocolVersions(peerInfo)
     const nodeToNode = new NodeToNode(new WebRtcEndpoint(
         peerInfo,
@@ -129,7 +129,7 @@ export const createNetworkNode = ({
         peerInfo,
         trackers,
         protocols: {
-            trackerNode,
+            nodeToTracker,
             nodeToNode
         },
         metricsContext,

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { MessageLayer, TrackerLayer, Utils } from 'streamr-client-protocol'
 import { NodeToNode, Event as NodeToNodeEvent } from '../protocol/NodeToNode'
-import { TrackerNode, Event as TrackerNodeEvent } from '../protocol/TrackerNode'
+import { NodeToTracker, Event as NodeToTrackerEvent } from '../protocol/NodeToTracker'
 import { MessageBuffer } from '../helpers/MessageBuffer'
 import { SeenButNotPropagatedSet } from '../helpers/SeenButNotPropagatedSet'
 import { Status, StreamIdAndPartition, TrackerInfo } from '../identifiers'
@@ -30,7 +30,7 @@ export enum Event {
 export interface NodeOptions {
     protocols: {
         nodeToNode: NodeToNode
-        trackerNode: TrackerNode
+        nodeToTracker: NodeToTracker
     }
     peerInfo: PeerInfo
     trackers: Array<TrackerInfo>
@@ -59,7 +59,7 @@ export interface Node {
 
 export class Node extends EventEmitter {
     protected readonly nodeToNode: NodeToNode
-    private readonly trackerNode: TrackerNode
+    private readonly nodeToTracker: NodeToTracker
     private readonly peerInfo: PeerInfo
     private readonly connectToBootstrapTrackersInterval: number
     private readonly bufferTimeoutInMs: number
@@ -89,7 +89,7 @@ export class Node extends EventEmitter {
     constructor(opts: NodeOptions) {
         super()
 
-        if (!(opts.protocols.trackerNode instanceof TrackerNode) || !(opts.protocols.nodeToNode instanceof NodeToNode)) {
+        if (!(opts.protocols.nodeToTracker instanceof NodeToTracker) || !(opts.protocols.nodeToNode instanceof NodeToNode)) {
             throw new Error('Provided protocols are not correct')
         }
         if (!opts.trackers) {
@@ -97,7 +97,7 @@ export class Node extends EventEmitter {
         }
 
         this.nodeToNode = opts.protocols.nodeToNode
-        this.trackerNode = opts.protocols.trackerNode
+        this.nodeToTracker = opts.protocols.nodeToTracker
         this.peerInfo = opts.peerInfo
 
         this.connectToBootstrapTrackersInterval = opts.connectToBootstrapTrackersInterval || 5000
@@ -129,9 +129,9 @@ export class Node extends EventEmitter {
         )
         this.consecutiveDeliveryFailures = {}
 
-        this.trackerNode.on(TrackerNodeEvent.CONNECTED_TO_TRACKER, (trackerId) => this.onConnectedToTracker(trackerId))
-        this.trackerNode.on(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED, (streamMessage, trackerId) => this.onTrackerInstructionReceived(trackerId, streamMessage))  // eslint-disable-line max-len
-        this.trackerNode.on(TrackerNodeEvent.TRACKER_DISCONNECTED, (trackerId) => this.onTrackerDisconnected(trackerId))
+        this.nodeToTracker.on(NodeToTrackerEvent.CONNECTED_TO_TRACKER, (trackerId) => this.onConnectedToTracker(trackerId))
+        this.nodeToTracker.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, (streamMessage, trackerId) => this.onTrackerInstructionReceived(trackerId, streamMessage))  // eslint-disable-line max-len
+        this.nodeToTracker.on(NodeToTrackerEvent.TRACKER_DISCONNECTED, (trackerId) => this.onTrackerDisconnected(trackerId))
         this.nodeToNode.on(NodeToNodeEvent.NODE_CONNECTED, (nodeId) => this.emit(Event.NODE_CONNECTED, nodeId))
         this.nodeToNode.on(NodeToNodeEvent.DATA_RECEIVED, (broadcastMessage, nodeId) => this.onDataReceived(broadcastMessage.streamMessage, nodeId))
         this.nodeToNode.on(NodeToNodeEvent.NODE_DISCONNECTED, (nodeId) => this.onNodeDisconnected(nodeId))
@@ -177,7 +177,7 @@ export class Node extends EventEmitter {
 
     onConnectedToTracker(tracker: string): void {
         this.logger.trace('connected to tracker %s', tracker)
-        const serverUrl = this.trackerNode.getServerUrlByTrackerId(tracker)
+        const serverUrl = this.nodeToTracker.getServerUrlByTrackerId(tracker)
         if (serverUrl !== undefined) {
             this.trackerBook[serverUrl] = tracker
             this.prepareAndSendMultipleStatuses(tracker)
@@ -400,7 +400,7 @@ export class Node extends EventEmitter {
 
         this.messageBuffer.clear()
         return Promise.all([
-            this.trackerNode.stop(),
+            this.nodeToTracker.stop(),
             this.nodeToNode.stop(),
         ])
     }
@@ -448,7 +448,7 @@ export class Node extends EventEmitter {
 
     private async sendStatus(tracker: string, status: Status) {
         try {
-            await this.trackerNode.sendStatus(tracker, status)
+            await this.nodeToTracker.sendStatus(tracker, status)
             this.logger.trace('sent status %j to tracker %s', status.streams, tracker)
         } catch (e) {
             this.logger.trace('failed to send status to tracker %s, reason: %s', tracker, e)
@@ -532,7 +532,7 @@ export class Node extends EventEmitter {
 
     private connectToBootstrapTrackers(): void {
         this.trackerRegistry.getAllTrackers().forEach((trackerInfo) => {
-            this.trackerNode.connectToTracker(trackerInfo.ws, PeerInfo.newTracker(trackerInfo.id))
+            this.nodeToTracker.connectToTracker(trackerInfo.ws, PeerInfo.newTracker(trackerInfo.id))
                 .catch((err) => {
                     this.logger.warn('could not connect to tracker %s, reason: %j', trackerInfo.ws, err)
                 })

--- a/packages/network/src/logic/RtcSignaller.ts
+++ b/packages/network/src/logic/RtcSignaller.ts
@@ -1,4 +1,4 @@
-import { TrackerNode, Event as TrackerNodeEvent } from '../protocol/TrackerNode'
+import { NodeToTracker, Event as NodeToTrackerEvent } from '../protocol/NodeToTracker'
 import { PeerInfo } from '../connection/PeerInfo'
 import { RtcSubTypes } from './RtcMessage'
 import { RelayMessage, RtcErrorMessage } from '../identifiers'
@@ -41,7 +41,7 @@ export interface ErrorOptions {
 
 export class RtcSignaller {
     private readonly peerInfo: PeerInfo
-    private readonly trackerNode: TrackerNode
+    private readonly nodeToTracker: NodeToTracker
     private offerListener: null | ((opts: OfferOptions) => void)
     private answerListener: null | ((opts: AnswerOptions) => void)
     private iceCandidateListener: null | ((opts: IceCandidateOptions) => void)
@@ -49,9 +49,9 @@ export class RtcSignaller {
     private errorListener: null | ((opts: ErrorOptions) => void)
     private readonly logger: Logger
 
-    constructor(peerInfo: PeerInfo, trackerNode: TrackerNode) {
+    constructor(peerInfo: PeerInfo, nodeToTracker: NodeToTracker) {
         this.peerInfo = peerInfo
-        this.trackerNode = trackerNode
+        this.nodeToTracker = nodeToTracker
         this.offerListener = null
         this.answerListener = null
         this.iceCandidateListener = null
@@ -59,7 +59,7 @@ export class RtcSignaller {
         this.errorListener = null
         this.logger = new Logger(module)
 
-        trackerNode.on(TrackerNodeEvent.RELAY_MESSAGE_RECEIVED, (relayMessage: RelayMessage, source: string) => {
+        nodeToTracker.on(NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED, (relayMessage: RelayMessage, source: string) => {
             const { originator, targetNode, subType } = relayMessage
             if (relayMessage.subType === RtcSubTypes.RTC_OFFER) {
                 this.offerListener!({
@@ -93,7 +93,7 @@ export class RtcSignaller {
                 this.logger.warn('unrecognized subtype %s with contents %o', subType, relayMessage)
             }
         })
-        trackerNode.on(TrackerNodeEvent.RTC_ERROR_RECEIVED, (message: RtcErrorMessage, source: string) => {
+        nodeToTracker.on(NodeToTrackerEvent.RTC_ERROR_RECEIVED, (message: RtcErrorMessage, source: string) => {
             this.errorListener!({
                 routerId: source,
                 targetNode: message.targetNode,
@@ -103,28 +103,28 @@ export class RtcSignaller {
     }
 
     sendRtcOffer(routerId: string, targetPeerId: string, connectionId: string, description: string): void {
-        this.trackerNode.sendRtcOffer(routerId, targetPeerId, connectionId, this.peerInfo, description)
+        this.nodeToTracker.sendRtcOffer(routerId, targetPeerId, connectionId, this.peerInfo, description)
             .catch((err: Error) => {
                 this.logger.debug('failed to sendRtcOffer via %s due to %s', routerId, err) // TODO: better?
             })
     }
 
     sendRtcAnswer(routerId: string, targetPeerId: string, connectionId: string, description: string): void {
-        this.trackerNode.sendRtcAnswer(routerId, targetPeerId, connectionId, this.peerInfo, description)
+        this.nodeToTracker.sendRtcAnswer(routerId, targetPeerId, connectionId, this.peerInfo, description)
             .catch((err: Error) => {
                 this.logger.debug('failed to sendRtcAnswer via %s due to %s', routerId, err) // TODO: better?
             })
     }
 
     sendRtcIceCandidate(routerId: string, targetPeerId: string, connectionId: string, candidate: string, mid: string): void {
-        this.trackerNode.sendRtcIceCandidate(routerId, targetPeerId, connectionId, this.peerInfo, candidate, mid)
+        this.nodeToTracker.sendRtcIceCandidate(routerId, targetPeerId, connectionId, this.peerInfo, candidate, mid)
             .catch((err: Error) => {
                 this.logger.debug('failed to sendRtcIceCandidate via %s due to %s', routerId, err) // TODO: better?
             })
     }
 
     sendRtcConnect(routerId: string, targetPeerId: string): void {
-        this.trackerNode.sendRtcConnect(routerId, targetPeerId, this.peerInfo)
+        this.nodeToTracker.sendRtcConnect(routerId, targetPeerId, this.peerInfo)
             .catch((err: Error) => {
                 this.logger.debug('failed to sendRtcConnect via %s due to %s', routerId, err) // TODO: better?
             })

--- a/packages/network/src/protocol/NodeToNode.ts
+++ b/packages/network/src/protocol/NodeToNode.ts
@@ -3,7 +3,7 @@ import { ControlLayer, MessageLayer } from 'streamr-client-protocol'
 import { Logger } from '../helpers/Logger'
 import { decode } from '../helpers/MessageEncoder'
 import { IWebRtcEndpoint, Event as WebRtcEndpointEvent } from '../connection/IWebRtcEndpoint'
-import { PeerId, PeerInfo } from '../connection/PeerInfo'
+import { PeerInfo } from '../connection/PeerInfo'
 import { Rtts } from "../identifiers"
 import { NodeId } from '../logic/Node'
 

--- a/packages/network/src/protocol/NodeToTracker.ts
+++ b/packages/network/src/protocol/NodeToTracker.ts
@@ -24,7 +24,7 @@ eventPerType[TrackerLayer.TrackerMessage.TYPES.InstructionMessage] = Event.TRACK
 eventPerType[TrackerLayer.TrackerMessage.TYPES.RelayMessage] = Event.RELAY_MESSAGE_RECEIVED
 eventPerType[TrackerLayer.TrackerMessage.TYPES.ErrorMessage] = Event.RTC_ERROR_RECEIVED
 
-export interface TrackerNode {
+export interface NodeToTracker {
     on(event: Event.CONNECTED_TO_TRACKER, listener: (trackerId: string) => void): this
     on(event: Event.TRACKER_DISCONNECTED, listener: (trackerId: string) => void): this
     on(event: Event.TRACKER_INSTRUCTION_RECEIVED, listener: (msg: TrackerLayer.InstructionMessage, trackerId: string) => void): this
@@ -34,7 +34,7 @@ export interface TrackerNode {
 
 export type UUID = string
 
-export class TrackerNode extends EventEmitter {
+export class NodeToTracker extends EventEmitter {
     private readonly endpoint: AbstractClientWsEndpoint<AbstractWsConnection>
     private readonly logger: Logger
 

--- a/packages/network/src/protocol/NodeToTracker.ts
+++ b/packages/network/src/protocol/NodeToTracker.ts
@@ -4,7 +4,7 @@ import { TrackerLayer } from 'streamr-client-protocol'
 import { Logger } from '../helpers/Logger'
 import { decode } from '../helpers/MessageEncoder'
 import { RelayMessage, Status } from '../identifiers'
-import { PeerId, PeerInfo } from '../connection/PeerInfo'
+import { PeerInfo } from '../connection/PeerInfo'
 import { RtcSubTypes } from '../logic/RtcMessage'
 import { NameDirectory } from '../NameDirectory'
 import { Event as WsEndpointEvent } from "../connection/ws/AbstractWsEndpoint"

--- a/packages/network/src/protocol/TrackerServer.ts
+++ b/packages/network/src/protocol/TrackerServer.ts
@@ -21,7 +21,7 @@ const eventPerType: { [key: number]: string } = {}
 eventPerType[TrackerLayer.TrackerMessage.TYPES.StatusMessage] = Event.NODE_STATUS_RECEIVED
 eventPerType[TrackerLayer.TrackerMessage.TYPES.RelayMessage] = Event.RELAY_MESSAGE_RECEIVED
 
-export interface TrackerNode {
+export interface NodeToTracker {
     on(event: Event.NODE_CONNECTED, listener: (nodeId: string) => void): this
     on(event: Event.NODE_DISCONNECTED, listener: (nodeId: string) => void): this
     on(event: Event.NODE_STATUS_RECEIVED, listener: (msg: TrackerLayer.StatusMessage, nodeId: string) => void): this

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -3,7 +3,7 @@ import { runAndWaitForEvents, wait } from 'streamr-test-utils'
 
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { startTracker, Tracker } from '../../src/composition'
-import { TrackerNode, Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { NodeToTracker, Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { getTopology } from '../../src/logic/trackerSummaryUtils'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
@@ -28,8 +28,8 @@ const formStatus = (counter1: number, counter2: number, nodes1: string[], nodes2
 
 describe('tracker: counter filtering', () => {
     let tracker: Tracker
-    let trackerNode1: TrackerNode
-    let trackerNode2: TrackerNode
+    let nodeToTracker1: NodeToTracker
+    let nodeToTracker2: NodeToTracker
 
     beforeEach(async () => {
         tracker = await startTracker({
@@ -37,42 +37,42 @@ describe('tracker: counter filtering', () => {
             port: 30420,
             id: 'tracker'
         })
-        const peerInfo1 = PeerInfo.newNode('trackerNode1')
-        const peerInfo2 = PeerInfo.newNode('trackerNode2')
+        const peerInfo1 = PeerInfo.newNode('nodeToTracker1')
+        const peerInfo2 = PeerInfo.newNode('nodeToTracker2')
         const trackerPeerInfo = PeerInfo.newTracker('tracker')
         const wsClient1 = new NodeClientWsEndpoint(peerInfo1)
         const wsClient2 = new NodeClientWsEndpoint(peerInfo2)
-        trackerNode1 = new TrackerNode(wsClient1)
-        trackerNode2 = new TrackerNode(wsClient2)
+        nodeToTracker1 = new NodeToTracker(wsClient1)
+        nodeToTracker2 = new NodeToTracker(wsClient2)
 
         await runAndWaitForEvents([
-            () => { trackerNode1.connectToTracker(tracker.getUrl(), trackerPeerInfo) },
-            () => { trackerNode2.connectToTracker(tracker.getUrl(), trackerPeerInfo) }], [
-            [trackerNode1, TrackerNodeEvent.CONNECTED_TO_TRACKER],
-            [trackerNode2, TrackerNodeEvent.CONNECTED_TO_TRACKER]
+            () => { nodeToTracker1.connectToTracker(tracker.getUrl(), trackerPeerInfo) },
+            () => { nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo) }], [
+            [nodeToTracker1, NodeToTrackerEvent.CONNECTED_TO_TRACKER],
+            [nodeToTracker2, NodeToTrackerEvent.CONNECTED_TO_TRACKER]
         ])
 
         await runAndWaitForEvents([
-            () => {  trackerNode1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
-            () => { trackerNode2.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) }], [
-            [trackerNode1, TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED],
-            [trackerNode2, TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED]
+            () => {  nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
+            () => { nodeToTracker2.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) }], [
+            [nodeToTracker1, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED],
+            [nodeToTracker2, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED]
         ])
     })
 
     afterEach(async () => {
-        await trackerNode1.stop()
-        await trackerNode2.stop()
+        await nodeToTracker1.stop()
+        await nodeToTracker2.stop()
         await tracker.stop()
     })
 
     test('handles status messages with counters equal or more to current counter(s)', async () => {
         let numOfInstructions = 0
-        trackerNode1.on(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
+        nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
 
-        trackerNode1.sendStatus('tracker', formStatus(1, 666, [], [], false) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(1, 666, [], [], false) as Status)
             .catch(() => {})
 
         await wait(WAIT_TIME)
@@ -81,11 +81,11 @@ describe('tracker: counter filtering', () => {
 
     test('ignores status messages with counters less than current counter(s)', async () => {
         let numOfInstructions = 0
-        trackerNode1.on(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
+        nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
 
-        trackerNode1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status)
             .catch(() => {})
 
         await wait(WAIT_TIME)
@@ -94,11 +94,11 @@ describe('tracker: counter filtering', () => {
 
     test('partly handles status messages with mixed counters compared to current counters', async () => {
         let numOfInstructions = 0
-        trackerNode1.on(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
+        nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
 
-        trackerNode1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
             .catch(() => {})
 
         await wait(WAIT_TIME)
@@ -109,7 +109,7 @@ describe('tracker: counter filtering', () => {
         const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
 
         await runAndWaitForEvents(
-            () => { trackerNode1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
+            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]
         )
@@ -122,7 +122,7 @@ describe('tracker: counter filtering', () => {
 
         await runAndWaitForEvents(
             () => {
-                trackerNode1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
+                nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
             },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -3,7 +3,7 @@ import { waitForEvent } from 'streamr-test-utils'
 
 import { StreamIdAndPartition } from '../../src/identifiers'
 import { NodeToNode, Event as NodeToNodeEvent } from '../../src/protocol/NodeToNode'
-import { TrackerNode, Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { NodeToTracker, Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { TrackerServer, Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { RtcSignaller } from "../../src/logic/RtcSignaller"
@@ -22,8 +22,8 @@ const UUID_REGEX = /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]
 describe('delivery of messages in protocol layer', () => {
     let nodeToNode1: NodeToNode
     let nodeToNode2: NodeToNode
-    let trackerNode: TrackerNode
-    let trackerNode2: TrackerNode
+    let nodeToTracker: NodeToTracker
+    let nodeToTracker2: NodeToTracker
     let trackerServer: TrackerServer
     let tracker: Tracker
     beforeAll(async () => {
@@ -39,13 +39,13 @@ describe('delivery of messages in protocol layer', () => {
         const wsEndpoint1 = new NodeClientWsEndpoint(peerInfo1)
         const wsEndpoint2 = new NodeClientWsEndpoint(peerInfo2)
         const wsEndpoint3 = await startServerWsEndpoint('127.0.0.1', 28516, PeerInfo.newTracker('trackerServer'))
-        trackerNode = new TrackerNode(wsEndpoint1)
-        trackerNode2 = new TrackerNode(wsEndpoint2)
+        nodeToTracker = new NodeToTracker(wsEndpoint1)
+        nodeToTracker2 = new NodeToTracker(wsEndpoint2)
 
         const wrtcEndpoint1 = new WebRtcEndpoint(
             peerInfo1,
             [],
-            new RtcSignaller(peerInfo1, trackerNode),
+            new RtcSignaller(peerInfo1, nodeToTracker),
             new MetricsContext('node1'),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory
@@ -53,7 +53,7 @@ describe('delivery of messages in protocol layer', () => {
         const wrtcEndpoint2 =  new WebRtcEndpoint(
             peerInfo2,
             [],
-            new RtcSignaller(peerInfo2, trackerNode2),
+            new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext('node2'),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
@@ -69,13 +69,13 @@ describe('delivery of messages in protocol layer', () => {
 
         trackerServer = new TrackerServer(wsEndpoint3)
 
-        // Connect trackerNode <-> trackerServer
-        await trackerNode.connectToTracker(trackerServer.getUrl(), trackerServerPeerInfo)
-        await trackerNode2.connectToTracker(trackerServer.getUrl(), trackerServerPeerInfo)
+        // Connect nodeToTracker <-> trackerServer
+        await nodeToTracker.connectToTracker(trackerServer.getUrl(), trackerServerPeerInfo)
+        await nodeToTracker2.connectToTracker(trackerServer.getUrl(), trackerServerPeerInfo)
 
-        // Connect trackerNode <-> Tracker
-        await trackerNode.connectToTracker(tracker.getUrl(), trackerPeerInfo)
-        await trackerNode2.connectToTracker(tracker.getUrl(), trackerPeerInfo)
+        // Connect nodeToTracker <-> Tracker
+        await nodeToTracker.connectToTracker(tracker.getUrl(), trackerPeerInfo)
+        await nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo)
 
         // Connect nodeToNode1 <-> nodeToNode2
         await Promise.all([
@@ -89,8 +89,8 @@ describe('delivery of messages in protocol layer', () => {
         return Promise.all([
             nodeToNode2.stop(),
             nodeToNode1.stop(),
-            trackerNode.stop(),
-            trackerNode2.stop(),
+            nodeToTracker.stop(),
+            nodeToTracker2.stop(),
             trackerServer.stop(),
             tracker.stop()
         ])
@@ -155,7 +155,7 @@ describe('delivery of messages in protocol layer', () => {
 
     it('sendInstruction is delivered', async () => {
         trackerServer.sendInstruction('node1', new StreamIdAndPartition('stream', 10), ['node1'], 15)
-        const [msg, trackerId]: any = await waitForEvent(trackerNode, TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
+        const [msg, trackerId]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED)
 
         expect(trackerId).toEqual('trackerServer')
         expect(msg).toBeInstanceOf(TrackerLayer.InstructionMessage)
@@ -167,7 +167,7 @@ describe('delivery of messages in protocol layer', () => {
     })
 
     it('sendStatus is delivered', async () => {
-        trackerNode.sendStatus('trackerServer', {
+        nodeToTracker.sendStatus('trackerServer', {
             // @ts-expect-error missing fields
             status: 'status',
         })
@@ -183,7 +183,7 @@ describe('delivery of messages in protocol layer', () => {
 
     it('sendUnknownPeerRtcError is delivered', async () => {
         trackerServer.sendUnknownPeerRtcError('node1', 'requestId', 'unknownTargetNode')
-        const [msg, source]: any = await waitForEvent(trackerNode, TrackerNodeEvent.RTC_ERROR_RECEIVED)
+        const [msg, source]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.RTC_ERROR_RECEIVED)
 
         expect(msg).toBeInstanceOf(TrackerLayer.ErrorMessage)
         expect(source).toEqual('trackerServer')
@@ -191,8 +191,8 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.targetNode).toEqual('unknownTargetNode')
     })
 
-    it('sendRtcOffer is delivered (trackerServer->trackerNode)', async () => {
-        const promise = waitForEvent(trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED)
+    it('sendRtcOffer is delivered (trackerServer->nodeToTracker)', async () => {
+        const promise = waitForEvent(nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED)
         trackerServer.sendRtcOffer('node1', 'requestId', PeerInfo.newNode('originatorNode'), 'connectionid','description')
         
         const [msg, source]: any = await (promise)
@@ -209,9 +209,9 @@ describe('delivery of messages in protocol layer', () => {
         })
     })
 
-    it('sendRtcAnswer is delivered (trackerServer->trackerNode)', async () => {
+    it('sendRtcAnswer is delivered (trackerServer->nodeToTracker)', async () => {
         trackerServer.sendRtcAnswer('node1', 'requestId', PeerInfo.newNode('originatorNode'), 'connectionid' , 'description')
-        const [msg, source]: any = await waitForEvent(trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED)
+        const [msg, source]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED)
 
         expect(msg).toBeInstanceOf(TrackerLayer.RelayMessage)
         expect(source).toEqual('trackerServer')
@@ -225,9 +225,9 @@ describe('delivery of messages in protocol layer', () => {
         })
     })
 
-    it('sendRtcConnect is delivered (trackerServer->trackerNode)', async () => {
+    it('sendRtcConnect is delivered (trackerServer->nodeToTracker)', async () => {
         trackerServer.sendRtcConnect('node1', 'requestId', PeerInfo.newNode('originatorNode'))
-        const [msg, source]: any = await waitForEvent(trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED)
+        const [msg, source]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED)
 
         expect(msg).toBeInstanceOf(TrackerLayer.RelayMessage)
         expect(source).toEqual('trackerServer')
@@ -238,9 +238,9 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.data).toEqual({})
     })
 
-    it('sendRtcIceCandidate is delivered (trackerServer->trackerNode)', async () => {
+    it('sendRtcIceCandidate is delivered (trackerServer->nodeToTracker)', async () => {
         trackerServer.sendRtcIceCandidate('node1', 'requestId', PeerInfo.newNode('originatorNode'), 'connectionid', 'candidate', 'mid')
-        const [msg, source]: any = await waitForEvent(trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED)
+        const [msg, source]: any = await waitForEvent(nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED)
 
         expect(msg).toBeInstanceOf(TrackerLayer.RelayMessage)
         expect(source).toEqual('trackerServer')
@@ -255,8 +255,8 @@ describe('delivery of messages in protocol layer', () => {
         })
     })
 
-    it('sendRtcOffer is delivered (trackerNode->trackerServer)', async () => {
-        trackerNode.sendRtcOffer(
+    it('sendRtcOffer is delivered (nodeToTracker->trackerServer)', async () => {
+        nodeToTracker.sendRtcOffer(
             'trackerServer',
             'targetNode',
             'connectionid',
@@ -277,8 +277,8 @@ describe('delivery of messages in protocol layer', () => {
         })
     })
 
-    it('sendRtcConnect is delivered (trackerNode->trackerServer)', async () => {
-        trackerNode.sendRtcConnect('trackerServer', 'targetNode', PeerInfo.newNode('originatorNode'))
+    it('sendRtcConnect is delivered (nodeToTracker->trackerServer)', async () => {
+        nodeToTracker.sendRtcConnect('trackerServer', 'targetNode', PeerInfo.newNode('originatorNode'))
         const [msg, source]: any = await waitForEvent(trackerServer, TrackerServerEvent.RELAY_MESSAGE_RECEIVED)
 
         expect(msg).toBeInstanceOf(TrackerLayer.RelayMessage)

--- a/packages/network/test/integration/message-duplication.test.ts
+++ b/packages/network/test/integration/message-duplication.test.ts
@@ -4,7 +4,7 @@ import { MessageLayer } from 'streamr-client-protocol'
 import { waitForCondition, waitForEvent } from 'streamr-test-utils'
 
 import { createNetworkNode, startTracker } from '../../src/composition'
-import { Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { Event as NodeEvent } from "../../src/logic/Node"
 
 const { StreamMessage, MessageID } = MessageLayer
@@ -62,7 +62,7 @@ describe('duplicate message detection and avoidance', () => {
 
         const allNodesConnnectedToTrackerPromise = Promise.all(otherNodes.map((node) => {
             // @ts-expect-error private field
-            return waitForEvent(node.trackerNode, TrackerNodeEvent.CONNECTED_TO_TRACKER)
+            return waitForEvent(node.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER)
         }))
         // eslint-disable-next-line no-restricted-syntax
         for (const node of otherNodes) {

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -5,7 +5,7 @@ import { TrackerLayer } from 'streamr-client-protocol'
 
 import { createNetworkNode, startTracker } from '../../src/composition'
 import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
-import { Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 import { Event as NodeEvent } from '../../src/logic/Node'
 
 // TODO: maybe worth re-designing this in a way that isn't this arbitrary?
@@ -19,9 +19,9 @@ const THIRD_STREAM_2 = 'stream-11'
 
 // Leave out WebRTC related events
 const TRACKER_NODE_EVENTS_OF_INTEREST = [
-    TrackerNodeEvent.CONNECTED_TO_TRACKER,
-    TrackerNodeEvent.TRACKER_DISCONNECTED,
-    TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED
+    NodeToTrackerEvent.CONNECTED_TO_TRACKER,
+    NodeToTrackerEvent.TRACKER_DISCONNECTED,
+    NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED
 ]
 
 describe('multi trackers', () => {
@@ -131,9 +131,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(FIRST_STREAM_2, 0)
 
         // @ts-expect-error private field
-        let nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        let nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        let nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        let nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
@@ -142,7 +142,7 @@ describe('multi trackers', () => {
 
         expect(nodeOneEvents).toHaveLength(4)
         expect(nodeTwoEvents).toHaveLength(4)
-        expect(nodeTwoEvents[3][0]).toEqual(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
+        expect(nodeTwoEvents[3][0]).toEqual(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED)
         expect(nodeTwoEvents[3][2]).toEqual('trackerOne')
 
         // second stream, second tracker
@@ -150,9 +150,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(SECOND_STREAM_2, 0)
 
         // @ts-expect-error private field
-        nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
@@ -161,7 +161,7 @@ describe('multi trackers', () => {
 
         expect(nodeOneEvents).toHaveLength(1)
         expect(nodeTwoEvents).toHaveLength(1)
-        expect(nodeTwoEvents[0][0]).toEqual(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
+        expect(nodeTwoEvents[0][0]).toEqual(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED)
         expect(nodeTwoEvents[0][2]).toEqual('trackerTwo')
 
         // third stream, third tracker
@@ -169,9 +169,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(THIRD_STREAM_2, 0)
 
         // @ts-expect-error private field
-        nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerNode, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
@@ -180,7 +180,7 @@ describe('multi trackers', () => {
 
         expect(nodeOneEvents).toHaveLength(1)
         expect(nodeTwoEvents).toHaveLength(1)
-        expect(nodeTwoEvents[0][0]).toEqual(TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
+        expect(nodeTwoEvents[0][0]).toEqual(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED)
         expect(nodeTwoEvents[0][2]).toEqual('trackerThree')
     })
 

--- a/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
+++ b/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
@@ -4,7 +4,7 @@ import { MetricsContext } from '../../src/helpers/MetricsContext'
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { Tracker } from '../../src/logic/Tracker'
 import { startTracker } from '../../src/composition'
-import { TrackerNode } from '../../src/protocol/TrackerNode'
+import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { NegotiatedProtocolVersions } from "../../src/connection/NegotiatedProtocolVersions"
 import { Event as ntnEvent, NodeToNode } from "../../src/protocol/NodeToNode"
 import { MessageID, StreamMessage } from "streamr-client-protocol"
@@ -15,9 +15,9 @@ import NodeWebRtcConnectionFactory from "../../src/connection/NodeWebRtcConnecti
 
 describe('Node-to-Node protocol version negotiation', () => {
     let tracker: Tracker
-    let trackerNode1: TrackerNode
-    let trackerNode2: TrackerNode
-    let trackerNode3: TrackerNode
+    let nodeToTracker1: NodeToTracker
+    let nodeToTracker2: NodeToTracker
+    let nodeToTracker3: NodeToTracker
     let ep1: WebRtcEndpoint
     let ep2: WebRtcEndpoint
     let ep3: WebRtcEndpoint
@@ -35,23 +35,23 @@ describe('Node-to-Node protocol version negotiation', () => {
         const peerInfo2 = new PeerInfo('node-endpoint2', PeerType.Node, [1, 2], [31, 32, 33])
         const peerInfo3 = new PeerInfo('node-endpoint3', PeerType.Node, [1, 2], [32])
         const trackerPeerInfo = PeerInfo.newTracker('tracker')
-        // Need to set up TrackerNodes and WsEndpoint(s) to exchange RelayMessage(s) via tracker
+        // Need to set up NodeToTrackers and WsEndpoint(s) to exchange RelayMessage(s) via tracker
         const wsEp1 = new NodeClientWsEndpoint(peerInfo1, new MetricsContext(peerInfo1.peerId))
         const wsEp2 = new NodeClientWsEndpoint(peerInfo2, new MetricsContext(peerInfo2.peerId))
         const wsEp3 = new NodeClientWsEndpoint(peerInfo3, new MetricsContext(peerInfo2.peerId))
-        trackerNode1 = new TrackerNode(wsEp1)
-        trackerNode2 = new TrackerNode(wsEp2)
-        trackerNode3 = new TrackerNode(wsEp3)
+        nodeToTracker1 = new NodeToTracker(wsEp1)
+        nodeToTracker2 = new NodeToTracker(wsEp2)
+        nodeToTracker3 = new NodeToTracker(wsEp3)
 
-        await trackerNode1.connectToTracker(tracker.getUrl(), trackerPeerInfo)
-        await trackerNode2.connectToTracker(tracker.getUrl(), trackerPeerInfo)
-        await trackerNode3.connectToTracker(tracker.getUrl(), trackerPeerInfo)
+        await nodeToTracker1.connectToTracker(tracker.getUrl(), trackerPeerInfo)
+        await nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo)
+        await nodeToTracker3.connectToTracker(tracker.getUrl(), trackerPeerInfo)
 
         // Set up WebRTC endpoints
         ep1 = new WebRtcEndpoint(
             peerInfo1,
             [],
-            new RtcSignaller(peerInfo1, trackerNode1),
+            new RtcSignaller(peerInfo1, nodeToTracker1),
             new MetricsContext('node-endpoint1'),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory,
@@ -60,7 +60,7 @@ describe('Node-to-Node protocol version negotiation', () => {
         ep2 = new WebRtcEndpoint(
             peerInfo2,
             [],
-            new RtcSignaller(peerInfo2, trackerNode2),
+            new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext('node-endpoint2'),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory,
@@ -69,7 +69,7 @@ describe('Node-to-Node protocol version negotiation', () => {
         ep3 = new WebRtcEndpoint(
             peerInfo3,
             [],
-            new RtcSignaller(peerInfo3, trackerNode3),
+            new RtcSignaller(peerInfo3, nodeToTracker3),
             new MetricsContext('node-endpoint3'),
             new NegotiatedProtocolVersions(peerInfo3),
             NodeWebRtcConnectionFactory,
@@ -87,9 +87,9 @@ describe('Node-to-Node protocol version negotiation', () => {
     afterEach(async () => {
         await Promise.allSettled([
             tracker.stop(),
-            trackerNode1.stop(),
-            trackerNode2.stop(),
-            trackerNode3.stop(),
+            nodeToTracker1.stop(),
+            nodeToTracker2.stop(),
+            nodeToTracker3.stop(),
             ep1.stop(),
             ep2.stop(),
             ep3.stop()

--- a/packages/network/test/integration/webrtc-error-scenarios-during-signalling.test.ts
+++ b/packages/network/test/integration/webrtc-error-scenarios-during-signalling.test.ts
@@ -4,7 +4,7 @@ import { Tracker } from '../../src/logic/Tracker'
 import { NetworkNode } from '../../src/NetworkNode'
 import { createNetworkNode, startTracker } from '../../src/composition'
 import { Event as NodeEvent } from '../../src/logic/Node'
-import { Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 
 /**
  * Tests for error scenarios during signalling
@@ -54,7 +54,7 @@ describe('Signalling error scenarios', () => {
     it('connection recovers after timeout if one endpoint closes during signalling', async () => {
         await runAndWaitForEvents([ ()=> { nodeOne.subscribe(streamId, 0) }, () => { nodeTwo.subscribe(streamId, 0) } ],
             // @ts-expect-error private field
-            [nodeTwo.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         )
 
         // @ts-expect-error private field
@@ -73,9 +73,9 @@ describe('Signalling error scenarios', () => {
         
         await runAndWaitForEvents([ () => { nodeOne.subscribe(streamId, 0)}, () => { nodeTwo.subscribe(streamId, 0) } ], [
             // @ts-expect-error private field
-            [ nodeTwo.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED],
+            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
             // @ts-expect-error private field
-            [nodeOne.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         ])
 
         await runAndWaitForEvents([
@@ -111,24 +111,24 @@ describe('Signalling error scenarios', () => {
 
         await runAndWaitForEvents([ () => { nodeOne.subscribe('stream-id', 0) }, () => { nodeTwo.subscribe('stream-id', 0) }] , [
             // @ts-expect-error private field
-            [nodeOne.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED],
+            [nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
             // @ts-expect-error private field
-            [nodeTwo.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         ])
 
         await runAndWaitForEvents([ 
             // @ts-expect-error private field
-            () => { nodeOne.trackerNode.endpoint.close('tracker') },
+            () => { nodeOne.nodeToTracker.endpoint.close('tracker') },
             // @ts-expect-error private field
-            () => { nodeTwo.trackerNode.endpoint.close('tracker') }], [
+            () => { nodeTwo.nodeToTracker.endpoint.close('tracker') }], [
             // @ts-expect-error private field
-            [ nodeOne.trackerNode, TrackerNodeEvent.TRACKER_DISCONNECTED ],
+            [ nodeOne.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [ nodeTwo.trackerNode, TrackerNodeEvent.TRACKER_DISCONNECTED ],
+            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [ nodeOne.trackerNode, TrackerNodeEvent.CONNECTED_TO_TRACKER ],
+            [ nodeOne.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
             // @ts-expect-error private field
-            [ nodeTwo.trackerNode, TrackerNodeEvent.CONNECTED_TO_TRACKER ],
+            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
         ], 15000)
     }, 20000)
 
@@ -138,17 +138,17 @@ describe('Signalling error scenarios', () => {
             () => { nodeOne.subscribe('stream-id', 0) },
             () => { nodeTwo.subscribe('stream-id', 0) } ], [
             // @ts-expect-error private field
-            [ nodeOne.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED ],
+            [ nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ],
             // @ts-expect-error private field
-            [ nodeTwo.trackerNode, TrackerNodeEvent.RELAY_MESSAGE_RECEIVED ]
+            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ]
         ], 9997)
 
         // @ts-expect-error private field
-        await runAndWaitForEvents( () => {  nodeOne.trackerNode.endpoint.close('tracker') }, [
+        await runAndWaitForEvents( () => {  nodeOne.nodeToTracker.endpoint.close('tracker') }, [
             // @ts-expect-error private field
-            [nodeOne.trackerNode, TrackerNodeEvent.TRACKER_DISCONNECTED ],
+            [nodeOne.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [nodeOne.trackerNode, TrackerNodeEvent.CONNECTED_TO_TRACKER],
+            [nodeOne.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER],
             [nodeOne, NodeEvent.NODE_CONNECTED, 15000],
             [nodeTwo, NodeEvent.NODE_CONNECTED, 15000]
         ], 20000)

--- a/packages/network/test/integration/webrtc-multi-signaller.test.ts
+++ b/packages/network/test/integration/webrtc-multi-signaller.test.ts
@@ -1,5 +1,5 @@
 import { MetricsContext, startTracker } from '../../src/composition'
-import { TrackerNode } from '../../src/protocol/TrackerNode'
+import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { Tracker, Event as TrackerEvent } from '../../src/logic/Tracker'
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { waitForEvent } from 'streamr-test-utils'
@@ -13,8 +13,8 @@ import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 describe('WebRTC multisignaller test', () => {
     let tracker1: Tracker
     let tracker2: Tracker
-    let trackerNode1: TrackerNode
-    let trackerNode2: TrackerNode
+    let nodeToTracker1: NodeToTracker
+    let nodeToTracker2: NodeToTracker
     let endpoint1: WebRtcEndpoint
     let endpoint2: WebRtcEndpoint
 
@@ -33,16 +33,16 @@ describe('WebRTC multisignaller test', () => {
         const ep1 = new NodeClientWsEndpoint(PeerInfo.newNode('node-1'), new MetricsContext(''))
         const ep2 = new NodeClientWsEndpoint(PeerInfo.newNode('node-2'), new MetricsContext(''))
 
-        trackerNode1 = new TrackerNode(ep1)
-        trackerNode2 = new TrackerNode(ep2)
+        nodeToTracker1 = new NodeToTracker(ep1)
+        nodeToTracker2 = new NodeToTracker(ep2)
 
-        trackerNode1.connectToTracker(tracker1.getUrl(), PeerInfo.newTracker('tracker1'))
+        nodeToTracker1.connectToTracker(tracker1.getUrl(), PeerInfo.newTracker('tracker1'))
         await waitForEvent(tracker1, TrackerEvent.NODE_CONNECTED)
-        trackerNode2.connectToTracker(tracker1.getUrl(), PeerInfo.newTracker('tracker1'))
+        nodeToTracker2.connectToTracker(tracker1.getUrl(), PeerInfo.newTracker('tracker1'))
         await waitForEvent(tracker1, TrackerEvent.NODE_CONNECTED)
-        trackerNode1.connectToTracker(tracker2.getUrl(), PeerInfo.newTracker('tracker2'))
+        nodeToTracker1.connectToTracker(tracker2.getUrl(), PeerInfo.newTracker('tracker2'))
         await waitForEvent(tracker2, TrackerEvent.NODE_CONNECTED)
-        trackerNode2.connectToTracker(tracker2.getUrl(), PeerInfo.newTracker('tracker2'))
+        nodeToTracker2.connectToTracker(tracker2.getUrl(), PeerInfo.newTracker('tracker2'))
         await waitForEvent(tracker2, TrackerEvent.NODE_CONNECTED)
 
         const peerInfo1 = PeerInfo.newNode('node-1')
@@ -50,7 +50,7 @@ describe('WebRTC multisignaller test', () => {
         endpoint1 = new WebRtcEndpoint(
             peerInfo1,
             ['stun:stun.l.google.com:19302'],
-            new RtcSignaller(peerInfo1, trackerNode1),
+            new RtcSignaller(peerInfo1, nodeToTracker1),
             new MetricsContext(''),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory
@@ -58,7 +58,7 @@ describe('WebRTC multisignaller test', () => {
         endpoint2 = new WebRtcEndpoint(
             peerInfo2,
             ['stun:stun.l.google.com:19302'],
-            new RtcSignaller(peerInfo2, trackerNode2),
+            new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext(''),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
@@ -69,8 +69,8 @@ describe('WebRTC multisignaller test', () => {
         await Promise.allSettled([
             tracker1.stop(),
             tracker2.stop(),
-            trackerNode1.stop(),
-            trackerNode2.stop(),
+            nodeToTracker1.stop(),
+            nodeToTracker2.stop(),
             endpoint1.stop(),
             endpoint2.stop(),
         ])

--- a/packages/network/test/unit/RtcSignaller.test.ts
+++ b/packages/network/test/unit/RtcSignaller.test.ts
@@ -3,44 +3,44 @@ import { TrackerLayer } from 'streamr-client-protocol'
 
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
-import { Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
+import { Event as NodeToTrackerEvent } from '../../src/protocol/NodeToTracker'
 
 const { ErrorMessage, RelayMessage } = TrackerLayer
 
 describe('RtcSignaller', () => {
     let peerInfo: PeerInfo
-    let trackerNodeMock: any
+    let nodeToTrackerMock: any
     let rtcSignaller: RtcSignaller
 
     beforeEach(() => {
         peerInfo = PeerInfo.newNode('node')
-        trackerNodeMock = new EventEmitter()
-        rtcSignaller = new RtcSignaller(peerInfo, trackerNodeMock)
+        nodeToTrackerMock = new EventEmitter()
+        rtcSignaller = new RtcSignaller(peerInfo, nodeToTrackerMock)
     })
 
-    it('invoking onConnectionNeeded delegates to sendRtcConnect on trackerNode', () => {
-        trackerNodeMock.sendRtcConnect = jest.fn().mockResolvedValue(true)
+    it('invoking onConnectionNeeded delegates to sendRtcConnect on nodeToTracker', () => {
+        nodeToTrackerMock.sendRtcConnect = jest.fn().mockResolvedValue(true)
         rtcSignaller.sendRtcConnect('router', 'targetNode')
-        expect(trackerNodeMock.sendRtcConnect).toHaveBeenCalledWith('router', 'targetNode', peerInfo)
+        expect(nodeToTrackerMock.sendRtcConnect).toHaveBeenCalledWith('router', 'targetNode', peerInfo)
     })
 
-    it('invoking sendRtcIceCandidate delegates to sendRtcIceCandidate on trackerNode', () => {
-        trackerNodeMock.sendRtcIceCandidate = jest.fn().mockResolvedValue(true)
+    it('invoking sendRtcIceCandidate delegates to sendRtcIceCandidate on nodeToTracker', () => {
+        nodeToTrackerMock.sendRtcIceCandidate = jest.fn().mockResolvedValue(true)
         rtcSignaller.sendRtcIceCandidate('router', 'targetNode', 'connectionid', 'candidate', 'mid')
-        expect(trackerNodeMock.sendRtcIceCandidate).toHaveBeenCalledWith('router', 'targetNode', 'connectionid', peerInfo, 'candidate', 'mid')
+        expect(nodeToTrackerMock.sendRtcIceCandidate).toHaveBeenCalledWith('router', 'targetNode', 'connectionid', peerInfo, 'candidate', 'mid')
     })
 
-    it('invoking sendRtcOffer delegates to sendRtcOffer on trackerNode', () => {
-        trackerNodeMock.sendRtcOffer = jest.fn().mockResolvedValue(true)
+    it('invoking sendRtcOffer delegates to sendRtcOffer on nodeToTracker', () => {
+        nodeToTrackerMock.sendRtcOffer = jest.fn().mockResolvedValue(true)
         rtcSignaller.sendRtcOffer('router', 'targetNode', 'connectionid', 'description')
-        expect(trackerNodeMock.sendRtcOffer).toHaveBeenCalledWith('router', 'targetNode', 'connectionid', peerInfo, 'description')
+        expect(nodeToTrackerMock.sendRtcOffer).toHaveBeenCalledWith('router', 'targetNode', 'connectionid', peerInfo, 'description')
     })
 
-    it('connectListener invoked when trackerNode emits rtcConnect message', () => {
+    it('connectListener invoked when nodeToTracker emits rtcConnect message', () => {
         const cbFn = jest.fn()
         rtcSignaller.setConnectListener(cbFn)
-        trackerNodeMock.emit(
-            TrackerNodeEvent.RELAY_MESSAGE_RECEIVED,
+        nodeToTrackerMock.emit(
+            NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED,
             new RelayMessage({
                 requestId: '',
                 originator: PeerInfo.newNode('originator'),
@@ -57,11 +57,11 @@ describe('RtcSignaller', () => {
         })
     })
 
-    it('offerListener invoked when trackerNode emits rtcOffer message', () => {
+    it('offerListener invoked when nodeToTracker emits rtcOffer message', () => {
         const cbFn = jest.fn()
         rtcSignaller.setOfferListener(cbFn)
-        trackerNodeMock.emit(
-            TrackerNodeEvent.RELAY_MESSAGE_RECEIVED,
+        nodeToTrackerMock.emit(
+            NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED,
             new RelayMessage({
                 requestId: '',
                 originator: PeerInfo.newNode('originator'),
@@ -80,11 +80,11 @@ describe('RtcSignaller', () => {
         })
     })
 
-    it('answerListener invoked when trackerNode emits rtcAnswer message', () => {
+    it('answerListener invoked when nodeToTracker emits rtcAnswer message', () => {
         const cbFn = jest.fn()
         rtcSignaller.setAnswerListener(cbFn)
-        trackerNodeMock.emit(
-            TrackerNodeEvent.RELAY_MESSAGE_RECEIVED,
+        nodeToTrackerMock.emit(
+            NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED,
             new RelayMessage({
                 requestId: '',
                 originator: PeerInfo.newNode('originator'),
@@ -103,11 +103,11 @@ describe('RtcSignaller', () => {
         })
     })
 
-    it('iceCandidateListener invoked when trackerNode emits iceCandidate message', () => {
+    it('iceCandidateListener invoked when nodeToTracker emits iceCandidate message', () => {
         const cbFn = jest.fn()
         rtcSignaller.setIceCandidateListener(cbFn)
-        trackerNodeMock.emit(
-            TrackerNodeEvent.RELAY_MESSAGE_RECEIVED,
+        nodeToTrackerMock.emit(
+            NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED,
             new RelayMessage({
                 requestId: '',
                 originator: PeerInfo.newNode('originator'),
@@ -128,11 +128,11 @@ describe('RtcSignaller', () => {
         })
     })
 
-    it('errorListener invoked when trackerNode emits RTC_ERROR_RECEIVED', () => {
+    it('errorListener invoked when nodeToTracker emits RTC_ERROR_RECEIVED', () => {
         const cbFn = jest.fn()
         rtcSignaller.setErrorListener(cbFn)
-        trackerNodeMock.emit(
-            TrackerNodeEvent.RTC_ERROR_RECEIVED,
+        nodeToTrackerMock.emit(
+            NodeToTrackerEvent.RTC_ERROR_RECEIVED,
             new ErrorMessage({
                 requestId: '',
                 targetNode: 'unknownTargetNode',

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -1,5 +1,5 @@
 import { MetricsContext, startTracker } from '../../src/composition'
-import { TrackerNode } from '../../src/protocol/TrackerNode'
+import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { Tracker, Event as TrackerEvent } from '../../src/logic/Tracker'
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { waitForCondition, waitForEvent, wait, runAndWaitForEvents } from 'streamr-test-utils'
@@ -12,8 +12,8 @@ import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 
 describe('WebRtcEndpoint', () => {
     let tracker: Tracker
-    let trackerNode1: TrackerNode
-    let trackerNode2: TrackerNode
+    let nodeToTracker1: NodeToTracker
+    let nodeToTracker2: NodeToTracker
     let endpoint1: WebRtcEndpoint
     let endpoint2: WebRtcEndpoint
 
@@ -30,14 +30,14 @@ describe('WebRtcEndpoint', () => {
             const trackerPeerInfo = PeerInfo.newTracker('tracker')
             const ep1 = await new NodeClientWsEndpoint(PeerInfo.newNode('node-1'))
             const ep2 = await new NodeClientWsEndpoint(PeerInfo.newNode('node-2'))
-            trackerNode1 = new TrackerNode(ep1)
-            trackerNode2 = new TrackerNode(ep2)
+            nodeToTracker1 = new NodeToTracker(ep1)
+            nodeToTracker2 = new NodeToTracker(ep2)
             await Promise.all([
-                trackerNode1.connectToTracker(tracker.getUrl(), trackerPeerInfo),
+                nodeToTracker1.connectToTracker(tracker.getUrl(), trackerPeerInfo),
                 waitForEvent(tracker, TrackerEvent.NODE_CONNECTED)
             ])
             await Promise.all([
-                trackerNode2.connectToTracker(tracker.getUrl(), trackerPeerInfo),
+                nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo),
                 waitForEvent(tracker, TrackerEvent.NODE_CONNECTED)
             ])
 
@@ -46,7 +46,7 @@ describe('WebRtcEndpoint', () => {
             endpoint1 = new WebRtcEndpoint(
                 peerInfo1,
                 ["stun:stun.l.google.com:19302"],
-                new RtcSignaller(peerInfo1, trackerNode1),
+                new RtcSignaller(peerInfo1, nodeToTracker1),
                 new MetricsContext(''),
                 new NegotiatedProtocolVersions(peerInfo1),
                 factory
@@ -54,7 +54,7 @@ describe('WebRtcEndpoint', () => {
             endpoint2 = new WebRtcEndpoint(
                 peerInfo2,
                 ["stun:stun.l.google.com:19302"],
-                new RtcSignaller(peerInfo2, trackerNode2),
+                new RtcSignaller(peerInfo2, nodeToTracker2),
                 new MetricsContext(''),
                 new NegotiatedProtocolVersions(peerInfo2),
                 factory
@@ -64,8 +64,8 @@ describe('WebRtcEndpoint', () => {
         afterEach(async () => {
             await Promise.allSettled([
                 tracker.stop(),
-                trackerNode1.stop(),
-                trackerNode2.stop(),
+                nodeToTracker1.stop(),
+                nodeToTracker2.stop(),
                 endpoint1.stop(),
                 endpoint2.stop()
             ])


### PR DESCRIPTION
Renamed the `TrackerNode` class to `NodeToTracker`. The role of the class is similar to `NodeToNode` class, and now the name reflects the similarity.