### PR TITLE
NET-658: avoid warning logs during client integration tests

### DIFF
--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -233,7 +233,7 @@ export class LeaksDetector {
         'rovider/formatter',
     ])
 
-    private counter = CounterId(this.id)
+    private counter = CounterId(this.id, { maxPrefixes: 1024 })
 
     add(name: string, obj: any) {
         if (!obj || typeof obj !== 'object') { return }


### PR DESCRIPTION
- Detecting memory leaks for tests sets over 500 components to CounterId, the maxPrefix setting is increased to avoid console.warn pam during client integration tests