### PR TITLE
NET-610: address in stream.getPermissions()

### DIFF
--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 import '../src/logLevel'
-import StreamrClient from 'streamr-client'
+import _ from 'lodash'
+import StreamrClient, { StreamPermission } from 'streamr-client'
 import { createClientCommand } from '../src/command'
+import { getPermissionId } from '../src/permission'
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: any) => {
     const stream = await client.getStream(streamId)
-    const obj = stream.toObject()
+    const obj: any = stream.toObject()
     if (options.includePermissions) {
-        // TODO the data of stream.getPermissions() should be transformed somehow (NET-610)
-        // @ts-expect-error permissions not on {}
-        obj.permissions = await stream.getPermissions()
+        const permissions = await stream.getPermissions()
+        obj.permissions = _.mapValues(permissions, (p: StreamPermission[]) => p.map(getPermissionId))
     }
     console.info(JSON.stringify(obj, null, 2))
 })

--- a/packages/cli-tools/src/permission.ts
+++ b/packages/cli-tools/src/permission.ts
@@ -20,6 +20,10 @@ export const PERMISSIONS = new Map<string,StreamPermission>([
     ['grant', StreamPermission.GRANT]
 ])
 
+export const getPermissionId = (permission: StreamPermission): string => {
+    return Array.from(PERMISSIONS.entries()).find(([_id, p]) => p === permission)![0]
+}
+
 export const runModifyPermissionsCommand = (
     modifyUserPermission: (stream: Stream, permission: StreamPermission, target: string) => Promise<void>,
     modifyPublicPermission: (stream: Stream, permission: StreamPermission) => Promise<void>,

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -352,8 +352,19 @@ function TestStreamEndpoints(getName: () => string, delay: number) {
         ]
 
         it('Stream.getPermissions', async () => {
-            const permissions = await createdStream.getPermissions()
-            return expect(permissions.length).toBeGreaterThan(0)
+            const stream = await createTestStream(client, module)
+            await stream.grantPublicPermission(StreamPermission.PUBLISH)
+            const permissions = await stream.getPermissions()
+            return expect(permissions).toEqual({
+                [wallet.address.toLowerCase()]: [
+                    StreamPermission.EDIT,
+                    StreamPermission.DELETE,
+                    StreamPermission.PUBLISH,
+                    StreamPermission.SUBSCRIBE,
+                    StreamPermission.GRANT
+                ],
+                public: [StreamPermission.PUBLISH]
+            })
         })
 
         describe('Stream.hasPermission', () => {
@@ -430,7 +441,6 @@ function TestStreamEndpoints(getName: () => string, delay: number) {
                 const previousPermissions = await createdStream.getPermissions()
                 await createdStream.grantPublicPermission(StreamPermission.SUBSCRIBE) // public read
                 const permissions = await createdStream.getPermissions()
-                expect(permissions).toHaveLength(previousPermissions.length)
                 expect(permissions).toEqual(previousPermissions)
             })
 


### PR DESCRIPTION
Modified `stream.getPermissions()` method to include addresses of permission assignments.

To support that, the return type has been restructured. The new return type is 
`Record<EthereumAddress|'public', StreamPermission[]>`

E.g. 
```
{
    '0x11111...': [StreamPermission.EDIT, StreamPermission.DELETE, ...],
    '0x22222...': [StreamPermission.PUBLISH],
    'public': [StreamPermission.SUBSCRIBE]
}
```

Updated the CLI-tools to use the new format in `stream show` command:
```
stream show 0x1111111111111111111111111111111111111111/foobar --include-permissions
{
  "id": "0x1111111111111111111111111111111111111111/foobar",
  ...
  "permissions": {
    "public": [
      "subscribe"
    ],
    "0x1111111111111111111111111111111111111111": [
      "edit",
      "delete",
      "publish",
      "subscribe",
      "grant"
    ],
    "0x2222222222222222222222222222222222222222": [
      "publish"
    ]
  }
}
```

### Open question

Should the `Stream.getPermissions` test wait until the permissions have been propagated to The Graph?