### PR TITLE
network: add support for jest-extended in browser tests

### DIFF
--- a/packages/network/karma-setup.js
+++ b/packages/network/karma-setup.js
@@ -4,6 +4,7 @@ import * as jestMock from 'jest-mock'
 import { ModernFakeTimers } from '@jest/fake-timers'
 // The matchers API
 import expect from 'expect'
+import jestExtendedMatchers from 'jest-extended/dist/matchers'
 
 let jest = jestMock
 const timers = new ModernFakeTimers({global: window, config: null })
@@ -26,6 +27,8 @@ jest.useRealTimers = timers.useRealTimers
 jest._checkFakeTimers = timers._checkFakeTimers
 
 Object.assign(jest,timers)
+
+expect.extend(jestExtendedMatchers)
 
 // Add missing Jest functions
 window.test = window.it

--- a/packages/network/karma.config.js
+++ b/packages/network/karma.config.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
             './test/browser/IntegrationBrowserWebRtcConnection.test.ts',
             './test/integration/**/!(NodeWebRtcConnection*|tracker-endpoints*|UnixSocketWsServer*).ts/',
 
-            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*|deprecated-tracker-status*).ts',
+            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*).ts',
         ],
         preprocessors: {
             './karma-setup.js': ['webpack'],
@@ -27,7 +27,7 @@ module.exports = function (config) {
             './test/browser/IntegrationBrowserWebRtcConnection.test.ts': ['webpack'],
             './test/integration/**/!(NodeWebRtcConnection*|tracker-endpoints*|UnixSocketWsServer*).ts/': ['webpack'],
 
-            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*|deprecated-tracker-status*).ts': ['webpack'],
+            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*).ts': ['webpack'],
         },
         customLaunchers: {
             CustomElectron: {

--- a/packages/network/karma.config.js
+++ b/packages/network/karma.config.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
             './test/browser/IntegrationBrowserWebRtcConnection.test.ts',
             './test/integration/**/!(NodeWebRtcConnection*|tracker-endpoints*|UnixSocketWsServer*).ts/',
 
-            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*).ts',
+            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*|deprecated-tracker-status*).ts',
         ],
         preprocessors: {
             './karma-setup.js': ['webpack'],
@@ -27,7 +27,7 @@ module.exports = function (config) {
             './test/browser/IntegrationBrowserWebRtcConnection.test.ts': ['webpack'],
             './test/integration/**/!(NodeWebRtcConnection*|tracker-endpoints*|UnixSocketWsServer*).ts/': ['webpack'],
 
-            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*).ts': ['webpack'],
+            './test/unit/**/!(LocationManager*|NodeWebRtcConnection*|WebRtcEndpoint*|Speedometer*|deprecated-tracker-status*).ts': ['webpack'],
         },
         customLaunchers: {
             CustomElectron: {

--- a/packages/network/test/unit/StreamManager.test.ts
+++ b/packages/network/test/unit/StreamManager.test.ts
@@ -24,11 +24,11 @@ describe('StreamManager', () => {
         expect(manager.isSetUp(new SPID('stream-1', 1))).toEqual(true)
         expect(manager.isSetUp(new SPID('stream-2', 0))).toEqual(true)
 
-        expect(Array.from(manager.getSPIDKeys()).concat([]).sort()).toEqual(['stream-1#0', 'stream-1#1', 'stream-2#0'])
+        expect(Array.from(manager.getSPIDKeys())).toIncludeSameMembers(['stream-1#0', 'stream-1#1', 'stream-2#0'])
 
-        expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toEqual([])
-        expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toEqual([])
-        expect(manager.getNeighborsForStream(new SPID('stream-2', 0))).toEqual([])
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toBeEmpty()
+        expect(manager.getNeighborsForStream(new SPID('stream-2', 0))).toBeEmpty()
     })
 
     test('cannot re-setup same stream', () => {
@@ -100,8 +100,8 @@ describe('StreamManager', () => {
         manager.addNeighbor(streamId2, 'node-2')
         manager.addNeighbor(streamId2, 'node-3')
 
-        expect(manager.getNeighborsForStream(streamId).concat([]).sort()).toEqual(['node-1', 'node-2'])
-        expect(manager.getNeighborsForStream(streamId2).concat([]).sort()).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         expect(manager.hasNeighbor(streamId, 'node-1')).toEqual(true)
         expect(manager.hasNeighbor(streamId, 'node-2')).toEqual(true)
@@ -126,19 +126,19 @@ describe('StreamManager', () => {
         manager.addNeighbor(streamId2, 'node-2')
         manager.addNeighbor(streamId2, 'node-3')
 
-        expect(manager.getNeighborsForStream(streamId).concat([]).sort()).toEqual(['node-1', 'node-2'])
-        expect(manager.getNeighborsForStream(streamId2).concat([]).sort()).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         manager.removeNodeFromStream(streamId, 'node-1')
 
-        expect(manager.getNeighborsForStream(streamId).concat([]).sort()).toEqual(['node-2'])
-        expect(manager.getNeighborsForStream(streamId2).concat([]).sort()).toEqual(['node-1', 'node-2', 'node-3'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2', 'node-3'])
 
         manager.removeNodeFromStream(streamId2, 'node-3')
-        expect(manager.getNeighborsForStream(streamId).concat([]).sort()).toEqual(['node-2'])
-        expect(manager.getNeighborsForStream(streamId2).concat([]).sort()).toEqual(['node-1', 'node-2'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
+        expect(manager.getNeighborsForStream(streamId2)).toIncludeSameMembers(['node-1', 'node-2'])
 
-        expect(manager.getNeighborsForStream(streamId).concat([]).sort()).toEqual(['node-2'])
+        expect(manager.getNeighborsForStream(streamId)).toIncludeSameMembers(['node-2'])
 
         expect(manager.hasNeighbor(streamId, 'node-1')).toEqual(false)
         expect(manager.isNodePresent('node-1')).toEqual(true)
@@ -163,9 +163,9 @@ describe('StreamManager', () => {
 
         manager.removeNodeFromAllStreams('node')
 
-        expect(manager.getNeighborsForStream(new SPID('stream-1', 0)).concat([]).sort()).toEqual(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new SPID('stream-1', 1)).concat([]).sort()).toEqual(['should-not-be-removed'])
-        expect(manager.getNeighborsForStream(new SPID('stream-2', 0)).concat([]).sort()).toEqual(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 0))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-1', 1))).toIncludeSameMembers(['should-not-be-removed'])
+        expect(manager.getNeighborsForStream(new SPID('stream-2', 0))).toIncludeSameMembers(['should-not-be-removed'])
 
         expect(manager.hasNeighbor(new SPID('stream-1', 0), 'node')).toEqual(false)
         expect(manager.hasNeighbor(new SPID('stream-2', 0), 'node')).toEqual(false)

--- a/packages/network/test/unit/TrackerConnector.test.ts
+++ b/packages/network/test/unit/TrackerConnector.test.ts
@@ -76,7 +76,7 @@ describe(TrackerConnector, () => {
         setUpConnector(TTL_IN_MS)
         connector.start()
         await wait(TTL_IN_MS * 2)
-        expect(Object.keys(activeConnections).length).toEqual(0)
+        expect(activeConnections).toBeEmpty()
     })
 
     it('maintains tracker connections based on active streams', async () => {
@@ -85,7 +85,7 @@ describe(TrackerConnector, () => {
 
         streams = []
         await wait(TTL_IN_MS + 1)
-        expect(Object.keys(activeConnections).length).toEqual(0)
+        expect(activeConnections).toBeEmpty()
 
         streams = [T1_STREAM]
         await wait(TTL_IN_MS + 1)
@@ -93,7 +93,7 @@ describe(TrackerConnector, () => {
 
         streams = []
         await wait(TTL_IN_MS + 1)
-        expect(Object.keys(activeConnections).length).toEqual(0)
+        expect(activeConnections).toBeEmpty()
 
         streams = [T2_STREAM, T3_STREAM]
         await wait(TTL_IN_MS + 1)
@@ -109,7 +109,7 @@ describe(TrackerConnector, () => {
 
         streams = []
         await wait(TTL_IN_MS + 1)
-        expect(Object.keys(activeConnections).length).toEqual(0)
+        expect(activeConnections).toBeEmpty()
     })
 
     it('onNewStream can be used to form immediate connections', () => {


### PR DESCRIPTION
Added support for `jest-extended` methods (e.g  the`toIncludeSameMembers()` matcher) in browser tests.

The injection in `karma-setup.js` is a bit hack as we need to import an internal file from `jest-extended` library:
```
import jestExtendedMatchers from 'jest-extended/dist/matchers'
```

This PR also brings back the use of `jest-extended` in two network test cases (reverts most of PR https://github.com/streamr-dev/network-monorepo/pull/269).