### PR TITLE
cli-tools: Rename partition-key argument in stream "publish command"

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Breaking) Rename `--config` argument to `--stream-config` in `stream create`
 - (Breaking) Remove `stream list` command
 - Add `stream search` command
+- (Breaking) Rename `--partition-key` argument to `--partition-key-field` in `stream publish`
 - Bump dependency streamr-client to 6.1.0
 - Bump dependency commander to 8.3.0
 


### PR DESCRIPTION
Renamed to `partition-key-field` as it actually gets the partition key from the content and doesn't use the partition key as it is.

Similar naming convention is used e.g. in Broker `websocketPlugin`: https://github.com/streamr-dev/network-monorepo/blob/826e8ce71aa6146985f7605c9b463090ff1521a9/packages/broker/src/plugins/websocket/PublishConnection.ts#L34