### PR TITLE
feat(client): allow auth.address in StreamrClient options

### DIFF
--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -25,7 +25,11 @@ export type ProviderAuthConfig = {
 }
 
 export type PrivateKeyAuthConfig = {
-    privateKey: string
+    privateKey: string,
+    // The address property is not used. It is included to make the object
+    // compatible with StreamrClient.generateEthereumAccount(), as we typically
+    // use that method to generate the client "auth" option.
+    address?: string
 }
 
 export type SessionTokenAuthConfig = {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -16,6 +16,10 @@
                     "type": "string",
                     "format": "ethereum-private-key"
                 },
+                "address": {
+                    "type": "string",
+                    "format": "ethereum-address"
+                },
                 "ethereum": {
                     "type": "object"
                 },

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -80,6 +80,15 @@ describe('Config', () => {
         })
     })
 
+    describe('ignorable properties', () => {
+        it('auth address', () => {
+            expect(() => {
+                const wallet = StreamrClient.generateEthereumAccount()
+                return new StreamrClient({ auth: wallet })
+            }).not.toThrow()
+        })
+    })
+
     describe('merging configs', () => {
         it('works with no arguments', () => {
             expect(new StreamrClient()).toBeInstanceOf(StreamrClient)


### PR DESCRIPTION
Relax validation rule for `auth` block: allow additional property of `address`.

The value of that property is not used by the client. It is included to make the `PrivateKeyAuthConfig` object compatible with `StreamrClient.generateEthereumAccount()`, as we typically use that method to generate the client "auth" option.