### PR TITLE
Fix tracker hashing

### DIFF
--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -10,12 +10,12 @@ import { Event as NodeEvent } from '../../src/logic/Node'
 
 // TODO: maybe worth re-designing this in a way that isn't this arbitrary?
 const FIRST_STREAM = 'stream-1' // assigned to trackerOne (arbitrarily by hashing algo)
-const SECOND_STREAM = 'stream-8' // assigned to trackerTwo
-const THIRD_STREAM = 'stream-9' // assigned to trackerThree
+const SECOND_STREAM = 'stream-3' // assigned to trackerTwo
+const THIRD_STREAM = 'stream-2' // assigned to trackerThree
 
-const FIRST_STREAM_2 = 'stream-12'
-const SECOND_STREAM_2 = 'stream-10'
-const THIRD_STREAM_2 = 'stream-11'
+const FIRST_STREAM_2 = 'stream-13' // assigned to trackerOne
+const SECOND_STREAM_2 = 'stream-10' // assigned to trackerTwo
+const THIRD_STREAM_2 = 'stream-15' // assigned to trackerThree
 
 // Leave out WebRTC related events
 const TRACKER_NODE_EVENTS_OF_INTEREST = [

--- a/packages/protocol/src/utils/HashUtil.ts
+++ b/packages/protocol/src/utils/HashUtil.ts
@@ -1,0 +1,31 @@
+import crypto from 'crypto'
+
+/**
+ * Computes a deterministic index for a given string or number key.
+ * Used for deterministically selecting an entry from an ordered list
+ * for various load balancing and partitioning purposes.
+ * 
+ * @param lengthOfArray Number of items to select from
+ * @param key Input string or number
+ * @returns Array index between [0..lengthOfArray-1]
+ */
+export const keyToArrayIndex = (lengthOfArray: number, key: string | number) => {
+    if (!(Number.isSafeInteger(lengthOfArray) && lengthOfArray > 0)) {
+        throw new Error(`lengthOfArray is not a safe positive integer! ${lengthOfArray}`)
+    }
+
+    if (lengthOfArray === 1) {
+        // Fast common case
+        return 0
+    }
+
+    // Number key handling
+    if (typeof key === 'number') {
+        return Math.abs(key) % lengthOfArray
+    }
+
+    // String key handling
+    const buffer = crypto.createHash('md5').update(key).digest()
+    const intHash = buffer.readInt32LE(0)
+    return Math.abs(intHash) % lengthOfArray
+}

--- a/packages/protocol/src/utils/TrackerRegistry.ts
+++ b/packages/protocol/src/utils/TrackerRegistry.ts
@@ -1,6 +1,8 @@
 import { Contract, providers } from 'ethers'
 import { ConnectionInfo } from 'ethers/lib/utils'
 
+import { keyToArrayIndex } from './HashUtil'
+
 import * as trackerRegistryConfig from '../../contracts/TrackerRegistry.json'
 
 const { JsonRpcProvider } = providers
@@ -12,13 +14,6 @@ export type SmartContractRecord = {
 }
 
 export type TrackerInfo = SmartContractRecord | string
-
-// source: https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
-function hashCode(str: string): number {
-    const a = str.split('')
-        .reduce((prevHash, currVal) => (((prevHash << 5) - prevHash) + currVal.charCodeAt(0)) | 0, 0)
-    return Math.abs(a)
-}
 
 export class TrackerRegistry<T extends TrackerInfo> {
     private readonly records: T[]
@@ -38,7 +33,8 @@ export class TrackerRegistry<T extends TrackerInfo> {
 
         const streamKey = `${streamId}::${partition}`
 
-        return this.records[hashCode(streamKey) % this.records.length]
+        const index = keyToArrayIndex(this.records.length, streamKey)
+        return this.records[index]
     }
 
     getAllTrackers(): T[] {

--- a/packages/protocol/src/utils/index.ts
+++ b/packages/protocol/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from "./SPID"
 import { createTrackerRegistry, getTrackerRegistryFromContract, TrackerRegistry, SmartContractRecord } from "./TrackerRegistry"
 import { createStorageNodeRegistry, getStorageNodeRegistryFromContract, StorageNodeRegistry } from "./StorageNodeRegistry"
 import { generateMnemonicFromAddress, parseAddressFromNodeId } from './NodeUtil'
+import { keyToArrayIndex } from "./HashUtil"
 
 export {
     TimestampUtil,
@@ -22,5 +23,6 @@ export {
     createStorageNodeRegistry,
     getStorageNodeRegistryFromContract,
     generateMnemonicFromAddress,
-    parseAddressFromNodeId
+    parseAddressFromNodeId,
+    keyToArrayIndex,
 }

--- a/packages/protocol/test/integration/TrackerRegistry.test.ts
+++ b/packages/protocol/test/integration/TrackerRegistry.test.ts
@@ -110,14 +110,14 @@ describe('TrackerRegistry', () => {
                 ws: 'ws://10.200.10.1:30301'
             })
             expect(trackerRegistry.getTracker('stream-2')).toEqual({
-                id: '0x0540A3e144cdD81F402e7772C76a5808B71d2d30',
-                http: 'http://10.200.10.1:30302',
-                ws: 'ws://10.200.10.1:30302'
-            })
-            expect(trackerRegistry.getTracker('stream-3')).toEqual({
                 id: '0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2',
                 http: 'http://10.200.10.1:30303',
                 ws: 'ws://10.200.10.1:30303'
+            })
+            expect(trackerRegistry.getTracker('stream-3')).toEqual({
+                id: '0x0540A3e144cdD81F402e7772C76a5808B71d2d30',
+                http: 'http://10.200.10.1:30302',
+                ws: 'ws://10.200.10.1:30302'
             })
         })
     })

--- a/packages/protocol/test/unit/utils/HashUtil.test.ts
+++ b/packages/protocol/test/unit/utils/HashUtil.test.ts
@@ -1,0 +1,29 @@
+import { keyToArrayIndex }  from '../../../src/utils/HashUtil'
+
+describe('HashUtil', () => {
+    describe('keyToArrayIndex', () => {
+        it('always returns 0 if there is only one item', () => {
+            expect(keyToArrayIndex(1, 'foo')).toBe(0)
+            expect(keyToArrayIndex(1, 'bar')).toBe(0)
+            expect(keyToArrayIndex(1, 123456)).toBe(0)
+        })
+    
+        it('selects a deterministic index for string inputs', () => {
+            expect(keyToArrayIndex(100, 'foo')).toBe(72)
+            expect(keyToArrayIndex(100, 'foo')).toBe(72)
+        })
+    
+        it('selects a deterministic index for number inputs', () => {
+            expect(keyToArrayIndex(100, 12345)).toBe(45)
+            expect(keyToArrayIndex(100, 12345)).toBe(45)
+        })
+
+        it('throws for zero lengthOfArray', () => {
+            expect(() => keyToArrayIndex(0, 'foo')).toThrow()
+        })
+
+        it('throws for negative lengthOfArray', () => {
+            expect(() => keyToArrayIndex(-1, 'foo')).toThrow()
+        })
+    })
+})


### PR DESCRIPTION
Use our "standard" string to array index hashing method for selecting tracker, instead of the simple home-made one.

The first commit was cherry-picked from #180 to get it into use faster.

This change is only breaking if there is a network where old and new code are mixed. But that won't be the case in testnet2 and beyond.