### PR TITLE
Net-588-scalability: disconnect from tracker after proxy connection attempts

### DIFF
--- a/packages/network/src/logic/node/Node.ts
+++ b/packages/network/src/logic/node/Node.ts
@@ -262,7 +262,7 @@ export class Node extends EventEmitter {
         return true
     }
 
-    async openOutgoingStreamConnection(spid: SPID, targetNodeId: string, reattempt = false): Promise<void> {
+    async openOutgoingStreamConnection(spid: SPID, targetNodeId: string): Promise<void> {
         const trackerId = this.trackerManager.getTrackerId(spid)
         const trackerAddress = this.trackerManager.getTrackerAddress(spid)
         try {

--- a/packages/network/src/logic/node/TrackerConnector.ts
+++ b/packages/network/src/logic/node/TrackerConnector.ts
@@ -24,6 +24,7 @@ export class TrackerConnector {
     private maintenanceTimer?: NodeJS.Timeout | null
     private readonly maintenanceInterval: number
     private connectionStates: Map<TrackerId, ConnectionState>
+    private readonly signallingOnlyTrackers: Set<TrackerId>
 
     constructor(
         getSPIDs: GetSPIDsFn,
@@ -38,6 +39,7 @@ export class TrackerConnector {
         this.trackerRegistry = trackerRegistry
         this.maintenanceInterval = maintenanceInterval
         this.connectionStates = new Map()
+        this.signallingOnlyTrackers = new Set()
     }
 
     onNewStream(spid: SPID): void {
@@ -45,10 +47,15 @@ export class TrackerConnector {
         this.connectTo(trackerInfo)
     }
 
-    async createTrackerConnectionForStream(spid: SPID): Promise<void> {
-        const { ws, id } = this.trackerRegistry.getTracker(spid)
-        logger.info('Connecting to tracker %s for stream %s', NameDirectory.getName(id), spid.key)
-        await this.connectToTracker(ws, PeerInfo.newTracker(id))
+    async createSignallingOnlyTrackerConnection(trackerId: TrackerId, trackerAddress: string): Promise<void> {
+        this.signallingOnlyTrackers.add(trackerId)
+        await this.connectToTracker(trackerAddress, PeerInfo.newTracker(trackerId))
+        logger.info('Connected to tracker %s for signalling only', NameDirectory.getName(trackerId))
+    }
+
+    removeSignallingOnlyTrackerConnection(trackerId: TrackerId): void {
+        this.signallingOnlyTrackers.delete(trackerId)
+        this.disconnectFromTracker(trackerId)
     }
 
     start(): void {
@@ -96,6 +103,9 @@ export class TrackerConnector {
     }
 
     private isActiveTracker(trackerId: TrackerId): boolean {
+        if (this.signallingOnlyTrackers.has(trackerId)) {
+            return true
+        }
         for (const { streamId, streamPartition } of this.getSPIDs()) {
             if (this.trackerRegistry.getTracker(new SPID(streamId, streamPartition)).id === trackerId) {
                 return true

--- a/packages/network/src/logic/node/TrackerManager.ts
+++ b/packages/network/src/logic/node/TrackerManager.ts
@@ -107,8 +107,12 @@ export class TrackerManager {
         this.trackerConnector.onNewStream(spid)
     }
 
-    async connectToTrackerForStream(spid: SPID): Promise<void> {
-        await this.trackerConnector.createTrackerConnectionForStream(spid)
+    async connectToSignallingOnlyTracker(trackerId: TrackerId, trackerAddress: string): Promise<void> {
+        await this.trackerConnector.createSignallingOnlyTrackerConnection(trackerId, trackerAddress)
+    }
+
+    disconnectFromSignallingOnlyTracker(trackerId: string): void {
+        this.trackerConnector.removeSignallingOnlyTrackerConnection(trackerId)
     }
 
     onUnsubscribeFromStream(spid: SPID): void {
@@ -224,5 +228,9 @@ export class TrackerManager {
 
     getTrackerId(spid: SPID): TrackerId {
         return this.trackerRegistry.getTracker(spid).id
+    }
+
+    getTrackerAddress(spid: SPID): TrackerId {
+        return this.trackerRegistry.getTracker(spid).ws
     }
 }


### PR DESCRIPTION
- Disconnect from trackers after proxy connection have been attempted

- `integration/publish-only-stream-connection.test.ts` Is more lightweight and less prone to hanging.