### PR TITLE
Fix a bug in node-fetch replacement in browser

### DIFF
--- a/packages/client/src/shim/node-fetch.ts
+++ b/packages/client/src/shim/node-fetch.ts
@@ -1,7 +1,7 @@
 type FetchResponse = Response
 // In browsers, the node-fetch package is replaced with this to use native fetch
 export default (
-    ((typeof window !== 'undefined' && window.fetch.bind(window)) || (typeof fetch !== 'undefined' && fetch) || undefined)!
+    ((typeof window !== 'undefined' && typeof window.fetch !== 'undefined' && window.fetch.bind(window)) || (typeof fetch !== 'undefined' && fetch) || undefined)!
 )
 
 export { FetchResponse as Response }

--- a/packages/client/src/shim/node-fetch.ts
+++ b/packages/client/src/shim/node-fetch.ts
@@ -1,7 +1,7 @@
 type FetchResponse = Response
 // In browsers, the node-fetch package is replaced with this to use native fetch
 export default (
-    ((typeof fetch !== 'undefined' && fetch) || (typeof window !== 'undefined' && window.fetch) || undefined)!
+    ((typeof window !== 'undefined' && window.fetch.bind(window)) || (typeof fetch !== 'undefined' && fetch) || undefined)!
 )
 
 export { FetchResponse as Response }


### PR DESCRIPTION
Following bug occurred in our product, this PR is a solution to solve this issue:

```
Error: Failed to publish to stream STREAM due to: TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
    at Object.<anonymous> (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:133844:64)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:106463:44)
    at _next (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:106478:33)
    at chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:106483:29
    at new Promise (<anonymous>)
    at new Wrapper (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:157801:44)
    at Object.<anonymous> (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:106475:32)
    at Object.authFetch [as default] (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:133827:39)
    at LoginEndpoints.<anonymous> (chrome-extension://jgcccciklffokknddmkbmkfdclnjajhp/background.js:133149:62).
Message was:
```