### PR TITLE
Update node-datachannel to 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11305,18 +11305,6 @@
             "version": "1.0.0",
             "license": "ISC"
         },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/fstream": {
             "version": "1.0.12",
             "license": "ISC",
@@ -18832,12 +18820,13 @@
             }
         },
         "node_modules/node-datachannel": {
-            "version": "0.1.12",
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.14.tgz",
+            "integrity": "sha512-NfehVCGlXbWD47P8nENpJUHh5ac2RwgtgwpLpmvdRNxhBmNfhKUl3WOmQ6odyHb3Fw36AGigPO0NcDR95JG07Q==",
             "bundleDependencies": [
                 "prebuild-install"
             ],
             "hasInstallScript": true,
-            "license": "GPL-2.0-or-later",
             "dependencies": {
                 "prebuild-install": "^6.1.4"
             }
@@ -27153,7 +27142,7 @@
                 "ipaddr.js": "^2.0.1",
                 "lodash": "^4.17.21",
                 "morgan": "^1.10.0",
-                "node-datachannel": "^0.1.11",
+                "node-datachannel": "^0.1.14",
                 "pino": "^6.11.3",
                 "setimmediate": "^1.0.5",
                 "streamr-client-protocol": "^9.1.1",
@@ -34788,11 +34777,6 @@
         "fs.realpath": {
             "version": "1.0.0"
         },
-        "fsevents": {
-            "version": "2.3.2",
-            "dev": true,
-            "optional": true
-        },
         "fstream": {
             "version": "1.0.12",
             "optional": true,
@@ -40032,7 +40016,9 @@
             "version": "0.0.1"
         },
         "node-datachannel": {
-            "version": "0.1.12",
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.14.tgz",
+            "integrity": "sha512-NfehVCGlXbWD47P8nENpJUHh5ac2RwgtgwpLpmvdRNxhBmNfhKUl3WOmQ6odyHb3Fw36AGigPO0NcDR95JG07Q==",
             "requires": {
                 "prebuild-install": "^6.1.4"
             },
@@ -43846,7 +43832,7 @@
                 "karma-webpack": "^5.0.0",
                 "lodash": "^4.17.21",
                 "morgan": "^1.10.0",
-                "node-datachannel": "^0.1.11",
+                "node-datachannel": "^0.1.14",
                 "node-module-polyfill": "^1.0.1",
                 "node-polyfill-webpack-plugin": "^1.1.4",
                 "patch-package": "^6.4.7",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -56,7 +56,7 @@
     "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",
     "morgan": "^1.10.0",
-    "node-datachannel": "^0.1.11",
+    "node-datachannel": "^0.1.14",
     "pino": "^6.11.3",
     "setimmediate": "^1.0.5",
     "streamr-client-protocol": "^9.1.1",


### PR DESCRIPTION
This PR updates node-datachannel to 0.1.14 to fix the Jest exit issue `Jest did not exit one second after the test run has completed. This usually means that there are asynchronous operations that weren't stopped in your tests.` and Jest errors with `console.log()` called after the end of tests.

The fix is rather extensive and consists of making the cleanup blocking in libdatachannel, adding support for cancelling JavaScript callbacks after close, and cleaning up handles on close rather than on garbage collection in the JavaScript wrapper (see details in https://github.com/murat-dogan/node-datachannel/pull/66).