### PR TITLE
broker [NET-268]: Sequence numbers in storage queries

### DIFF
--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -214,8 +214,8 @@ export const router = (storage: Storage, streamFetcher: StreamFetcher, metricsCo
                 fromSequenceNumber,
                 toTimestamp,
                 toSequenceNumber,
-                (publisherId as string) || null,
-                (msgChainId as string) || null
+                publisherId,
+                msgChainId
             ))
         }
     })

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -181,7 +181,7 @@ export const router = (storage: Storage, streamFetcher: StreamFetcher, metricsCo
                 partition,
                 fromTimestamp,
                 fromSequenceNumber,
-                publisherId || null
+                publisherId
             ))
         }
     })

--- a/packages/broker/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/broker/test/integration/plugins/storage/Storage.test.ts
@@ -124,7 +124,7 @@ describe('Storage', () => {
     })
 
     test('requestFrom not throwing exception if timestamp is zero', async () => {
-        const a = storage.requestFrom(streamId, 0, 0, 0, null)
+        const a = storage.requestFrom(streamId, 0, 0, 0, undefined)
         const resultsA = await toArray(a)
         expect(resultsA).toEqual([])
     })
@@ -195,18 +195,19 @@ describe('Storage', () => {
     describe('fetch messages starting from a timestamp', () => {
 
         test('happy path', async () => {
-            const msg1 = buildMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 0 })
-            const msg2 = buildMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 1 })
+            const msg1 = buildMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 6 })
+            const msg2 = buildMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 7 })
             const msg3 = buildEncryptedMsg({
-                streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 2, publisherId: 'publisher', msgChainId: '2'
+                streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 8, publisherId: 'publisher', msgChainId: '2'
             })
-            const msg4 = buildEncryptedMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 3 })
+            const msg4 = buildEncryptedMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 9 })
             const msg5 = buildEncryptedMsg({ streamId, streamPartition: 10, timestamp: 4000, sequenceNumber: 0 })
 
             await Promise.all([
                 storage.store(buildMsg({ streamId, streamPartition: 10, timestamp: 0, sequenceNumber: 0 })),
                 storage.store(buildMsg({ streamId, streamPartition: 10, timestamp: 1000, sequenceNumber: 0 })),
                 storage.store(buildEncryptedMsg({ streamId, streamPartition: 10, timestamp: 2000, sequenceNumber: 0 })),
+                storage.store(buildMsg({ streamId, streamPartition: 10, timestamp: 3000, sequenceNumber: 5 })),
                 storage.store(msg1),
                 storage.store(msg4),
                 storage.store(msg3),
@@ -216,7 +217,7 @@ describe('Storage', () => {
                 storage.store(buildMsg({ streamId: `${streamId}-wrong`, streamPartition: 10, timestamp: 8000, sequenceNumber: 0 })),
             ])
 
-            const streamingResults = storage.requestFrom(streamId, 10, 3000, 0, null)
+            const streamingResults = storage.requestFrom(streamId, 10, 3000, 6, undefined)
             const results = await toArray(streamingResults)
 
             expect(results).toEqual([msg1, msg2, msg3, msg4, msg5])
@@ -360,13 +361,13 @@ describe('Storage', () => {
         })
 
         it('can requestFrom', async () => {
-            const streamingResults = storage.requestFrom(storedStreamId, 0, 1000, 0, null)
+            const streamingResults = storage.requestFrom(storedStreamId, 0, 1000, 0, undefined)
             const results = await toArray(streamingResults)
             expect(results.length).toEqual(NUM_MESSAGES)
         })
 
         it('can requestFrom again', async () => {
-            const streamingResults = storage.requestFrom(storedStreamId, 0, 1000, 0, null)
+            const streamingResults = storage.requestFrom(storedStreamId, 0, 1000, 0, undefined)
             const results = await toArray(streamingResults)
             expect(results.length).toEqual(NUM_MESSAGES)
         })

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -179,7 +179,7 @@ describe('cassanda-queries', () => {
             const minMockTimestamp = MOCK_MESSAGES[0].getTimestamp()
             const maxMockTimestamp = MOCK_MESSAGES[MOCK_MESSAGES.length - 1].getTimestamp()
             if (requestType === REQUEST_TYPE_FROM) {
-                return storage.requestFrom(streamId, 0, minMockTimestamp, 0, publisherId ?? null)
+                return storage.requestFrom(streamId, 0, minMockTimestamp, 0, publisherId)
             } else if (requestType === REQUEST_TYPE_RANGE) {
                 return storage.requestRange(streamId, 0, minMockTimestamp, 0, maxMockTimestamp, 0, publisherId, msgChainId)
             } else {

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -169,17 +169,17 @@ describe('cassanda-queries', () => {
     })
 
     describe.each([
-        [REQUEST_TYPE_FROM, null, null],
-        [REQUEST_TYPE_FROM, MOCK_PUBLISHER_ID, null],
-        [REQUEST_TYPE_RANGE, null, null],
+        [REQUEST_TYPE_FROM, undefined, undefined],
+        [REQUEST_TYPE_FROM, MOCK_PUBLISHER_ID, undefined],
+        [REQUEST_TYPE_RANGE, undefined, undefined],
         [REQUEST_TYPE_RANGE, MOCK_PUBLISHER_ID, MOCK_MSG_CHAIN_ID],
-    ])('%s, publisher: %p', (requestType: string, publisherId: string|null, msgChainId: string|null) => {
+    ])('%s, publisher: %p', (requestType: string, publisherId: string|undefined, msgChainId: string|undefined) => {
 
         const getResultStream = (streamId: string): Readable => {
             const minMockTimestamp = MOCK_MESSAGES[0].getTimestamp()
             const maxMockTimestamp = MOCK_MESSAGES[MOCK_MESSAGES.length - 1].getTimestamp()
             if (requestType === REQUEST_TYPE_FROM) {
-                return storage.requestFrom(streamId, 0, minMockTimestamp, 0, publisherId)
+                return storage.requestFrom(streamId, 0, minMockTimestamp, 0, publisherId ?? null)
             } else if (requestType === REQUEST_TYPE_RANGE) {
                 return storage.requestRange(streamId, 0, minMockTimestamp, 0, maxMockTimestamp, 0, publisherId, msgChainId)
             } else {

--- a/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
@@ -362,8 +362,8 @@ describe('DataQueryEndpoints', () => {
                     MIN_SEQUENCE_NUMBER_VALUE,
                     1496415670909,
                     MAX_SEQUENCE_NUMBER_VALUE,
-                    null,
-                    null,
+                    undefined,
+                    undefined,
                 )
             })
 

--- a/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
@@ -219,7 +219,7 @@ describe('DataQueryEndpoints', () => {
                     0,
                     1496408255672,
                     MIN_SEQUENCE_NUMBER_VALUE,
-                    null
+                    undefined
                 )
             })
 
@@ -394,8 +394,8 @@ describe('DataQueryEndpoints', () => {
                     1,
                     2000,
                     2,
-                    null,
-                    null,
+                    undefined,
+                    undefined,
                 )
             })
 


### PR DESCRIPTION
Fix for storage node queries. The `sequenceNumber` parameter was ignored for these queries:
- resend range, when publisher(+chain) was not specified
- resend from, when publisher was not specified

Previously both queries had separate implementations for:
- query with a publisher parameter
- query without a publisher parameter

The implementation with a publisher parameter didn't have the bug. Therefore we now use the unified implementation, which is based on the non-buggy implementation. It is only modified to support the optionality of the publisher parameter.

Also updated some method parameters to use `undefined` instead of `null`.