### PR TITLE
network, broker [NET-440]: improve logging

### DIFF
--- a/packages/broker/src/plugins/legacyWebsocket/Connection.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/Connection.ts
@@ -162,7 +162,7 @@ export class Connection extends EventEmitter {
         } catch (e) {
             // no need to check this error
         } finally {
-            logger.warn('connection %s was terminated, reason: %s', this.id, reason)
+            logger.info('connection %s was terminated, reason: %s', this.id, reason)
             this.dead = true
             this.emit('close')
         }

--- a/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/legacyWebsocket/WebsocketServer.ts
@@ -269,7 +269,7 @@ export class WebsocketServer extends EventEmitter {
 
     private pingConnections() {
         function logAndForceClose(connection: Connection, reason: string | Error): void {
-            logger.error(`Failed to ping connection: ${connection.id}, reason ${reason}`)
+            logger.info(`Failed to ping connection: ${connection.id}, reason ${reason}`)
             connection.forceClose(reason.toString())
         }
 
@@ -283,7 +283,7 @@ export class WebsocketServer extends EventEmitter {
             try {
                 connection.ping()
             } catch (e) {
-                logger.error(`Failed to ping connection: ${connection.id}, error ${e}`)
+                logger.info(`Failed to ping connection: ${connection.id}, error ${e}`)
                 logAndForceClose(connection, 'failed to ping')
             }
         })

--- a/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
+++ b/packages/broker/src/plugins/testnetMiner/TestnetMinerPlugin.ts
@@ -147,7 +147,7 @@ export class TestnetMinerPlugin extends Plugin<TestnetMinerPluginConfig> {
             await fetchOrThrow(`${this.pluginConfig.claimServerUrl}/ping`)
             return Date.now() - startTime
         } catch (e) {
-            logger.warn('Ping error')
+            logger.info('Unable to analyze latency')
             return undefined
         }
     }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -39,7 +39,6 @@ export interface NodeOptions {
     peerInfo: PeerInfo
     trackers: Array<TrackerInfo>
     metricsContext?: MetricsContext
-    connectToBootstrapTrackersInterval?: number
     bufferTimeoutInMs?: number
     bufferMaxSize?: number
     disconnectionWaitTime?: number
@@ -66,7 +65,6 @@ export class Node extends EventEmitter {
     protected readonly nodeToNode: NodeToNode
     private readonly nodeToTracker: NodeToTracker
     private readonly peerInfo: PeerInfo
-    private readonly connectToBootstrapTrackersInterval: number
     private readonly bufferTimeoutInMs: number
     private readonly bufferMaxSize: number
     private readonly disconnectionWaitTime: number
@@ -105,7 +103,6 @@ export class Node extends EventEmitter {
         this.nodeToTracker = opts.protocols.nodeToTracker
         this.peerInfo = opts.peerInfo
 
-        this.connectToBootstrapTrackersInterval = opts.connectToBootstrapTrackersInterval || 5000
         this.bufferTimeoutInMs = opts.bufferTimeoutInMs || 60 * 1000
         this.bufferMaxSize = opts.bufferMaxSize || 10000
         this.disconnectionWaitTime = opts.disconnectionWaitTime || 30 * 1000

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -16,6 +16,7 @@ import { InstructionRetryManager } from "./InstructionRetryManager"
 import { NameDirectory } from '../NameDirectory'
 import { DisconnectionReason } from "../connection/ws/AbstractWsEndpoint"
 import { TrackerId } from './Tracker'
+import { TrackerConnector } from './TrackerConnector'
 
 export type NodeId = string
 
@@ -59,65 +60,6 @@ export interface Node {
     on(event: Event.MESSAGE_PROPAGATION_FAILED, listener: (msg: MessageLayer.StreamMessage, nodeId: NodeId, error: Error) => void): this
     on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
     on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
-}
-
-class TrackerConnector {
-
-    private readonly getStreams: () => ReadonlyArray<StreamIdAndPartition>
-    private readonly nodeToTracker: NodeToTracker
-    private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
-    private readonly logger: Logger
-    private maintenanceTimer?: NodeJS.Timeout | null
-    private readonly maintenanceInterval: number
-    private connectionErrors: Map<TrackerId,boolean>
-
-    constructor(getStreams: () => ReadonlyArray<StreamIdAndPartition>, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
-        this.getStreams = getStreams
-        this.nodeToTracker = nodeToTracker
-        this.trackerRegistry = trackerRegistry
-        this.logger = logger
-        this.maintenanceInterval = maintenanceInterval
-        this.connectionErrors = new Map()
-    }
-
-    maintainConnections(): void {
-        const activeTrackers = new Set<string>()
-        this.getStreams().forEach((s) => {
-            const trackerInfo = this.trackerRegistry.getTracker(s.id, s.partition)
-            activeTrackers.add(trackerInfo.id)
-        })
-        this.trackerRegistry.getAllTrackers().forEach(({ id, ws }) => {
-            if (activeTrackers.has(id)) {
-                this.nodeToTracker.connectToTracker(ws, PeerInfo.newTracker(id))
-                    .then(() => this.connectionErrors.delete(id))
-                    .catch((err) => {
-                        if (this.connectionErrors.get(id) === undefined) {
-                            // TODO we could also store the previous error and check that the current error is the same?
-                            // -> now it doesn't log anything if the connection error reason changes 
-                            this.connectionErrors.set(id, true)
-                            this.logger.warn('could not connect to tracker %s, reason: %j', ws, err)
-                        }
-                    })
-            } else {
-                this.nodeToTracker.disconnectFromTracker(id)
-            }
-        })
-    }
-
-    start() {
-        this.maintainConnections()
-        this.maintenanceTimer = setInterval(
-            this.maintainConnections.bind(this),
-            this.maintenanceInterval
-        )
-    }
-
-    stop() {
-        if (this.maintenanceTimer) {
-            clearInterval(this.maintenanceTimer)
-            this.maintenanceTimer = null
-        }
-    }
 }
 
 export class Node extends EventEmitter {

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -320,7 +320,7 @@ export class Node extends EventEmitter {
                 subscribedNodeIds.push(res.value)
             } else {
                 failedInstructions = true
-                this.logger.warn('failed to subscribe (or connect) to node, reason: %s', res.reason)
+                this.logger.info('failed to subscribe (or connect) to node, reason: %s', res.reason)
             }
         })
         if (!reattempt || failedInstructions) {

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -1,0 +1,65 @@
+import { Utils } from 'streamr-client-protocol'
+import { StreamIdAndPartition, TrackerInfo } from '../identifiers'
+import { NodeToTracker } from '../protocol/NodeToTracker'
+import { Logger } from '../helpers/Logger'
+import { PeerInfo } from '../connection/PeerInfo'
+import { TrackerId } from './Tracker'
+
+export class TrackerConnector {
+
+    private readonly getStreams: () => ReadonlyArray<StreamIdAndPartition>
+    private readonly nodeToTracker: NodeToTracker
+    private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
+    private readonly logger: Logger
+    private maintenanceTimer?: NodeJS.Timeout | null
+    private readonly maintenanceInterval: number
+    private connectionErrors: Map<TrackerId,boolean>
+
+    constructor(getStreams: () => ReadonlyArray<StreamIdAndPartition>, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
+        this.getStreams = getStreams
+        this.nodeToTracker = nodeToTracker
+        this.trackerRegistry = trackerRegistry
+        this.logger = logger
+        this.maintenanceInterval = maintenanceInterval
+        this.connectionErrors = new Map()
+    }
+
+    maintainConnections(): void {
+        const activeTrackers = new Set<string>()
+        this.getStreams().forEach((s) => {
+            const trackerInfo = this.trackerRegistry.getTracker(s.id, s.partition)
+            activeTrackers.add(trackerInfo.id)
+        })
+        this.trackerRegistry.getAllTrackers().forEach(({ id, ws }) => {
+            if (activeTrackers.has(id)) {
+                this.nodeToTracker.connectToTracker(ws, PeerInfo.newTracker(id))
+                    .then(() => this.connectionErrors.delete(id))
+                    .catch((err) => {
+                        if (this.connectionErrors.get(id) === undefined) {
+                            // TODO we could also store the previous error and check that the current error is the same?
+                            // -> now it doesn't log anything if the connection error reason changes 
+                            this.connectionErrors.set(id, true)
+                            this.logger.warn('could not connect to tracker %s, reason: %j', ws, err)
+                        }
+                    })
+            } else {
+                this.nodeToTracker.disconnectFromTracker(id)
+            }
+        })
+    }
+
+    start() {
+        this.maintainConnections()
+        this.maintenanceTimer = setInterval(
+            this.maintainConnections.bind(this),
+            this.maintenanceInterval
+        )
+    }
+
+    stop() {
+        if (this.maintenanceTimer) {
+            clearInterval(this.maintenanceTimer)
+            this.maintenanceTimer = null
+        }
+    }
+}

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -48,7 +48,7 @@ export class TrackerConnector {
         })
     }
 
-    start() {
+    start(): void {
         this.maintainConnections()
         this.maintenanceTimer = setInterval(
             this.maintainConnections.bind(this),
@@ -56,7 +56,7 @@ export class TrackerConnector {
         )
     }
 
-    stop() {
+    stop(): void {
         if (this.maintenanceTimer) {
             clearInterval(this.maintenanceTimer)
             this.maintenanceTimer = null


### PR DESCRIPTION
Small improvements for logging:
- If a node is unable to connect a tracker, the warning is logged only once. Previously the warning was logged once in every 5 seconds. To implement that, the connection logic was extracted to `TrackerConnector` class.
- Changed the log levels of some connection/ping errors from from `warn` to `info`. Closed connections are normal behavior of a node -> no need to warn about that.

Removed also deprecated `connectToBootstrapTrackersInterval` configuration option (https://github.com/streamr-dev/network-monorepo/pull/184)