### PR TITLE
network: remove support for full status messages

### DIFF
--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -50,18 +50,18 @@ export interface Location {
     city: string | null
 }
 
-export type StatusStreams = Record<StreamKey, {
+export interface StreamStatus {
+    streamKey: StreamKey
     inboundNodes: NodeId[]
     outboundNodes: NodeId[]
-    counter: number
-}>
+    counter: number // TODO this field could be a field of "Status" interface, not this interface?
+}
 
 export interface Status {
-    streams: StatusStreams
+    stream: StreamStatus
     rtts: Rtts | null
     location: Location
     started: string
-    singleStream: boolean // indicate whether this is a status update for only a single stream
     extra: Record<string, unknown>
 }
 

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -143,13 +143,12 @@ export class TrackerManager {
     private async sendStatus(streamId: StreamIdAndPartition, trackerId: TrackerId): Promise<void> {
         const nodeDescriptor = this.getNodeDescriptor(this.shouldIncludeRttInfo(trackerId))
         const status = {
-            streams: this.streamManager.getStreamState(streamId),
-            singleStream: true,
+            stream: this.streamManager.getStreamStatus(streamId),
             ...nodeDescriptor
         }
         try {
             await this.nodeToTracker.sendStatus(trackerId, status)
-            logger.trace('sent status %j to tracker %s', status.streams, trackerId)
+            logger.trace('sent status %j to tracker %s', status.stream, trackerId)
         } catch (e) {
             logger.trace('failed to send status to tracker %s, reason: %s', trackerId, e)
         }

--- a/packages/network/src/logic/tracker/InstructionCounter.ts
+++ b/packages/network/src/logic/tracker/InstructionCounter.ts
@@ -1,5 +1,7 @@
-import { Status, StatusStreams, StreamKey } from '../../identifiers'
+import { Status, StreamKey } from '../../identifiers'
 import { NodeId } from '../node/Node'
+
+export const COUNTER_UNSUBSCRIBE = -1
 
 type Counters = Record<NodeId,Record<StreamKey,number>>
 
@@ -14,15 +16,9 @@ export class InstructionCounter {
         return this.counters[nodeId][streamKey]
     }
 
-    filterStatus(status: Status, source: NodeId): StatusStreams {
-        const filteredStreams: StatusStreams = {}
-        Object.entries(status.streams).forEach(([streamKey, entry]) => {
-            const currentCounter = this.getAndSetIfNecessary(source, streamKey)
-            if (entry.counter >= currentCounter || entry.counter === -1) {
-                filteredStreams[streamKey] = entry
-            }
-        })
-        return filteredStreams
+    isMostRecent(status: Status, source: NodeId): boolean {
+        const currentCounter = this.getAndSetIfNecessary(source, status.stream.streamKey)
+        return (status.stream.counter >= currentCounter || status.stream.counter === COUNTER_UNSUBSCRIBE)
     }
 
     removeNode(nodeId: NodeId): void {

--- a/packages/network/src/protocol/NodeToTracker.ts
+++ b/packages/network/src/protocol/NodeToTracker.ts
@@ -39,7 +39,6 @@ export class NodeToTracker extends EventEmitter {
     private readonly endpoint: AbstractClientWsEndpoint<AbstractWsConnection>
     private readonly logger: Logger
 
-    // ServerWsEndpoint
     constructor(endpoint: AbstractClientWsEndpoint<AbstractWsConnection>) {
         super()
         this.endpoint = endpoint

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -11,7 +11,7 @@ import { NodeId } from '../logic/node/Node'
 
 const WAIT_TIME = 2000
 
-const formStatus = (counter1: number, counter2: number, nodes1: NodeId[], nodes2: NodeId[]): Partial<Status> => ({
+const formStatus = (counter1: number, nodes1: NodeId[]): Partial<Status> => ({
     stream: {
         streamKey: 'stream-1::0',
         inboundNodes: nodes1,
@@ -50,8 +50,8 @@ describe('tracker: instruction counter filtering', () => {
         ])
 
         await runAndWaitForEvents([
-            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status) },
-            () => { nodeToTracker2.sendStatus('tracker', formStatus(0, 0, [], []) as Status) }
+            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, []) as Status) },
+            () => { nodeToTracker2.sendStatus('tracker', formStatus(0, []) as Status) }
         ], [
             [nodeToTracker1, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED],
             [nodeToTracker2, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED]
@@ -67,8 +67,8 @@ describe('tracker: instruction counter filtering', () => {
     test('handles status messages with counters equal or more to current counter(s)', async () => {
         await runAndWaitForEvents(
             () => {
-                nodeToTracker1.sendStatus('tracker', formStatus(1, 666, [], []) as Status)
-                .catch(() => {})
+                nodeToTracker1.sendStatus('tracker', formStatus(1, []) as Status)
+                    .catch(() => {})
             },
             [nodeToTracker1, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED],
             WAIT_TIME
@@ -80,7 +80,7 @@ describe('tracker: instruction counter filtering', () => {
         nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
-        nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(0, []) as Status)
             .catch(() => {})
         await wait(WAIT_TIME)
         expect(numOfInstructions).toEqual(0)
@@ -91,7 +91,7 @@ describe('tracker: instruction counter filtering', () => {
         nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
-        nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], []) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(1, []) as Status)
             .catch(() => {})
         await wait(WAIT_TIME)
         expect(numOfInstructions).toEqual(1)
@@ -100,7 +100,7 @@ describe('tracker: instruction counter filtering', () => {
     test('NET-36: tracker receiving status with old counter should not affect topology', async () => {
         const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
         await runAndWaitForEvents(
-            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status) },
+            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, []) as Status) },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]
         )
@@ -111,7 +111,7 @@ describe('tracker: instruction counter filtering', () => {
         const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
         await runAndWaitForEvents(
             () => {
-                nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], []) as Status)
+                nodeToTracker1.sendStatus('tracker', formStatus(1, []) as Status)
             },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]

--- a/packages/network/test/integration/counter-filtering-in-tracker.test.ts
+++ b/packages/network/test/integration/counter-filtering-in-tracker.test.ts
@@ -9,25 +9,18 @@ import { getTopology } from '../../src/logic/tracker/trackerSummaryUtils'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 import { NodeId } from '../logic/node/Node'
 
-const WAIT_TIME = 200
+const WAIT_TIME = 2000
 
-const formStatus = (counter1: number, counter2: number, nodes1: NodeId[], nodes2: NodeId[], singleStream: boolean): Partial<Status> => ({
-    streams: {
-        'stream-1::0': {
-            inboundNodes: nodes1,
-            outboundNodes: nodes1,
-            counter: counter1,
-        },
-        'stream-2::0': {
-            inboundNodes: nodes2,
-            outboundNodes: nodes2,
-            counter: counter2
-        }
-    },
-    singleStream
+const formStatus = (counter1: number, counter2: number, nodes1: NodeId[], nodes2: NodeId[]): Partial<Status> => ({
+    stream: {
+        streamKey: 'stream-1::0',
+        inboundNodes: nodes1,
+        outboundNodes: nodes1,
+        counter: counter1
+    }
 })
 
-describe('tracker: counter filtering', () => {
+describe('tracker: instruction counter filtering', () => {
     let tracker: Tracker
     let nodeToTracker1: NodeToTracker
     let nodeToTracker2: NodeToTracker
@@ -50,14 +43,16 @@ describe('tracker: counter filtering', () => {
 
         await runAndWaitForEvents([
             () => { nodeToTracker1.connectToTracker(tracker.getUrl(), trackerPeerInfo) },
-            () => { nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo) }], [
+            () => { nodeToTracker2.connectToTracker(tracker.getUrl(), trackerPeerInfo) }
+        ], [
             [nodeToTracker1, NodeToTrackerEvent.CONNECTED_TO_TRACKER],
             [nodeToTracker2, NodeToTrackerEvent.CONNECTED_TO_TRACKER]
         ])
 
         await runAndWaitForEvents([
-            () => {  nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
-            () => { nodeToTracker2.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) }], [
+            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status) },
+            () => { nodeToTracker2.sendStatus('tracker', formStatus(0, 0, [], []) as Status) }
+        ], [
             [nodeToTracker1, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED],
             [nodeToTracker2, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED]
         ])
@@ -70,16 +65,14 @@ describe('tracker: counter filtering', () => {
     })
 
     test('handles status messages with counters equal or more to current counter(s)', async () => {
-        let numOfInstructions = 0
-        nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
-            numOfInstructions += 1
-        })
-
-        nodeToTracker1.sendStatus('tracker', formStatus(1, 666, [], [], false) as Status)
-            .catch(() => {})
-
-        await wait(WAIT_TIME)
-        expect(numOfInstructions).toEqual(2)
+        await runAndWaitForEvents(
+            () => {
+                nodeToTracker1.sendStatus('tracker', formStatus(1, 666, [], []) as Status)
+                .catch(() => {})
+            },
+            [nodeToTracker1, NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED],
+            WAIT_TIME
+        )
     })
 
     test('ignores status messages with counters less than current counter(s)', async () => {
@@ -87,10 +80,8 @@ describe('tracker: counter filtering', () => {
         nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
-
-        nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status)
             .catch(() => {})
-
         await wait(WAIT_TIME)
         expect(numOfInstructions).toEqual(0)
     })
@@ -100,32 +91,27 @@ describe('tracker: counter filtering', () => {
         nodeToTracker1.on(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
             numOfInstructions += 1
         })
-
-        nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
+        nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], []) as Status)
             .catch(() => {})
-
         await wait(WAIT_TIME)
         expect(numOfInstructions).toEqual(1)
     })
 
     test('NET-36: tracker receiving status with old counter should not affect topology', async () => {
         const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
-
         await runAndWaitForEvents(
-            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], [], false) as Status) },
+            () => { nodeToTracker1.sendStatus('tracker', formStatus(0, 0, [], []) as Status) },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]
         )
-
         expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual(topologyBefore)
     })
 
     test('NET-36: tracker receiving status with partial old counter should not affect topology', async () => {
         const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
-
         await runAndWaitForEvents(
             () => {
-                nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], [], false) as Status)
+                nodeToTracker1.sendStatus('tracker', formStatus(1, 0, [], []) as Status)
             },
             // @ts-expect-error trackerServer is private
             [tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED]

--- a/packages/network/test/integration/rtc-signalling-messages-routing.test.ts
+++ b/packages/network/test/integration/rtc-signalling-messages-routing.test.ts
@@ -1,5 +1,5 @@
 import { Tracker } from '../../src/logic/tracker/Tracker'
-import { waitForEvent } from 'streamr-test-utils'
+import { runAndWaitForEvents, waitForEvent } from 'streamr-test-utils'
 import { TrackerLayer } from 'streamr-client-protocol'
 
 import { PeerInfo } from '../../src/connection/PeerInfo'
@@ -54,16 +54,21 @@ describe('RTC signalling messages are routed to destination via tracker', () => 
     })
 
     it('Offer messages are delivered', async () => {
-        const requestId = await originatorNodeToTracker.sendRtcOffer(
-            'tracker',
-            'target',
-            'connectionid',
-            PeerInfo.newNode('originator'),
-            'description'
+        let requestId: string|undefined
+        const [rtcOffers]: any[] = await runAndWaitForEvents(
+            async () => {
+                requestId = await originatorNodeToTracker.sendRtcOffer(
+                    'tracker',
+                    'target',
+                    'connectionid',
+                    PeerInfo.newNode('originator'),
+                    'description'
+                )
+            },
+            [targetNodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED]
         )
-        const [rtcOffer] = await waitForEvent(targetNodeToTracker, NodeToTrackerEvent.RELAY_MESSAGE_RECEIVED)
-        expect(rtcOffer).toEqual(new RelayMessage({
-            requestId,
+        expect(rtcOffers[0]).toEqual(new RelayMessage({
+            requestId: requestId!,
             originator: PeerInfo.newNode('originator'),
             targetNode: 'target',
             subType: RtcSubTypes.RTC_OFFER,

--- a/packages/network/test/unit/InstructionCounter.test.ts
+++ b/packages/network/test/unit/InstructionCounter.test.ts
@@ -8,186 +8,101 @@ describe('InstructionCounter', () => {
         instructionCounter = new InstructionCounter()
     })
 
-    it('filterStatus returns all if counters have not been set', () => {
+    it('if counters have not been set', () => {
         const status: Partial<Status> = {
-            streams: {
-                'stream-1': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 1
-                },
-                'stream-2': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 3
-                },
+            stream: {
+                streamKey: 'stream-1',
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 123
             }
         }
-        const filtered = instructionCounter.filterStatus(status as Status, 'node')
-        expect(filtered).toEqual(status.streams)
+        const isMostRecent = instructionCounter.isMostRecent(status as Status, 'node')
+        expect(isMostRecent).toEqual(true)
     })
 
-    it('filterStatus filters streams according to counters', () => {
+    it('stream specific', () => {
         instructionCounter.setOrIncrement('node', 'stream-1')
         instructionCounter.setOrIncrement('node', 'stream-1')
-
         instructionCounter.setOrIncrement('node', 'stream-2')
         instructionCounter.setOrIncrement('node', 'stream-2')
         instructionCounter.setOrIncrement('node', 'stream-2')
-
-        instructionCounter.setOrIncrement('node', 'stream-3')
-
-        const status = {
-            streams: {
-                'stream-1': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 1
-                },
-                'stream-2': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 3
-                },
-                'stream-3': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 0
-                },
+        const status1 = {
+            stream: {
+                streamKey: 'stream-1',
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 1
             }
         }
-        const filtered = instructionCounter.filterStatus(status as any, 'node')
-        expect(filtered).toEqual({
-            'stream-2': {
+        const status2 = {
+            stream: {
+                streamKey: 'stream-2',
                 inboundNodes: [],
                 outboundNodes: [],
                 counter: 3
-            },
-        })
-    })
-
-    it('filterStatus is node-specific', () => {
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-1')
-        instructionCounter.setOrIncrement('node', 'stream-1')
-
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-
-        const status = {
-            streams: {
-                'stream-1': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 1
-                },
-                'stream-2': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 3
-                },
-                'stream-3': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 0
-                },
             }
         }
-        const filtered = instructionCounter.filterStatus(status as any, 'another-node')
-        expect(filtered).toEqual(status.streams)
+        expect(instructionCounter.isMostRecent(status1 as any, 'node')).toBe(false)
+        expect(instructionCounter.isMostRecent(status2 as any, 'node')).toBe(true)
+    })
+
+    it('node specific', () => {
+        instructionCounter.setOrIncrement('node-1', 'stream-1')
+        instructionCounter.setOrIncrement('node-1', 'stream-1')
+        instructionCounter.setOrIncrement('node-2', 'stream-1')
+        instructionCounter.setOrIncrement('node-2', 'stream-1')
+        instructionCounter.setOrIncrement('node-2', 'stream-1')
+        const status1 = {
+            stream: {
+                streamKey: 'stream-1',
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 1
+            }
+        }
+        const status2 = {
+            stream: {
+                streamKey: 'stream-1',
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 3
+            }
+        }
+        expect(instructionCounter.isMostRecent(status1 as any, 'node-1')).toBe(false)
+        expect(instructionCounter.isMostRecent(status2 as any, 'node-2')).toBe(true)
     })
 
     it('removeNode unsets counters', () => {
         instructionCounter.setOrIncrement('node', 'stream-1')
         instructionCounter.setOrIncrement('node', 'stream-1')
         instructionCounter.setOrIncrement('node', 'stream-1')
-
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-
+        instructionCounter.removeNode('node')
         const status = {
-            streams: {
-                'stream-1': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 1
-                },
-                'stream-2': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 3
-                },
-                'stream-3': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 0
-                },
+            stream: {
+                streamKey: 'stream-1',
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 0
             }
         }
-
-        instructionCounter.removeNode('node')
-        const filtered = instructionCounter.filterStatus(status as any, 'node')
-        expect(filtered).toEqual(status.streams)
+        expect(instructionCounter.isMostRecent(status as any, 'node')).toEqual(true)
     })
 
     it('removeStream unsets counters', () => {
         instructionCounter.setOrIncrement('node', 'stream-1')
         instructionCounter.setOrIncrement('node', 'stream-1')
         instructionCounter.setOrIncrement('node', 'stream-1')
-
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-        instructionCounter.setOrIncrement('node', 'stream-2')
-
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-        instructionCounter.setOrIncrement('node', 'stream-3')
-
+        instructionCounter.removeStream('stream-1')
         const status = {
-            streams: {
-                'stream-1': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 1
-                },
-                'stream-2': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 3
-                },
-                'stream-3': {
-                    inboundNodes: [],
-                    outboundNodes: [],
-                    counter: 0
-                },
-            }
-        }
-
-        instructionCounter.removeStream('stream-3')
-        const filtered = instructionCounter.filterStatus(status as any, 'node')
-
-        expect(filtered).toEqual({
-            'stream-2': {
-                inboundNodes: [],
-                outboundNodes: [],
-                counter: 3
-            },
-            'stream-3': {
+            stream: {
+                streamKey: 'stream-1',
                 inboundNodes: [],
                 outboundNodes: [],
                 counter: 0
-            },
-        })
+            }
+        }
+        expect(instructionCounter.isMostRecent(status as any, 'node')).toEqual(true)
     })
 
     test('setOrIncrement returns node/stream-specific counter value', () => {
@@ -200,11 +115,9 @@ describe('InstructionCounter', () => {
         expect(instructionCounter.setOrIncrement('node-b', 'stream-2')).toEqual(1)
         expect(instructionCounter.setOrIncrement('node-b', 'stream-3')).toEqual(1)
         expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(4)
-
         instructionCounter.removeStream('stream-1')
         expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(1)
         expect(instructionCounter.setOrIncrement('node-b', 'stream-1')).toEqual(1)
-
         instructionCounter.removeNode('node-a')
         expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(1)
         expect(instructionCounter.setOrIncrement('node-a', 'stream-2')).toEqual(1)

--- a/packages/network/test/unit/StreamManager.test.ts
+++ b/packages/network/test/unit/StreamManager.test.ts
@@ -116,18 +116,6 @@ describe('StreamManager', () => {
         expect(manager.getInboundNodesForStream(streamId)).toEqual(['node-1', 'node-2'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-1', 'node-3'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-1', 'node-3'])
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-id-2::0', 'stream-id::0'].includes(streamKey))).toEqual({
-            'stream-id-2::0': {
-                inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: ['node-3'],
-                counter: 0
-            },
-            'stream-id::0': {
-                inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: ['node-1', 'node-3'],
-                counter: 0
-            }
-        })
         expect(manager.getAllNodesForStream(streamId)).toEqual(['node-1', 'node-2', 'node-3'])
         expect(manager.getAllNodesForStream(streamId2)).toEqual(['node-1', 'node-2', 'node-3'])
 
@@ -172,18 +160,6 @@ describe('StreamManager', () => {
 
         expect(manager.getInboundNodesForStream(streamId)).toEqual(['node-2'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-3'])
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-id-2::0', 'stream-id::0'].includes(streamKey))).toEqual({
-            'stream-id-2::0': {
-                inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: [],
-                counter: 0
-            },
-            'stream-id::0': {
-                inboundNodes: ['node-2'],
-                outboundNodes: ['node-3'],
-                counter: 0
-            }
-        })
 
         expect(manager.hasInboundNode(streamId, 'node-1')).toEqual(false)
         expect(manager.hasOutboundNode(streamId, 'node-1')).toEqual(false)
@@ -219,23 +195,6 @@ describe('StreamManager', () => {
         expect(manager.getOutboundNodesForStream(new StreamIdAndPartition('stream-1', 1))).toEqual(['should-not-be-removed'])
         expect(manager.getInboundNodesForStream(new StreamIdAndPartition('stream-2', 0))).toEqual(['should-not-be-removed'])
         expect(manager.getOutboundNodesForStream(new StreamIdAndPartition('stream-2', 0))).toEqual([])
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
-            'stream-1::0': {
-                inboundNodes: [],
-                outboundNodes: ['should-not-be-removed'],
-                counter: 0
-            },
-            'stream-1::1': {
-                inboundNodes: ['should-not-be-removed'],
-                outboundNodes: ['should-not-be-removed'],
-                counter: 0
-            },
-            'stream-2::0': {
-                inboundNodes: ['should-not-be-removed'],
-                outboundNodes: [],
-                counter: 0
-            }
-        })
 
         expect(manager.hasInboundNode(new StreamIdAndPartition('stream-1', 0), 'node')).toEqual(false)
         expect(manager.hasOutboundNode(new StreamIdAndPartition('stream-2', 0), 'node')).toEqual(false)
@@ -261,47 +220,13 @@ describe('StreamManager', () => {
         expect(manager.getStreams()).toEqual([
             new StreamIdAndPartition('stream-2', 0)
         ])
-
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
-            'stream-2::0': {
-                inboundNodes: ['n1'],
-                outboundNodes: ['n1'],
-                counter: 0
-            }
-        })
     })
 
     test('updating counter', () => {
         manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
         manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
 
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
-            'stream-1::0': {
-                inboundNodes: [],
-                outboundNodes: [],
-                counter: 0
-            },
-            'stream-2::0': {
-                inboundNodes: [],
-                outboundNodes: [],
-                counter: 0
-            }
-        })
-
         manager.updateCounter(new StreamIdAndPartition('stream-1', 0), 50)
         manager.updateCounter(new StreamIdAndPartition('stream-2', 0), 100)
-
-        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
-            'stream-1::0': {
-                inboundNodes: [],
-                outboundNodes: [],
-                counter: 50
-            },
-            'stream-2::0': {
-                inboundNodes: [],
-                outboundNodes: [],
-                counter: 100
-            }
-        })
     })
 })


### PR DESCRIPTION
Currently all status messages that nodes send include only one stream. In https://github.com/streamr-dev/network-monorepo/pull/174 we modified the sending logic in node, but didn't change the tracker behavior (to keep the backwards compatibility).

In this PR we drop the backwards compatibility. The trackers is no longer able to process status messages that contain multiple streams.