### PR TITLE
ETH-187 fix sidechain address query

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -14,7 +14,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - '**'
   schedule:
     # run every day at 00:00
     - cron:  '0 0 * * *'

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -501,12 +501,21 @@ export class StreamrClient extends EventEmitter { // eslint-disable-line no-rede
         return token.balanceOf(addr)
     }
 
-    getDataUnion(contractAddress: EthereumAddress) {
-        return DataUnion._fromContractAddress(contractAddress, this) // eslint-disable-line no-underscore-dangle
+    /* TODO: in v6, rename this to unsafeGetDataUnion */
+    getDataUnion(mainnetAddress: EthereumAddress, sidechainAddress?: EthereumAddress) {
+        if (!sidechainAddress) {
+            const contracts = new Contracts(this)
+            const calculatedSidechainAddress = contracts.calculateDataUnionSidechainAddress(mainnetAddress)
+            return new DataUnion(mainnetAddress, calculatedSidechainAddress, this)
+        }
+        return new DataUnion(mainnetAddress, sidechainAddress, this)
     }
 
+    /* TODO: in v6, rename this to getDataUnion */
     async safeGetDataUnion(contractAddress: EthereumAddress) {
-        const du = DataUnion._fromContractAddress(contractAddress, this) // eslint-disable-line no-underscore-dangle
+        const contracts = new Contracts(this)
+        const sidechainAddress = await contracts.fetchDataUnionSidechainAddress(contractAddress)
+        const du = new DataUnion(contractAddress, sidechainAddress, this)
         const version = await du.getVersion()
         if (version === 0) {
             throw new Error(`${contractAddress} is not a Data Union!`)
@@ -515,7 +524,7 @@ export class StreamrClient extends EventEmitter { // eslint-disable-line no-rede
         } else if (version === 2) {
             return du
         }
-        throw new Error(`${contractAddress} is an unknown Data Union version "${version}"`)
+        throw new Error(`${contractAddress} is of unknown Data Union version: ${version}`)
     }
 
     async deployDataUnion(options?: DataUnionDeployOptions) {
@@ -555,14 +564,6 @@ export class StreamrClient extends EventEmitter { // eslint-disable-line no-rede
         const to = getAddress(recipientAddress) // throws if bad address
         const signer = this.ethereum.getSigner()
         return DataUnion._createSetBinanceRecipientSignature(to, signer, new Contracts(this)) // eslint-disable-line no-underscore-dangle
-    }
-
-    /** @internal */
-    _getDataUnionFromName({ dataUnionName, deployerAddress }: { dataUnionName: string, deployerAddress: EthereumAddress}) {
-        return DataUnion._fromName({ // eslint-disable-line no-underscore-dangle
-            dataUnionName,
-            deployerAddress
-        }, this)
     }
 
     /**

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -566,6 +566,14 @@ export class StreamrClient extends EventEmitter { // eslint-disable-line no-rede
         return DataUnion._createSetBinanceRecipientSignature(to, signer, new Contracts(this)) // eslint-disable-line no-underscore-dangle
     }
 
+    /** @internal used by Marketplace to predict deployed address */
+    _getDataUnionFromName({ dataUnionName, deployerAddress }: { dataUnionName: string, deployerAddress: EthereumAddress}) {
+        const contracts = new Contracts(this)
+        const mainnetAddressPredicted = contracts.calculateDataUnionMainnetAddress(dataUnionName, deployerAddress)
+        const sidechainAddressPredicted = contracts.calculateDataUnionSidechainAddress(mainnetAddressPredicted)
+        return new DataUnion(mainnetAddressPredicted, sidechainAddressPredicted, this)
+    }
+
     /**
      * @category Important
      */

--- a/packages/client/src/dataunion/DataUnion.ts
+++ b/packages/client/src/dataunion/DataUnion.ts
@@ -734,21 +734,7 @@ export class DataUnion {
 
     // Internal functions
 
-    /** @internal */
-    static _fromContractAddress(contractAddress: string, client: StreamrClient) {
-        const contracts = new Contracts(client)
-        const sidechainAddress = contracts.getDataUnionSidechainAddress(contractAddress) // throws if bad address
-        return new DataUnion(contractAddress, sidechainAddress, client)
-    }
-
-    /** @internal */
-    static _fromName({ dataUnionName, deployerAddress }: { dataUnionName: string, deployerAddress: string}, client: StreamrClient) {
-        const contracts = new Contracts(client)
-        const contractAddress = contracts.getDataUnionMainnetAddress(dataUnionName, deployerAddress) // throws if bad address
-        return DataUnion._fromContractAddress(contractAddress, client) // eslint-disable-line no-underscore-dangle
-    }
-
-    /** @internal */
+    /** @internal  TODO: remove, inline into the tests that use this */
     async _getContract() {
         const ret = this.getContracts().getMainnetContract(this.contractAddress)
         // @ts-expect-error


### PR DESCRIPTION
The real fix is to use the safeGetDataUnion until v6 where it should be fixed (when it's ok to break interface)

Removed lots of "internal functions" that were only used in tests. There still is lots to remove, e.g. the whole Contracts.ts class.