### PR TITLE
Unify types for StorageNode, Tracker and SmartContract configs.

### DIFF
--- a/packages/broker/src/StorageNodeRegistry.ts
+++ b/packages/broker/src/StorageNodeRegistry.ts
@@ -1,7 +1,9 @@
 import fetch from 'node-fetch'
-import { GenericError } from './errors/GenericError'
-import { StorageNodeRegistryItem, Config } from './config'
 import { Logger } from 'streamr-network'
+import { StorageNodeRecord } from 'streamr-network/dist/streamr-client-protocol'
+
+import { GenericError } from './errors/GenericError'
+import { Config } from './config'
 
 export class StorageNodeRegistry {
     urlByAddress: Record<string,string>
@@ -18,7 +20,7 @@ export class StorageNodeRegistry {
         return this.urlByAddress[address]
     }
 
-    static createInstance(config: Config, storageNodeRegistry: StorageNodeRegistryItem[]): StorageNodeRegistry {
+    static createInstance(config: Config, storageNodeRegistry: StorageNodeRecord[]): StorageNodeRegistry {
         const urlByAddress: Record<string,string> = {}
         storageNodeRegistry.forEach((item) => {
             urlByAddress[item.address] = item.url
@@ -49,7 +51,7 @@ export class StorageNodeRegistry {
         }
     }
 
-    getStorageNodes(): StorageNodeRegistryItem[] {
+    getStorageNodes(): StorageNodeRecord[] {
         return Object.entries(this.urlByAddress).map(([address, url]) => ({
             address,
             url

--- a/packages/broker/src/config.ts
+++ b/packages/broker/src/config.ts
@@ -1,13 +1,4 @@
-export interface NetworkSmartContract {
-    contractAddress: string
-    jsonRpcProvider: string
-}
-
-export interface TrackerRegistryItem {
-    id: string
-    ws: string
-    http: string
-}
+import { SmartContractConfig, TrackerRecord, StorageNodeRecord } from 'streamr-network/dist/streamr-client-protocol'
 
 export interface TurnConfig {
     url: string,
@@ -17,7 +8,7 @@ export interface TurnConfig {
 
 export interface NetworkConfig {
     name: string,
-    trackers: TrackerRegistryItem[] | NetworkSmartContract,
+    trackers: TrackerRecord[] | SmartContractConfig,
     stun: string | null,
     turn: TurnConfig | null
     location: {
@@ -29,18 +20,13 @@ export interface NetworkConfig {
 }
 
 export interface HttpServerConfig {
-    port: number, 
+    port: number,
     privateKeyFileName: string | null,
     certFileName: string | null
 }
 
-export interface StorageNodeRegistryItem {
-    address: string
-    url: string
-}
-
 export interface StorageNodeConfig {
-    registry: StorageNodeRegistryItem[] | NetworkSmartContract
+    registry: StorageNodeRecord[] | SmartContractConfig
 }
 
 export interface Config {

--- a/packages/broker/src/helpers/ConfigAutoMigrate.ts
+++ b/packages/broker/src/helpers/ConfigAutoMigrate.ts
@@ -1,4 +1,6 @@
-import { Config, TrackerRegistryItem } from '../config'
+import { TrackerRecord } from 'streamr-network/dist/streamr-client-protocol'
+
+import { Config } from '../config'
 import fs from 'fs'
 import path from 'path'
 import { validateConfig } from './validateConfig'
@@ -72,7 +74,7 @@ const TESTNET2_STREAM_IDS = [
     'streamr.eth/brubeck-testnet/rewards/25kpf4'
 ]
 
-const migrateTrackerRegistry = (trackerRegistry: TrackerRegistryItem[]): TrackerRegistryItem[] => {
+const migrateTrackerRegistry = (trackerRegistry: TrackerRecord[]): TrackerRecord[] => {
     if (trackerRegistry.length === 1) {
         return TESTNET2_TRACKER_REGISTRY
     } else {
@@ -105,7 +107,7 @@ export const testnet2AutoMigrate = (config: any, configFilePath: string): Config
             console.info('Backing up testnet1 config to ' + backupFilePath)
             fs.writeFileSync(backupFilePath, backup)
 
-            config['network']['trackers'] = migrateTrackerRegistry(config['network']['trackers'] as TrackerRegistryItem[])
+            config['network']['trackers'] = migrateTrackerRegistry(config['network']['trackers'] as TrackerRecord[])
             delete config['plugins']['testnetMiner']['rewardStreamId']
             config['plugins']['testnetMiner']['rewardStreamIds'] = TESTNET2_STREAM_IDS
             validateConfig(config.plugins.testnetMiner, schemaTestnet2)

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -226,7 +226,7 @@
               "type": "array",
               "description": "List of storageNode HTTP URLs to connect to",
               "items": {
-                "$ref": "#/definitions/storageNodeRegistryItem"
+                "$ref": "#/definitions/storageNodeRecord"
               }
             },
             {
@@ -264,7 +264,7 @@
       "minimum": 0,
       "maximum": 65353
     },
-    "storageNodeRegistryItem": {
+    "storageNodeRecord": {
       "type": "object",
       "required": [
         "address",
@@ -277,7 +277,7 @@
         },
         "url": {
           "type": "string"
-        }  
+        }
       }
     },
     "smartContractConfig": {

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -1,304 +1,350 @@
 {
-  "$id": "config.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Broker configuration format",
-  "type": "object",
-  "required": [
-    "plugins",
-    "ethereumPrivateKey",
-    "network"
-  ],
-  "additionalProperties": false,
-  "properties": {
-    "plugins": {
-      "type": "object",
-      "description": "Pluging configurations",
-      "additionalProperties": true
+    "$id": "config.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Broker configuration format",
+    "type": "object",
+    "required": [
+        "plugins",
+        "ethereumPrivateKey",
+        "network"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "plugins": {
+            "type": "object",
+            "description": "Pluging configurations",
+            "additionalProperties": true
+        },
+        "httpServer": {
+            "type": [
+                "object"
+            ],
+            "description": "HTTP server configuration",
+            "default": {},
+            "additionalProperties": false,
+            "properties": {
+                "port": {
+                    "$ref": "#/definitions/port",
+                    "description": "Port to start HTTP server on",
+                    "default": 7171
+                },
+                "certFileName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Path of certificate file to use for SSL",
+                    "default": null
+                },
+                "privateKeyFileName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Path of private key file to use for SSL",
+                    "default": null
+                }
+            }
+        },
+        "ethereumPrivateKey": {
+            "type": "string",
+            "description": "Ethereum private key to establish broker identity",
+            "pattern": "^(0x)?[a-f0-9]{64}$"
+        },
+        "generateSessionId": {
+            "type": "boolean",
+            "description": "Whether to generate a session id that gets attached to node id (or not). Disable for consistent node id.",
+            "default": true
+        },
+        "network": {
+            "type": "object",
+            "description": "Network node settings",
+            "required": [
+                "name",
+                "location"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable name for network node"
+                },
+                "trackers": {
+                    "default": [
+                        {
+                            "id": "0x7b9ad7B9E377dFd17fb4fF8F946956BDa1572849",
+                            "ws": "wss://corea1.streamr.network:30300",
+                            "http": "https://corea1.streamr.network:30300"
+                        },
+                        {
+                            "id": "0xeC3471C25f47FD62D181Af7fd5cB82D4520E26BC",
+                            "ws": "wss://corea2.streamr.network:30300",
+                            "http": "https://corea2.streamr.network:30300"
+                        }
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "description": "List of tracker ids and HTTP/WebSocket URLs to connect to",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "id",
+                                    "ws",
+                                    "http"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "ws": {
+                                        "type": "string"
+                                    },
+                                    "http": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "description": "Tracker registry smart contract to use for fetching tracker WebSocket URLs",
+                            "$ref": "#/definitions/smartContractConfig"
+                        }
+                    ]
+                },
+                "location": {
+                    "description": "Location of node",
+                    "default": null,
+                    "oneOf": [
+                        {
+                            "type": "null",
+                            "description": "Location undefined"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "latitude",
+                                "longitude",
+                                "country",
+                                "city"
+                            ],
+                            "properties": {
+                                "latitude": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "longitude": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "country": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "city": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "stun": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Address of a STUN server for NAT traversal with ICE, port included"
+                },
+                "turn": {
+                    "description": "Address of a TURN server if direct connections cannot be established between hosts behind NATs, port included",
+                    "oneOf": [
+                        {
+                            "type": "null",
+                            "description": "TURN-server undefined"
+                        }, {
+                        "type": "object",
+                        "required": [
+                            "url",
+                            "username",
+                            "password"
+                        ],
+                        "properties": {
+                            "url": {
+                                "type": "string"
+                            },
+                            "username": {
+                                "type": "string"
+                            },
+                            "password": {
+                                "type": "string"
+                            }
+                        }
+                        }
+                    ]
+                }
+            }
+        },
+        "streamrUrl": {
+            "type": "string",
+            "description": "Base URL of Core (E&E) API to use",
+            "default": "https://streamr.network",
+            "format": "uri"
+        },
+        "streamrAddress": {
+            "type": "string",
+            "description": "Ethereum address Core (E&E)",
+            "default": "0xf3E5A65851C3779f468c9EcB32E6f25D9D68601a",
+            "pattern": "^0x[a-fA-F0-9]{40}$"
+        },
+        "storageNodeConfig": {
+            "type": "object",
+            "description": "Storage node settings",
+            "default": {
+                "registry": [{
+                    "address": "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916",
+                    "url": "https://corea1.streamr.network:8001"
+                }]
+            },
+            "required": [
+                "registry"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "registry": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "description": "List of storageNode HTTP URLs to connect to",
+                            "items": {
+                                "$ref": "#/definitions/storageNodeRecord"
+                            }
+                        },
+                        {
+                            "description": "Storage Node Registry Config",
+                            "$ref": "#/definitions/smartContractConfig"
+                        }
+                    ]
+                }
+            }
+        },
+        "apiAuthentication": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "description": "Plugins should restrict the API access: if an endpoint requires authentication, the user must provide one of the API keys e.g. in a request header",
+            "default": null,
+            "required": [
+                "keys"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
     },
-    "httpServer": {
-      "type": [
-        "object"
-      ],
-      "description": "HTTP server configuration",
-      "default": {},
-      "additionalProperties": false,
-      "properties": {
+    "definitions": {
         "port": {
-          "$ref": "#/definitions/port",
-          "description": "Port to start HTTP server on",
-          "default": 7171
+            "type": "number",
+            "minimum": 0,
+            "maximum": 65353
         },
-        "certFileName": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Path of certificate file to use for SSL",
-          "default": null
-        },
-        "privateKeyFileName": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Path of private key file to use for SSL",
-          "default": null
-        }
-      }
-    },
-    "ethereumPrivateKey": {
-      "type": "string",
-      "description": "Ethereum private key to establish broker identity",
-      "pattern": "^(0x)?[a-f0-9]{64}$"
-    },
-    "generateSessionId": {
-      "type": "boolean",
-      "description": "Whether to generate a session id that gets attached to node id (or not). Disable for consistent node id.",
-      "default": true
-    },
-    "network": {
-      "type": "object",
-      "description": "Network node settings",
-      "required": [
-        "name",
-        "location"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Human-readable name for network node"
-        },
-        "trackers": {
-          "default": [
-            {
-              "id": "0x7b9ad7B9E377dFd17fb4fF8F946956BDa1572849",
-              "ws": "wss://corea1.streamr.network:30300",
-              "http": "https://corea1.streamr.network:30300"
-            },
-            {
-              "id": "0xeC3471C25f47FD62D181Af7fd5cB82D4520E26BC",
-              "ws": "wss://corea2.streamr.network:30300",
-              "http": "https://corea2.streamr.network:30300"
-            }
-          ],
-          "oneOf": [
-            {
-              "type": "array",
-              "description": "List of tracker ids and HTTP/WebSocket URLs to connect to",
-              "items": {
-                "type": "object",
-                "required": [
-                  "id",
-                  "ws",
-                  "http"
-                ],
-                "properties": {
-                  "id": {
+        "storageNodeRecord": {
+            "type": "object",
+            "required": [
+                "address",
+                "url"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "address": {
                     "type": "string"
-                  },
-                  "ws": {
-                    "type": "string"
-                  },
-                  "http": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            {
-              "description": "Tracker registry smart contract to use for fetching tracker WebSocket URLs",
-              "$ref": "#/definitions/smartContractConfig"
-            }
-          ]
-        },
-        "location": {
-          "description": "Location of node",
-          "default": null,
-          "oneOf": [
-            {
-              "type": "null",
-              "description": "Location undefined"
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "latitude",
-                "longitude",
-                "country",
-                "city"
-              ],
-              "properties": {
-                "latitude": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
                 },
-                "longitude": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "country": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "city": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "stun": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Address of a STUN server for NAT traversal with ICE, port included"
-        },
-        "turn": {
-          "description": "Address of a TURN server if direct connections cannot be established between hosts behind NATs, port included",
-          "oneOf": [
-            {
-              "type": "null",
-              "description": "TURN-server undefined"
-            }, {
-              "type": "object",
-              "required": [
-                "url",
-                "username",
-                "password"
-              ],
-              "properties": {
                 "url": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string"
-                },
-                "password": {
-                  "type": "string"
+                    "type": "string"
                 }
-              }
             }
-          ]
-        }
-      }
-    },
-    "streamrUrl": {
-      "type": "string",
-      "description": "Base URL of Core (E&E) API to use",
-      "default": "https://streamr.network",
-      "format": "uri"
-    },
-    "streamrAddress": {
-      "type": "string",
-      "description": "Ethereum address Core (E&E)",
-      "default": "0xf3E5A65851C3779f468c9EcB32E6f25D9D68601a",
-      "pattern": "^0x[a-fA-F0-9]{40}$"
-    },
-    "storageNodeConfig": {
-      "type": "object",
-      "description": "Storage node settings",
-      "default": {
-        "registry": [{
-          "address": "0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916",
-          "url": "https://corea1.streamr.network:8001"
-        }]
-      },
-      "required": [
-        "registry"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "registry": {
-          "oneOf": [
-            {
-              "type": "array",
-              "description": "List of storageNode HTTP URLs to connect to",
-              "items": {
-                "$ref": "#/definitions/storageNodeRecord"
-              }
-            },
-            {
-              "description": "Storage Node Registry Config",
-              "$ref": "#/definitions/smartContractConfig"
+        },
+        "smartContractConfig": {
+            "type": "object",
+            "required": [
+                "contractAddress",
+                "jsonRpcProvider"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "contractAddress": {
+                    "type": "string",
+                    "description": "Ethereum address of registry smart contract",
+                    "pattern": "^0x[a-fA-F0-9]{40}$"
+                },
+                "jsonRpcProvider": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "description": "URL for JSON RPC Provider",
+                            "format": "uri"
+                        },
+                        {
+                            "type": "object",
+                            "description": "Ethers ConnectionInfo",
+                            "properties": {
+                                "allowGzip": {
+                                    "type": "boolean"
+                                },
+                                "allowInsecureAuthentication": {
+                                    "type": "boolean"
+                                },
+                                "headers": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": [
+                                            "string",
+                                            "number"
+                                        ]
+                                    }
+                                },
+                                "password": {
+                                    "type": "string"
+                                },
+                                "throttleCallback": {
+                                    "type": "object"
+                                },
+                                "throttleLimit": {
+                                    "type": "number"
+                                },
+                                "throttleSlotInterval": {
+                                    "type": "number"
+                                },
+                                "timeout": {
+                                    "type": "number"
+                                },
+                                "url": {
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                }
             }
-          ]
         }
-      }
-    },
-    "apiAuthentication": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "description": "Plugins should restrict the API access: if an endpoint requires authentication, the user must provide one of the API keys e.g. in a request header",
-      "default": null,
-      "required": [
-        "keys"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
     }
-  },
-  "definitions": {
-    "port": {
-      "type": "number",
-      "minimum": 0,
-      "maximum": 65353
-    },
-    "storageNodeRecord": {
-      "type": "object",
-      "required": [
-        "address",
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "address": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        }
-      }
-    },
-    "smartContractConfig": {
-      "type": "object",
-      "required": [
-        "contractAddress",
-        "jsonRpcProvider"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "contractAddress": {
-          "type": "string",
-          "description": "Ethereum address of registry smart contract",
-          "pattern": "^0x[a-fA-F0-9]{40}$"
-        },
-        "jsonRpcProvider": {
-          "type": "string",
-          "description": "URL for JSON RPC Provider",
-          "format": "uri"
-        }
-      }
-    }
-  }
 }

--- a/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
+++ b/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
@@ -42,10 +42,9 @@ describe('DataMetadataEndpoints', () => {
             },
             id: 'tracker'
         })
-        const trackerInfo = { id: 'tracker', ws: tracker.getUrl(), http: '' }
         publisherNode = createNetworkNode({
             id: 'publisherNode',
-            trackers: [trackerInfo]
+            trackers: [tracker.getTrackerRecord()]
         })
         publisherNode.start()
         storageNode = await startBroker({
@@ -56,7 +55,7 @@ describe('DataMetadataEndpoints', () => {
             wsPort: wsPort1,
             enableCassandra: true,
             streamrAddress: engineAndEditorAccount.address,
-            trackers: [trackerInfo]
+            trackers: [tracker.getTrackerRecord()]
         })
         client1 = createClient(wsPort1)
         assignmentEventManager = new StorageAssignmentEventManager(wsPort1, engineAndEditorAccount)

--- a/packages/broker/test/integration/plugins/storage/resends-cancelled-on-client-disconnect.test.ts
+++ b/packages/broker/test/integration/plugins/storage/resends-cancelled-on-client-disconnect.test.ts
@@ -83,7 +83,7 @@ describe('resend cancellation', () => {
         })
         networkNode = createNetworkNode({
             id: 'networkNode',
-            trackers: [tracker.getUrl()],
+            trackers: [tracker.getTrackerRecord()],
         })
         const storageNodeAddress = Wallet.createRandom().address
         const storageNodeRegistry = StorageNodeRegistry.createInstance(

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import * as Protocol from 'streamr-client-protocol'
 import { MetricsContext } from './helpers/MetricsContext'
-import { Location, TrackerInfo } from './identifiers'
+import { Location, TrackerRecord } from './identifiers'
 import { PeerInfo } from './connection/PeerInfo'
 import { HttpServerConfig, ServerWsEndpoint, startHttpServer } from './connection/ws/ServerWsEndpoint'
 import { TopologyStabilizationOptions, Tracker } from './logic/Tracker'
@@ -49,7 +49,7 @@ export interface TrackerOptions extends AbstractNodeOptions {
 }
 
 export interface NetworkNodeOptions extends AbstractNodeOptions {
-    trackers: TrackerInfo[],
+    trackers: TrackerRecord[],
     disconnectionWaitTime?: number,
     peerPingInterval?: number
     newWebrtcConnectionTimeout?: number,

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -1,6 +1,8 @@
-import { TrackerLayer, SmartContractRecord } from 'streamr-client-protocol'
+import { TrackerLayer } from 'streamr-client-protocol'
 import { NodeId } from './logic/Node'
 import { RtcSubTypes } from './logic/RtcMessage'
+
+export { TrackerRecord } from 'streamr-client-protocol'
 
 /**
  * Uniquely identifies a stream
@@ -109,5 +111,3 @@ export interface RtcErrorMessage {
     targetNode: NodeId
     errorCode: string
 }
-
-export type TrackerInfo = SmartContractRecord

--- a/packages/network/src/logic/Tracker.ts
+++ b/packages/network/src/logic/Tracker.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from 'events'
 import { Logger } from '../helpers/Logger'
 import { Metrics, MetricsContext } from '../helpers/MetricsContext'
 import { TrackerServer, Event as TrackerServerEvent } from '../protocol/TrackerServer'
+import { StatusMessage } from 'streamr-client-protocol'
 import { OverlayTopology } from './OverlayTopology'
 import { InstructionCounter } from './InstructionCounter'
 import { LocationManager } from './LocationManager'
 import { attachRtcSignalling } from './rtcSignallingHandlers'
 import { PeerInfo } from '../connection/PeerInfo'
-import { Location, Status, StatusStreams, StreamKey } from '../identifiers'
-import { TrackerLayer } from 'streamr-client-protocol'
+import { Location, Status, StatusStreams, StreamKey, TrackerRecord } from '../identifiers'
 import { NodeId } from './Node'
 import { InstructionSender } from './InstructionSender'
 
@@ -109,7 +109,7 @@ export class Tracker extends EventEmitter {
         this.removeNode(node)
     }
 
-    processNodeStatus(statusMessage: TrackerLayer.StatusMessage, source: NodeId): void {
+    processNodeStatus(statusMessage: StatusMessage, source: NodeId): void {
         this.metrics.record('processNodeStatus', 1)
         const status = statusMessage.status as Status
         const { streams, rtts, location, singleStream, extra } = status
@@ -253,5 +253,13 @@ export class Tracker extends EventEmitter {
 
     getOverlayPerStream(): Readonly<OverlayPerStream> {
         return this.overlayPerStream
+    }
+
+    getTrackerRecord(): TrackerRecord {
+        return {
+            id: this.peerInfo.peerId,
+            http: this.getUrl().replace(/^ws/, 'http'),
+            ws: this.getUrl()
+        }
     }
 }

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -1,5 +1,5 @@
 import { Utils } from 'streamr-client-protocol'
-import { StreamIdAndPartition, TrackerInfo } from '../identifiers'
+import { StreamIdAndPartition, TrackerRecord } from '../identifiers'
 import { NodeToTracker } from '../protocol/NodeToTracker'
 import { Logger } from '../helpers/Logger'
 import { PeerInfo } from '../connection/PeerInfo'
@@ -9,13 +9,19 @@ export class TrackerConnector {
 
     private readonly getStreams: () => ReadonlyArray<StreamIdAndPartition>
     private readonly nodeToTracker: NodeToTracker
-    private readonly trackerRegistry: Utils.TrackerRegistry<TrackerInfo>
+    private readonly trackerRegistry: Utils.TrackerRegistry
     private readonly logger: Logger
     private maintenanceTimer?: NodeJS.Timeout | null
     private readonly maintenanceInterval: number
     private unconnectables: Set<TrackerId>
 
-    constructor(getStreams: () => ReadonlyArray<StreamIdAndPartition>, nodeToTracker: NodeToTracker, trackerRegistry: Utils.TrackerRegistry<TrackerInfo>, logger: Logger, maintenanceInterval: number) {
+    constructor(
+        getStreams: () => ReadonlyArray<StreamIdAndPartition>,
+        nodeToTracker: NodeToTracker,
+        trackerRegistry: Utils.TrackerRegistry,
+        logger: Logger,
+        maintenanceInterval: number
+    ) {
         this.getStreams = getStreams
         this.nodeToTracker = nodeToTracker
         this.trackerRegistry = trackerRegistry

--- a/packages/network/src/logic/TrackerConnector.ts
+++ b/packages/network/src/logic/TrackerConnector.ts
@@ -1,5 +1,5 @@
 import { Utils } from 'streamr-client-protocol'
-import { StreamIdAndPartition, TrackerRecord } from '../identifiers'
+import { StreamIdAndPartition } from '../identifiers'
 import { NodeToTracker } from '../protocol/NodeToTracker'
 import { Logger } from '../helpers/Logger'
 import { PeerInfo } from '../connection/PeerInfo'

--- a/packages/network/src/streamr-client-protocol.ts
+++ b/packages/network/src/streamr-client-protocol.ts
@@ -1,0 +1,3 @@
+import Protocol from 'streamr-client-protocol'
+export * from 'streamr-client-protocol'
+export default Protocol

--- a/packages/protocol/src/utils/SmartContractUtil.ts
+++ b/packages/protocol/src/utils/SmartContractUtil.ts
@@ -1,0 +1,24 @@
+import { Contract, ContractInterface, providers } from 'ethers'
+import { ConnectionInfo } from 'ethers/lib/utils'
+
+const { JsonRpcProvider } = providers
+
+export type JSONRpcProviderConfig = string | ConnectionInfo
+
+export type SmartContractConfig = {
+    contractAddress: string
+    jsonRpcProvider: JSONRpcProviderConfig
+}
+
+export async function initContract(config: SmartContractConfig, contractInterface: ContractInterface): Promise<Contract> {
+    const { jsonRpcProvider, contractAddress } = config
+    const provider = new JsonRpcProvider(jsonRpcProvider)
+    // check that provider is connected and has some valid blockNumber
+    await provider.getBlockNumber()
+
+    const contract = new Contract(contractAddress, contractInterface, provider)
+    // check that contract is connected
+    await contract.addressPromise
+    return contract
+}
+

--- a/packages/protocol/src/utils/TrackerRegistry.ts
+++ b/packages/protocol/src/utils/TrackerRegistry.ts
@@ -9,15 +9,15 @@ export type TrackerRecord = {
     ws: string
 }
 
-export class TrackerRegistry<T extends TrackerRecord = TrackerRecord> {
-    private readonly records: T[]
+export class TrackerRegistry {
+    private readonly records: TrackerRecord[]
 
-    constructor(records: T[]) {
+    constructor(records: TrackerRecord[]) {
         this.records = records
         this.records.sort()  // TODO does this actually sort anything?
     }
 
-    getTracker(streamId: string, partition = 0): T {
+    getTracker(streamId: string, partition = 0): TrackerRecord {
         if (typeof streamId !== 'string' || streamId.indexOf('::') >= 0) {
             throw new Error(`invalid id: ${streamId}`)
         }
@@ -31,7 +31,7 @@ export class TrackerRegistry<T extends TrackerRecord = TrackerRecord> {
         return this.records[index]
     }
 
-    getAllTrackers(): T[] {
+    getAllTrackers(): TrackerRecord[] {
         return this.records
     }
 }
@@ -45,11 +45,11 @@ async function fetchTrackers(config: SmartContractConfig) {
     return await contract.getNodes()
 }
 
-export function createTrackerRegistry<T extends TrackerRecord = TrackerRecord>(servers: T[]): TrackerRegistry<T> {
+export function createTrackerRegistry(servers: TrackerRecord[]): TrackerRegistry {
     return new TrackerRegistry(servers)
 }
 
-export async function getTrackerRegistryFromContract(config: SmartContractConfig): Promise<TrackerRegistry<TrackerRecord>> {
+export async function getTrackerRegistryFromContract(config: SmartContractConfig): Promise<TrackerRegistry> {
     const trackers = await fetchTrackers(config)
     const records: TrackerRecord[] = []
     for (let i = 0; i < trackers.length; ++i) {

--- a/packages/protocol/src/utils/index.ts
+++ b/packages/protocol/src/utils/index.ts
@@ -4,8 +4,9 @@ import StreamMessageValidator from "./StreamMessageValidator"
 import CachingStreamMessageValidator from "./CachingStreamMessageValidator"
 import SigningUtil from "./SigningUtil"
 export * from "./SPID"
-import { createTrackerRegistry, getTrackerRegistryFromContract, TrackerRegistry, SmartContractRecord } from "./TrackerRegistry"
-import { createStorageNodeRegistry, getStorageNodeRegistryFromContract, StorageNodeRegistry } from "./StorageNodeRegistry"
+export * from "./SmartContractUtil"
+import { createTrackerRegistry, getTrackerRegistryFromContract, TrackerRegistry, TrackerRecord } from "./TrackerRegistry"
+import { createStorageNodeRegistry, getStorageNodeRegistryFromContract, StorageNodeRegistry, StorageNodeRecord } from "./StorageNodeRegistry"
 import { generateMnemonicFromAddress, parseAddressFromNodeId } from './NodeUtil'
 import { keyToArrayIndex } from "./HashUtil"
 
@@ -15,11 +16,12 @@ export {
     StreamMessageValidator,
     CachingStreamMessageValidator,
     SigningUtil,
-    SmartContractRecord,
+    TrackerRecord,
     TrackerRegistry,
     createTrackerRegistry,
     getTrackerRegistryFromContract,
     StorageNodeRegistry,
+    StorageNodeRecord,
     createStorageNodeRegistry,
     getStorageNodeRegistryFromContract,
     generateMnemonicFromAddress,


### PR DESCRIPTION
This is some low priority typing/refactoring.

### Problem

Currently there's multiple definitions + names for tracker & storage node records.

* `SmartContractRecord` (protocol) is identical to `TrackerRegistryItem` (broker).
* `StorageNodeInfo` (protocol) is identical to `StorageNodeRegistryItem` (broker).
* `SmartContractRecord` is confusingly named as we have multiple smart contracts.

Likely this duplication is because of the way `Protocol` is exported from `network` seems to lose type exports, so they needed to be redefined. Going forward it's possible we should just make protocol a direct dependency of broker.

### Fixes

This is a subset of some changes I've been working with on the `NET-201-brubeck-client` branch.

* `TrackerRegistryItem` and `SmartContractRecord` are now `TrackerRecord` from protocol.
* `StorageNodeRegistryItem` and `StorageNodeInfo` are now `StorageNodeRecord` from protocol.
* Removed the `T extends TrackerInfo` generic parameter from `TrackerRegistry` as it was unused (was always `TrackerInfo` or equivalent). 
* Added a new file `network/src/streamr-client-protocol.ts` that allows you to import the protocol via the network and use it as if it were just the protocol module. e.g.
```typescript
import { StorageNodeRecord } from 'streamr-network/dist/streamr-client-protocol'
```
* Added `getTrackerRecord()` method to the `Tracker` class. This gives the correct shape for consumption of a `tracker` instance in `NetworkNode` `trackers` config. e.g.
```typescript
publisherNode = createNetworkNode({
    id: 'publisherNode',
    trackers: [tracker.getTrackerRecord()]
})
```
* `{ contractAddress: string, jsonRpcProvider: string | ConnectionInfo }` is now `SmartContractConfig` from protocol. This also addresses some inconsistency with the typing of `jsonRpcProvider` as `string | ConnectionInfo` vs just `string`. 
* Also updated the broker config JSON schema to be consistent with this change using the typescript definition of `ConnectionInfo` (via `typescript-json-schema`).