### PR TITLE
fix(network): close WS connection, if endpoint already stopped

### DIFF
--- a/packages/network/src/connection/ws/AbstractWsEndpoint.ts
+++ b/packages/network/src/connection/ws/AbstractWsEndpoint.ts
@@ -169,6 +169,7 @@ export abstract class AbstractWsEndpoint<C extends AbstractWsConnection> extends
      */
     protected onNewConnection(connection: C): void {
         if (this.stopped) {
+            connection.close(DisconnectionCode.GRACEFUL_SHUTDOWN, DisconnectionReason.GRACEFUL_SHUTDOWN)
             return
         }
         const peerInfo = connection.getPeerInfo()


### PR DESCRIPTION
Explicitly close a websocket connection, if it is formed after the websocket endpoint has stopped. 

Before the fix e.g. this Node.js script wasn't able to exit as it had an open handle from the WS connection:
```javascript
#!/usr/bin/env node
const wtf = require('wtfnode')
import StreamrClient, { ConfigTest } from '.'

const opts = {
    ...ConfigTest,
    auth: {
        privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001'
    }
}

const client = new StreamrClient(opts)

const main = async () => {
    const streamId = await client.createStream('/test/' + Date.now())
    await client.publish(streamId, { foo: 'bar '})
    // the Node starts to connect to Tracker
    await client.destroy()
    // the WS connection between Node and Tracker is now formed, 
    // but we've already stopped AbstractWsEndpoint by calling client.destroy()
}

setTimeout(() => {
    wtf.dump()  // prints e.g. "Sockets 127.0.0.1:50864 -> 127.0.0.1:30302"
}, 10000)

main()
```