### PR TITLE
NET-663: fix hanging resources in broker tests

### DIFF
--- a/packages/broker/jest.config.js
+++ b/packages/broker/jest.config.js
@@ -1,36 +1,12 @@
-const path = require('path')
-
-// process.env.DEBUG = '*'
-
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-
-    // Preset ts-jest
-    preset: 'ts-jest',
-
-    // Automatically clear mock calls and instances between every test
-    clearMocks: true,
-
-    // An array of glob patterns indicating a set of files for which coverage information should be collected
-    collectCoverageFrom: ['src/**'],
-
-    // The directory where Jest should output its coverage files
-    coverageDirectory: 'coverage',
-
-    globalTeardown: './jest.teardown.js',
-   
     preset: 'ts-jest/presets/js-with-ts',
-
-    // This option allows use of a custom test runner
+    clearMocks: true,
+    globalTeardown: './jest.teardown.js',
     testRunner: 'jest-circus/runner',
-
-    // The test environment that will be used for testing
     testEnvironment: 'node',
-
-    // Default timeout of a test in milliseconds
     testTimeout: 10000,
-
     setupFilesAfterEnv: ["jest-extended"]
 }

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -22,7 +22,7 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "build": "tsc -b tsconfig.node.json",
     "test-unit": "jest test/unit",
-    "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
+    "test-sequential": "jest --forceExit --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
     "test-integration": "jest --forceExit test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -23,7 +23,7 @@
     "build": "tsc -b tsconfig.node.json",
     "test-unit": "jest test/unit",
     "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest test/integration && npm run test-sequential",
+    "test-integration": "jest --forceExit test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -17,13 +17,13 @@
   "scripts": {
     "check": "tsc -p ./tsconfig.json --noEmit",
     "prepare": "npm run build",
-    "test": "jest --forceExit test/unit test/integration && npm run test-sequential",
+    "test": "jest test/unit test/integration && npm run test-sequential",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "build": "tsc -b tsconfig.node.json",
-    "test-unit": "jest test/unit --forceExit --detectOpenHandles",
-    "test-sequential": "jest --maxWorkers=1 test/sequential --forceExit --detectOpenHandles # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --forceExit --detectOpenHandles test/integration && npm run test-sequential",
+    "test-unit": "jest test/unit",
+    "test-sequential": "jest --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest test/integration && npm run test-sequential",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.com>",

--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -49,9 +49,6 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
 
     constructor(options: PluginOptions) {
         super(options)
-        if (this.streamrClient === undefined) {
-            throw new Error('StreamrClient is not available')
-        }
         this.dummyMessagesReceived = 0
         this.rewardSubscriptionRetryRef = null
         this.subscriptionRetryInterval = 3 * 60 * 1000

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -17,9 +17,6 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
 
     constructor(options: PluginOptions) {
         super(options)
-        if (this.streamrClient === undefined) {
-            throw new Error('StreamrClient is not available')   
-        }
     }
 
     async start(): Promise<void> {

--- a/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
+++ b/packages/broker/src/plugins/publishHttp/PublishHttpPlugin.ts
@@ -5,9 +5,6 @@ export class PublishHttpPlugin extends Plugin<void> {
 
     constructor(options: PluginOptions) {
         super(options)
-        if (this.streamrClient === undefined) {
-            throw new Error('StreamrClient is not available')   
-        }
     }
 
     async start(): Promise<void> {

--- a/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
+++ b/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
@@ -22,9 +22,6 @@ export class SubscriberPlugin extends Plugin<SubscriberPluginConfig> {
 
     constructor(options: PluginOptions) {
         super(options)
-        if (this.streamrClient === undefined) {
-            throw new Error('StreamrClient is not available')
-        }
         this.streamParts = this.pluginConfig.streams.map((stream) => {
             return toStreamPartID(toStreamID(stream.streamId), stream.streamPartition)
         })

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -21,9 +21,6 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
 
     constructor(options: PluginOptions) {
         super(options)
-        if (this.streamrClient === undefined) {
-            throw new Error('StreamrClient is not available')   
-        }
     }
 
     async start(): Promise<void> {

--- a/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
@@ -32,7 +32,7 @@ describe('NodeMetrics', () => {
         streamIdPrefix = stream.id.replace('sec', '')
 
         metricsGeneratingBroker = await startBroker({
-            name: 'broker1',
+            name: 'metricsGeneratingBroker',
             privateKey: tmpAccount.privateKey,
             trackerPort,
             extraPlugins: {

--- a/packages/broker/test/integration/plugins/mqtt/MqttServer.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/MqttServer.test.ts
@@ -1,9 +1,9 @@
-import mqtt from 'async-mqtt'
+import mqtt, { AsyncMqttClient } from 'async-mqtt'
 import { MqttServer } from '../../../../src/plugins/mqtt/MqttServer'
 
 const MQTT_PORT = 1883
 
-const createClient = (apiKey?: string) => {
+const createClient = (apiKey?: string): Promise<AsyncMqttClient> => {
     return mqtt.connectAsync('mqtt://localhost:' + MQTT_PORT, (apiKey !== undefined) ? {
         username: '',
         password: apiKey,
@@ -11,9 +11,9 @@ const createClient = (apiKey?: string) => {
 }
 
 describe('MQTT server', () => {
-
-    let server: MqttServer
     const REQUIRED_API_KEY = 'required-api-key'
+    let server: MqttServer
+    let client: AsyncMqttClient
 
     describe('authentication required', () => {
 
@@ -25,11 +25,12 @@ describe('MQTT server', () => {
         })
 
         afterEach(async () => {
-            await server.stop()
+            await client?.end(true)
+            await server?.stop()
         })
 
         it('connect with required authentication', async () => {
-            const client = await createClient(REQUIRED_API_KEY)
+            client = await createClient(REQUIRED_API_KEY)
             expect(client).toBeDefined()
         })
 
@@ -44,7 +45,7 @@ describe('MQTT server', () => {
     })
 
     describe('authentication not required', () => {
-
+        let client: AsyncMqttClient
         let server: MqttServer
 
         beforeEach(async () => {
@@ -55,16 +56,17 @@ describe('MQTT server', () => {
         })
 
         afterEach(async () => {
-            await server.stop()
+            await client?.end(true)
+            await server?.stop()
         })
 
         it('connect without authentication', async () => {
-            const client = await createClient(undefined)
+            client = await createClient(undefined)
             expect(client).toBeDefined()
         })
 
         it('connect with some authentication', async () => { 
-            const client = await createClient('ignorable-api-key')
+            client = await createClient('ignorable-api-key')
             expect(client).toBeDefined()
         })
 

--- a/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
@@ -47,8 +47,8 @@ describe('StorageConfig', () => {
         })
     })
 
-    afterAll(() => {
-        cassandraClient.shutdown()
+    afterAll(async () => {
+        await cassandraClient?.shutdown()
     })
 
     beforeEach(async () => {

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -22,7 +22,7 @@ describe('StorageNode', () => {
 
     beforeAll(async () => {
         storageNodeAccount = new Wallet(await fetchPrivateKeyWithGas())
-        storageNode = await startStorageNode(storageNodeAccount.privateKey, httpPort1, trackerPort)
+        storageNode = await startStorageNode(storageNodeAccount.privateKey, 1234, trackerPort)
     }, 30 * 1000)
 
     afterAll(async () => {

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -8,7 +8,6 @@ import {
 import { Broker } from "../../../../src/broker"
 import StreamrClient from 'streamr-client'
 
-const httpPort1 = 12501
 const trackerPort = 12503
 
 describe('StorageNode', () => {
@@ -29,7 +28,7 @@ describe('StorageNode', () => {
     afterAll(async () => {
         await tracker?.stop()
         await storageNode?.stop()
-        await storageNodeClient?.stop()
+        await storageNodeClient?.destroy()
     })
 
     it('has node id same as address', async () => {

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -113,21 +113,16 @@ describe('cassanda-queries', () => {
                 bucketKeepAliveSeconds: 1
             }
         })
-        realClient = new Client({
-            contactPoints,
-            localDataCenter,
-            keyspace
-        })
+        realClient = storage.cassandraClient
         await Promise.all(MOCK_MESSAGES.map((msg) => storage.store(msg)))
         await waitForStoredMessageCount(MOCK_MESSAGES.length)
     })
 
     afterAll(async () => {
-        await realClient?.shutdown()
-        await storage?.close()
+        await storage?.close() // also cleans up realClient
     })
 
-    beforeEach(() => {
+    beforeEach(async () => {
         const proxyClient = new ProxyClient(realClient) as any
         storage.cassandraClient = proxyClient
         storage.bucketManager.cassandraClient = proxyClient

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -123,6 +123,7 @@ describe('cassanda-queries', () => {
     })
 
     afterAll(async () => {
+        await realClient?.shutdown()
         await storage?.close()
     })
 

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -2,11 +2,12 @@ import { Tracker } from 'streamr-network'
 import { createClient, startTestTracker } from '../../../utils'
 import { Wallet } from 'ethers'
 import { SubscriberPlugin } from '../../../../src/plugins/subscriber/SubscriberPlugin'
+import StreamrClient from 'streamr-client'
 
 const TRACKER_PORT = 12465
 const wallet = Wallet.createRandom()
 
-const createMockPlugin = async (tracker: Tracker) => {
+const createMockPlugin = async (streamrClient: StreamrClient) => {
     const brokerConfig: any = {
         client: {
             auth: {
@@ -34,7 +35,7 @@ const createMockPlugin = async (tracker: Tracker) => {
     }
     return new SubscriberPlugin({
         name: 'subscriber',
-        streamrClient: await createClient(tracker, wallet.privateKey),
+        streamrClient,
         apiAuthenticator: undefined as any,
         brokerConfig
     })
@@ -42,16 +43,19 @@ const createMockPlugin = async (tracker: Tracker) => {
 
 describe('Subscriber Plugin', () => {
     let tracker: Tracker
+    let client: StreamrClient
     let plugin: any
 
     beforeAll(async () => {
         tracker = await startTestTracker(TRACKER_PORT)
-        plugin = await createMockPlugin(tracker)
+        client = await createClient(tracker, wallet.privateKey)
+        plugin = await createMockPlugin(client)
         await plugin.start()
     })
 
     afterAll(async () => {
         await Promise.allSettled([
+            client?.destroy(),
             plugin?.stop(),
             tracker?.stop(),
         ])


### PR DESCRIPTION
- Add some missing stop / destroy / cleanup calls in broker tests `afterEach` / `afterAll` blocks. 
- Remove unnecessary checks for `this.streamrClient === undefined` in broker plugins