### PR TITLE
fix(client): unsubscribe from node

### DIFF
--- a/packages/client/src/SubscriptionSession.ts
+++ b/packages/client/src/SubscriptionSession.ts
@@ -102,7 +102,7 @@ export default class SubscriptionSession<T> implements Context, Stoppable {
         this.pipeline.onError.end(new Error('done'))
         node.removeMessageListener(this.onMessageInput)
         const { streamId, streamPartition } = this.spid
-        node.subscribe(streamId, streamPartition)
+        node.unsubscribe(streamId, streamPartition)
     }
 
     updateNodeSubscriptions = (() => {


### PR DESCRIPTION
Fixed `SubscriptionSession` to call `node.unsubscribe` instead of `node.subscribe`.

The original change is from a commit two months ago: https://github.com/streamr-dev/network-monorepo/commit/cb1436ddddfdc70b51deed858fccc2183a00e488