### PR TITLE
test-utils: add logging to KeyServer

### DIFF
--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -278,11 +278,11 @@ export const toReadableStream = (...args: unknown[]): Readable => {
  * Used to spin up an HTTP server used by integration tests to fetch private keys having non-zero ERC-20 token
  * balances in streamr-docker-dev environment.
  */
+/* eslint-disable no-console */
 export class KeyServer {
     public static readonly KEY_SERVER_PORT = 45454
     private readonly server: http.Server
 
-    /* eslint-disable no-console */
     constructor() {
         const app = express()
         app.use(cors())
@@ -317,6 +317,7 @@ export class KeyServer {
                 if (err) {
                     reject(err)
                 } else {
+                    console.info(`closed keyserver on port ${KeyServer.KEY_SERVER_PORT}`)
                     resolve(true)
                 }
             })

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -282,6 +282,7 @@ export class KeyServer {
     public static readonly KEY_SERVER_PORT = 45454
     private readonly server: http.Server
 
+    /* eslint-disable no-console */
     constructor() {
         const app = express()
         app.use(cors())
@@ -303,7 +304,11 @@ export class KeyServer {
                 c = 11
             }
         })
+        console.info(`starting up keyserver on port ${KeyServer.KEY_SERVER_PORT}...`)
         this.server = app.listen(KeyServer.KEY_SERVER_PORT)
+            .on('listening', () => {
+                console.info(`keyserver started on port ${KeyServer.KEY_SERVER_PORT}`)
+            })
     }
 
     destroy(): Promise<unknown> {


### PR DESCRIPTION
Was seeing a weird situation happen in CI where keyserver could not be started due to port conflict. Adding logging so that when this occurs again, we have more information to work with.