### PR TITLE
NET-419: Update node-datachannel to v0.1.10

### DIFF
--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -9344,9 +9344,9 @@
 			"dev": true
 		},
 		"node-datachannel": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.5.tgz",
-			"integrity": "sha512-rramnXjtM5itsmVYYGDO/NxE2ybwRbLIeURCNld9vQ7qU4oxEakiJ2kSvr7IqEWuSOoMo0XJY0PRVVnspUBmrg==",
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.10.tgz",
+			"integrity": "sha512-q8iD3VUbY1xws5OFiPukS/G4twrekTmQNI/cRK0F3K5wwMffM2PUgkmL+/6DrPYTh7+QM35+evS8+k+83Z/yTQ==",
 			"requires": {
 				"prebuild-install": "^5.3.6"
 			},

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
     "morgan": "^1.10.0",
-    "node-datachannel": "^0.1.5",
+    "node-datachannel": "^0.1.10",
     "pino": "^6.11.3",
     "setimmediate": "^1.0.5",
     "streamr-client-protocol": "^9.0.0",


### PR DESCRIPTION
This PR fixes "Aborted" errors when running the network CI by updating node-datachannel to v0.1.10. The errors were caused by a possible race condition when closing a Peer Connection early in its lifecycle, which should be fixed in libdatachannel v0.15.2.

The fix should apply to different kind of failures linked to transport initialization, like termination without exception and segfaults, which often followed `[rtc::impl::PeerConnection::initDtlsTransport@251] Connection is closed` errors in the log.