### PR TITLE
cleaned up tests that were commented out / disabled on ocr branch

### DIFF
--- a/packages/broker/test/integration/StreamFetcher.test.ts
+++ b/packages/broker/test/integration/StreamFetcher.test.ts
@@ -63,53 +63,6 @@ describe('StreamFetcher', () => {
             })
         })
 
-        // it('escapes any forward slashes ("/") in streamId', async () => {
-        //     streamId = 'sandbox/stream/aaa'
-        //     await streamFetcher.checkPermission('sandbox/stream/aaa', StreamPermission.SUBSCRIBE, null)
-        //     expect(numOfRequests).toEqual(1) // would not land at handler if "/" not escaped
-        // })
-
-        // it('caches repeated invocations', async () => {
-        //     const streamId2 = (await createTestStream(client, module)).streamId
-        //     const streamId3 = (await createTestStream(client, module)).streamId
-
-        //     await Promise.all([streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId2, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId2, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId3, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId2, StreamPermission.SUBSCRIBE, null),
-        //         streamFetcher.checkPermission(streamId3, StreamPermission.SUBSCRIBE, null),
-        //     ]).catch(() => {
-        //         assert.equal(numOfRequests, 3)
-        //     })
-        // })
-
-        // it('does not cache errors', (done) => {
-        //     broken = true
-        //     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null).catch(() => {
-        //         streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null).catch(() => {
-        //             streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null).catch(() => {
-        //                 assert.equal(numOfRequests, 3)
-        //                 broken = false
-        //                 Promise.all([
-        //                     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //                     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //                     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //                     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //                     streamFetcher.checkPermission(streamId, StreamPermission.SUBSCRIBE, null),
-        //                 ]).then(() => {
-        //                     assert.equal(numOfRequests, 3 + 1)
-        //                     done()
-        //                 }).catch(() => {
-        //                     done(new Error('test fail'))
-        //                 })
-        //             })
-        //         })
-        //     })
-        // })
     })
 
     describe('fetch', () => {
@@ -125,127 +78,11 @@ describe('StreamFetcher', () => {
             })
         })
 
-        // it('rejects with unauthorized if session token does not grant access to stream', (done) => {
-        //     streamFetcher.fetch(streamId).catch((err: Todo) => {
-        //         expect(err.errorCode).toContain('unauthorized')
-        //         done()
-        //     })
-        // })
-
         it('resolves with stream if session token provides privilege to stream', async () => {
             const stream = await streamFetcher.fetch(streamId)
             expect(stream.streamId).toEqual(streamId)
             expect(stream.partitions).toEqual(1)
         })
 
-        // it('resolves with stream if stream is publicly readable', (done) => {
-        //     requestHandlers.stream = (req: Request, res: Response) => {
-        //         assert.equal(req.params.id, 'publicStream')
-        //         res.status(200).send(streamJson)
-        //     }
-        //     streamFetcher.fetch('publicStream').then((response: Todo) => {
-        //         assert.deepEqual(response, streamJson)
-        //         done()
-        //     }).catch((err: Todo) => {
-        //         done(err)
-        //     })
-        // })
-
-        // it('escapes any forward slashes ("/") in streamId', async () => {
-        //     await streamFetcher.fetch('sandbox/stream/aaa')
-        //     expect(numOfRequests).toEqual(1) // would not land at handler if "/" not escaped
-        // })
-
-        // it('caches repeated invocations', async () => {
-        //     const streamId2 = (await createTestStream(client, module)).streamId
-        //     const streamId3 = (await createTestStream(client, module)).streamId
-
-        //     await Promise.all([streamFetcher.fetch(streamId),
-        //         streamFetcher.fetch(streamId),
-        //         streamFetcher.fetch(streamId),
-        //         streamFetcher.fetch(streamId2),
-        //         streamFetcher.fetch(streamId),
-        //         streamFetcher.fetch(streamId2),
-        //         streamFetcher.fetch(streamId3),
-        //         streamFetcher.fetch(streamId2),
-        //         streamFetcher.fetch(streamId3),
-        //     ]).catch(() => {
-        //         assert.equal(numOfRequests, 3)
-        //     })
-        // })
-
-        // it('does not cache errors', (done) => {
-        //     broken = true
-        //     streamFetcher.fetch(streamId).catch(() => {
-        //         streamFetcher.fetch(streamId).catch(() => {
-        //             streamFetcher.fetch(streamId).catch(() => {
-        //                 assert.equal(numOfRequests, 3)
-        //                 broken = false
-        //                 Promise.all([
-        //                     streamFetcher.fetch(streamId),
-        //                     streamFetcher.fetch(streamId),
-        //                     streamFetcher.fetch(streamId),
-        //                     streamFetcher.fetch(streamId),
-        //                     streamFetcher.fetch(streamId),
-        //                 ]).then(() => {
-        //                     assert.equal(numOfRequests, 3 + 1)
-        //                     done()
-        //                 }).catch(() => {
-        //                     done(new Error('test fail'))
-        //                 })
-        //             })
-        //         })
-        //     })
-        // })
     })
-
-    // describe('authenticate', () => {
-    // it('fails if the requested permission has not been granted', (done) => {
-    //     // Only stream_get permission
-    //     permissions = [
-    //         {
-    //             id: null,
-    //             user: 'tester1@streamr.com',
-    //             operation: 'stream_get',
-    //         }
-    //     ]
-
-    //     // Should reject promise
-    //     streamFetcher.authenticate(streamId, StreamPermission.SUBSCRIBE, null)
-    //         .catch((_err: Todo) => {
-    //             done()
-    //         })
-    // })
-
-    // it('accepts and returns stream if the permission is granted', (done) => {
-    //     permissions.push({
-    //         id: null,
-    //         user: 'tester1@streamr.com',
-    //         operation: 'stream_publish',
-    //     })
-
-    // streamFetcher.authenticate(streamId, StreamPermission.PUBLISH, null).then((json: Todo) => {
-    //     assert.equal(numOfRequests, 2)
-    //     assert.deepEqual(json, streamJson)
-    //     done()
-    // }).catch(() => {
-    //     done(new Error('test fail'))
-    // })
-    // })
-
-    // it('fails with an invalid session token', (done) => {
-    //     streamFetcher.authenticate(streamId, StreamPermission.SUBSCRIBE, null).catch((_err: Todo) => {
-    //         assert.equal(numOfRequests, 1)
-    //         done()
-    //     })
-    // })
-
-    // it('escapes any forward slashes ("/") in streamId', async () => {
-    //     streamId = 'sandbox/stream/aaa'
-    //     await streamFetcher.authenticate('sandbox/stream/aaa', StreamPermission.SUBSCRIBE, null)
-    //     expect(numOfRequests).toEqual(2) // would not land at handlers if "/" not escaped
-    // })
-
-    // TODO: write cache tests
-    // })
 })

--- a/packages/broker/test/unit/RequestAuthenticatorMiddleware.test.ts
+++ b/packages/broker/test/unit/RequestAuthenticatorMiddleware.test.ts
@@ -26,22 +26,6 @@ describe('AuthenticationMiddleware', () => {
         middlewareInstance = authenticator(streamFetcherStub, StreamPermission.SUBSCRIBE, 'fakeaddress')
     })
 
-    // to get stream no session is needed any more, streamFetcher is getting streams from chain
-    // describe('given no authorization token', () => {
-    //     it('delegates streamId to streamFetcher#authenticate without session token', () => {
-    //         streamFetcherStub.authenticate = sinon.stub()
-    //         streamFetcherStub.authenticate.returns(Promise.resolve({}))
-
-    //         middlewareInstance(request, response, next)
-
-    //         sinon.assert.calledOnce(streamFetcherStub.authenticate)
-    //         sinon.assert.calledWithExactly(
-    //             streamFetcherStub.authenticate,
-    //             'streamId', undefined, 'stream_subscribe',
-    //         )
-    //     })
-    // })
-
     it('responds 400 and error message if authorization header malformed', () => {
         streamFetcherStub.authenticate = sinon.stub()
         request.headers.authorization = 'foobar 90rjsdojg9823jtopsdjglsd'
@@ -66,80 +50,6 @@ describe('AuthenticationMiddleware', () => {
             }
         })
 
-        // to get stream no session is needed any more, streamFetcher is getting streams from chain
-        // it('delegates streamId and session token to streamFetcher#authenticate', () => {
-        //     streamFetcherStub.authenticate = sinon.stub()
-        //     streamFetcherStub.authenticate.returns(Promise.resolve({}))
-
-        //     middlewareInstance(request, response, next)
-
-        //     sinon.assert.calledOnce(streamFetcherStub.authenticate)
-        //     sinon.assert.calledWithExactly(
-        //         streamFetcherStub.authenticate,
-        //         'streamId', 'session-token', 'stream_subscribe',
-        //     )
-        // })
-
-        // it('authenticates with an explicitly given permission', () => {
-        //     streamFetcherStub.authenticate = sinon.stub()
-        //     streamFetcherStub.authenticate.returns(Promise.resolve({}))
-
-        //     middlewareInstance = authenticator(streamFetcherStub, 'stream_publish')
-        //     middlewareInstance(request, response, next)
-
-        //     sinon.assert.calledOnce(streamFetcherStub.authenticate)
-        //     sinon.assert.calledWithExactly(
-        //         streamFetcherStub.authenticate,
-        //         'streamId', 'session-token', 'stream_publish',
-        //     )
-        // })
-
-        // it('responds 403 and error message if streamFetcher#authenticate results in 403', (done) => {
-        //     streamFetcherStub.authenticate = () => Promise.reject(new HttpError(403, 'GET', ''))
-
-        //     middlewareInstance(request, response, next)
-
-        //     setTimeout(() => {
-        //         sinon.assert.notCalled(next)
-        //         sinon.assert.calledOnce(response.status)
-        //         sinon.assert.calledOnce(response.send)
-        //         sinon.assert.calledWithExactly(response.status, 403)
-        //         sinon.assert.calledWithExactly(response.send, {
-        //             error: 'Authentication failed.',
-        //         })
-        //         done()
-        //     })
-        // })
-
-        // it('responds with 404 if the stream is not found', (done) => {
-        //     streamFetcherStub.authenticate = () => Promise.reject(new HttpError(404, 'GET', ''))
-
-        //     middlewareInstance(request, response, next)
-
-        //     setTimeout(() => {
-        //         sinon.assert.notCalled(next)
-        //         sinon.assert.calledOnce(response.status)
-        //         sinon.assert.calledOnce(response.send)
-        //         sinon.assert.calledWithExactly(response.status, 404)
-        //         sinon.assert.calledWithExactly(response.send, {
-        //             error: 'Stream streamId not found.',
-        //         })
-        //         done()
-        //     })
-        // })
-
-        // it('responds with whatever status code the backend returns', (done) => {
-        //     streamFetcherStub.authenticate = () => Promise.reject(new HttpError(123, 'GET', ''))
-
-        //     middlewareInstance(request, response, next)
-
-        //     setTimeout(() => {
-        //         sinon.assert.notCalled(next)
-        //         sinon.assert.calledWithExactly(response.status, 123)
-        //         done()
-        //     })
-        // })
-
         describe('given streamFetcher#authenticate authenticates successfully', () => {
             beforeEach(() => {
                 streamFetcherStub.authenticate = (streamId: string) => Promise.resolve({
@@ -160,22 +70,6 @@ describe('AuthenticationMiddleware', () => {
                     done()
                 })
             })
-
-            // it('puts stream JSON in request object', (done) => {
-            //     middlewareInstance(request, response, next)
-            //     setTimeout(() => {
-            //         assert.deepEqual(request.stream, {
-            //             id: 'streamId',
-            //             partitions: 5,
-            //             name: 'my stream',
-            //             feed: {},
-            //             config: {},
-            //             description: 'description',
-            //             uiChannel: null,
-            //         })
-            //         done()
-            //     })
-            // })
         })
     })
 })

--- a/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
@@ -47,11 +47,7 @@ describe('DataQueryEndpoints', () => {
         streamFetcher = {
             authenticate() {
                 return new Promise(((resolve) => {
-                    // if (sessionToken === 'mock-session-token') {
                     resolve({})
-                    // } else {
-                    //     reject(new HttpError(403, 'GET', ''))
-                    // }
                 }))
             },
         }
@@ -81,15 +77,6 @@ describe('DataQueryEndpoints', () => {
                         error: 'Path parameter "partition" not a number: zero',
                     }, done)
             })
-
-            // does not have to be autorized with session, endpoint will check permission onchain
-            // it('responds 403 and error message if not authorized', (done) => {
-            //     testGetRequest('/api/v1/streams/streamId/data/partitions/0/last', 'wrong-session-token')
-            //         .expect('Content-Type', /json/)
-            //         .expect(403, {
-            //             error: 'Authentication failed.',
-            //         }, done)
-            // })
 
             it('responds 400 and error message if optional param "count" not a number', (done) => {
                 testGetRequest('/api/v1/streams/streamId/data/partitions/0/last?count=sixsixsix')
@@ -284,14 +271,6 @@ describe('DataQueryEndpoints', () => {
                         error: 'Path parameter "partition" not a number: zero',
                     }, done)
             })
-            // does not have to be autorized with session, endpoint will check permission onchain
-            // it('responds 403 and error message if not authorized', (done) => {
-            //     testGetRequest('/api/v1/streams/streamId/data/partitions/0/range', 'wrong-session-token')
-            //         .expect('Content-Type', /json/)
-            //         .expect(403, {
-            //             error: 'Authentication failed.',
-            //         }, done)
-            // })
             it('responds 400 and error message if param "fromTimestamp" not given', (done) => {
                 testGetRequest('/api/v1/streams/streamId/data/partitions/0/range')
                     .expect('Content-Type', /json/)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,7 +46,7 @@
         "test-types": "npm run test-browser-types",
         "test-browser-types": "tsc -b tsconfig.browser.json",
         "coverage": "jest --coverage",
-        "test-integration": "jest --verbose --useStderr --forceExit test/integration",
+        "test-integration": "jest --verbose --useStderr --maxWorkers=2 --forceExit test/integration",
         "test-exports": "cd test/exports && npm run link && tsc --noEmit --project ./tsconfig.json && npm test",
         "test-integration-no-resend": "jest --verbose --useStderr --forceExit --testTimeout=30000 --testPathIgnorePatterns='resend|Resend' --testNamePattern='^((?!(resend|Resend|resent|Resent|gap|Gap)).)*$' test/integration/*.test.*",
         "test-integration-resend": "jest --verbose --useStderr --forceExit --testTimeout=40000 --testNamePattern='(resend|Resend|resent|Resent)' test/integration/*.test.*",

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -6,7 +6,6 @@ function toNumber(value: any): number | undefined {
  * Streamr client constructor options that work in the test environment
  */
 export default {
-    // ganache 1: 0x4178baBE9E5148c6D5fd431cD72884B07Ad855a0
     auth: {
         privateKey: process.env.ETHEREUM_PRIVATE_KEY || '0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb',
     },

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -344,12 +344,6 @@ describeRepeats('Group Key Persistence', () => {
                     privateKey: publisherPrivateKey,
                 },
             })
-
-            // streams = await Promise.all(Array(NUM_STREAMS).fill(true).map(async () => {
-            //     return createTestStream(publisher, module, {
-            //         requireEncryptedData: false,
-            //     })
-            // }))
             for (let i = 0; i < NUM_STREAMS; i++) {
                 // eslint-disable-next-line no-await-in-loop
                 const stream = await createTestStream(publisher, module, {

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -6,7 +6,7 @@ import {
     getPublishTestStreamMessages,
     getWaitForStorage,
     createTestStream,
-    getCreateClient
+    clientOptions
 } from '../utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import Resend from '../../src/Resends'
@@ -21,11 +21,9 @@ import { storageNodeTestConfig } from './devEnvironment'
 const WAIT_FOR_STORAGE_TIMEOUT = process.env.CI ? 20000 : 10000
 const MAX_MESSAGES = 5
 
-const createClient = getCreateClient()
-
 jest.setTimeout(60000)
 
-describeRepeats.skip('resends', () => {
+describeRepeats('resends', () => {
     let expectErrors = 0 // check no errors by default
     let onError = jest.fn()
     let client: StreamrClient
@@ -36,7 +34,9 @@ describeRepeats.skip('resends', () => {
     let storageNodeAddress: string
 
     beforeAll(async () => {
-        client = await createClient()
+        client = new StreamrClient({
+            ...clientOptions
+        })
         subscriber = client.resends
 
         // eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
- re-enabled tests that got disabled on OCR branch (Resends)
- removed commented out tests that are now obsolete (testing mostly authentication in streamfetcher, that now works without authentication and also mostly delegates calls to client)