### PR TITLE
CI: clean up broker streamr-docker-dev stack

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "cassandra init-keyspace nginx parity-sidechain-node0 graph-deploy-streamregistry-subgraph parity-node0"
+          services-to-start: "cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph parity-node0"
       - run: npm run test-integration
         env:
           CI: true

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "parity-node0 parity-sidechain-node0 cassandra init-keyspace graph-deploy-streamregistry-subgraph"
+          services-to-start: "nginx trackers parity-node0 parity-sidechain-node0 broker-node-no-storage-1 graph-deploy-streamregistry-subgraph"
       - run: |
           for (( i=0; i < 5; i=i+1 )); do
               curl -s http://localhost:8791/api/v1/volume;

--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Start Streamr Docker Stack
         uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
         with:
-          services-to-start: "nginx trackers parity-node0 parity-sidechain-node0 broker-node-no-storage-1 graph-deploy-streamregistry-subgraph"
+          services-to-start: "parity-node0 parity-sidechain-node0 cassandra init-keyspace graph-deploy-streamregistry-subgraph"
       - run: |
           for (( i=0; i < 5; i=i+1 )); do
               curl -s http://localhost:8791/api/v1/volume;


### PR DESCRIPTION
Tiny change on my quest to make things a tiny wee faster. Service `nginx` not needed in broker tests.