### PR TITLE
network [NET-472]: debounced instruction send for Tracker

### DIFF
--- a/packages/broker/bin/tracker.js
+++ b/packages/broker/bin/tracker.js
@@ -16,6 +16,8 @@ program
     .option('--attachHttpEndpoints', 'attach http endpoints')
     .option('--privateKeyFileName <privateKeyFileName>', 'private key filename', undefined)
     .option('--certFileName <certFileName>', 'cert filename', undefined)
+    .option('--topologyStabilizationDebounceWait <topologyStabilizationDebounceWait>', 'topologyStabilizationDebounceWait')
+    .option('--topologyStabilizationMaxWait <topologyStabilizationMaxWait>', 'topologyStabilizationMaxWait')
     .description('Run tracker with reporting')
     .parse(process.argv)
 
@@ -29,6 +31,19 @@ const address = wallet ? wallet.address : null
 const id = address || `tracker-${program.opts().port}`
 const name = trackerName || address
 
+const getTopologyStabilization = () => {
+    const debounceWait = program.opts().topologyStabilizationDebounceWait
+    const maxWait = program.opts().topologyStabilizationMaxWait
+    if ((debounceWait !== undefined) || (maxWait !== undefined)) {
+        return {
+            debounceWait: parseInt(debounceWait),
+            maxWait: parseInt(maxWait)
+        }
+    } else {
+        return undefined
+    }
+}
+
 async function main() {
     try {
         await startTracker({
@@ -39,7 +54,8 @@ async function main() {
             maxNeighborsPerNode: Number.parseInt(program.opts().maxNeighborsPerNode),
             attachHttpEndpoints: program.opts().attachHttpEndpoints,
             privateKeyFileName: program.opts().privateKeyFileName,
-            certFileName: program.opts().certFileName
+            certFileName: program.opts().certFileName,
+            topologyStabilization: getTopologyStabilization()
         })
 
         const trackerObj = {}

--- a/packages/network/bin/tracker.js
+++ b/packages/network/bin/tracker.js
@@ -15,12 +15,27 @@ program
     .option('--maxNeighborsPerNode <maxNeighborsPerNode>', 'maxNeighborsPerNode', '4')
     .option('--metrics <metrics>', 'output metrics to console', false)
     .option('--metricsInterval <metricsInterval>', 'metrics output interval (ms)', '5000')
+    .option('--topologyStabilizationDebounceWait <topologyStabilizationDebounceWait>', 'topologyStabilizationDebounceWait')
+    .option('--topologyStabilizationMaxWait <topologyStabilizationMaxWait>', 'topologyStabilizationMaxWait')
     .description('Run tracker with reporting')
     .parse(process.argv)
 
 const id = program.opts().id || `TR${program.opts().port}`
 const name = program.opts().trackerName || id
 const logger = new Logger(module)
+
+const getTopologyStabilization = () => {
+    const debounceWait = program.opts().topologyStabilizationDebounceWait
+    const maxWait = program.opts().topologyStabilizationMaxWait
+    if ((debounceWait !== undefined) || (maxWait !== undefined)) {
+        return {
+            debounceWait: parseInt(debounceWait),
+            maxWait: parseInt(maxWait)
+        }
+    } else {
+        return undefined
+    }
+}
 
 async function main() {
     const metricsContext = new MetricsContext(id)
@@ -31,7 +46,8 @@ async function main() {
             id,
             name,
             maxNeighborsPerNode: Number.parseInt(program.opts().maxNeighborsPerNode, 10),
-            metricsContext
+            metricsContext,
+            topologyStabilization: getTopologyStabilization()
         })
 
         const trackerObj = {}

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -4,7 +4,7 @@ import { MetricsContext } from './helpers/MetricsContext'
 import { Location, TrackerInfo } from './identifiers'
 import { PeerInfo } from './connection/PeerInfo'
 import { ServerWsEndpoint, startHttpServer } from './connection/ws/ServerWsEndpoint'
-import { Tracker } from './logic/Tracker'
+import { TopologyStabilizationOptions, Tracker } from './logic/Tracker'
 import { TrackerServer } from './protocol/TrackerServer'
 import { trackerHttpEndpoints } from './helpers/trackerHttpEndpoints'
 import { NodeToTracker } from './protocol/NodeToTracker'
@@ -45,7 +45,8 @@ export interface TrackerOptions extends AbstractNodeOptions {
     attachHttpEndpoints?: boolean
     maxNeighborsPerNode?: number
     privateKeyFileName?: string
-    certFileName?: string
+    certFileName?: string,
+    topologyStabilization?: TopologyStabilizationOptions
 }
 
 export interface NetworkNodeOptions extends AbstractNodeOptions {
@@ -71,6 +72,7 @@ export const startTracker = async ({
     trackerPingInterval,
     privateKeyFileName,
     certFileName,
+    topologyStabilization
 }: TrackerOptions): Promise<Tracker> => {
     const peerInfo = PeerInfo.newTracker(id, name, undefined, undefined, location)
     const httpServer = await startHttpServer(host, port, privateKeyFileName, certFileName)
@@ -83,6 +85,7 @@ export const startTracker = async ({
         },
         metricsContext,
         maxNeighborsPerNode,
+        topologyStabilization
     })
 
     if (attachHttpEndpoints) {

--- a/packages/network/src/logic/InstructionSender.ts
+++ b/packages/network/src/logic/InstructionSender.ts
@@ -1,0 +1,108 @@
+import _ from 'lodash'
+import { Logger } from '../helpers/Logger'
+import { Metrics } from '../helpers/MetricsContext'
+import { StreamIdAndPartition, StreamKey } from '../identifiers'
+import { TrackerServer } from '../protocol/TrackerServer'
+import { NodeId } from './Node'
+import { TopologyStabilizationOptions } from './Tracker'
+
+/**
+ * Instructions are collected to buffers and sent after a short delay. For each stream
+ * there is a separate buffer.
+ * 
+ * We use debouncing to delay the sending. It means that we send the buffered instructions 
+ * when either of these conditions is satisfied: 
+ * - the topology stabilizes: no new instructions has been formed for the stream in 
+ *   X milliseconds
+ * - the buffer times out: we have buffered an instruction for Y milliseconds
+ * 
+ * When an instruction is added to a stream buffer, it may overwrite an existing
+ * instruction in the buffer if the both instructions share the same nodeId. In that 
+ * situation we expect that the previous instruction is no longer valid (it has a lower
+ * counterValue) and can be ignored.
+ */
+
+const DEFAULT_TOPOLOGY_STABILIZATION: TopologyStabilizationOptions = {
+    debounceWait: 100,
+    maxWait: 2000
+}
+
+const logger = new Logger(module)
+
+export interface Instruction {
+    nodeId: NodeId,
+    streamKey: StreamKey,
+    newNeighbors: NodeId[],
+    counterValue: number
+}
+
+class StreamInstructionBuffer {
+    private instructions: Map<NodeId,Instruction> = new Map()
+    private debouncedOnReady: () => void
+
+    constructor(topologyStabilization: TopologyStabilizationOptions, onReady: () => void) {
+        this.debouncedOnReady = _.debounce(onReady, topologyStabilization.debounceWait, {
+            maxWait: topologyStabilization.maxWait
+        })
+    }
+
+    addInstruction(instruction: Instruction) {
+        // may overwrite an earlier instruction for the same node
+        this.instructions.set(instruction.nodeId, instruction)
+        this.debouncedOnReady()
+    }
+
+    getInstructions(): IterableIterator<Instruction> {
+        return this.instructions.values()
+    }
+}
+
+export class InstructionSender {
+
+    private readonly streamBuffers: Map<StreamKey,StreamInstructionBuffer> = new Map()
+    private readonly topologyStabilization: TopologyStabilizationOptions
+    private readonly trackerServer: TrackerServer
+    private readonly metrics: Metrics
+
+    constructor(topologyStabilization: TopologyStabilizationOptions|undefined, trackerServer: TrackerServer, metrics: Metrics) {
+        this.topologyStabilization = topologyStabilization ?? DEFAULT_TOPOLOGY_STABILIZATION
+        this.trackerServer = trackerServer
+        this.metrics = metrics
+    }
+
+    addInstruction(instruction: Instruction) {
+        this.getOrCreateBuffer(instruction.streamKey).addInstruction(instruction)
+    }
+
+    getOrCreateBuffer(streamKey: StreamKey) {
+        const existingBuffer = this.streamBuffers.get(streamKey)
+        if (existingBuffer !== undefined) {
+            return existingBuffer
+        } else {
+            const newBuffer = new StreamInstructionBuffer(this.topologyStabilization, () => {
+                this.streamBuffers.delete(streamKey)
+                this.sendInstructions(newBuffer)
+            })
+            this.streamBuffers.set(streamKey, newBuffer)
+            return newBuffer
+        }
+    }
+
+    private async sendInstructions(buffer: StreamInstructionBuffer) {
+        for (const instruction of buffer!.getInstructions()) {
+            const { nodeId, streamKey, newNeighbors, counterValue } = instruction
+            this.metrics.record('instructionsSent', 1)
+            try {
+                await this.trackerServer.sendInstruction(
+                    nodeId,
+                    StreamIdAndPartition.fromKey(streamKey),
+                    newNeighbors,
+                    counterValue
+                )
+                logger.debug('Instruction %o sent to node %o', newNeighbors, { counterValue, streamKey, nodeId })
+            } catch (err) {
+                logger.error(`Failed to send instructions %o to node %o, reason: %s`, newNeighbors, { counterValue, streamKey, nodeId }, err)
+            }
+        }
+    }
+}

--- a/packages/network/src/logic/Tracker.ts
+++ b/packages/network/src/logic/Tracker.ts
@@ -7,9 +7,10 @@ import { InstructionCounter } from './InstructionCounter'
 import { LocationManager } from './LocationManager'
 import { attachRtcSignalling } from './rtcSignallingHandlers'
 import { PeerInfo } from '../connection/PeerInfo'
-import { Location, Status, StatusStreams, StreamIdAndPartition, StreamKey } from '../identifiers'
+import { Location, Status, StatusStreams, StreamKey } from '../identifiers'
 import { TrackerLayer } from 'streamr-client-protocol'
 import { NodeId } from './Node'
+import { InstructionSender } from './InstructionSender'
 
 export type TrackerId = string
 
@@ -19,13 +20,19 @@ export enum Event {
     NODE_CONNECTED = 'streamr:tracker:node-connected'
 }
 
+export interface TopologyStabilizationOptions {
+    debounceWait: number
+    maxWait: number
+}
+
 export interface TrackerOptions {
     maxNeighborsPerNode: number
     peerInfo: PeerInfo
     protocols: {
         trackerServer: TrackerServer
     }
-    metricsContext?: MetricsContext
+    metricsContext?: MetricsContext,
+    topologyStabilization?: TopologyStabilizationOptions
 }
 
 export type OverlayPerStream = Record<StreamKey,OverlayTopology>
@@ -45,6 +52,7 @@ export class Tracker extends EventEmitter {
     private readonly overlayConnectionRtts: OverlayConnectionRtts
     private readonly locationManager: LocationManager
     private readonly instructionCounter: InstructionCounter
+    private readonly instructionSender: InstructionSender
     private readonly extraMetadatas: Record<NodeId,Record<string, unknown>>
     private readonly logger: Logger
     private readonly metrics: Metrics
@@ -87,6 +95,8 @@ export class Tracker extends EventEmitter {
             .addRecordedMetric('processNodeStatus')
             .addRecordedMetric('instructionsSent')
             .addRecordedMetric('_removeNode')
+
+        this.instructionSender = new InstructionSender(opts.topologyStabilization, this.trackerServer, this.metrics)
     }
 
     onNodeConnected(node: NodeId): void {
@@ -180,21 +190,13 @@ export class Tracker extends EventEmitter {
             if (this.overlayPerStream[streamKey]) {
                 const instructions = this.overlayPerStream[streamKey].formInstructions(node, forceGenerate)
                 Object.entries(instructions).forEach(async ([nodeId, newNeighbors]) => {
-                    this.metrics.record('instructionsSent', 1)
                     const counterValue = this.instructionCounter.setOrIncrement(nodeId, streamKey)
-                    try {
-                        await this.trackerServer.sendInstruction(
-                            nodeId,
-                            StreamIdAndPartition.fromKey(streamKey),
-                            newNeighbors,
-                            counterValue
-                        )
-                        this.logger.debug('Instruction %o sent to node %o',
-                            newNeighbors, { counterValue, streamKey, nodeId })
-                    } catch (err) {
-                        this.logger.error(`Failed to send instructions %o to node %o, reason: %s`,
-                            newNeighbors, { counterValue, streamKey, nodeId }, err)
-                    }
+                    await this.instructionSender.addInstruction({
+                        nodeId,
+                        streamKey,
+                        newNeighbors,
+                        counterValue
+                    })
                 })
             }
         })

--- a/packages/network/test/unit/InstructionSender.test.ts
+++ b/packages/network/test/unit/InstructionSender.test.ts
@@ -1,0 +1,102 @@
+import { Instruction, InstructionSender } from '../../src/logic/InstructionSender'
+import { StreamKey } from '../../src/identifiers'
+
+const MOCK_STREAM_1 = 'stream-id::1'
+const MOCK_STREAM_2 = 'stream-id::2'
+const STARTUP_TIME = 1234567890
+
+const DEBOUNCE_WAIT = 100
+const MAX_WAIT = 2000
+
+let mockInstructionIdSuffix = 0
+
+const createMockInstruction = (streamKey: StreamKey) => {
+    mockInstructionIdSuffix++
+    return {
+        nodeId: `mock-node-id-${mockInstructionIdSuffix}`,
+        streamKey
+    } as any
+}
+
+const assertEqualInstructions = (
+    callArgs: [buffer: { getInstructions: () => IterableIterator<Instruction>}],
+    expected: Instruction[]
+) => {
+    const actual = Array.from(callArgs[0].getInstructions())
+    expect(actual).toEqual(expected)
+}
+
+describe('InstructionSender', () => {
+    let sender: any
+    let send: any
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(STARTUP_TIME)
+        sender = new InstructionSender({
+            debounceWait: DEBOUNCE_WAIT,
+            maxWait: MAX_WAIT
+        }, undefined as any, undefined as any) as any
+        send = jest.spyOn(sender, 'sendInstructions').mockResolvedValue(undefined) as any
+    })
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers()
+        jest.useRealTimers()
+    })
+
+    it('wait stabilization', () => {
+        const instruction = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction)
+        expect(send).not.toBeCalled()
+        jest.advanceTimersByTime(DEBOUNCE_WAIT)
+        expect(send).toBeCalledTimes(1)
+        assertEqualInstructions(send.mock.calls[0], [ instruction ])
+    })
+
+    it('add within stabilization wait', () => {
+        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction1)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
+        const instruction2 = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction2)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT)
+        expect(send).toBeCalledTimes(1)
+        assertEqualInstructions(send.mock.calls[0], [ instruction1, instruction2 ])
+    })
+
+    it('add after stabilization wait', () => {
+        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction1)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT)
+        const instruction2 = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction2)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT)
+        expect(send).toBeCalledTimes(2)
+        assertEqualInstructions(send.mock.calls[1], [ instruction2 ])
+    })
+
+    it('max wait reached', () => {
+        const expected: Instruction[] = []
+        while ((Date.now() - STARTUP_TIME) < MAX_WAIT) {
+            const instruction = createMockInstruction(MOCK_STREAM_1)
+            sender.addInstruction(instruction)
+            expected.push(instruction)
+            jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
+        }
+        expect(send).toBeCalledTimes(1)
+        assertEqualInstructions(send.mock.calls[0], expected)
+    })
+
+    it('independent stream buffers', () => {
+        const instruction1 = createMockInstruction(MOCK_STREAM_1)
+        sender.addInstruction(instruction1)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT / 2)
+        const instruction2 = createMockInstruction(MOCK_STREAM_2)
+        sender.addInstruction(instruction2)
+        jest.advanceTimersByTime(DEBOUNCE_WAIT)
+        expect(send).toBeCalledTimes(2)
+        assertEqualInstructions(send.mock.calls[0], [ instruction1 ])
+        assertEqualInstructions(send.mock.calls[1], [ instruction2 ])
+    })
+})


### PR DESCRIPTION
Tracker instructions are collected to buffers and sent after a short delay. For each stream there is a separate buffer.

We use debouncing to delay the sending. We send all the instructions in a stream buffer, when either when of these conditions is satisfied: 
 - the topology stabilizes: no new instructions has been formed for the stream in X milliseconds
- the buffer times out: we have buffered an instruction for Y milliseconds

Added new command line options for the two configuration options. The default values are currently 100 ms and 2000 ms (we can optimize the values later, if needed).