### PR TITLE
Fix broker docker build so new images compatible with main branch can be pushed.

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -81,8 +81,9 @@ jobs:
           docker rm $(docker ps -a -q)
 
   test-docker:
-    name: Build & Test Docker images
+    name: Build + Test Docker images
     runs-on: self-hosted
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Cache Docker layers
@@ -111,7 +112,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "broker-node-no-storage-1 parity-node0 parity-sidechain-node0"
+          services-to-start: "nginx trackers parity-node0 parity-sidechain-node0 broker-node-no-storage-1"
       - run: |
           for (( i=0; i < 5; i=i+1 )); do
               curl -s http://localhost:8791/api/v1/volume;
@@ -143,11 +144,11 @@ jobs:
           docker rm $(docker ps -a -q)
 
   docker-push:
-    name: Build & Push Docker images
+    name: Build + Push Docker images
     needs: [test-unit, test-integration, test-docker]
     runs-on: self-hosted
     # only push for main and tags
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: ${{ always() && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
     steps:
       - uses: actions/checkout@v2.4.0
@@ -167,9 +168,23 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker meta
-        id: docker_meta
+        id: docker_meta_failure
         uses: docker/metadata-action@v3.6.0
+        # if test steps failed, push sha anyway
+        if: ${{ always() && (needs.test-unit.result == 'failure' || needs.test-integration.result == 'failure' || needs.test-docker.result == 'failure') }}
+        with:
+          images: streamr/broker-node
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=debug
+      - name: Docker meta
+        id: docker_meta_success
+        uses: docker/metadata-action@v3.6.0
+        # if test steps succeeded
+        if: ${{ always() && !(needs.test-unit.result == 'failure' || needs.test-integration.result == 'failure' || needs.test-docker.result == 'failure') }}
         with:
           images: streamr/broker-node
           tags: |
@@ -195,13 +210,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           load: false
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          # only one of these should have tags
+          tags: ${{ steps.docker_meta_success.outputs.tags }}${{ steps.docker_meta_failure.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   publish:
-    needs: [docker-push]
+    needs: [test-unit, test-integration, test-docker, docker-push]
     name: Publishing main using Node 16
     runs-on: ubuntu-latest
 

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -44,6 +44,7 @@ jobs:
           npm run bootstrap-pkg streamr-broker
       - run: npm run eslint
       - run: npm run test-unit
+
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -79,11 +80,9 @@ jobs:
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
 
-  docker:
-    needs: [test-unit, test-integration]
-    name: Build, test, and publish Docker images
+  test-docker:
+    name: Build & Test Docker images
     runs-on: self-hosted
-
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Cache Docker layers
@@ -131,6 +130,27 @@ jobs:
         run: |
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
+  docker-push:
+    name: Build & Push Docker images
+    needs: [test-unit, test-integration, test-docker]
+    runs-on: self-hosted
+    # only push for main and tags
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.6
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        with:
+          driver-opts: |
+            network=host
       - uses: docker/login-action@v1.10.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -156,8 +176,6 @@ jobs:
           driver-opts: |
             network=host
       - name: Build & Push
-        # only push for main and tags
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v2.7.0
         with:
           context: .
@@ -171,7 +189,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   publish:
-    needs: [test-unit, test-integration]
+    needs: [docker-push]
     name: Publishing main using Node 16
     runs-on: ubuntu-latest
 

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -125,11 +125,23 @@ jobs:
               fi;
           done;
           exit 1
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2.0.2
+        with:
+          dest: 'logs'
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: docker-logs-node${{ matrix.node-version }}--${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
+          path: 'logs'
       - name: Stop Streamr Docker Stack
         if: always()
         run: |
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
+
   docker-push:
     name: Build & Push Docker images
     needs: [test-unit, test-integration, test-docker]

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -84,8 +84,6 @@ jobs:
     name: Build, test, and publish Docker images
     runs-on: self-hosted
 
-    # run job only for main and tags
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Cache Docker layers
@@ -157,7 +155,9 @@ jobs:
         with:
           driver-opts: |
             network=host
-      - name: Build
+      - name: Build & Push
+        # only push for main and tags
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v2.7.0
         with:
           context: .

--- a/.github/workflows/client-code.yml
+++ b/.github/workflows/client-code.yml
@@ -117,22 +117,22 @@ jobs:
           services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge brokers trackers nginx smtp"
       - name: Run Test
         run: npm run $TEST_NAME
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2.0.2
+        with:
+          dest: 'logs'
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: docker-logs-${{ matrix.test-name }}-${{ matrix.websocket-url.name }}-node${{ matrix.node-version }}--${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
+          path: 'logs'
       - name: Stop Streamr Docker Stack
         if: always()
         run: |
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
-      - name: Collect docker logs on failure
-        if: failure()
-        uses: jwalton/gh-docker-logs@v2.0.2
-        with:
-          dest: 'packages/client/logs'
-      - name: Upload logs to GitHub
-        if: failure()
-        uses: actions/upload-artifact@v2.2.4
-        with:
-          name: docker-logs-${{ matrix.test-name }}-${{ matrix.websocket-url.name }}-node${{ matrix.node-version }}--${{ github.run_number }}-${{ github.run_id }}
-          path: packages/client/logs
 
   flakey:
     if: ${{ false }}

--- a/.github/workflows/client-dataunions.yml
+++ b/.github/workflows/client-dataunions.yml
@@ -74,19 +74,19 @@ jobs:
           services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge brokers trackers nginx smtp"
       - name: Run Test
         run: npm run $TEST_NAME
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2.0.2
+        with:
+          dest: 'logs'
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: docker-logs-${{ matrix.test-name }}-${{ matrix.websocket-url.name }}-node${{ matrix.node-version }}--${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
+          path: 'logs'
       - name: Stop Streamr Docker Stack
         if: always()
         run: |
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
-      - name: Collect docker logs on failure
-        if: failure()
-        uses: jwalton/gh-docker-logs@v2.0.2
-        with:
-          dest: 'packages/client/logs'
-      - name: Upload logs to GitHub
-        if: failure()
-        uses: actions/upload-artifact@v2.2.4
-        with:
-          name: docker-logs-${{ matrix.test-name }}-${{ matrix.websocket-url.name }}-node${{ matrix.node-version }}--${{ github.run_number }}-${{ github.run_id }}
-          path: packages/client/logs

--- a/.github/workflows/cross-client.yml
+++ b/.github/workflows/cross-client.yml
@@ -85,19 +85,19 @@ jobs:
           timeout_minutes: 15
           retry_on: error
           command: cd packages/cross-client-testing && DEBUG='' make run
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2.0.2
+        with:
+          dest: 'logs'
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: docker-logs-${{ matrix.test-name }}-${{ matrix.config-name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
+          path: logs
       - name: Stop Streamr Docker Stack
         if: always()
         run: |
           docker kill $(docker ps -q)
           docker rm $(docker ps -a -q)
-      - name: Collect docker logs on failure
-        if: failure()
-        uses: jwalton/gh-docker-logs@v2.0.2
-        with:
-          dest: 'packages/cross-client-testing/logs'
-      - name: Upload logs to GitHub
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: docker-logs-${{ github.job }}-${{ github.run_number }}-${{ github.run_id }}
-          path: packages/cross-client-testing/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:16-buster as build
 WORKDIR /usr/src/monorepo
 RUN npm set unsafe-perm true && \
-	# explicitly use npm v6
-	npm install -g npm@6 --prefer-offline
+	# explicitly use npm v8
+	npm install -g npm@8 --no-audit --progress=false
 COPY ["./*.json", "./*.js", "./*.mjs", ".npmrc",  ".gitignore", "./"]
 RUN npm ci
 COPY ["./packages", "./packages"]
@@ -12,7 +12,7 @@ RUN npm run bootstrap-pkg -- streamr-broker
 # --ignore-scripts as sqlite package in the client tries running its
 # 'install' script, which uses node-pre-gyp, which is a devDependency that
 # gets removed by prune.
-RUN npx lerna exec -- npm prune --production --ignore-scripts && \
+RUN npx lerna exec --parallel --include-dependencies --scope "streamr-broker" -- npm prune --production --ignore-scripts --prefer-offline --no-audit && \
 	# restore inter-package symlinks removed by npm prune
 	npx lerna link
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ RUN npm set unsafe-perm true && \
 	# explicitly use npm v6
 	npm install -g npm@6 && \
 	npm ci && \
-	npm run bootstrap-pkg streamr-broker && \
-	# image contains all packages, remove devDeps to keep image size down
-	# --ignore-scripts as sqlite package in the client tries running its
-	# 'install' script, which uses node-pre-gyp, which is a devDependency that
-	# gets removed by prune.
-	npx lerna exec -- npm prune --production --ignore-scripts && \
+	npm run bootstrap-pkg streamr-broker
+
+# image contains all packages, remove devDeps to keep image size down
+# --ignore-scripts as sqlite package in the client tries running its
+# 'install' script, which uses node-pre-gyp, which is a devDependency that
+# gets removed by prune.
+RUN npx lerna exec -- npm prune --production --ignore-scripts && \
 	# restore inter-package symlinks removed by npm prune
 	npx lerna link
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:16-buster as build
 WORKDIR /usr/src/monorepo
-COPY . .
 RUN npm set unsafe-perm true && \
 	# explicitly use npm v6
-	npm install -g npm@6 && \
-	npm ci && \
-	npm run bootstrap-pkg streamr-broker
+	npm install -g npm@6 --prefer-offline
+COPY ["./*.json", "./*.js", "./*.mjs", ".npmrc",  ".gitignore", "./"]
+RUN npm ci
+COPY ["./packages", "./packages"]
+RUN npm run bootstrap-pkg -- streamr-broker
 
 # image contains all packages, remove devDeps to keep image size down
 # --ignore-scripts as sqlite package in the client tries running its
@@ -31,4 +32,6 @@ EXPOSE 7170/tcp
 EXPOSE 7171/tcp
 
 WORKDIR /usr/src/monorepo/packages/broker
-CMD ./bin/broker.js # start broker from default config
+
+# start broker from default config
+CMD ["./bin/broker.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN npm set unsafe-perm true && \
 	npm ci && \
 	npm run bootstrap-pkg streamr-broker && \
 	# image contains all packages, remove devDeps to keep image size down
-	npx lerna exec -- npm prune --production && \
+	# --ignore-scripts as sqlite package in the client tries running its
+	# 'install' script, which uses node-pre-gyp, which is a devDependency that
+	# gets removed by prune.
+	npx lerna exec -- npm prune --production --ignore-scripts && \
 	# restore inter-package symlinks removed by npm prune
 	npx lerna link
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,10 @@
     "packages/*"
   ],
   "version": "independent",
-  "npmClient": "npm"
+  "npmClient": "npm",
+  "npmClientArgs": [
+    "--prefer-offline",
+    "--no-audit",
+    "--progress=false"
+  ]
 }


### PR DESCRIPTION
* CI is failing for all of the cross-client tests that involve the JS client because
* the network nodes are incompatible with the trackers run in docker because
* the Docker images for the broker haven't been updated in a month because
* the broker's CI docker image build fails because
* the client's `sqlite3` dependency is trying to run an npm `install` script during the `npm prune --production`, and that `install` script uses a development dependency `node-pre-gyp` which was removed during that same `npm prune --production`.

😵‍💫 

Not clear how/why this changed, possibly a change in the npm 6 line, or a dependency of npm 6?

### Changes

* Set the Dockerfile to use `--ignore-scripts` with `npm prune`. This seems to fix the issue.
* Set the broker CI config to build & tests images even if they're not tagged or on main branch. i.e. it should build & test the docker image for PRs now. This allows me to test the above change and should help catch a broken docker push step sooner in the future.

It's possible this issue goes away with the move to npm 8 and npm workspaces in #259. The change to run the docker build step for PRs will help.