### PR TITLE
fix broker [NET-493]: don't store sec metrics

### DIFF
--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -22,9 +22,9 @@ const logger = new Logger(module)
 
 export class MetricsPublisher {
 
-    nodeAddress: string
-    client: StreamrClient
-    storageNodeAddress: string
+    private readonly nodeAddress: string
+    private readonly client: StreamrClient
+    private readonly storageNodeAddress: string
 
     constructor(nodeAddress: string, clientOptions: ClientOptions) {
         this.nodeAddress = nodeAddress

--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -58,7 +58,7 @@ export class MetricsPublisher {
         const streamId = this.getStreamId(periodLength)
         try {
             await this.client.publish(streamId, sample)
-        } catch (e) {
+        } catch (e: any) {
             logger.warn(`Unable to publish NodeMetrics: ${e.message}`)
         }
     }
@@ -78,7 +78,7 @@ export class MetricsPublisher {
             // https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
             try {
                 await stream.addToStorageNode(this.storageNodeAddress)
-            } catch (e) {
+            } catch (e: any) {
                 if (!e.body) { throw e }
                 let parsedBody
                 try {

--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -64,7 +64,7 @@ export class MetricsPublisher {
     }
 
     async ensureStreamsCreated() {
-        await Promise.all(Object.keys(STREAM_ID_SUFFIXES).map((periodLength: any) => this.ensureStreamCreated(periodLength)))
+        await Promise.all(Object.keys(STREAM_ID_SUFFIXES).map((periodLengthAsString: string) => this.ensureStreamCreated(Number(periodLengthAsString))))
     }
 
     // TODO simplify error handling?

--- a/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
+++ b/packages/broker/src/plugins/metrics/node/MetricsPublisher.ts
@@ -68,12 +68,12 @@ export class MetricsPublisher {
     }
 
     // TODO simplify error handling?
-    private async ensureStreamCreated(periodLegth: number): Promise<string> {
+    private async ensureStreamCreated(periodLength: number): Promise<string> {
         const stream = await this.client.getOrCreateStream({
-            id: this.getStreamId(periodLegth)
+            id: this.getStreamId(periodLength)
         })
 
-        if (periodLegth !== PERIOD_LENGTHS.FIVE_SECONDS) {
+        if (periodLength !== PERIOD_LENGTHS.FIVE_SECONDS) {
             // TODO: pretify this error handler
             // https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
             try {

--- a/packages/broker/test/unit/plugins/metrics/node/MetricsPublisher.test.ts
+++ b/packages/broker/test/unit/plugins/metrics/node/MetricsPublisher.test.ts
@@ -1,0 +1,40 @@
+import { Stream } from 'streamr-client'
+import { MetricsPublisher } from '../../../../../src/plugins/metrics/node/MetricsPublisher'
+
+describe('MetricsPublisher', () => {
+    let publisher: MetricsPublisher
+    let mockStream: Stream
+
+    beforeAll(() => {
+        const nodeAddress = '0x1111111111111111111111111111111111111111'
+        const storageNodeAddress = '0x2222222222222222222222222222222222222222'
+        publisher = new MetricsPublisher(nodeAddress, {
+            clientWsUrl: 'ws://websocket.mock',
+            storageNode: storageNodeAddress,
+            storageNodes: [{
+                address: storageNodeAddress,
+                url: 'http://storage.mock'
+            }]
+        } as any)
+        mockStream = {
+            addToStorageNode: jest.fn(),
+            grantPermission: jest.fn()
+        } as any
+        // @ts-expect-error private field
+        publisher.client = {
+            getOrCreateStream: jest.fn().mockReturnValue(mockStream)
+        } as any
+    })
+
+    const getClient = () => {
+        // @ts-expect-error private field
+        return publisher.client
+    }
+
+    it('ensure streams created: happy path', async () => {
+        await publisher.ensureStreamsCreated()
+        expect(getClient().getOrCreateStream).toBeCalledTimes(4)
+        expect(mockStream.addToStorageNode).toBeCalledTimes(3)
+        expect(mockStream.grantPermission).toBeCalledTimes(8)
+    })
+})


### PR DESCRIPTION
Bug fix for metrics stream storage node assignments. 

**Expected**:
We should should not assign the `sec` metrics to a storage node (but `min`, `hour` and `day` should be assigned)

**Actual**:
All for metrics stream are assigned, including the `sec` stream

**Reason**:
The if statement didn't filter out anything as compared a `string` to a `number` with !== operator. The root cause was in `ensureStreamsCreated` method which provided the `periodLength` as a string.

Added also a unit test for `MetricsPublisher` and fixed some type annotations.

