### PR TITLE
feat(network): add backwards compatibility to tracker for TN3 status

### DIFF
--- a/packages/network/src/logic/tracker/Tracker.ts
+++ b/packages/network/src/logic/tracker/Tracker.ts
@@ -118,6 +118,11 @@ export class Tracker extends EventEmitter {
             return
         }
 
+        // TODO: Testnet (3rd iteration) compatibility, rm when no more testnet nodes
+        if (statusMessage.status.stream !== undefined) {
+            statusMessage.status.streamPart = statusMessage.status.stream
+        }
+
         this.metrics.record('processNodeStatus', 1)
         const status = statusMessage.status as Status
         const isMostRecent = this.instructionCounter.isMostRecent(status, source)


### PR DESCRIPTION
Add backwards compatibility to tracker for Testnet-3 nodes status
messages. Should be removed when Brubeck is launched and testnet nodes
are no longer present (at least in large amounts).