### PR TITLE
fix: fixed err with storagenode being not synced to theGraph

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -21,8 +21,8 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "build": "tsc -b tsconfig.node.json",
     "test-unit": "jest test/unit --forceExit --detectOpenHandles",
-    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --forceExit test/integration && npm run test-sequential",
+    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit --detectOpenHandles # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest --forceExit --detectOpenHandles test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -16,13 +16,13 @@
   "main": "bin/broker.js",
   "scripts": {
     "prepare": "npm run build",
-    "test": "jest test/unit test/integration && npm run test-sequential",
+    "test": "jest --forceExit test/unit test/integration && npm run test-sequential",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "build": "tsc -b tsconfig.node.json",
     "test-unit": "jest test/unit --forceExit --detectOpenHandles",
-    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit --detectOpenHandles # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --forceExit --detectOpenHandles test/integration && npm run test-sequential",
+    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest --forceExit test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/packages/client/src/NodeRegistry.ts
+++ b/packages/client/src/NodeRegistry.ts
@@ -116,9 +116,11 @@ export class NodeRegistry {
     async setNode(nodeMetadata: string): Promise<void> {
         log('setNode %s -> %s', nodeMetadata)
         await this.connectToNodeRegistryContract()
-
+        const nodeAddress = await this.ethereum.getAddress()
         const tx = await this.nodeRegistryContract!.createOrUpdateNodeSelf(nodeMetadata)
         await tx.wait()
+        await until(async () => { return this.getStorageNodeUrl(nodeAddress) !== undefined }, 10000, 500,
+            () => `Failed to create/update node ${nodeAddress}, timed out querying fact from theGraph`)
     }
 
     async removeNode(): Promise<void> {

--- a/packages/client/src/NodeRegistry.ts
+++ b/packages/client/src/NodeRegistry.ts
@@ -122,9 +122,8 @@ export class NodeRegistry {
         await until(async () => {
             try {
                 const url = await this.getStorageNodeUrl(nodeAddress)
-                return nodeMetadata.indexOf(url) !== -1
+                return nodeMetadata.includes(url)
             } catch (err) {
-                log('node not found yet %o', err)
                 return false
             }
         }, 10000, 500,

--- a/packages/client/src/NodeRegistry.ts
+++ b/packages/client/src/NodeRegistry.ts
@@ -119,8 +119,16 @@ export class NodeRegistry {
         const nodeAddress = await this.ethereum.getAddress()
         const tx = await this.nodeRegistryContract!.createOrUpdateNodeSelf(nodeMetadata)
         await tx.wait()
-        await until(async () => { return this.getStorageNodeUrl(nodeAddress) !== undefined }, 10000, 500,
-            () => `Failed to create/update node ${nodeAddress}, timed out querying fact from theGraph`)
+        await until(async () => {
+            try {
+                const url = await this.getStorageNodeUrl(nodeAddress)
+                return nodeMetadata.indexOf(url) !== -1
+            } catch (err) {
+                log('node not found yet %o', err)
+                return false
+            }
+        }, 10000, 500,
+        () => `Failed to create/update node ${nodeAddress}, timed out querying fact from theGraph`)
     }
 
     async removeNode(): Promise<void> {


### PR DESCRIPTION
fix: fixed err with storagenode being not synced to theGraph when accessing its streams;

also **removed detectOpenHandles for integration tests**, since it forces jest to run all tests in band instead of parallel