### PR TITLE
NET-554: add option to filter remote ICE candidates with private IPv4

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -25,7 +25,8 @@
       "city": "Helsinki"
     },
     "stun": null,
-    "turn": null
+    "turn": null,
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -25,7 +25,8 @@
       "city": "Helsinki"
     },
     "stun": null,
-    "turn": null
+    "turn": null,
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -25,7 +25,8 @@
       "city": "Helsinki"
     },
     "stun": null,
-    "turn": null
+    "turn": null,
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://127.0.0.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/development-prod-resend.env.json
+++ b/packages/broker/configs/development-prod-resend.env.json
@@ -9,7 +9,8 @@
       "longitude": 24.95,
       "country": "Finland",
       "city": "Helsinki"
-    }
+    },
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://streamr.network",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -12,7 +12,8 @@
       "longitude": 24.95,
       "country": "Finland",
       "city": "Helsinki"
-    }
+    },
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -12,7 +12,8 @@
       "longitude": 13.40,
       "country": "Germany",
       "city": "Berlin"
-    }
+    },
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -12,7 +12,8 @@
       "longitude": 8.51,
       "country": "Switzerland",
       "city": "Zug"
-    }
+    },
+    "webrtcDisallowPrivateAddresses": false
   },
   "streamrUrl": "http://10.200.10.1",
   "streamrAddress": "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c",

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -85,7 +85,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
 
     const usePredeterminedNetworkId = !config.generateSessionId || config.plugins['storage']
 
-    const webrtcDisallowPrivateAddresses = config.network?.webrtcDisallowPrivateAddresses || false
+    const webrtcDisallowPrivateAddresses = config.network.webrtcDisallowPrivateAddresses
 
     const streamrClient = new StreamrClient({
         auth: {

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -96,7 +96,8 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             trackers,
             location: config.network.location,
             metricsContext,
-            stunUrls: getStunTurnUrls(config)
+            stunUrls: getStunTurnUrls(config),
+            webrtcDisallowPrivateAddresses: config.network?.webrtcDisallowPrivateAddresses || false
         }
     })
     const publisher = new Publisher(streamrClient, metricsContext)

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -84,6 +84,9 @@ export const createBroker = async (config: Config): Promise<Broker> => {
     const storageNodeRegistry = StorageNodeRegistry.createInstance(config, storageNodes)
 
     const usePredeterminedNetworkId = !config.generateSessionId || config.plugins['storage']
+
+    const webrtcDisallowPrivateAddresses = config.network?.webrtcDisallowPrivateAddresses || false
+
     const streamrClient = new StreamrClient({
         auth: {
             privateKey: config.ethereumPrivateKey,
@@ -97,7 +100,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             location: config.network.location,
             metricsContext,
             stunUrls: getStunTurnUrls(config),
-            webrtcDisallowPrivateAddresses: config.network?.webrtcDisallowPrivateAddresses || false
+            webrtcDisallowPrivateAddresses
         }
     })
     const publisher = new Publisher(streamrClient, metricsContext)
@@ -146,6 +149,10 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             logger.info(`Configured with trackers: [${trackers.map((tracker) => tracker.http).join(', ')}]`)
             logger.info(`Configured with Streamr: ${config.streamrUrl}`)
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
+
+            if (!webrtcDisallowPrivateAddresses) {
+                logger.warn('WebRTC private address probing is allowed, this might cause issues for hosted nodes.')
+            }
         },
         stop: async () => {
             if (httpServer !== undefined) {

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -151,7 +151,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
 
             if (!webrtcDisallowPrivateAddresses) {
-                logger.warn('WebRTC private address probing is allowed, this might cause issues for hosted nodes.')
+                logger.warn('WebRTC private address probing is allowed. This can trigger false-positives for port scanning detection on some web hosts. More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')
             }
         },
         stop: async () => {

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -151,7 +151,9 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
 
             if (!webrtcDisallowPrivateAddresses) {
-                logger.warn('WebRTC private address probing is allowed. This can trigger false-positives for port scanning detection on some web hosts. More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')
+                logger.warn('WebRTC private address probing is allowed. ' +
+                    'This can trigger false-positives for port scanning detection on some web hosts. ' +
+                    'More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')
             }
         },
         stop: async () => {

--- a/packages/broker/src/config.ts
+++ b/packages/broker/src/config.ts
@@ -17,13 +17,14 @@ export interface NetworkConfig {
     name: string,
     trackers: TrackerRegistryItem[] | NetworkSmartContract,
     stun: string | null,
-    turn: TurnConfig | null
+    turn: TurnConfig | null,
     location: {
         latitude: number,
         longitude: number,
         country: string,
         city: string
-    } | null
+    } | null,
+    webrtcDisallowPrivateAddresses: boolean
 }
 
 export interface HttpServerConfig {

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -195,7 +195,7 @@
         "webrtcDisallowPrivateAddresses": {
             "type": "boolean",
             "description": "If true, disallow WebRTC from probing private addresses",
-            "default": "false"
+            "default": false
         }
       }
     },

--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -191,6 +191,11 @@
               }
             }
           ]
+        },
+        "webrtcDisallowPrivateAddresses": {
+            "type": "boolean",
+            "description": "If true, disallow WebRTC from probing private addresses",
+            "default": "false"
         }
       }
     },
@@ -277,7 +282,7 @@
         },
         "url": {
           "type": "string"
-        }  
+        }
       }
     },
     "smartContractConfig": {

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -103,7 +103,8 @@ export const formConfig = ({
                 city: 'Helsinki'
             },
             stun: null,
-            turn : null
+            turn: null,
+            webrtcDisallowPrivateAddresses: false
         },
         streamrUrl,
         streamrAddress,

--- a/packages/network/package-lock.json
+++ b/packages/network/package-lock.json
@@ -5759,9 +5759,9 @@
 			"dev": true
 		},
 		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+			"integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
 		},
 		"is": {
 			"version": "0.2.7",
@@ -10921,6 +10921,13 @@
 			"requires": {
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
+			},
+			"dependencies": {
+				"ipaddr.js": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+					"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+				}
 			}
 		},
 		"prr": {

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -50,6 +50,7 @@
     "express": "^4.17.1",
     "geoip-lite": "^1.4.2",
     "heap": "^0.2.6",
+    "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",
     "morgan": "^1.10.0",
     "node-datachannel": "^0.1.11",

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -56,6 +56,7 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     newWebrtcConnectionTimeout?: number,
     webrtcDatachannelBufferThresholdLow?: number,
     webrtcDatachannelBufferThresholdHigh?: number,
+    webrtcDisallowPrivateAddresses?: boolean,
     stunUrls?: string[],
     rttUpdateTimeout?: number,
     trackerConnectionMaintenanceInterval?: number
@@ -108,6 +109,7 @@ export const createNetworkNode = ({
     rttUpdateTimeout,
     webrtcDatachannelBufferThresholdLow,
     webrtcDatachannelBufferThresholdHigh,
+    webrtcDisallowPrivateAddresses = false,
     stunUrls = ['stun:stun.l.google.com:19302'],
     trackerConnectionMaintenanceInterval
 }: NetworkNodeOptions): NetworkNode => {
@@ -128,6 +130,7 @@ export const createNetworkNode = ({
         peerPingInterval,
         webrtcDatachannelBufferThresholdLow,
         webrtcDatachannelBufferThresholdHigh,
+        webrtcDisallowPrivateAddresses,
     ))
 
     return new NetworkNode({

--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -260,7 +260,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         }
     }
 
-    private isIceCandidateAllowed(candidate: string): boolean {
+    isIceCandidateAllowed(candidate: string): boolean {
         if (this.disallowPrivateAddresses) {
             const address = getAddressFromIceCandidate(candidate)
             if (address && isPrivateIPv4(address)) {

--- a/packages/network/src/connection/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/WebRtcEndpoint.ts
@@ -18,6 +18,7 @@ import { MessageQueue } from './MessageQueue'
 import { NameDirectory } from '../NameDirectory'
 import { NegotiatedProtocolVersions } from "./NegotiatedProtocolVersions"
 import { v4 as uuidv4 } from 'uuid'
+import { getAddressFromIceCandidate, isPrivateIPv4 } from '../helpers/AddressTools'
 
 class WebRtcError extends Error {
     constructor(msg: string) {
@@ -47,7 +48,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private stopped = false
     private readonly bufferThresholdLow: number
     private readonly bufferThresholdHigh: number
-    private readonly maxMessageSize
+    private readonly disallowPrivateAddresses: boolean
+    private readonly maxMessageSize: number
 
     private statusReportTimer?: NodeJS.Timeout
 
@@ -62,7 +64,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         pingInterval = 5 * 1000,
         webrtcDatachannelBufferThresholdLow = 2 ** 15,
         webrtcDatachannelBufferThresholdHigh = 2 ** 17,
-        maxMessageSize = 1048576
+        webrtcDisallowPrivateAddresses = false,
+        maxMessageSize = 1048576,
     ) {
         super()
         this.peerInfo = peerInfo
@@ -77,6 +80,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.logger = new Logger(module)
         this.bufferThresholdLow = webrtcDatachannelBufferThresholdLow
         this.bufferThresholdHigh = webrtcDatachannelBufferThresholdHigh
+        this.disallowPrivateAddresses = webrtcDisallowPrivateAddresses
         this.maxMessageSize = maxMessageSize
 
         rtcSignaller.setOfferListener(async (options: OfferOptions) => {
@@ -167,7 +171,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         const connection = this.connectionFactory.createConnection(connectionOptions)
 
         if (connection.isOffering()) {
-            connection.once('localDescription', (type, description) => {            
+            connection.once('localDescription', (type, description) => {
                 this.rtcSignaller.sendRtcOffer(routerId, connection.getPeerId(), connection.getConnectionId(), description)
                 this.attemptProtocolVersionValidation(connection)
             })
@@ -212,18 +216,18 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         connection.on('failed', () => {
             this.metrics.record('failedConnection', 1)
         })
-        
+
         return connection
     }
-    
+
     private onRtcOfferFromSignaller({ routerId, originatorInfo, description, connectionId }: OfferOptions): void {
         const { peerId } = originatorInfo
-        
+
         let connection: WebRtcConnection
-       
+
         if (!this.connections[peerId]) {
             connection = this.createConnection(peerId, routerId,null)
-            
+
             try {
                 connection.connect()
             } catch(e) {
@@ -256,18 +260,30 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         }
     }
 
+    private isIceCandidateAllowed(candidate: string): boolean {
+        if (this.disallowPrivateAddresses) {
+            const address = getAddressFromIceCandidate(candidate)
+            if (address && isPrivateIPv4(address)) {
+                return false
+            }
+        }
+        return true
+    }
+
     private onIceCandidateFromSignaller({ originatorInfo, candidate, mid, connectionId }: IceCandidateOptions): void {
         const { peerId } = originatorInfo
         const connection = this.connections[peerId]
-        if (!connection) { 
+        if (!connection) {
             this.logger.debug('unexpected iceCandidate from %s: %s (no connection)', peerId, candidate)
         } else if (connection.getConnectionId() !== connectionId) {
             this.logger.debug('unexpected iceCandidate from %s (connectionId mismatch %s !== %s)', peerId, connection.getConnectionId(), connectionId)
         } else {
-            connection.addRemoteCandidate(candidate, mid)
-        } 
+            if (this.isIceCandidateAllowed(candidate)) {
+                connection.addRemoteCandidate(candidate, mid)
+            }
+        }
     }
-    
+
     private onErrorFromSignaller({ targetNode, errorCode }: ErrorOptions): void {
         const error = new WebRtcError(`RTC error ${errorCode} while attempting to signal with node ${targetNode}`)
         const connection = this.connections[targetNode]
@@ -275,7 +291,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         if (connection) {
             connection.close(error)
         }
-    } 
+    }
 
     private onConnectFromSignaller({ originatorInfo, routerId }: ConnectOptions): void {
         const { peerId } = originatorInfo
@@ -336,7 +352,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 NameDirectory.getName(targetPeerId),
                 lastState
             )
-            
+
             if (lastState === 'connected') {
                 return Promise.resolve(targetPeerId)
             } else if (deferredConnectionAttempt) {
@@ -345,7 +361,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 throw new Error(`unexpected deferedConnectionAttempt == null ${connection.getPeerId()}`)
             }
         }
-        
+
         const connection = this.createConnection(targetPeerId, routerId, null)
 
         if (connection.isOffering()) {
@@ -354,15 +370,15 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
 
         this.connections[targetPeerId] = connection
         connection.connect()
-        
+
         if (!trackerInstructed && !connection.isOffering()) {
             // If we are non-offerer and this connection was not instructed by the tracker, we need
             // to let the offering side know about it so it can send us the initial offer message.
-            
+
             this.rtcSignaller.sendRtcConnect(routerId, connection.getPeerId())
         }
 
-        const deferredAttempt = connection.getDeferredConnectionAttempt() 
+        const deferredAttempt = connection.getDeferredConnectionAttempt()
         if (deferredAttempt) {
             return deferredAttempt.getPromise()
         } else {

--- a/packages/network/src/helpers/AddressTools.ts
+++ b/packages/network/src/helpers/AddressTools.ts
@@ -5,7 +5,7 @@ const IPv4PrivateRanges = [
     '10.0.0.0/8',
     '172.16.0.0/12',
     '192.168.0.0/16',
-].map((a: string) => ipaddr.parseCIDR(a))
+].map((a) => ipaddr.parseCIDR(a))
 
 export function isPrivateIPv4(address: string): boolean {
     if (ipaddr.IPv4.isValid(address)) {
@@ -21,7 +21,7 @@ export function isPrivateIPv4(address: string): boolean {
 }
 
 export function getAddressFromIceCandidate(candidate: string): string | undefined {
-    const fields = candidate.split(' ').filter((field: string) => field.length > 0)
+    const fields = candidate.split(' ').filter((field) => field.length > 0)
     return fields.length >= 5 && ipaddr.isValid(fields[4]) ? fields[4] : undefined
 }
 

--- a/packages/network/src/helpers/AddressTools.ts
+++ b/packages/network/src/helpers/AddressTools.ts
@@ -20,7 +20,7 @@ export function isPrivateIPv4(address: string): boolean {
     return false
 }
 
-export function getAddressFromIceCandidate(candidate: string) : string | undefined {
+export function getAddressFromIceCandidate(candidate: string): string | undefined {
     const fields = candidate.split(' ').filter((field: string) => field.length > 0)
     return fields.length >= 5 && ipaddr.isValid(fields[4]) ? fields[4] : undefined
 }

--- a/packages/network/src/helpers/AddressTools.ts
+++ b/packages/network/src/helpers/AddressTools.ts
@@ -1,0 +1,27 @@
+import ipaddr from 'ipaddr.js'
+
+// IPv4 private address ranges as specified by RFC 1918
+const IPv4PrivateRanges = [
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+].map((a: string) => ipaddr.parseCIDR(a))
+
+export function isPrivateIPv4(address: string): boolean {
+    if (ipaddr.IPv4.isValid(address)) {
+        const ip = ipaddr.IPv4.parse(address)
+        for (const range of IPv4PrivateRanges) {
+            if (ip.match(range)) {
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
+export function getAddressFromIceCandidate(candidate: string) : string | undefined {
+    const fields = candidate.split(' ').filter((field: string) => field.length > 0)
+    return fields.length >= 5 && ipaddr.isValid(fields[4]) ? fields[4] : undefined
+}
+

--- a/packages/network/test/unit/AddressTools.test.ts
+++ b/packages/network/test/unit/AddressTools.test.ts
@@ -1,0 +1,41 @@
+import { getAddressFromIceCandidate, isPrivateIPv4 } from '../../src/helpers/AddressTools'
+
+describe(getAddressFromIceCandidate, () => {
+    it('extract IPv4 address from ICE host candidate', () => {
+        expect(getAddressFromIceCandidate('candidate:1 1 udp 2122262783 203.0.113.180 4444 typ host'))
+            .toEqual('203.0.113.180')
+    })
+
+    it('extract IPv4 address from ICE server reflexive candidate', () => {
+        expect(getAddressFromIceCandidate('candidate:1 1 udp 2122262783 198.51.100.130 4445 typ srflx raddr 0.0.0.0 rport 0'))
+            .toEqual('198.51.100.130')
+    })
+
+    it('extract IPv6 address from ICE candidate', () => {
+        expect(getAddressFromIceCandidate('candidate:1 1 udp 3756231458 2001:db8::4125:918c:4402:cc54 6666 typ host'))
+            .toEqual('2001:db8::4125:918c:4402:cc54')
+    })
+
+    it('fail on mDNS ICE candidate', () => {
+        expect(getAddressFromIceCandidate('candidate:1 1 udp 2122296321 9b36eaac-bb2e-49bb-bb78-21c41c499900.local 7000 typ host')).toBeUndefined()
+    })
+})
+
+describe(isPrivateIPv4, () => {
+    it('return true for range 10.0.0.0/8', () => {
+        expect(isPrivateIPv4('10.11.12.13')).toBe(true)
+    })
+
+    it('return true for range 172.16.0.0/12', () => {
+        expect(isPrivateIPv4('172.16.130.131')).toBe(true)
+    })
+
+    it('return true for range 192.168.0.0/16', () => {
+        expect(isPrivateIPv4('192.168.1.1')).toBe(true)
+    })
+
+    it('return false for a public address', () => {
+        expect(isPrivateIPv4('203.0.113.181')).toBe(false)
+    })
+})
+

--- a/packages/network/test/unit/AddressTools.test.ts
+++ b/packages/network/test/unit/AddressTools.test.ts
@@ -1,6 +1,6 @@
 import { getAddressFromIceCandidate, isPrivateIPv4 } from '../../src/helpers/AddressTools'
 
-describe(getAddressFromIceCandidate, () => {
+describe('getAddressFromIceCandidate', () => {
     it('extract IPv4 address from ICE host candidate', () => {
         expect(getAddressFromIceCandidate('candidate:1 1 udp 2122262783 203.0.113.180 4444 typ host'))
             .toEqual('203.0.113.180')
@@ -21,7 +21,7 @@ describe(getAddressFromIceCandidate, () => {
     })
 })
 
-describe(isPrivateIPv4, () => {
+describe('isPrivateIPv4', () => {
     it('return true for range 10.0.0.0/8', () => {
         expect(isPrivateIPv4('10.11.12.13')).toBe(true)
     })


### PR DESCRIPTION
This PR adds the option `network.webrtcDisallowPrivateAddresses` to filter out ICE candidates with private IPv4 to prevent the WebRTC agent from probing those addresses. 

The options is disabled by default (meaning private IPv4 addresses are allowed).

```
"network": {
    "webRtcDisallowPrivateAddresses": true // default false
}
```