### PR TITLE
NET-672: Skip the unguarded test-breaking code

### DIFF
--- a/packages/client/src/encryption/Encryption.ts
+++ b/packages/client/src/encryption/Encryption.ts
@@ -26,8 +26,6 @@ function getSubtle() {
     return subtle
 }
 
-getSubtle()
-
 export class StreamMessageProcessingError extends StreamMessageError {
     constructor(message = '', streamMessage: StreamMessage) {
         super(`Could not process. ${message}`, streamMessage)


### PR DESCRIPTION
This little function is used in other areas of the code and make things explode when it's actually necessary. Here it behaves more like a environment precondition. So I drop it.

@timoxley, lmk if I'm missing something.