### PR TITLE
broker [NET-573]: MQTT plugin improvements

### DIFF
--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -1,9 +1,17 @@
 import { StreamrClient, Subscription } from 'streamr-client'
-import { Logger } from 'streamr-network'
+import { Logger, Protocol } from 'streamr-network'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
 import { MqttServer, MqttServerListener } from './MqttServer'
 
 const logger = new Logger(module)
+
+type MessageChainKey = string
+
+const createMessageChainKey = (message: Protocol.StreamMessage<any>) => {
+    const DELIMITER = '-'
+    const { messageId } = message
+    return [messageId.streamId, messageId.streamPartition, messageId.publisherId, messageId.msgChainId].join(DELIMITER)
+}
 
 export class Bridge implements MqttServerListener {
 
@@ -11,6 +19,7 @@ export class Bridge implements MqttServerListener {
     private readonly mqttServer: MqttServer
     private readonly payloadFormat: PayloadFormat
     private readonly streamIdDomain?: string
+    private publishMessageChains = new Set<MessageChainKey>()
 
     constructor(streamrClient: StreamrClient, mqttServer: MqttServer, payloadFormat: PayloadFormat, streamIdDomain?: string) {
         this.streamrClient = streamrClient
@@ -19,7 +28,7 @@ export class Bridge implements MqttServerListener {
         this.streamIdDomain = streamIdDomain
     }
 
-    onMessageReceived(topic: string, payload: string): void {
+    async onMessageReceived(topic: string, payload: string): Promise<void> {
         let message
         try {
             message = this.payloadFormat.createMessage(payload)
@@ -28,15 +37,43 @@ export class Bridge implements MqttServerListener {
             return
         }
         const { content, metadata } = message
-        this.streamrClient.publish(this.getStreamId(topic), content, metadata.timestamp)
+        const publishedMessage = await this.streamrClient.publish(this.getStreamId(topic), content, metadata.timestamp)
+        this.publishMessageChains.add(createMessageChainKey(publishedMessage))
     }
 
     onSubscribed(topic: string): void {
         logger.info('Client subscribed: ' + topic)
-        this.streamrClient.subscribe(this.getStreamId(topic), (content: any, metadata: any) => {
-            const payload = this.payloadFormat.createPayload(content, metadata.messageId)
-            this.mqttServer.publish(topic, payload)
+        this.streamrClient.subscribe(this.getStreamId(topic), (content: any, metadata: Protocol.StreamMessage) => {
+            if (!this.isSelfPublishedMessage(metadata)) {
+                const payload = this.payloadFormat.createPayload(content, metadata.messageId)
+                this.mqttServer.publish(topic, payload)    
+            }
         })
+    }
+
+    /**
+     * 
+     * If a stream is subscribed with a MQTT client and also published with same or another
+     * MQTT client, the message could be delivered to the subscribed client two
+     * ways:
+     * 
+     * 1) automatic mirroring by Aedes (delivers all published messages to all subscribers)
+     * 2) via network node: the subscribing MQTT client receives the published message from the
+     *    network node as it subscribes to the stream (by calling streamrClient.subscribe)
+     * 
+     * The message should be delivered to the subscribed client only once. Theferore we filter
+     * out the "via network node" case by checking whether the message is one of the messages
+     * which the Bridge published to the network node. 
+     * 
+     * Each publishing session of a stream yields to a unique MessageChainKey value. We store that
+     * key value when we call streamrClient.publish(). 
+     * 
+     * Here we simply check if the incoming message belongs to one of the publish chains. If it 
+     * does, it must have been published by this Bridge. 
+     */
+    private isSelfPublishedMessage(message: Protocol.StreamMessage<any>): boolean {
+        const messageChainKey = createMessageChainKey(message)
+        return this.publishMessageChains.has(messageChainKey)
     }
 
     onUnsubscribed(topic: string): void {

--- a/packages/broker/src/plugins/mqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/mqtt/MqttServer.ts
@@ -9,8 +9,8 @@ const logger = new Logger(module)
 
 export interface MqttServerListener {
     onMessageReceived(topic: string, payload: string): void
-    onSubscribed(topics: string): void
-    onUnsubscribed(topics: string): void
+    onSubscribed(topics: string, clientId: string): void
+    onUnsubscribed(topics: string, clientId: string): void
 }
 
 export class MqttServer {
@@ -34,12 +34,12 @@ export class MqttServer {
                 this.listener?.onMessageReceived(packet.topic, packet.payload.toString())
             }
         })
-        this.aedes.on('subscribe', (subscriptions: ISubscription[]) => {
+        this.aedes.on('subscribe', (subscriptions: ISubscription[], client: aedes.Client) => {
             const topics = subscriptions.map((subscription) => subscription.topic)
-            topics.forEach((topic) => this.listener?.onSubscribed(topic))
+            topics.forEach((topic) => this.listener?.onSubscribed(topic, client.id))
         })
-        this.aedes.on('unsubscribe', (topics: string[]) => {
-            topics.forEach((topic) => this.listener?.onUnsubscribed(topic))
+        this.aedes.on('unsubscribe', (topics: string[], client: aedes.Client) => {
+            topics.forEach((topic) => this.listener?.onUnsubscribed(topic, client.id))
         })
     }
 

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -1,0 +1,98 @@
+import { Stream, StreamrClient } from 'streamr-client'
+import { startTracker, Tracker } from 'streamr-network'
+import mqtt from 'async-mqtt'
+import { Broker } from '../../../../src/broker'
+import { createClient, startBroker, createTestStream, createMockUser, Queue } from '../../../utils'
+import { wait } from 'streamr-test-utils'
+
+const MQTT_PLUGIN_PORT = 12470
+const TRACKER_PORT = 12471
+
+const createMqttClient = () => {
+    return mqtt.connectAsync('mqtt://localhost:' + MQTT_PLUGIN_PORT)
+}
+
+describe('MQTT Bridge', () => {
+    let stream: Stream
+    let streamrClient: StreamrClient
+    let tracker: Tracker
+    let broker: Broker
+    const brokerUser = createMockUser()
+
+    const createSubscriber = async (messageQueue: Queue<any>) => {
+        const subscriber = await createMqttClient()
+        subscriber.on('message', (_topic, message) => messageQueue.push(JSON.parse(message.toString())))
+        subscriber.subscribe(stream.id)
+        return subscriber
+    }
+
+    beforeAll(async () => {
+        tracker = await startTracker({
+            id: 'tracker-1',
+            listen: {
+                hostname: '127.0.0.1',
+                port: TRACKER_PORT
+            },
+        })
+        broker = await startBroker({
+            name: 'broker',
+            privateKey: brokerUser.privateKey,
+            trackerPort: TRACKER_PORT,
+            extraPlugins: {
+                mqtt: {
+                    port: MQTT_PLUGIN_PORT
+                }
+            }
+        })
+    })
+
+    afterAll(async () => {
+        await Promise.allSettled([
+            broker.stop(),
+            tracker.stop()
+        ])
+    })
+
+    beforeEach(async () => {
+        streamrClient = createClient(tracker, brokerUser.privateKey)
+        stream = await createTestStream(streamrClient, module)
+    })
+
+    afterEach(async () => {
+        streamrClient?.debug('destroy after test')
+        await streamrClient?.destroy()
+    })
+
+    test('message published by a MQTT client is delivered only once', async () => {
+        const message = {
+            foo: Date.now()
+        }
+        const messageQueue = new Queue<any>()
+        const subscriber = await createSubscriber(messageQueue)
+
+        const publisher = await createMqttClient()
+        publisher.publish(stream.id, JSON.stringify(message))
+        await wait(1000)
+
+        expect(messageQueue.items).toEqual([message])
+
+        await Promise.allSettled([
+            subscriber.end(true),
+            publisher.end(true)
+        ])
+    })
+
+    test('message published by a StreamrClient is delivered', async () => {
+        const expected = {
+            foo: Date.now()
+        }
+        const messageQueue = new Queue<any>()
+        const subscriber = await createSubscriber(messageQueue)
+        streamrClient.publish(stream.id, expected)
+
+        const actual = await messageQueue.pop()
+        expect(actual).toEqual(expected)
+
+        await subscriber.end(true)
+    })
+})

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -116,7 +116,7 @@ describe('MQTT Bridge', () => {
         ])
     })
 
-    it('subscription should not be unsubcribed if it was not subscribed by that client', async () => {
+    it('subscription should not be unsubscribed if it was not subscribed by that client', async () => {
         const expected = {
             foo: Date.now()
         }
@@ -135,7 +135,7 @@ describe('MQTT Bridge', () => {
         ])
     })
 
-    test('message should be delivered to remaining subscribers if one subscriber unsubcribes', async () => {
+    test('message should be delivered to remaining subscribers if one subscriber unsubscribes', async () => {
         const expected = {
             foo: Date.now()
         }

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -6,6 +6,8 @@ const MOCK_TOPIC = 'mock-topic'
 const MOCK_STREAM_ID_DOMAIN = 'mock.ens'
 const MOCK_STREAM_ID = `${MOCK_STREAM_ID_DOMAIN}/${MOCK_TOPIC}`
 const MOCK_CONTENT = { foo: 'bar' }
+const MOCK_CLIENT_ID = 'mock-client-id'
+
 const MOCK_MESSAGE_ID = {
     streamId: MOCK_STREAM_ID,
     streamPartition: 0,
@@ -22,13 +24,18 @@ describe('MQTT Bridge', () => {
 
         let bridge: Bridge
         let streamrClient: Partial<StreamrClient>
+        let subscription: any
 
         beforeEach(() => {
+            subscription = {
+                streamId: MOCK_STREAM_ID,
+                unsubscribe: jest.fn().mockResolvedValue(undefined)
+            }
             streamrClient = {
                 publish: jest.fn().mockResolvedValue({
                     messageId: MOCK_MESSAGE_ID
                 }),
-                subscribe: jest.fn().mockResolvedValue(undefined),
+                subscribe: jest.fn().mockResolvedValue(subscription),
                 unsubscribe: jest.fn().mockResolvedValue(undefined)
             }
             bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), streamIdDomain)
@@ -39,18 +46,15 @@ describe('MQTT Bridge', () => {
             expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, undefined)
         })
 
-        it('onSubscribed', () => {
-            bridge.onSubscribed(topic)
+        it('onSubscribed', async () => {
+            await bridge.onSubscribed(topic, MOCK_CLIENT_ID)
             expect(streamrClient.subscribe).toBeCalledWith(MOCK_STREAM_ID, expect.anything())
         })
 
-        it('onUnsubscribed', () => {
-            const subscription = {
-                streamId: MOCK_STREAM_ID
-            }
-            streamrClient.getSubscriptions = jest.fn().mockReturnValue([subscription])
-            bridge.onUnsubscribed(topic)
-            expect(streamrClient.unsubscribe).toBeCalledWith(subscription)
+        it('onUnsubscribed', async () => {
+            await bridge.onSubscribed(topic, MOCK_CLIENT_ID)
+            await bridge.onUnsubscribed(topic, MOCK_CLIENT_ID)
+            expect(subscription.unsubscribe).toBeCalled()
         })
     
     })

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -6,6 +6,12 @@ const MOCK_TOPIC = 'mock-topic'
 const MOCK_STREAM_ID_DOMAIN = 'mock.ens'
 const MOCK_STREAM_ID = `${MOCK_STREAM_ID_DOMAIN}/${MOCK_TOPIC}`
 const MOCK_CONTENT = { foo: 'bar' }
+const MOCK_MESSAGE_ID = {
+    streamId: MOCK_STREAM_ID,
+    streamPartition: 0,
+    publisherId: 'mock-publisher-id',
+    msgChainId: 'mock-msgChain-id'
+}
 
 describe('MQTT Bridge', () => {
 
@@ -19,15 +25,17 @@ describe('MQTT Bridge', () => {
 
         beforeEach(() => {
             streamrClient = {
-                publish: jest.fn().mockResolvedValue(undefined),
+                publish: jest.fn().mockResolvedValue({
+                    messageId: MOCK_MESSAGE_ID
+                }),
                 subscribe: jest.fn().mockResolvedValue(undefined),
                 unsubscribe: jest.fn().mockResolvedValue(undefined)
             }
             bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), streamIdDomain)
         })
 
-        it('onMessageReceived', () => {
-            bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT))
+        it('onMessageReceived', async () => {
+            await bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT))
             expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, undefined)
         })
 


### PR DESCRIPTION
Fixes:

1) A message was delivered to a subscriber twice if it was published by a MQTT client. Now we store message chain ids of the message which are published via MQTT server. We don't re-deliver those messages as Aedes mirrors the messages to all subscribers. (Aedes doesn't have a feature for disabling mirroring. If it had, that would be an alternative way to implement the functionality.)

2) A message was delivered multiple times if there were multiple subscribers. Now we subscribe to `streamrClient` only once. Messages are delivered to the MQTT server and it propagates the messages  to all subscribers.

3) A subscription was unsubscribed if any of the clients unsubscribed the topic. Now we store list of `clientId`s and unsubscribes only if all clients have unsubscribed. 

4) Unsubscribes can't interfere other plugins. The MQTT plugin explictly unsubscribes from the  subscriptions it has created.