### PR TITLE
feat: re-enabled grant- and revoke- endpoints and tests

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,7 +46,7 @@
         "test-types": "npm run test-browser-types",
         "test-browser-types": "tsc -b tsconfig.browser.json",
         "coverage": "jest --coverage",
-        "test-integration": "jest --verbose --useStderr --maxWorkers=2 --forceExit test/integration",
+        "test-integration": "jest --verbose --useStderr --maxWorkers=8 --forceExit test/integration",
         "test-exports": "cd test/exports && npm run link && tsc --noEmit --project ./tsconfig.json && npm test",
         "test-integration-no-resend": "jest --verbose --useStderr --forceExit --testTimeout=30000 --testPathIgnorePatterns='resend|Resend' --testNamePattern='^((?!(resend|Resend|resent|Resent|gap|Gap)).)*$' test/integration/*.test.*",
         "test-integration-resend": "jest --verbose --useStderr --forceExit --testTimeout=40000 --testNamePattern='(resend|Resend|resent|Resent)' test/integration/*.test.*",

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -203,25 +203,27 @@ class StreamrStream implements StreamMetadata {
         return this._streamRegistry.hasPublicPermission(this.id, permission)
     }
 
-    // async hasUserPermissions(operations: StreamPermission[], userId: string) {
-    //     this.assertUserId(userId)
-    //     const permissions = this._streamRegistry.getPermissionsForUser(this.id, userId, )
-    //     return this.hasPermissions(operations, userId)
-    // }
-    // async hasPermissions(operations: StreamPermission[], userId: string) {
-    //     const permissions = await this._streamRegistry.getPermissionsForUser(this.id, userId)
+    async hasUserPermissions(requestedPermissions: StreamPermission[], userId: string): Promise<boolean> {
+        this.assertUserId(userId)
+        const permissions = await this._streamRegistry.getDirectPermissionsForUser(this.id, userId)
+        for (const requestedPermission of requestedPermissions) {
+            if (!permissions[requestedPermission]) {
+                return false
+            }
+        }
+        return true
+    }
 
-    //     if (operation === StreamPermission.PUBLISH || operation === StreamPermission.SUBSCRIBE) {
-    //         return permissions[operation].gt(Date.now())
-    //     }
-    //     return permissions[operation]
-    // }
-
-    // async hasPermission(operation: StreamPermission, userId: string|undefined) {
-    //     const permissions = await this.hasPermissions([operation], userId)
-    //     if (!Array.isArray(permissions) || !permissions.length) { return undefined }
-    //     return permissions[0]
-    // }
+    async hasPermissions(requestedPermissions: StreamPermission[], userId: string): Promise<boolean> {
+        this.assertUserId(userId)
+        const permissions = await this._streamRegistry.getPermissionsForUser(this.id, userId)
+        for (const requestedPermission of requestedPermissions) {
+            if (!permissions[requestedPermission]) {
+                return false
+            }
+        }
+        return true
+    }
 
     async grantUserPermission(permission: StreamPermission, userId: string) {
         try {
@@ -231,15 +233,19 @@ class StreamrStream implements StreamMetadata {
         }
     }
 
-    // private async grantUserPermissions(permissions: StreamPermissions, userId: string) {
-    //     this.assertUserIdOrPublic(userId)
-    //     try {
-    //         await this.setPermissions(userId, permissions.edit, permissions.canDelete,
-    //             permissions.publishExpiration, permissions.subscribeExpiration, permissions.share)
-    //     } finally {
-    //         this._streamEndpointsCached.clearStream(this.id)
-    //     }
-    // }
+    async grantUserPermissions(permissions: StreamPermission[], userId: string) {
+        this.assertUserIdOrPublic(userId)
+        const permissionsBase = await this.getUserPermissions(userId)
+        for (const permission of permissions) {
+            permissionsBase[permission] = true
+        }
+        try {
+            await this.setPermissionsForUser(userId, permissionsBase.canEdit, permissionsBase.canDelete,
+                permissionsBase.canPublish, permissionsBase.canSubscribe, permissionsBase.canGrant)
+        } finally {
+            this._streamEndpointsCached.clearStream(this.id)
+        }
+    }
 
     async grantPublicPermission(permission: StreamPermission) {
         try {
@@ -258,6 +264,20 @@ class StreamrStream implements StreamMetadata {
         }
     }
 
+    async revokeUserPermissions(permissions: StreamPermission[], userId: string) {
+        this.assertUserId(userId)
+        const permissionsBase = await this.getUserPermissions(userId)
+        for (const permission of permissions) {
+            permissionsBase[permission] = false
+        }
+        try {
+            await this.setPermissionsForUser(userId, permissionsBase.canEdit, permissionsBase.canDelete,
+                permissionsBase.canPublish, permissionsBase.canSubscribe, permissionsBase.canGrant)
+        } finally {
+            this._streamEndpointsCached.clearStream(this.id)
+        }
+    }
+
     async revokePublicPermission(permission: StreamPermission) {
         try {
             return this._streamRegistry.revokePublicPermission(this.id, permission)
@@ -265,46 +285,6 @@ class StreamrStream implements StreamMetadata {
             this._streamEndpointsCached.clearStream(this.id)
         }
     }
-
-    // async getMatchingPermissions(operations: StreamPermission[]|false, userId: string|undefined|false): Promise<StreamPermision[]> {
-    //     if (operations && !operations.length) { return [] }
-
-    //     if (userId !== false) {
-    //         this.assertUserIdOrPublic(userId)
-    //     }
-
-    //     const permissions = await this.getPermissions()
-    //     // eth addresses may be in checksumcase, but userId from server has no case
-    //     const userIdCaseInsensitive = typeof userId === 'string' ? userId.toLowerCase() : undefined // if not string then undefined
-    //     const operationSet = new Set<StreamPermission>(operations === false ? [] : operations)
-    //     return permissions.filter((p) => {
-    //         if (operations !== false) {
-    //             if (!operationSet.has(p.operation)) {
-    //                 return false
-    //             }
-    //         }
-
-    //         if (userId !== false) {
-    //             if (userIdCaseInsensitive === undefined) {
-    //                 return !!('anonymous' in p && p.anonymous) // match nullish userId against p.anonymous
-    //             }
-    //             return 'user' in p && p.user && p.user.toLowerCase() === userIdCaseInsensitive // match against userId
-    //         }
-
-    //         return true
-    //     })
-    // }
-
-    // async revokeMatchingPermissions(operations: StreamPermission[], userId: string|undefined) {
-    //     this.assertUserIdOrPublic(userId)
-    //     const matchingPermissions = await this.getMatchingPermissions(operations, userId)
-
-    //     const tasks = matchingPermissions.map(async (p: any) => {
-    //         await this.revokePermission(p.id)
-    //     })
-    //     await Promise.allSettled(tasks)
-    //     await Promise.all(tasks)
-    // }
 
     async revokeAllUserPermissions(userId: string) {
         this.assertUserId(userId)

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -116,10 +116,21 @@ export class StreamRegistry implements Context {
             StreamRegistry.streamPermissionToSolidityType(permission))
     }
 
-    async getPermissionsForUser(streamId: string, userAddress?: EthereumAddress): Promise<StreamPermissions> {
+    async getPermissionsForUser(streamId: string, userAddress: EthereumAddress): Promise<StreamPermissions> {
         await this.connectToStreamRegistryContract()
         this.debug('Getting permissions for stream %s for user %s', streamId, userAddress)
-        const permissions = await this.streamRegistryContract!.getPermissionsForUser(streamId, userAddress || AddressZero)
+        return StreamRegistry.getPermissionsForUserFromChain(streamId, userAddress, this.streamRegistryContract!.getPermissionsForUser)
+
+    }
+
+    async getDirectPermissionsForUser(streamId: string, userAddress: EthereumAddress): Promise<StreamPermissions> {
+        await this.connectToStreamRegistryContract()
+        this.debug('Getting permissions for stream %s for user %s', streamId, userAddress)
+        return StreamRegistry.getPermissionsForUserFromChain(streamId, userAddress, this.streamRegistryContract!.getDirectPermissionsForUser)
+    }
+
+    private static async getPermissionsForUserFromChain(streamId: string, userAddress: EthereumAddress, contractMethod: Function) {
+        const permissions = await contractMethod(streamId, userAddress)
         return {
             canEdit: permissions.canEdit,
             canDelete: permissions.canDelete,

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -525,26 +525,62 @@ function TestStreamEndpoints(getName: () => string, delay: number) {
             })
         })
 
-        describe('Stream.{grant,revoke,has}UserPermissions', () => {
-            // it('creates & revokes permissions for user', async () => {
-            //     await createdStream.revokeAllUserPermissions(otherWallet.address)
-            //     expect(
-            //         await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.GET], otherWallet.address)
-            //     ).not.toBeTruthy()
+        describe('Stream.{grant,revoke,has} Direct UserPermissions', () => {
+            it('creates & revokes permissions for user', async () => {
+                await createdStream.revokeAllUserPermissions(otherWallet.address)
+                expect(
+                    await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.EDIT], otherWallet.address)
+                ).not.toBeTruthy()
 
-            //     await createdStream.grantUserPermissions([StreamPermission.GET, StreamPermission.SUBSCRIBE], otherWallet.address)
+                await createdStream.grantUserPermissions([StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE, StreamPermission.EDIT],
+                    otherWallet.address)
 
-            //     expect(
-            //         await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.GET], otherWallet.address)
-            //     ).toBeTruthy()
+                expect(
+                    await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.PUBLISH, StreamPermission.EDIT],
+                        otherWallet.address)
+                ).toBeTruthy()
 
-            //     // revoke permissions we just created
-            //     await createdStream.revokeUserPermissions([StreamPermission.GET, StreamPermission.SUBSCRIBE], otherWallet.address)
+                // revoke permissions we just created
+                await createdStream.revokeUserPermissions([StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE, StreamPermission.EDIT],
+                    otherWallet.address)
 
-            //     expect(
-            //         await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.GET], otherWallet.address)
-            //     ).not.toBeTruthy()
-            // })
+                expect(
+                    await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.PUBLISH, StreamPermission.EDIT],
+                        otherWallet.address)
+                ).not.toBeTruthy()
+            })
+
+            it('fails if no user id provided', async () => {
+                await expect(async () => {
+                    // @ts-expect-error should require userId, this is part of the test
+                    await createdStream.revokeUserPermissions([StreamPermission.SUBSCRIBE], undefined)
+                }).rejects.toThrow()
+            })
+        })
+        describe('Stream.{grant,revoke,has} UserPermissions', () => {
+            it('creates & revokes permissions for user', async () => {
+                await createdStream.revokeAllUserPermissions(otherWallet.address)
+                expect(
+                    await createdStream.hasUserPermissions([StreamPermission.SUBSCRIBE, StreamPermission.EDIT], otherWallet.address)
+                ).not.toBeTruthy()
+
+                await createdStream.grantPublicPermission(StreamPermission.PUBLISH)
+                await createdStream.grantPublicPermission(StreamPermission.SUBSCRIBE)
+
+                expect(
+                    await createdStream.hasPermissions([StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE],
+                        otherWallet.address)
+                ).toBeTruthy()
+
+                // revoke permissions we just created
+                await createdStream.revokePublicPermission(StreamPermission.PUBLISH)
+                await createdStream.revokePublicPermission(StreamPermission.SUBSCRIBE)
+
+                expect(
+                    await createdStream.hasPermissions([StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE],
+                        otherWallet.address)
+                ).not.toBeTruthy()
+            })
 
             it('fails if no user id provided', async () => {
                 await expect(async () => {


### PR DESCRIPTION
feat: re-enabled grant- and revoke- endpoints taking arrays of permissions, re-enabled their tests