### PR TITLE
fix(client): null query parameters

### DIFF
--- a/packages/client/src/Resends.ts
+++ b/packages/client/src/Resends.ts
@@ -20,6 +20,7 @@ import { StreamEndpoints } from './StreamEndpoints'
 import { BrubeckContainer } from './Container'
 import { StreamRegistry } from './StreamRegistry'
 import { WebStreamToNodeStream } from './utils/WebStreamToNodeStream'
+import { createQueryString } from './Rest'
 
 const MIN_SEQUENCE_NUMBER_VALUE = 0
 
@@ -61,9 +62,7 @@ const createUrl = (baseUrl: string, endpointSuffix: string, spid: SPID, query: Q
         ...query,
         format: 'raw'
     }
-
-    const queryString = new URLSearchParams(Object.entries(queryMap).filter(([_key, value]) => value != null)).toString()
-
+    const queryString = createQueryString(queryMap)
     return `${baseUrl}/streams/${encodeURIComponent(spid.streamId)}/data/partitions/${spid.streamPartition}/${endpointSuffix}?${queryString}`
 }
 

--- a/packages/client/src/Rest.ts
+++ b/packages/client/src/Rest.ts
@@ -2,6 +2,8 @@
  * More ergonomic wrapper around fetch/authFetch
  */
 import { Lifecycle, scoped, inject, DependencyContainer } from 'tsyringe'
+import omitBy from 'lodash/omitBy'
+import isNil from 'lodash/isNil'
 
 import { Debugger } from './utils/log'
 import { instanceId } from './utils'
@@ -30,6 +32,10 @@ function serialize(body: any): string | undefined {
     return typeof body === 'string' ? body : JSON.stringify(body)
 }
 
+export const createQueryString = (query: Record<string, any>) => {
+    return new URLSearchParams(omitBy(query, isNil)).toString()
+}
+
 @scoped(Lifecycle.ContainerScoped)
 export class Rest implements Context {
     id
@@ -45,8 +51,7 @@ export class Rest implements Context {
 
     getUrl(urlParts: UrlParts, query = {}, restUrl = this.options.restUrl) {
         const url = new URL(urlParts.map((s) => encodeURIComponent(s)).join('/'), restUrl + '/')
-        const searchParams = new URLSearchParams(query)
-        url.search = searchParams.toString()
+        url.search = createQueryString(query)
         return url
     }
 

--- a/packages/client/src/Rest.ts
+++ b/packages/client/src/Rest.ts
@@ -2,8 +2,6 @@
  * More ergonomic wrapper around fetch/authFetch
  */
 import { Lifecycle, scoped, inject, DependencyContainer } from 'tsyringe'
-import omitBy from 'lodash/omitBy'
-import isNil from 'lodash/isNil'
 
 import { Debugger } from './utils/log'
 import { instanceId } from './utils'
@@ -33,7 +31,8 @@ function serialize(body: any): string | undefined {
 }
 
 export const createQueryString = (query: Record<string, any>) => {
-    return new URLSearchParams(omitBy(query, isNil)).toString()
+    const withoutEmpty = Object.fromEntries(Object.entries(query).filter(([_k, v]) => v != null))
+    return new URLSearchParams(withoutEmpty).toString()
 }
 
 @scoped(Lifecycle.ContainerScoped)

--- a/packages/client/test/unit/Rest.test.ts
+++ b/packages/client/test/unit/Rest.test.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata'
+import { createQueryString } from '../../src/Rest'
+
+describe('Rest', () => {
+    it('query parameters with null/undefined', () => {
+        const actual = createQueryString({
+            a: 'foo',
+            b: undefined,
+            c: null,
+            d: 123,
+            e: ['x', 'y']
+        })
+        expect(actual).toBe('a=foo&d=123&e=x%2Cy')
+    })
+})


### PR DESCRIPTION
Fix `Rest.getUrl` to support `null` / `undefined` query parameter values. The new helper method is also used in `Resends`, no functionality change there.