### PR TITLE
client: validate publish parameters

### DIFF
--- a/packages/client/src/PublishPipeline.ts
+++ b/packages/client/src/PublishPipeline.ts
@@ -20,13 +20,12 @@ import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamDefinition } from './types'
 
 export class FailedToPublishError extends Error {
-    definition: string
-    msg
+    publishMetadata
     reason
-    constructor(definition: StreamDefinition, data: PublishMetadata | StreamMessage, reason?: Error) {
-        super(`Failed to publish to stream ${definition} due to: ${reason && reason.stack ? reason.stack : reason}.`)
-        this.definition = JSON.stringify(definition)
-        this.msg = data
+    constructor(publishMetadata: PublishMetadataStrict, reason?: Error) {
+        // eslint-disable-next-line max-len
+        super(`Failed to publish to stream ${JSON.stringify(publishMetadata.streamDefinition)} due to: ${reason && reason.stack ? reason.stack : reason}.`)
+        this.publishMetadata = publishMetadata
         this.reason = reason
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, this.constructor)
@@ -197,7 +196,7 @@ export default class PublishPipeline implements Context, Stoppable {
             await this.streamMessageQueue.push([publishMetadata, defer])
             return await defer
         } catch (err) {
-            const error = new FailedToPublishError(publishMetadata.streamDefinition, publishMetadata, err)
+            const error = new FailedToPublishError(publishMetadata, err)
             defer.reject(error)
             throw error
         } finally {

--- a/packages/client/src/PublishPipeline.ts
+++ b/packages/client/src/PublishPipeline.ts
@@ -112,7 +112,10 @@ export default class PublishPipeline implements Context, Stoppable {
             const { streamDefinition, ...options } = publishMetadata
             try {
                 const [streamId, partition] = await this.streamIdBuilder.toStreamPartElements(streamDefinition)
-                options.partitionKey ??= partition // TODO: add runtime check for both partitionKey AND partition set?
+                if ((partition !== undefined) && (options.partitionKey !== undefined)) {
+                    throw new Error('Invalid combination of "partition" and "partitionKey"')
+                }
+                options.partitionKey ??= partition
                 const streamMessage = await this.messageCreator.create(streamId, options)
                 yield [streamMessage, defer]
             } catch (err) {

--- a/packages/client/test/unit/FakeStreamRegistry.ts
+++ b/packages/client/test/unit/FakeStreamRegistry.ts
@@ -1,6 +1,6 @@
 import { EthereumAddress, StreamID, toStreamID } from 'streamr-client-protocol'
 import { DependencyContainer } from 'tsyringe'
-import { NotFoundError, Stream } from '../../src'
+import { NotFoundError, Stream, StreamPermission } from '../../src'
 import { StreamRegistry } from '../../src/StreamRegistry'
 
 export class FakeStreamRegistry implements Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'> {
@@ -32,5 +32,10 @@ export class FakeStreamRegistry implements Pick<StreamRegistry, 'getStream' | 'i
     async isStreamPublisher(streamId: string, userAddress: EthereumAddress): Promise<boolean> {
         return ((toStreamID(streamId) === this.streamId)
             && (userAddress.toLowerCase() === this.publisher.toLowerCase()))
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async hasPublicPermission(_streamIdOrPath: string, _permission: StreamPermission): Promise<boolean> {
+        return false
     }
 }

--- a/packages/client/test/unit/FakeStreamRegistry.ts
+++ b/packages/client/test/unit/FakeStreamRegistry.ts
@@ -1,0 +1,36 @@
+import { EthereumAddress, StreamID, toStreamID } from 'streamr-client-protocol'
+import { DependencyContainer } from 'tsyringe'
+import { NotFoundError, Stream } from '../../src'
+import { StreamRegistry } from '../../src/StreamRegistry'
+
+export class FakeStreamRegistry implements Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'> {
+
+    private streamId: StreamID
+    private publisher: EthereumAddress
+    private dependencyContainer: DependencyContainer
+
+    constructor(streamId: StreamID, publisher: EthereumAddress, dependencyContainer: DependencyContainer) {
+        this.streamId = streamId
+        this.publisher = publisher
+        this.dependencyContainer = dependencyContainer
+    }
+
+    // path support not implemented
+    async getStream(streamId: string): Promise<Stream> {
+        if (toStreamID(streamId) === this.streamId) {
+            return new Stream({
+                id: this.streamId,
+                partitions: 1,
+            }, this.dependencyContainer)
+            // eslint-disable-next-line no-else-return
+        } else {
+            throw new NotFoundError('Stream not found: id=' + streamId)
+        }
+    }
+
+    // path support not implemented
+    async isStreamPublisher(streamId: string, userAddress: EthereumAddress): Promise<boolean> {
+        return ((toStreamID(streamId) === this.streamId)
+            && (userAddress.toLowerCase() === this.publisher.toLowerCase()))
+    }
+}

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -4,7 +4,6 @@ import { toStreamID } from 'streamr-client-protocol'
 import BrubeckNode from '../../src/BrubeckNode'
 import Publisher from '../../src/Publisher'
 import { initContainer } from '../../src'
-import Ethereum from '../../src/Ethereum'
 import { StreamRegistry } from '../../src/StreamRegistry'
 import { BrubeckContainer } from '../../src/Container'
 import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
@@ -18,12 +17,6 @@ const STREAM_ID = toStreamID('/path', AUTHENTICATED_USER)
 const createMockContainer = (
     brubeckNode: Pick<BrubeckNode, 'publishToNode'>,
 ) => {
-    const ethereum = {
-        isAuthenticated: jest.fn().mockReturnValue(true),
-        getAddress: jest.fn().mockResolvedValue(AUTHENTICATED_USER),
-        canEncrypt: jest.fn(),
-        getStreamRegistryChainProvider: jest.fn()
-    }
     const { childContainer } = initContainer({
         auth: {
             privateKey: PRIVATE_KEY
@@ -33,7 +26,6 @@ const createMockContainer = (
     return childContainer
         .registerInstance(StreamRegistry, streamRegistry as any)
         .registerInstance(BrubeckNode, brubeckNode)
-        .registerInstance(Ethereum, ethereum as any)
         .registerInstance(BrubeckContainer, childContainer)
 }
 

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -1,0 +1,106 @@
+import 'reflect-metadata'
+import { container, DependencyContainer } from 'tsyringe'
+import { toStreamID } from 'streamr-client-protocol'
+import BrubeckNode from '../../src/BrubeckNode'
+import Publisher from '../../src/Publisher'
+import { initContainer, Stream } from '../../src'
+import Ethereum from '../../src/Ethereum'
+import { StreamRegistry } from '../../src/StreamRegistry'
+import { BrubeckContainer } from '../../src/Container'
+import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
+
+const AUTHENTICATED_USER = '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf'
+const PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001'
+const TIMESTAMP = Date.parse('2001-02-03T04:05:06Z')
+const STREAM_ID = toStreamID('/path', AUTHENTICATED_USER)
+
+const createMockContainer = (
+    streamRegistry: Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'>,
+    brubeckNode: Pick<BrubeckNode, 'publishToNode'>,
+) => {
+    const ethereum = {
+        isAuthenticated: jest.fn().mockReturnValue(true),
+        getAddress: jest.fn().mockResolvedValue(AUTHENTICATED_USER),
+        canEncrypt: jest.fn(),
+        getStreamRegistryChainProvider: jest.fn()
+    }
+    const { childContainer } = initContainer({
+        auth: {
+            privateKey: PRIVATE_KEY
+        }
+    }, container)
+    return childContainer
+        .registerInstance(StreamRegistry, streamRegistry)
+        .registerInstance(BrubeckNode, brubeckNode)
+        .registerInstance(Ethereum, ethereum as any)
+        .registerInstance(BrubeckContainer, childContainer)
+}
+
+describe('Publisher', () => {
+
+    let publisher: Pick<Publisher, 'publish'|'stop'>
+    let streamRegistry: Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'>
+    let brubeckNode: Pick<BrubeckNode, 'publishToNode'>
+
+    beforeEach(() => {
+        let mockContainer: DependencyContainer
+        streamRegistry = {
+            getStream: jest.fn().mockImplementation(() => {
+                return new Stream({
+                    id: STREAM_ID,
+                    partitions: 1,
+                }, mockContainer!)
+            }),
+            isStreamPublisher: jest.fn().mockResolvedValue(true)
+        }
+        brubeckNode = {
+            publishToNode: jest.fn()
+        }
+        mockContainer = createMockContainer(streamRegistry, brubeckNode)
+        publisher = mockContainer.resolve(Publisher)
+    })
+
+    it('happy path', async () => {
+        await publisher.publish(STREAM_ID, {
+            foo: 'bar'
+        }, TIMESTAMP)
+        await publisher.stop()
+        expect(streamRegistry.getStream).toBeCalledWith(STREAM_ID)
+        expect(streamRegistry.isStreamPublisher).toBeCalledWith(STREAM_ID, AUTHENTICATED_USER.toLowerCase())
+        expect(brubeckNode.publishToNode).toBeCalledTimes(1)
+        const actual = (brubeckNode.publishToNode as any).mock.calls[0][0]
+        expect(actual).toMatchObject({
+            contentType: 0,
+            encryptionType: 0,
+            groupKeyId: null,
+            messageId: {
+                msgChainId: expect.anything(),
+                publisherId: AUTHENTICATED_USER.toLowerCase(),
+                sequenceNumber: 0,
+                streamId: STREAM_ID,
+                streamPartition: DEFAULT_PARTITION,
+                timestamp: TIMESTAMP
+            },
+            messageType: 27,
+            newGroupKey: null,
+            parsedContent: { foo: 'bar' },
+            prevMsgRef: null,
+            serializedContent: '{"foo":"bar"}',
+            signature: expect.anything(),
+            signatureType: 2
+        })
+    })
+
+    it('partition and partitionKey', async () => {
+        // eslint-disable-next-line max-len
+        const errorMessage = `Failed to publish to stream {"streamId":"${STREAM_ID}","partition":0} due to: Error: Invalid combination of "partition" and "partitionKey`
+        return expect(() => {
+            return publisher.publish({
+                streamId: STREAM_ID,
+                partition: 0
+            }, {
+                foo: 'bar'
+            }, TIMESTAMP, 'mockPartitionKey')
+        }).rejects.toThrow(errorMessage)
+    })
+})


### PR DESCRIPTION
Now `client.publish` throws an error if it is called with `partition` and `partitionKey`. Earlier `partition` was ignored with both were provided (`PublishPipeline:117`).

Fixed the error message of `FailedToPublishError`. Earlier a stream definition was stringified like this: `"Failed to publish to stream [object Object]"`. Also simplified the constructor parameters and fields of the class.

Added unit test for `Publisher` class and a unit test helper class `FakeStreamRegistry`.

