### PR TITLE
fix: adding stream to storageNode now also waits for theGraph sync

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -20,10 +20,9 @@
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "build": "tsc -b tsconfig.node.json",
-    "test-unit": "jest test/unit",
-    "t": "jest --forceExit test/integration/broker.test.ts",
-    "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --forceExit test/integration && npm run test-sequential",
+    "test-unit": "jest test/unit --forceExit --detectOpenHandles",
+    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit --detectOpenHandles # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest --forceExit --detectOpenHandles test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -187,7 +187,7 @@ export class StorageAssignmentEventManager {
 
     async addStreamToStorageNode(streamId: string, storageNodeAddress: string, client: StreamrClient): Promise<void> {
         await client.addStreamToStorageNode(streamId, storageNodeAddress)
-        await until(async () => { return client.isStreamStoredInStorageNode(streamId, storageNodeAddress) }, 100000, 1000)
+        await until(async () => { return client.isStreamStoredInStorageNode(streamId, storageNodeAddress) }, 10000, 500)
         this.publishAddEvent(streamId)
     }
 

--- a/packages/client/src/NodeRegistry.ts
+++ b/packages/client/src/NodeRegistry.ts
@@ -14,6 +14,7 @@ import { Config, StrictStreamrClientConfig } from './Config'
 import { Stream, StreamProperties } from './Stream'
 import Ethereum from './Ethereum'
 import { EthereumAddress, NotFoundError } from '.'
+import { until } from './utils'
 
 const log = debug('StreamrClient:NodeRegistry')
 
@@ -134,6 +135,8 @@ export class NodeRegistry {
 
         const tx = await this.streamStorageRegistryContract!.addStorageNode(streamId, nodeAddress)
         await tx.wait()
+        await until(async () => { return this.isStreamStoredInStorageNode(streamId, nodeAddress) }, 10000, 500,
+            () => `Failed to add stream ${streamId} to storageNode ${nodeAddress}, timed out querying fact from theGraph`)
     }
 
     async removeStreamFromStorageNode(streamId: string, nodeAddress: string): Promise<void> {

--- a/packages/client/src/shim/node-fetch.ts
+++ b/packages/client/src/shim/node-fetch.ts
@@ -1,7 +1,8 @@
 type FetchResponse = Response
 // In browsers, the node-fetch package is replaced with this to use native fetch
 export default (
-    ((typeof window !== 'undefined' && typeof window.fetch !== 'undefined' && window.fetch.bind(window)) || (typeof fetch !== 'undefined' && fetch) || undefined)!
+    ((typeof window !== 'undefined' && typeof window.fetch !== 'undefined' && window.fetch.bind(window))
+        || (typeof fetch !== 'undefined' && fetch) || undefined)!
 )
 
 export { FetchResponse as Response }


### PR DESCRIPTION
fix: adding stream to storageNode now also waits for theGraph sync, not only transaction being mined

This wait logic will be changed for all calls, that create transactions, in
https://linear.app/streamr/issue/ETH-199/configurable-wait-parameters-for-transaction-generating-call-on-client