### PR TITLE
Report storage refresh failure correctly.

### DIFF
--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -97,7 +97,14 @@ export class StorageConfig {
 
     async refresh(): Promise<void> {
         const res = await fetch(`${this.apiUrl}/storageNodes/${this.nodeId}/streams`)
+        if (!res.ok) {
+            throw new Error(`Refresh failed: ${res.status} ${await res.text()}`)
+        }
         const json = await res.json()
+        if (!Array.isArray(json)) {
+            throw new Error(`Invalid response. Refresh failed: ${json}`)
+        }
+
         const streamKeys = new Set<StreamKey>(json.flatMap((stream: { id: string, partitions: number }) => ([
             ...getKeysFromStream(stream.id, stream.partitions)
         ])))


### PR DESCRIPTION
Changes errors like this:
```
Unable to refresh storage config: TypeError: json.flatMap is not a function
```

into something more clear:
```
Unable to refresh storage config: Error: Refresh failed: 500 {"code":"MySQLSyntaxErrorException","message":"Unknown column 'this_.id' in 'field list'"}
```

![image](https://user-images.githubusercontent.com/43438/133795937-6ae0120f-98bb-4b7b-bd2b-d5a5cc0cd708.png)
