### PR TITLE
feat(ens): Start chainlink when running tests

### DIFF
--- a/.github/workflows/client-code.yml
+++ b/.github/workflows/client-code.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge brokers trackers nginx smtp graph-deploy-streamregistry-subgraph"
+          services-to-start: "mysql redis core-api cassandra parity-node0 parity-sidechain-node0 bridge brokers trackers nginx smtp graph-deploy-streamregistry-subgraph chainlink"
       - name: Run Test
         run: npm run $TEST_NAME
       - name: Collect docker logs on failure


### PR DESCRIPTION
Add `chainlink` to `services-to-start` to support ENS related tests in `StreamEndpoints.test.ts`