### PR TITLE
skip known flaky tests

### DIFF
--- a/packages/broker/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/broker/test/integration/plugins/storage/Storage.test.ts
@@ -294,7 +294,8 @@ describe('Storage', () => {
         })
     })
 
-    test('multiple buckets', async () => {
+    // TODO: fix flaky test in NET-646
+    test.skip('multiple buckets', async () => {
         const messageCount = 3 * MAX_BUCKET_MESSAGE_COUNT
         await storeMockMessages({ streamId, streamPartition: 777, minTimestamp: 123000000, maxTimestamp: 456000000, count: messageCount, storage })
 

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -11,7 +11,7 @@ import { getPublishTestStreamMessages, createTestStream, getCreateClient, descri
 import { storageNodeTestConfig } from './devEnvironment'
 
 const MAX_MESSAGES = 10
-jest.setTimeout(50000)
+jest.setTimeout(3 * 60 * 1000)
 
 function monkeypatchMessageHandler<T = any>(sub: Subscription<T>, fn: ((msg: StreamMessage<T>, count: number) => void | null)) {
     let count = 0
@@ -51,7 +51,7 @@ describeRepeats('GapFill', () => {
         client.debug('connecting before test >>')
         stream = await createTestStream(client, module, {
             requireSignedData: true
-        })
+        }, 120000)
         // const storageNodeClient = await createClient({ auth: {
         //     privateKey: storageNodeTestConfig.privatekey
         // } })
@@ -243,7 +243,7 @@ describeRepeats('GapFill', () => {
                 // new stream, assign to storage node not called
                 stream = await createTestStream(client, module, {
                     requireSignedData: true,
-                })
+                }, 120000)
 
                 await expect(async () => {
                     await client.resend({

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -11,7 +11,7 @@ import { getPublishTestStreamMessages, createTestStream, getCreateClient, descri
 import { storageNodeTestConfig } from './devEnvironment'
 
 const MAX_MESSAGES = 10
-jest.setTimeout(3 * 60 * 1000)
+jest.setTimeout(50000)
 
 function monkeypatchMessageHandler<T = any>(sub: Subscription<T>, fn: ((msg: StreamMessage<T>, count: number) => void | null)) {
     let count = 0
@@ -51,7 +51,7 @@ describeRepeats('GapFill', () => {
         client.debug('connecting before test >>')
         stream = await createTestStream(client, module, {
             requireSignedData: true
-        }, 120000)
+        })
         // const storageNodeClient = await createClient({ auth: {
         //     privateKey: storageNodeTestConfig.privatekey
         // } })
@@ -243,7 +243,7 @@ describeRepeats('GapFill', () => {
                 // new stream, assign to storage node not called
                 stream = await createTestStream(client, module, {
                     requireSignedData: true,
-                }, 120000)
+                })
 
                 await expect(async () => {
                     await client.resend({

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -153,7 +153,8 @@ describeRepeats('Group Key Persistence', () => {
             expect(received).toEqual(published.slice(0, 1))
         }, 2 * TIMEOUT)
 
-        it('subscriber persists group key with resend last', async () => {
+        // TODO: fix flaky test in NET-641b
+        it.skip('subscriber persists group key with resend last', async () => {
             // we want to check that subscriber can read a group key
             // persisted by another subscriber:
             // 1. create publisher and subscriber

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -328,7 +328,8 @@ describe('StreamEndpoints', () => {
             // null, undefined are the public user.
         ]
 
-        it('Stream.getPermissions', async () => {
+        // TODO: fix flaky test in NET-653 / NET-606
+        it.skip('Stream.getPermissions', async () => {
             const stream = await createTestStream(client, module)
             await stream.grantPublicPermission(StreamPermission.PUBLISH)
             const permissions = await stream.getPermissions()

--- a/packages/client/test/unit/IteratorTest.js
+++ b/packages/client/test/unit/IteratorTest.js
@@ -18,7 +18,8 @@ export default function IteratorTest(name, fn) {
             expect(received).toEqual(expected)
         })
 
-        it('can return in finally', async () => {
+        // TODO: fix in NET-621
+        it.skip('can return in finally', async () => {
             const received = []
             const itr = (async function* Outer() {
                 const innerItr = fn({

--- a/packages/client/test/unit/PushBuffer.test.ts
+++ b/packages/client/test/unit/PushBuffer.test.ts
@@ -67,7 +67,8 @@ describe('PushBuffer', () => {
             expect(await pushBuffer.push(expected[1])).toBe(false)
         })
 
-        it('push resolves false if errored', async () => {
+        // TODO: fix flaky test in NET-664
+        it.skip('push resolves false if errored', async () => {
             const err = new Error(counterId('expected error'))
             const pushBuffer = new PushBuffer(3)
             leaksDetector.add('PushBuffer', pushBuffer)

--- a/packages/client/test/unit/PushBuffer.test.ts
+++ b/packages/client/test/unit/PushBuffer.test.ts
@@ -17,7 +17,8 @@ async function* generate(items = expected, waitTime = WAIT) {
     await wait(waitTime * 0.1)
 }
 
-describe('PushBuffer', () => {
+// TODO: fix flaky test in NET-664 / 621
+describe.skip('PushBuffer', () => {
     let leaksDetector: LeaksDetector
 
     beforeEach(async () => {

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -165,15 +165,20 @@ export const createRelativeTestStreamId = (module: NodeModule, suffix?: string) 
     return counterId(`/test/${randomTestRunId}/${getTestName(module)}${(suffix !== undefined) ? '-' + suffix : ''}`, '-')
 }
 
-// eslint-disable-next-line no-undef
-export const createTestStream = async (streamrClient: StreamrClient, module: NodeModule, props?: Partial<StreamProperties>) => {
+export const createTestStream = async (
+    streamrClient: StreamrClient,
+    // eslint-disable-next-line no-undef
+    module: NodeModule,
+    props?: Partial<StreamProperties>,
+    graphTimeoutInMs = 20000
+) => {
     const stream = await streamrClient.createStream({
         id: createRelativeTestStreamId(module),
         ...props
     })
     await until(
         async () => { return streamrClient.streamExistsOnTheGraph(stream.id) },
-        20000,
+        graphTimeoutInMs,
         500, () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
     )
     return stream

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -173,7 +173,7 @@ export const createTestStream = async (streamrClient: StreamrClient, module: Nod
     })
     await until(
         async () => { return streamrClient.streamExistsOnTheGraph(stream.id) },
-        30000,
+        45000,
         500, () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
     )
     return stream

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -165,21 +165,17 @@ export const createRelativeTestStreamId = (module: NodeModule, suffix?: string) 
     return counterId(`/test/${randomTestRunId}/${getTestName(module)}${(suffix !== undefined) ? '-' + suffix : ''}`, '-')
 }
 
-export const createTestStream = async (
-    streamrClient: StreamrClient,
-    // eslint-disable-next-line no-undef
-    module: NodeModule,
-    props?: Partial<StreamProperties>,
-    graphTimeoutInMs = 20000
-) => {
+// eslint-disable-next-line no-undef
+export const createTestStream = async (streamrClient: StreamrClient, module: NodeModule, props?: Partial<StreamProperties>) => {
     const stream = await streamrClient.createStream({
         id: createRelativeTestStreamId(module),
         ...props
     })
     await until(
         async () => { return streamrClient.streamExistsOnTheGraph(stream.id) },
-        graphTimeoutInMs,
-        500, () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
+        20000,
+        500,
+        () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
     )
     return stream
 }

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -171,7 +171,11 @@ export const createTestStream = async (streamrClient: StreamrClient, module: Nod
         id: createRelativeTestStreamId(module),
         ...props
     })
-    await until(async () => { return streamrClient.streamExistsOnTheGraph(stream.id) }, 20000, 500)
+    await until(
+        async () => { return streamrClient.streamExistsOnTheGraph(stream.id) },
+        30000,
+        500, () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
+    )
     return stream
 }
 

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -173,7 +173,7 @@ export const createTestStream = async (streamrClient: StreamrClient, module: Nod
     })
     await until(
         async () => { return streamrClient.streamExistsOnTheGraph(stream.id) },
-        45000,
+        20000,
         500, () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
     )
     return stream

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -285,7 +285,7 @@ export class KeyServer {
     constructor() {
         const app = express()
         app.use(cors())
-        let c = Math.floor((Math.random() * 998) + 1) // TODO: add explanation why needed
+        let c = 1
         app.get('/key', (_req, res) => {
             const hexString = c.toString(16)
             const privateKey = '0x' + hexString.padStart(64, '0')

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -293,6 +293,8 @@ export class KeyServer {
             c += 1
             if (c > 1000) {
                 c = 1
+            } else if (c === 10) { // 10th key broken...
+                c = 11
             }
         })
         this.server = app.listen(KeyServer.KEY_SERVER_PORT)

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -285,7 +285,7 @@ export class KeyServer {
     constructor() {
         const app = express()
         app.use(cors())
-        let c = 1
+        let c = Math.floor((Math.random() * 998) + 1) // TODO: add explanation why needed
         app.get('/key', (_req, res) => {
             const hexString = c.toString(16)
             const privateKey = '0x' + hexString.padStart(64, '0')

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -293,7 +293,13 @@ export class KeyServer {
             c += 1
             if (c > 1000) {
                 c = 1
-            } else if (c === 10) { // 10th key broken...
+            } else if (c === 10) {
+                /*
+                    NET-666: There is something weird about the 10th key '0x0000000000....a'
+                    that causes StreamRegistryContract to read a weird value to msg.sender
+                    that does NOT correspond to the public address. Until that is investigated
+                    and solved, skipping this key.
+                 */
                 c = 11
             }
         })


### PR DESCRIPTION
- Disable known flaky tests for now with Jest's `skip` keyword. They are listed under [NET-620](https://linear.app/streamr/issue/NET-620/flaky-tests) and have their associated tickets' priority increased.
- With respect to [NET-666](https://linear.app/streamr/issue/NET-666/the-mystery-of-key) and the weird behavior of private key `000000000000000000000000000000000000000000000000000000000000000a`, make it so that the `KeyServer` never returns it as a result when fetching a private key.