### PR TITLE
NET-507: Node tracker logic refactor & performance increases

### DIFF
--- a/packages/network/jest.config.js
+++ b/packages/network/jest.config.js
@@ -23,5 +23,7 @@ module.exports = {
     // This option allows use of a custom test runner
     testRunner: 'jest-circus/runner',
 
-    testPathIgnorePatterns: ["/browser/", "/node_modules/"]
+    testPathIgnorePatterns: ["/browser/", "/node_modules/"],
+
+    setupFilesAfterEnv: ["jest-extended"],
 }

--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -6471,6 +6471,366 @@
 				"jest-util": "^27.0.6"
 			}
 		},
+		"jest-extended": {
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.5.tgz",
+			"integrity": "sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==",
+			"dev": true,
+			"requires": {
+				"expect": "^24.1.0",
+				"jest-get-type": "^22.4.3",
+				"jest-matcher-utils": "^22.0.0"
+			},
+			"dependencies": {
+				"@jest/console": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+					"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+					"dev": true,
+					"requires": {
+						"@jest/source-map": "^24.9.0",
+						"chalk": "^2.0.1",
+						"slash": "^2.0.0"
+					}
+				},
+				"@jest/source-map": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+					"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.1.15",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+					"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/istanbul-lib-coverage": "^2.0.0"
+					}
+				},
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/stack-utils": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+					"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+					"dev": true
+				},
+				"@types/yargs": {
+					"version": "13.0.12",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+					"integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"diff-sequences": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+					"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+					"dev": true
+				},
+				"expect": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+					"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-styles": "^3.2.0",
+						"jest-get-type": "^24.9.0",
+						"jest-matcher-utils": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-regex-util": "^24.9.0"
+					},
+					"dependencies": {
+						"jest-get-type": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+							"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+							"dev": true
+						},
+						"jest-matcher-utils": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+							"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+							"dev": true,
+							"requires": {
+								"chalk": "^2.0.1",
+								"jest-diff": "^24.9.0",
+								"jest-get-type": "^24.9.0",
+								"pretty-format": "^24.9.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"jest-diff": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+					"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					},
+					"dependencies": {
+						"jest-get-type": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+							"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+							"dev": true
+						}
+					}
+				},
+				"jest-get-type": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+					"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+					"dev": true
+				},
+				"jest-matcher-utils": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"pretty-format": {
+							"version": "22.4.3",
+							"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+							"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0",
+								"ansi-styles": "^3.2.0"
+							}
+						}
+					}
+				},
+				"jest-message-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+					"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^2.0.1",
+						"micromatch": "^3.1.10",
+						"slash": "^2.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-regex-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+					"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"react-is": {
+					"version": "16.13.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"stack-utils": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.5.tgz",
+					"integrity": "sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^2.0.0"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+							"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+							"dev": true
+						}
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"jest-get-type": {
 			"version": "26.3.0",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -86,6 +86,7 @@
     "expect": "^27.0.2",
     "jest": "^27.0.5",
     "jest-circus": "^27.0.5",
+    "jest-extended": "^0.11.5",
     "jest-mock": "^27.0.3",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -110,7 +110,7 @@ export class Node extends EventEmitter {
         const metricsContext = opts.metricsContext || new MetricsContext('')
 
         this.streams = new StreamManager()
-        this.trackerManager = new TrackerManager(this.formStatus.bind(this), opts, this.logger, this.nodeToTracker, this.streams)
+        this.trackerManager = new TrackerManager(this.formStatus.bind(this), opts, this.nodeToTracker, this.streams)
         this.messageBuffer = new MessageBuffer(this.bufferTimeoutInMs, this.bufferMaxSize, (streamId) => {
             this.logger.trace(`failed to deliver buffered messages of stream ${streamId}`)
         })

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -177,7 +177,12 @@ export class Node extends EventEmitter {
         }
     }
 
-    subscribeToStreamsOnNode(nodeIds: NodeId[], streamId: StreamIdAndPartition, trackerId: TrackerId, reattempt: boolean): Promise<PromiseSettledResult<NodeId>[]> {
+    subscribeToStreamsOnNode(
+        nodeIds: NodeId[],
+        streamId: StreamIdAndPartition,
+        trackerId: TrackerId,
+        reattempt: boolean
+    ): Promise<PromiseSettledResult<NodeId>[]> {
         const subscribePromises = nodeIds.map(async (nodeId) => {
             await promiseTimeout(this.nodeConnectTimeout, 
                 this.nodeToNode.connectToNode(nodeId, trackerId, !reattempt))
@@ -387,7 +392,7 @@ export class Node extends EventEmitter {
             const peerIds = this.nodeToNode.getAllConnectionNodeIds()
             const unusedConnections = peerIds.filter((peer) => !this.isNodePresent(peer))
             if (unusedConnections.length > 0) {
-                this.logger.debug(`Disconnecting from ${unusedConnections.length} unused connections`)
+                logger.debug(`Disconnecting from ${unusedConnections.length} unused connections`)
                 unusedConnections.forEach((peerId) => {
                     this.nodeToNode.disconnectFromNode(peerId, 'Unused connection')
                 })

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -437,9 +437,8 @@ export class Node extends EventEmitter {
         this.metrics.record('onNodeDisconnect', 1)
         const streams = this.streams.removeNodeFromAllStreams(node)
         this.logger.trace('removed all subscriptions of node %s', node)
-        const trackers = new Set(streams.map((streamId) => this.trackerManager.getTrackerId(streamId))) // TODO: streams could grow to be quite large if lots of shared streams with neihgbor
-        trackers.forEach((trackerId) => {
-            this.trackerManager.prepareAndSendMultipleStatuses(trackerId, streams)
+        streams.forEach((s) => {
+            this.trackerManager.prepareAndSendStreamStatus(s)
         })
         this.emit(Event.NODE_DISCONNECTED, node)
     }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { MessageLayer, TrackerLayer, Utils } from 'streamr-client-protocol'
+import { MessageLayer, TrackerLayer } from 'streamr-client-protocol'
 import { NodeToNode, Event as NodeToNodeEvent } from '../protocol/NodeToNode'
 import { NodeToTracker, Event as NodeToTrackerEvent } from '../protocol/NodeToTracker'
 import { MessageBuffer } from '../helpers/MessageBuffer'
@@ -16,7 +16,7 @@ import { InstructionRetryManager } from "./InstructionRetryManager"
 import { NameDirectory } from '../NameDirectory'
 import { DisconnectionReason } from "../connection/ws/AbstractWsEndpoint"
 import { TrackerId } from './Tracker'
-import { TrackerConnector } from './TrackerConnector'
+import { TrackerManager } from './TrackerManager'
 
 export type NodeId = string
 
@@ -59,110 +59,6 @@ export interface Node {
     on(event: Event.MESSAGE_PROPAGATION_FAILED, listener: (msg: MessageLayer.StreamMessage, nodeId: NodeId, error: Error) => void): this
     on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
     on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, streamId: StreamIdAndPartition) => void): this
-}
-
-type FormStatusFn = (streamId: StreamIdAndPartition, includeRtt: boolean) => Status
-
-class TrackerManager {
-    private readonly rttUpdateTimeoutsOnTrackers: Record<TrackerId, NodeJS.Timeout> = {}
-    private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
-    private readonly trackerConnector: TrackerConnector
-    private readonly formStatus: FormStatusFn
-    private readonly nodeToTracker: NodeToTracker
-    private readonly streamManager: StreamManager
-    private readonly logger: Logger
-    private readonly rttUpdateInterval: number
-
-    constructor(
-        formStatus: FormStatusFn,
-        opts: NodeOptions,
-        logger: Logger,
-        nodeToTracker: NodeToTracker,
-        streamManager: StreamManager,
-    ) {
-        this.trackerRegistry = Utils.createTrackerRegistry<TrackerInfo>(opts.trackers)
-        this.trackerConnector = new TrackerConnector(
-            streamManager,
-            nodeToTracker,
-            this.trackerRegistry,
-            logger,
-            opts.trackerConnectionMaintenanceInterval ?? 5000
-        )
-        this.formStatus = formStatus
-        this.nodeToTracker = nodeToTracker
-        this.streamManager = streamManager
-        this.logger = logger
-        this.rttUpdateInterval = opts.rttUpdateTimeout || 15000
-    }
-
-    prepareAndSendStreamStatus(streamId: StreamIdAndPartition): void {
-        const trackerId = this.getTrackerId(streamId)
-        const status = this.getStreamStatus(streamId, trackerId)
-        this.sendStatus(trackerId, status)
-    }
-
-    prepareAndSendMultipleStatuses(trackerId: TrackerId, streams?: StreamIdAndPartition[]): void {
-        const listOfStatus = this.getMultipleStatus(trackerId, streams)
-        listOfStatus.forEach((status) => {
-            this.sendStatus(trackerId, status)
-        })
-    }
-
-    getTrackerId(streamId: StreamIdAndPartition): TrackerId {
-        return this.trackerRegistry.getTracker(streamId.id, streamId.partition).id
-    }
-
-    onConnectedToTracker(trackerId: TrackerId): void {
-        // TODO: add guard for connectivity if deemed necessary
-        this.logger.trace('connected to tracker %s', trackerId)
-        this.prepareAndSendMultipleStatuses(trackerId)
-    }
-
-    onNewStream(_streamId: StreamIdAndPartition): void {
-        // TODO: we could use streamId value to only connect to the tracker of interest
-        this.trackerConnector.maintainConnections()
-    }
-
-    start(): void {
-        this.trackerConnector.start()
-    }
-
-    stop(): void {
-        this.trackerConnector.stop()
-        Object.values(this.rttUpdateTimeoutsOnTrackers).forEach((timeout) => clearTimeout(timeout))
-    }
-
-    // Gets statuses of all streams assigned to a tracker by default
-    private getMultipleStatus(tracker: TrackerId, explicitStreams?: StreamIdAndPartition[]): Status[] {
-        const streams = explicitStreams || this.streamManager.getStreams()
-        return streams
-            .filter((streamId) => this.getTrackerId(streamId) === tracker) // TODO: is this check necessary? internal business
-            .map((streamId) => this.getStreamStatus(streamId, tracker))
-    }
-
-    private getStreamStatus(streamId: StreamIdAndPartition, trackerId: TrackerId): Status {
-        return this.formStatus(streamId, this.shouldIncludeRttInfo(trackerId))
-    }
-
-    private shouldIncludeRttInfo(trackerId: TrackerId): boolean {
-        if (!(trackerId in this.rttUpdateTimeoutsOnTrackers)) {
-            this.rttUpdateTimeoutsOnTrackers[trackerId] = setTimeout(() => {
-                this.logger.trace(`RTT timeout to ${trackerId} triggered, RTTs to connections will be updated with the next status message`)
-                delete this.rttUpdateTimeoutsOnTrackers[trackerId]
-            }, this.rttUpdateInterval)
-            return true
-        }
-        return false
-    }
-
-    private async sendStatus(tracker: TrackerId, status: Status) {
-        try {
-            await this.nodeToTracker.sendStatus(tracker, status)
-            this.logger.trace('sent status %j to tracker %s', status.streams, tracker)
-        } catch (e) {
-            this.logger.trace('failed to send status to tracker %s, reason: %s', tracker, e)
-        }
-    }
 }
 
 export class Node extends EventEmitter {

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -71,7 +71,6 @@ export class Node extends EventEmitter {
     private readonly bufferMaxSize: number
     private readonly disconnectionWaitTime: number
     private readonly nodeConnectTimeout: number
-    private readonly instructionRetryInterval: number
     private readonly started: string
 
     private readonly disconnectionTimers: Record<NodeId,NodeJS.Timeout>
@@ -104,7 +103,6 @@ export class Node extends EventEmitter {
         this.bufferMaxSize = opts.bufferMaxSize || 10000
         this.disconnectionWaitTime = opts.disconnectionWaitTime || 30 * 1000
         this.nodeConnectTimeout = opts.nodeConnectTimeout || 15000
-        this.instructionRetryInterval = opts.instructionRetryInterval || 3 * 60 * 1000
         this.started = new Date().toLocaleString()
 
         const metricsContext = opts.metricsContext || new MetricsContext('')
@@ -122,7 +120,7 @@ export class Node extends EventEmitter {
         this.instructionThrottler = new InstructionThrottler(this.handleTrackerInstruction.bind(this))
         this.instructionRetryManager = new InstructionRetryManager(
             this.handleTrackerInstruction.bind(this),
-            this.instructionRetryInterval
+            opts.instructionRetryInterval || 3 * 60 * 1000
         )
 
         this.nodeToTracker.on(NodeToTrackerEvent.CONNECTED_TO_TRACKER, (trackerId) => this.onConnectedToTracker(trackerId))

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -93,8 +93,6 @@ export class Node extends EventEmitter {
         this.metrics = metricsContext.create('node')
             .addQueriedMetric('messageBufferSize', () => this.messageBuffer.size())
             .addQueriedMetric('seenButNotPropagatedSetSize', () => this.seenButNotPropagatedSet.size())
-            .addRecordedMetric('unexpectedTrackerInstructions')
-            .addRecordedMetric('trackerInstructions')
             .addRecordedMetric('onDataReceived')
             .addRecordedMetric('onDataReceived:invalidNumbering')
             .addRecordedMetric('onDataReceived:gapMismatch')

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -159,7 +159,7 @@ export class Node extends EventEmitter {
             this.streams.setUpStream(streamId)
             this.trackerManager.onNewStream(streamId) // TODO: perhaps we should react based on event from StreamManager?
             if (sendStatus) {
-                this.trackerManager.prepareAndSendStreamStatus(streamId)
+                this.trackerManager.sendStreamStatus(streamId)
             }
         }
     }
@@ -169,7 +169,7 @@ export class Node extends EventEmitter {
         this.streams.removeStream(streamId)
         this.trackerManager.onUnsubscribeFromStream(streamId)
         if (sendStatus) {
-            this.trackerManager.prepareAndSendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(streamId)
         }
     }
 
@@ -319,7 +319,7 @@ export class Node extends EventEmitter {
         this.streams.addOutboundNode(streamId, node)
         this.handleBufferedMessages(streamId)
         if (sendStatus) {
-            this.trackerManager.prepareAndSendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(streamId)
         }
         this.emit(Event.NODE_SUBSCRIBED, node, streamId)
         return node
@@ -345,7 +345,7 @@ export class Node extends EventEmitter {
             }, this.disconnectionWaitTime)
         }
         if (sendStatus) {
-            this.trackerManager.prepareAndSendStreamStatus(streamId)
+            this.trackerManager.sendStreamStatus(streamId)
         }
     }
 
@@ -354,7 +354,7 @@ export class Node extends EventEmitter {
         const streams = this.streams.removeNodeFromAllStreams(node)
         logger.trace('removed all subscriptions of node %s', node)
         streams.forEach((s) => {
-            this.trackerManager.prepareAndSendStreamStatus(s)
+            this.trackerManager.sendStreamStatus(s)
         })
         this.emit(Event.NODE_DISCONNECTED, node)
     }

--- a/packages/network/src/logic/StreamManager.ts
+++ b/packages/network/src/logic/StreamManager.ts
@@ -148,6 +148,12 @@ export class StreamManager {
         return result
     }
 
+    // efficient way to access streams
+    getStreamKeys(): IterableIterator<StreamKey> {
+        return this.streams.keys()
+    }
+
+    // TODO: rename to getStreamKeysAsSortedArray (or remove sort functionality altogether)
     getStreamsAsKeys(): ReadonlyArray<StreamKey> {
         return [...this.streams.keys()].sort()
     }

--- a/packages/network/src/logic/StreamManager.ts
+++ b/packages/network/src/logic/StreamManager.ts
@@ -130,6 +130,7 @@ export class StreamManager {
         })
     }
 
+    // TODO: rename to getSortedStreams() (or remove sort functionality altogether)
     getStreams(): ReadonlyArray<StreamIdAndPartition> {
         return this.getStreamsAsKeys().map((key) => StreamIdAndPartition.fromKey(key))
     }

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -4,10 +4,11 @@ import { NodeToTracker } from '../protocol/NodeToTracker'
 import { Logger } from '../helpers/Logger'
 import { PeerInfo } from '../connection/PeerInfo'
 import { TrackerId } from './Tracker'
+import { StreamManager } from './StreamManager'
 
 export class TrackerConnector {
 
-    private readonly getStreams: () => ReadonlyArray<StreamIdAndPartition>
+    private readonly streamManager: StreamManager
     private readonly nodeToTracker: NodeToTracker
     private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
     private readonly logger: Logger
@@ -15,8 +16,8 @@ export class TrackerConnector {
     private readonly maintenanceInterval: number
     private unconnectables: Set<TrackerId>
 
-    constructor(getStreams: () => ReadonlyArray<StreamIdAndPartition>, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
-        this.getStreams = getStreams
+    constructor(streamManager: StreamManager, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
+        this.streamManager = streamManager
         this.nodeToTracker = nodeToTracker
         this.trackerRegistry = trackerRegistry
         this.logger = logger
@@ -26,7 +27,7 @@ export class TrackerConnector {
 
     maintainConnections(): void {
         const activeTrackers = new Set<string>()
-        this.getStreams().forEach((s) => {
+        this.streamManager.getStreams().forEach((s) => {
             const trackerInfo = this.trackerRegistry.getTracker(s.id, s.partition)
             activeTrackers.add(trackerInfo.id)
         })

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -22,7 +22,12 @@ export class TrackerConnector {
     private readonly maintenanceInterval: number
     private connectionStates: Map<TrackerId,ConnectionState>
 
-    constructor(streamManager: StreamManager, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, maintenanceInterval: number) {
+    constructor(
+        streamManager: StreamManager,
+        nodeToTracker: NodeToTracker,
+        trackerRegistry: Utils.TrackerRegistry<TrackerInfo>,
+        maintenanceInterval: number
+    ) {
         this.streamManager = streamManager
         this.nodeToTracker = nodeToTracker
         this.trackerRegistry = trackerRegistry
@@ -67,6 +72,7 @@ export class TrackerConnector {
                     logger.info('Connected to tracker %s', id)
                     this.connectionStates.set(id, ConnectionState.SUCCESS)
                 }
+                return
             })
             .catch((err) => {
                 if (this.connectionStates.get(id) !== ConnectionState.ERROR) {

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -6,21 +6,21 @@ import { PeerInfo } from '../connection/PeerInfo'
 import { TrackerId } from './Tracker'
 import { StreamManager } from './StreamManager'
 
+const logger = new Logger(module)
+
 export class TrackerConnector {
 
     private readonly streamManager: StreamManager
     private readonly nodeToTracker: NodeToTracker
     private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
-    private readonly logger: Logger
     private maintenanceTimer?: NodeJS.Timeout | null
     private readonly maintenanceInterval: number
     private unconnectables: Set<TrackerId>
 
-    constructor(streamManager: StreamManager, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
+    constructor(streamManager: StreamManager, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, maintenanceInterval: number) {
         this.streamManager = streamManager
         this.nodeToTracker = nodeToTracker
         this.trackerRegistry = trackerRegistry
-        this.logger = logger
         this.maintenanceInterval = maintenanceInterval
         this.unconnectables = new Set()
     }
@@ -35,7 +35,7 @@ export class TrackerConnector {
         })
     }
 
-    onNewStream(streamId: StreamIdAndPartition) {
+    onNewStream(streamId: StreamIdAndPartition): void {
         const trackerInfo = this.trackerRegistry.getTracker(streamId.id, streamId.partition)
         this.connectTo(trackerInfo)
     }
@@ -63,7 +63,7 @@ export class TrackerConnector {
                     // TODO we could also store the previous error and check that the current error is the same?
                     // -> now it doesn't log anything if the connection error reason changes
                     this.unconnectables.add(id)
-                    this.logger.warn('could not connect to tracker %s, reason: %j', ws, err)
+                    logger.warn('could not connect to tracker %s, reason: %j', ws, err)
                 }
             })
     }

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -59,6 +59,8 @@ export class TrackerManager {
         this.streamManager = streamManager
         this.rttUpdateInterval = opts.rttUpdateTimeout || 15000
         this.metrics = metrics
+            .addRecordedMetric('unexpectedTrackerInstructions')
+            .addRecordedMetric('trackerInstructions')
         this.subscriber = subscriber
         this.trackerConnector = new TrackerConnector(
             streamManager,

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -1,0 +1,111 @@
+import { Status, StreamIdAndPartition, TrackerInfo } from '../identifiers'
+import { TrackerId } from './Tracker'
+import { TrackerConnector } from './TrackerConnector'
+import { NodeToTracker } from '../protocol/NodeToTracker'
+import { StreamManager } from './StreamManager'
+import { Logger } from '../helpers/Logger'
+import { NodeOptions } from './Node'
+import { Utils } from 'streamr-client-protocol'
+
+type FormStatusFn = (streamId: StreamIdAndPartition, includeRtt: boolean) => Status
+
+export class TrackerManager {
+    private readonly rttUpdateTimeoutsOnTrackers: Record<TrackerId, NodeJS.Timeout> = {}
+    private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
+    private readonly trackerConnector: TrackerConnector
+    private readonly formStatus: FormStatusFn
+    private readonly nodeToTracker: NodeToTracker
+    private readonly streamManager: StreamManager
+    private readonly logger: Logger
+    private readonly rttUpdateInterval: number
+
+    constructor(
+        formStatus: FormStatusFn,
+        opts: NodeOptions,
+        logger: Logger,
+        nodeToTracker: NodeToTracker,
+        streamManager: StreamManager,
+    ) {
+        this.trackerRegistry = Utils.createTrackerRegistry<TrackerInfo>(opts.trackers)
+        this.trackerConnector = new TrackerConnector(
+            streamManager,
+            nodeToTracker,
+            this.trackerRegistry,
+            logger,
+            opts.trackerConnectionMaintenanceInterval ?? 5000
+        )
+        this.formStatus = formStatus
+        this.nodeToTracker = nodeToTracker
+        this.streamManager = streamManager
+        this.logger = logger
+        this.rttUpdateInterval = opts.rttUpdateTimeout || 15000
+    }
+
+    prepareAndSendStreamStatus(streamId: StreamIdAndPartition): void {
+        const trackerId = this.getTrackerId(streamId)
+        const status = this.getStreamStatus(streamId, trackerId)
+        this.sendStatus(trackerId, status)
+    }
+
+    prepareAndSendMultipleStatuses(trackerId: TrackerId, streams?: StreamIdAndPartition[]): void {
+        const listOfStatus = this.getMultipleStatus(trackerId, streams)
+        listOfStatus.forEach((status) => {
+            this.sendStatus(trackerId, status)
+        })
+    }
+
+    getTrackerId(streamId: StreamIdAndPartition): TrackerId {
+        return this.trackerRegistry.getTracker(streamId.id, streamId.partition).id
+    }
+
+    onConnectedToTracker(trackerId: TrackerId): void {
+        // TODO: add guard for connectivity if deemed necessary
+        this.logger.trace('connected to tracker %s', trackerId)
+        this.prepareAndSendMultipleStatuses(trackerId)
+    }
+
+    onNewStream(streamId: StreamIdAndPartition): void {
+        this.trackerConnector.onNewStream(streamId)
+    }
+
+    start(): void {
+        this.trackerConnector.start()
+    }
+
+    stop(): void {
+        this.trackerConnector.stop()
+        Object.values(this.rttUpdateTimeoutsOnTrackers).forEach((timeout) => clearTimeout(timeout))
+    }
+
+    // Gets statuses of all streams assigned to a tracker by default
+    private getMultipleStatus(tracker: TrackerId, explicitStreams?: StreamIdAndPartition[]): Status[] {
+        const streams = explicitStreams || this.streamManager.getStreams()
+        return streams
+            .filter((streamId) => this.getTrackerId(streamId) === tracker) // TODO: is this check necessary? internal business
+            .map((streamId) => this.getStreamStatus(streamId, tracker))
+    }
+
+    private getStreamStatus(streamId: StreamIdAndPartition, trackerId: TrackerId): Status {
+        return this.formStatus(streamId, this.shouldIncludeRttInfo(trackerId))
+    }
+
+    private shouldIncludeRttInfo(trackerId: TrackerId): boolean {
+        if (!(trackerId in this.rttUpdateTimeoutsOnTrackers)) {
+            this.rttUpdateTimeoutsOnTrackers[trackerId] = setTimeout(() => {
+                this.logger.trace(`RTT timeout to ${trackerId} triggered, RTTs to connections will be updated with the next status message`)
+                delete this.rttUpdateTimeoutsOnTrackers[trackerId]
+            }, this.rttUpdateInterval)
+            return true
+        }
+        return false
+    }
+
+    private async sendStatus(tracker: TrackerId, status: Status) {
+        try {
+            await this.nodeToTracker.sendStatus(tracker, status)
+            this.logger.trace('sent status %j to tracker %s', status.streams, tracker)
+        } catch (e) {
+            this.logger.trace('failed to send status to tracker %s, reason: %s', tracker, e)
+        }
+    }
+}

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -5,7 +5,7 @@ import { TrackerConnector } from './TrackerConnector'
 import { NodeToTracker, Event as NodeToTrackerEvent } from '../protocol/NodeToTracker'
 import { StreamManager } from './StreamManager'
 import { Logger } from '../helpers/Logger'
-import { NodeId, NodeOptions } from './Node'
+import { NodeId } from './Node'
 import { InstructionThrottler } from './InstructionThrottler'
 import { InstructionRetryManager } from './InstructionRetryManager'
 import { Metrics } from '../helpers/MetricsContext'
@@ -25,6 +25,13 @@ interface Subscriber {
     unsubscribeFromStreamOnNode: (node: NodeId, streamId: StreamIdAndPartition, sendStatus?: boolean) => void
 }
 
+export interface TrackerManagerOptions {
+    trackers: Array<TrackerInfo>
+    rttUpdateTimeout?: number
+    trackerConnectionMaintenanceInterval?: number
+    instructionRetryInterval?: number
+}
+
 export class TrackerManager {
     private readonly rttUpdateTimeoutsOnTrackers: Record<TrackerId, NodeJS.Timeout> = {}
     private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
@@ -39,15 +46,16 @@ export class TrackerManager {
     private readonly subscriber: Subscriber
 
     constructor(
+        nodeToTracker: NodeToTracker,
         formStatus: FormStatusFn,
-        opts: NodeOptions,
+        opts: TrackerManagerOptions,
         streamManager: StreamManager,
         metrics: Metrics,
         subscriber: Subscriber
     ) {
         this.trackerRegistry = Utils.createTrackerRegistry<TrackerInfo>(opts.trackers)
         this.formStatus = formStatus
-        this.nodeToTracker =  opts.protocols.nodeToTracker
+        this.nodeToTracker =  nodeToTracker
         this.streamManager = streamManager
         this.rttUpdateInterval = opts.rttUpdateTimeout || 15000
         this.metrics = metrics

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -77,14 +77,14 @@ export class TrackerManager {
         this.sendStatus(streamId, trackerId)
     }
 
-    prepareAndSendMultipleStatuses(trackerId: TrackerId): void {
+    private prepareAndSendMultipleStatuses(trackerId: TrackerId): void {
         const relevantStreams = this.getStreamsForTracker(trackerId)
         relevantStreams.forEach((streamId) => {
             this.sendStatus(streamId, trackerId)
         })
     }
 
-    getTrackerId(streamId: StreamIdAndPartition): TrackerId {
+    private getTrackerId(streamId: StreamIdAndPartition): TrackerId {
         return this.trackerRegistry.getTracker(streamId.id, streamId.partition).id
     }
 

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -16,7 +16,12 @@ type FormStatusFn = (streamId: StreamIdAndPartition, includeRtt: boolean) => Sta
 
 interface Subscriber {
     subscribeToStreamIfHaveNotYet: (streamId: StreamIdAndPartition, sendStatus?: boolean) => void
-    subscribeToStreamsOnNode: (nodeIds: NodeId[], streamId: StreamIdAndPartition, trackerId: TrackerId, reattempt: boolean) => Promise<PromiseSettledResult<NodeId>[]>,
+    subscribeToStreamsOnNode: (
+        nodeIds: NodeId[],
+        streamId: StreamIdAndPartition,
+        trackerId: TrackerId,
+        reattempt: boolean
+    ) => Promise<PromiseSettledResult<NodeId>[]>,
     unsubscribeFromStreamOnNode: (node: NodeId, streamId: StreamIdAndPartition, sendStatus?: boolean) => void
 }
 
@@ -127,7 +132,11 @@ export class TrackerManager {
         }
     }
 
-    private async handleTrackerInstruction(instructionMessage: TrackerLayer.InstructionMessage, trackerId: TrackerId, reattempt = false): Promise<void> {
+    private async handleTrackerInstruction(
+        instructionMessage: TrackerLayer.InstructionMessage,
+        trackerId: TrackerId,
+        reattempt = false
+    ): Promise<void> {
         const streamId = StreamIdAndPartition.fromMessage(instructionMessage)
         const { nodeIds, counter } = instructionMessage
 

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -117,7 +117,8 @@ export class TrackerManager {
     }
 
     private getStreamsForTracker(trackerId: TrackerId): Array<StreamIdAndPartition> {
-        return [...this.streamManager.getStreamKeys()].map((key) => StreamIdAndPartition.fromKey(key))
+        return [...this.streamManager.getStreamKeys()]
+            .map((key) => StreamIdAndPartition.fromKey(key))
             .filter((streamId) => this.getTrackerId(streamId) === trackerId)
     }
 
@@ -132,7 +133,7 @@ export class TrackerManager {
         return false
     }
 
-    private async sendStatus(streamId: StreamIdAndPartition, trackerId: TrackerId) {
+    private async sendStatus(streamId: StreamIdAndPartition, trackerId: TrackerId): Promise<void> {
         const status = this.formStatus(streamId, this.shouldIncludeRttInfo(trackerId))
         try {
             await this.nodeToTracker.sendStatus(trackerId, status)

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -79,12 +79,14 @@ export class TrackerManager {
         this.sendStatus(streamId, trackerId)
     }
 
-    private getTrackerId(streamId: StreamIdAndPartition): TrackerId {
-        return this.trackerRegistry.getTracker(streamId.id, streamId.partition).id
-    }
-
     onNewStream(streamId: StreamIdAndPartition): void {
         this.trackerConnector.onNewStream(streamId)
+    }
+
+    onUnsubscribeFromStream(streamId: StreamIdAndPartition): void {
+        const key = streamId.key()
+        this.instructionThrottler.removeStream(key)
+        this.instructionRetryManager.removeStream(key)
     }
 
     start(): void {
@@ -181,9 +183,7 @@ export class TrackerManager {
         }
     }
 
-    onUnsubscribeFromStream(streamId: StreamIdAndPartition): void {
-        const key = streamId.key()
-        this.instructionThrottler.removeStream(key)
-        this.instructionRetryManager.removeStream(key)
+    private getTrackerId(streamId: StreamIdAndPartition): TrackerId {
+        return this.trackerRegistry.getTracker(streamId.id, streamId.partition).id
     }
 }

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -62,7 +62,9 @@ export class TrackerManager {
 
         this.nodeToTracker.on(NodeToTrackerEvent.CONNECTED_TO_TRACKER, (trackerId) => {
             logger.trace('connected to tracker %s', trackerId)
-            this.prepareAndSendMultipleStatuses(trackerId)
+            this.getStreamsForTracker(trackerId).forEach((streamId) => {
+                this.sendStatus(streamId, trackerId)
+            })
         })
         this.nodeToTracker.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, (instructionMessage, trackerId) => {
             this.instructionThrottler.add(instructionMessage, trackerId)
@@ -72,16 +74,9 @@ export class TrackerManager {
         })
     }
 
-    prepareAndSendStreamStatus(streamId: StreamIdAndPartition): void {
+    sendStreamStatus(streamId: StreamIdAndPartition): void {
         const trackerId = this.getTrackerId(streamId)
         this.sendStatus(streamId, trackerId)
-    }
-
-    private prepareAndSendMultipleStatuses(trackerId: TrackerId): void {
-        const relevantStreams = this.getStreamsForTracker(trackerId)
-        relevantStreams.forEach((streamId) => {
-            this.sendStatus(streamId, trackerId)
-        })
     }
 
     private getTrackerId(streamId: StreamIdAndPartition): TrackerId {
@@ -173,7 +168,7 @@ export class TrackerManager {
             }
         })
         if (!reattempt || failedInstructions) {
-            this.prepareAndSendStreamStatus(streamId)
+            this.sendStreamStatus(streamId)
         }
 
         logger.trace('subscribed to %j and unsubscribed from %j (streamId=%s, counter=%d)',

--- a/packages/network/src/types/global.d.ts
+++ b/packages/network/src/types/global.d.ts
@@ -1,0 +1,1 @@
+import 'jest-extended'

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -111,9 +111,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(FIRST_STREAM_2, 0)
 
         // @ts-expect-error private field
-        let nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        let nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        let nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        let nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
@@ -130,9 +130,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(SECOND_STREAM_2, 0)
 
         // @ts-expect-error private field
-        nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
@@ -149,9 +149,9 @@ describe('multi trackers', () => {
         nodeTwo.subscribe(THIRD_STREAM_2, 0)
 
         // @ts-expect-error private field
-        nodeOneEvents = eventsWithArgsToArray(nodeOne.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeOneEvents = eventsWithArgsToArray(nodeOne.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
         // @ts-expect-error private field
-        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
+        nodeTwoEvents = eventsWithArgsToArray(nodeTwo.trackerManager.nodeToTracker, TRACKER_NODE_EVENTS_OF_INTEREST)
 
         await Promise.all([
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),

--- a/packages/network/test/integration/multi-trackers.test.ts
+++ b/packages/network/test/integration/multi-trackers.test.ts
@@ -175,7 +175,8 @@ describe('multi trackers', () => {
             ],
             counter: 0
         })
-        await nodeOne.handleTrackerInstruction(unexpectedInstruction, 'trackerOne')
+        // @ts-expect-error private field
+        await nodeOne.trackerManager.handleTrackerInstruction(unexpectedInstruction, 'trackerOne')
         expect(nodeOne.getStreams()).not.toContain('stream-2::0')
     })
 })

--- a/packages/network/test/integration/tracker-endpoints.test.ts
+++ b/packages/network/test/integration/tracker-endpoints.test.ts
@@ -243,7 +243,7 @@ describe('tracker endpoint', () => {
     it('/nodes/node-1/streams', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/nodes/node-1/streams/`)
         expect(status).toEqual(200)
-        expect(jsonResult).toEqual([
+        expect(jsonResult).toIncludeSameMembers([
             {
                 "partition": 0,
                 "streamId": "sandbox/test/stream-3",
@@ -258,7 +258,7 @@ describe('tracker endpoint', () => {
                 "partition": 0,
                 "streamId": "stream-2",
                 "topologySize": 1
-            }
+            },
         ])
     })
 

--- a/packages/network/test/integration/tracker-instructions.test.ts
+++ b/packages/network/test/integration/tracker-instructions.test.ts
@@ -77,8 +77,10 @@ describe('check tracker, nodes and statuses from nodes', () => {
         })
 
         await Promise.race([
-            node1.onTrackerInstructionReceived('tracker', trackerInstruction1),
-            node2.onTrackerInstructionReceived('tracker', trackerInstruction2)
+            // @ts-expect-error private field
+            node1.trackerManager.instructionThrottler.add(trackerInstruction1, 'tracker'),
+            // @ts-expect-error private field
+            node2.trackerManager.instructionThrottler.add(trackerInstruction2, 'tracker')
         ]).catch(() => {})
 
         await Promise.race([

--- a/packages/network/test/integration/webrtc-error-scenarios-during-signalling.test.ts
+++ b/packages/network/test/integration/webrtc-error-scenarios-during-signalling.test.ts
@@ -54,7 +54,7 @@ describe('Signalling error scenarios', () => {
     it('connection recovers after timeout if one endpoint closes during signalling', async () => {
         await runAndWaitForEvents([ ()=> { nodeOne.subscribe(streamId, 0) }, () => { nodeTwo.subscribe(streamId, 0) } ],
             // @ts-expect-error private field
-            [nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         )
 
         // @ts-expect-error private field
@@ -73,9 +73,9 @@ describe('Signalling error scenarios', () => {
         
         await runAndWaitForEvents([ () => { nodeOne.subscribe(streamId, 0)}, () => { nodeTwo.subscribe(streamId, 0) } ], [
             // @ts-expect-error private field
-            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
+            [ nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
             // @ts-expect-error private field
-            [nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         ])
 
         await runAndWaitForEvents([
@@ -111,24 +111,24 @@ describe('Signalling error scenarios', () => {
 
         await runAndWaitForEvents([ () => { nodeOne.subscribe('stream-id', 0) }, () => { nodeTwo.subscribe('stream-id', 0) }] , [
             // @ts-expect-error private field
-            [nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
+            [nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED],
             // @ts-expect-error private field
-            [nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
+            [nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         ])
 
         await runAndWaitForEvents([ 
             // @ts-expect-error private field
-            () => { nodeOne.nodeToTracker.endpoint.close('tracker') },
+            () => { nodeOne.trackerManager.nodeToTracker.endpoint.close('tracker') },
             // @ts-expect-error private field
-            () => { nodeTwo.nodeToTracker.endpoint.close('tracker') }], [
+            () => { nodeTwo.trackerManager.nodeToTracker.endpoint.close('tracker') }], [
             // @ts-expect-error private field
-            [ nodeOne.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
+            [ nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
+            [ nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [ nodeOne.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
+            [ nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
             // @ts-expect-error private field
-            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
+            [ nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER ],
         ], 15000)
     }, 20000)
 
@@ -138,17 +138,17 @@ describe('Signalling error scenarios', () => {
             () => { nodeOne.subscribe('stream-id', 0) },
             () => { nodeTwo.subscribe('stream-id', 0) } ], [
             // @ts-expect-error private field
-            [ nodeOne.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ],
+            [ nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ],
             // @ts-expect-error private field
-            [ nodeTwo.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ]
+            [ nodeTwo.trackerManager.nodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED ]
         ], 9997)
 
         // @ts-expect-error private field
-        await runAndWaitForEvents( () => {  nodeOne.nodeToTracker.endpoint.close('tracker') }, [
+        await runAndWaitForEvents( () => {  nodeOne.trackerManager.nodeToTracker.endpoint.close('tracker') }, [
             // @ts-expect-error private field
-            [nodeOne.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
+            [nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.TRACKER_DISCONNECTED ],
             // @ts-expect-error private field
-            [nodeOne.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER],
+            [nodeOne.trackerManager.nodeToTracker, NodeToTrackerEvent.CONNECTED_TO_TRACKER],
             [nodeOne, NodeEvent.NODE_CONNECTED, 15000],
             [nodeTwo, NodeEvent.NODE_CONNECTED, 15000]
         ], 20000)


### PR DESCRIPTION
- Performance improvement: `maintainConnections()` no longer has to loop thru all streams
    - Previous implementation would loop through all streams and collect associated trackers into a set
    - Now we loop all trackers, and for each tracker, check whether a stream exists that is assigned to it. This is done in a short-circuit way, which should make it quite efficient compared to the old way.
    - We know that `#streams >> #trackers` so this way of doing things is more efficient.
- Performance improvement: now when we join a stream, instead of going and maintaining _all_ tracker connections (via `maintainConnections()`) we only connect to the associated tracker.
- Refactor: Found way to simplify `StatusMessage` forming & sending logic.
- Refactor: Moved all Node's tracker related logic to `TrackerManager`.