### PR TITLE
ETH-215: Search stream by id and permissions

### DIFF
--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -67,11 +67,43 @@ Useful for generating test data to be published to a stream with `publish`, e.g.
 streamr mock-data generate | streamr stream publish <streamId> --private-key <key>
 ```
 
-### list
-Fetch a list of streams that are accessible to the user authenticated by the private key
+### search
+Query a list of streams by a search term and/or permissions. E.g.:
 ```
-streamr stream list --private-key <key>
+streamr stream search foobar --user 0x1234567890123456789012345678901234567890
 ```
+
+#### Search term
+A search term query searchers over the stream id field. E.g:
+```
+streamr stream search foobar
+```
+It could find these streams:
+```
+0x1234567890123456789012345678901234567890/abc/foobar/1
+foobar.eth/lorem-ipsum
+```
+
+#### Permission
+A permission query searches over stream permissions. You can either query by direct permissions (which are explicitly granted to a user), or by all permissions (including public permissions, which apply to all users).
+
+E.g. all streams where a user has some direct permission:
+```
+streamr stream search --user 0x1234567890123456789012345678901234567890
+```
+All streams accessible by a user:
+```
+streamr stream search --user 0x1234567890123456789012345678901234567890 --public
+```
+
+The argument of the `--user` option can be omitted. In that case, it defaults to the authenticated user (specified by `--private-key`).
+
+It is also possible to filter by specific permissions by using `--all` and `--any`. E.g. if you want to find the streams you can subscribe to:
+```
+streamr stream search --user --public --all subscribe --private-key <key>
+```
+
+If more than one permission is needed, specify the permissions in a comma-separated list (e.g. `--all subscribe,publish`). It returns streams where _all_ listed permissions are granted. If just _any_ of the permissions is required, use `--any` instead of `--all`. Please prefer `--all` to `--any` when possible as it has better query performance.
 
 ### show
 Show detailed information about a specific stream

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -1,14 +1,54 @@
 #!/usr/bin/env node
 import '../src/logLevel'
-import StreamrClient from 'streamr-client'
+import StreamrClient, { SearchStreamsPermissionFilter, StreamPermission } from 'streamr-client'
 import { createClientCommand } from '../src/command'
+import { Option } from 'commander'
+import { getPermission, PERMISSIONS } from '../src/permission'
+import { getOptionType, OptionType } from '../src/common'
 
-createClientCommand(async (client: StreamrClient, term: string) => {
-    const streams = client.searchStreams(term)
+const createPermissionFilter = async (
+    user: string | boolean | undefined,
+    allowPublic: boolean | undefined,
+    allOf: StreamPermission[] | undefined,
+    anyOf: StreamPermission[] | undefined,
+    client: StreamrClient
+): Promise<SearchStreamsPermissionFilter| undefined> => {
+    if (user !== undefined) {
+        return {
+            user: (getOptionType(user) === OptionType.ARGUMENT) ? user as string : await client.getAddress(),
+            allowPublic: allowPublic ?? false,
+            allOf,
+            anyOf
+        }
+    } else if ((allowPublic !== undefined) || (allOf !== undefined) || (anyOf !== undefined)) {
+        console.error('specify a user with "--user" when using "--public", "--all" or "--any"')
+        process.exit(1)
+    }
+}
+
+const createPermissionListOption = (id: string) => {
+    return new Option(`--${id} <permissions>`, 'comma-separated list of permissions')
+        .choices(Array.from(PERMISSIONS.keys()))
+        .argParser((value: string) => value.split(',').map((id) => getPermission(id)))
+}
+
+createClientCommand(async (client: StreamrClient, term: string, options: any ) => {
+    const permissionFilter = await createPermissionFilter(
+        options.user,
+        options.public,
+        options.all,
+        options.any,
+        client
+    )
+    const streams = client.searchStreams(term, permissionFilter)
     for await (const stream of streams) {
         console.log(stream.id)
     }
 })
-    .arguments('<term>')
+    .arguments('[term]')
     .description('search streams')
+    .option('--user [user]', 'a stream must have permissions for the given user, defaults to the authenticated user')
+    .option('--public', 'the permission can be implicit (a public permission to the stream)')
+    .addOption(createPermissionListOption('all'))
+    .addOption(createPermissionListOption('any'))
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -32,7 +32,7 @@ const createPermissionListOption = (id: string) => {
         .argParser((value: string) => value.split(',').map((id) => getPermission(id)))
 }
 
-createClientCommand(async (client: StreamrClient, term: string, options: any ) => {
+createClientCommand(async (client: StreamrClient, term: string | undefined, options: any ) => {
     const permissionFilter = await createPermissionFilter(
         options.user,
         options.public,

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -1,15 +1,12 @@
 #!/usr/bin/env node
 import '../src/logLevel'
-import EasyTable from 'easy-table'
 import StreamrClient from 'streamr-client'
 import { createClientCommand } from '../src/command'
 
 createClientCommand(async (client: StreamrClient, term: string) => {
-    const streams = await client.searchStreams(term)
-    if (streams.length > 0) {
-        console.info(EasyTable.print(streams.map(({id}) => ({
-            id
-        }))))
+    const streams = client.searchStreams(term)
+    for await (const stream of streams) {
+        console.log(stream.id)
     }
 })
     .arguments('<term>')

--- a/packages/cli-tools/src/common.ts
+++ b/packages/cli-tools/src/common.ts
@@ -4,6 +4,21 @@ export interface GlobalCommandLineArgs {
     privateKey?: string
 }
 
+export enum OptionType {
+    FLAG, // e.g. "--enable"
+    ARGUMENT  // e.g. "--private-key 0x1234"
+}
+
+export const getOptionType = (value: string | boolean): OptionType | never => {
+    if (typeof value === 'boolean') {
+        return OptionType.FLAG
+    } else if (typeof value === 'string') {
+        return OptionType.ARGUMENT
+    } else {
+        throw new Error(`unknown option type (value: ${value})`)
+    }
+}
+
 export function createFnParseInt(name: string): (s: string) => number {
     return (str: string) => {
         const n = parseInt(str, 10)

--- a/packages/cli-tools/src/permission.ts
+++ b/packages/cli-tools/src/permission.ts
@@ -20,7 +20,7 @@ export const PERMISSIONS = new Map<string,StreamPermission>([
     ['grant', StreamPermission.GRANT]
 ])
 
-export const getPermission = (id: string): StreamPermission => {
+export const getPermission = (id: string): StreamPermission | never => {
     const result = PERMISSIONS.get(id)
     if (result === undefined) {
         throw new Error(`unknown permission: ${id}`)

--- a/packages/cli-tools/src/permission.ts
+++ b/packages/cli-tools/src/permission.ts
@@ -20,6 +20,14 @@ export const PERMISSIONS = new Map<string,StreamPermission>([
     ['grant', StreamPermission.GRANT]
 ])
 
+export const getPermission = (id: string): StreamPermission => {
+    const result = PERMISSIONS.get(id)
+    if (result === undefined) {
+        throw new Error(`unknown permission: ${id}`)
+    }
+    return result
+}
+
 export const getPermissionId = (permission: StreamPermission): string => {
     return Array.from(PERMISSIONS.entries()).find(([_id, p]) => p === permission)![0]
 }

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -23,11 +23,12 @@ import { GraphQLClient } from './utils/GraphQLClient'
 import { fetchSearchStreamsResultFromTheGraph, SearchStreamsPermissionFilter, SearchStreamsQueryItem } from './searchStreams'
 import { filter, map } from './utils/GeneratorUtils'
 
-export type PermissionQueryResult = {
+type PermissionQueryResult = {
     id: string
     userAddress: string
 } & ChainPermissions
 
+/** @internal */
 export type ChainPermissions = {
     canEdit: boolean
     canDelete: boolean
@@ -36,21 +37,19 @@ export type ChainPermissions = {
     canGrant: boolean
 }
 
-export type StreamPermissionsQueryResult = {
+type StreamPermissionsQueryResult = {
     id: string
     metadata: string
     permissions: PermissionQueryResult[]
 }
 
+/** @internal */
 export type StreamQueryResult = {
     id: string,
     metadata: string
 }
 
-export type FilteredStreamListQueryResult = {
-    streams: StreamPermissionsQueryResult[]
-}
-
+/** @internal */
 export type SingleStreamQueryResult = {
     stream: StreamPermissionsQueryResult | null
 }

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -20,12 +20,7 @@ import {
 import { AddressZero, MaxInt256 } from '@ethersproject/constants'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { GraphQLClient } from './utils/GraphQLClient'
-
-export interface SearchStreamsOptions {
-    order?: 'asc'|'desc'
-    max?: number
-    offset?: number
-}
+import { SearchStreamsPermissionFilter } from './searchStreams'
 
 export type PermissionQueryResult = {
     id: string
@@ -477,10 +472,9 @@ export class StreamRegistry implements Context {
         }
     }
 
-    async searchStreams(term: string, opts: SearchStreamsOptions = {}): Promise<Stream[]> {
-        this.debug('Getting all streams from thegraph that match filter %s %o', term, opts)
-        const response = await this.graphQLClient.sendQuery(StreamRegistry.buildSearchStreamsQuery(term, opts)) as FilteredStreamListQueryResult
-        return response.streams.map((s) => this.parseStream(toStreamID(s.id), s.metadata))
+    searchStreams(term?: string | undefined, permissionsFilter?: SearchStreamsPermissionFilter | undefined): AsyncGenerator<Stream> {
+        this.debug('Search streams term=%s permissions=%j', term, permissionsFilter)
+        return undefined as any
     }
 
     async getStreamPublishers(streamIdOrPath: string, pagesize: number = 1000) {

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -8,7 +8,7 @@ export * from './encryption/Encryption'
 export * from './Subscriber'
 export * from './LoginEndpoints'
 export * from './StreamEndpoints'
-export { SearchStreamsOptions } from './StreamRegistry'
+export { SearchStreamsPermissionFilter } from './searchStreams'
 import ConfigTest from './ConfigTest'
 import validateConfig from './ConfigBase'
 

--- a/packages/client/src/searchStreams.ts
+++ b/packages/client/src/searchStreams.ts
@@ -45,13 +45,13 @@ export async function* fetchSearchStreamsResultFromTheGraph(
 
     if (permissionFilter !== undefined) {
         /*
-         * Usually The Graph returns only assigments which contains one or more granted permissions
-         * as The Graphs adds the Permission entity to the index only when we grant a permission.
-         * But if a user revokes all permissions from an assignment, The Graph doesn't remove the
-         * entity. Therefore we may receive an assignment which doesn't have any permissions granted.
-         * Similar situation may happen also when some expirable permission (subscribe or publish)
-         * expire as the expiration doesn't trigger the removal of the Permission entity.
-         * -> To filter out these empty assignments, we define a fallback value for anyOf filter
+         * There are situations where the The Graph may contain empty assignments (all boolean flags false,
+         * and all expirations in the past). E.g.:
+         * - if we granted some permissions to a user, but then removed all those permissions
+         * - if we granted an expirable permission (subscribe or publish), and it has now expired
+         * We don't want to return empty assignments to the user, because from user's perspective those are
+         * non-existing assignments.
+         * -> Here we filter out the empty assignments by defining a fallback value for anyOf filter
          */
         const anyOf = permissionFilter.anyOf ?? Object.values(StreamPermission) as StreamPermission[]
         yield* filter(withoutDuplicates, (item: SearchStreamsResultItem) => {

--- a/packages/client/src/searchStreams.ts
+++ b/packages/client/src/searchStreams.ts
@@ -1,0 +1,13 @@
+/* eslint-disable padding-line-between-statements */
+import { EthereumAddress} from 'streamr-client-protocol'
+import { StreamPermission } from './Stream'
+
+export interface SearchStreamsPermissionFilter {
+    user: EthereumAddress
+    /*
+     * If possible, prefer allOf to anyOf because the query performance is better
+     */
+    allOf?: StreamPermission[]
+    anyOf?: StreamPermission[]
+    allowPublic: boolean
+}

--- a/packages/client/src/searchStreams.ts
+++ b/packages/client/src/searchStreams.ts
@@ -15,7 +15,7 @@ export interface SearchStreamsPermissionFilter {
     allowPublic: boolean
 }
 
-export type SearchStreamsQueryItem = {
+export type SearchStreamsResultItem = {
     id: string
     userAddress: string
     stream: StreamQueryResult
@@ -25,8 +25,8 @@ export async function* fetchSearchStreamsResultFromTheGraph(
     term: string | undefined,
     permissionFilter: SearchStreamsPermissionFilter | undefined,
     graphQLClient: GraphQLClient,
-): AsyncGenerator<SearchStreamsQueryItem> {
-    const backendResults = graphQLClient.fetchPaginatedResults<SearchStreamsQueryItem>(
+): AsyncGenerator<SearchStreamsResultItem> {
+    const backendResults = graphQLClient.fetchPaginatedResults<SearchStreamsResultItem>(
         (lastId: string, pageSize: number) => buildQuery(term, permissionFilter, lastId, pageSize)
     )
     /*
@@ -54,8 +54,8 @@ export async function* fetchSearchStreamsResultFromTheGraph(
          * -> To filter out these empty assignments, we define a fallback value for anyOf filter
          */
         const anyOf = permissionFilter.anyOf ?? Object.values(StreamPermission) as StreamPermission[]
-        yield* filter(withoutDuplicates, (item: SearchStreamsQueryItem) => {
-            const actual = StreamRegistry.getPermissionsFromChainPermissions(item)
+        yield* filter(withoutDuplicates, (item: SearchStreamsResultItem) => {
+            const actual = StreamRegistry.convertChainPermissionsToStreamPermissions(item)
             return anyOf.some((p) => actual.includes(p))
         })
     } else {

--- a/packages/client/src/searchStreams.ts
+++ b/packages/client/src/searchStreams.ts
@@ -1,6 +1,9 @@
 /* eslint-disable padding-line-between-statements */
-import { EthereumAddress} from 'streamr-client-protocol'
+import { EthereumAddress } from 'streamr-client-protocol'
 import { StreamPermission } from './Stream'
+import { ChainPermissions, PUBLIC_PERMISSION_ADDRESS, StreamQueryResult, StreamRegistry } from './StreamRegistry'
+import { GraphQLClient } from './utils/GraphQLClient'
+import { filter, unique } from './utils/GeneratorUtils'
 
 export interface SearchStreamsPermissionFilter {
     user: EthereumAddress
@@ -10,4 +13,111 @@ export interface SearchStreamsPermissionFilter {
     allOf?: StreamPermission[]
     anyOf?: StreamPermission[]
     allowPublic: boolean
+}
+
+export type SearchStreamsQueryItem = {
+    id: string
+    userAddress: string
+    stream: StreamQueryResult
+} & ChainPermissions
+
+export async function* fetchSearchStreamsResultFromTheGraph(
+    term: string | undefined,
+    permissionFilter: SearchStreamsPermissionFilter | undefined,
+    graphQLClient: GraphQLClient,
+): AsyncGenerator<SearchStreamsQueryItem> {
+    const backendResults = graphQLClient.fetchPaginatedResults<SearchStreamsQueryItem>(
+        (lastId: string, pageSize: number) => buildQuery(term, permissionFilter, lastId, pageSize)
+    )
+    /*
+     * There can be orphaned permission entities if a stream is deleted (currently
+     * we don't remove the assigned permissions, see ETH-222)
+     * TODO remove the filtering when ETH-222 has been implemented
+     */
+    const withoutOrphaned = filter(backendResults, (p) => p.stream !== null)
+    /*
+     * As we query via permissions entity, any stream can appear multiple times (once per
+     * permission user) if we don't do have exactly one userAddress in the GraphQL query.
+     * That is the case if no permission filter is defined at all, or if permission.allowPublic
+     * is true (then it appears twice: once for the user, and once for the public address).
+     */
+    const withoutDuplicates = unique(withoutOrphaned, (p) => p.stream.id)
+
+    if (permissionFilter !== undefined) {
+        /*
+         * Usually The Graph returns only assigments which contains one or more granted permissions
+         * as The Graphs adds the Permission entity to the index only when we grant a permission.
+         * But if a user revokes all permissions from an assignment, The Graph doesn't remove the
+         * entity. Therefore we may receive an assignment which doesn't have any permissions granted.
+         * Similar situation may happen also when some expirable permission (subscribe or publish)
+         * expire as the expiration doesn't trigger the removal of the Permission entity.
+         * -> To filter out these empty assignments, we define a fallback value for anyOf filter
+         */
+        const anyOf = permissionFilter.anyOf ?? Object.values(StreamPermission) as StreamPermission[]
+        yield* filter(withoutDuplicates, (item: SearchStreamsQueryItem) => {
+            const actual = StreamRegistry.getPermissionsFromChainPermissions(item)
+            return anyOf.some((p) => actual.includes(p))
+        })
+    } else {
+        yield* withoutDuplicates
+    }
+}
+
+/*
+ * Note that we query the results via permissions entity even if there is no permission filter
+ * defined. It is maybe possible to optimize the non-permission related queries by searching over
+ * the Stream entity. To support that we'd need to add a new field to The Graph (e.g. "idAsString"),
+ * as we can't do substring filtering by Stream id field (there is no "id_contains" because
+ * ID type is not a string)
+ */
+const buildQuery = (
+    term: string | undefined,
+    permissionFilter: SearchStreamsPermissionFilter | undefined,
+    lastId: string,
+    pageSize: number
+): string => {
+    const variables: Record<string, any> = {
+        stream_contains: term,
+        id_gt: lastId
+    }
+    if (permissionFilter !== undefined) {
+        variables.userAddress_in = [permissionFilter.user]
+        if (permissionFilter.allowPublic) {
+            variables.userAddress_in.push(PUBLIC_PERMISSION_ADDRESS)
+        }
+        if (permissionFilter.allOf !== undefined) {
+            const now = String(Date.now())
+            variables.canEdit = permissionFilter.allOf.includes(StreamPermission.EDIT)
+            variables.canDelete = permissionFilter.allOf.includes(StreamPermission.DELETE)
+            variables.publishExpiration_gt = permissionFilter.allOf.includes(StreamPermission.PUBLISH) ? now : undefined
+            variables.subscribeExpiration_gt = permissionFilter.allOf.includes(StreamPermission.SUBSCRIBE) ? now : undefined
+            variables.canGrant = permissionFilter.allOf.includes(StreamPermission.GRANT)
+        }
+    }
+    const query = `
+        query (
+            $stream_contains: String,
+            $userAddress_in: [Bytes!]
+            $canEdit: Boolean
+            $canDelete: Boolean
+            $publishExpiration_gt: BigInt
+            $subscribeExpiration_gt: BigInt
+            $canGrant: Boolean
+            $id_gt: String
+        ) {
+            permissions (first: ${pageSize} ${GraphQLClient.createWhereClause(variables)}) {
+                id
+                stream {
+                    id
+                    metadata
+                }
+                userAddress
+                canEdit
+                canDelete
+                publishExpiration
+                subscribeExpiration
+                canGrant
+            }
+        }`
+    return JSON.stringify({ query, variables })
 }

--- a/packages/client/src/utils/GeneratorUtils.ts
+++ b/packages/client/src/utils/GeneratorUtils.ts
@@ -149,3 +149,17 @@ export async function consume<InType>(
 ): Promise<void> {
     return noopConsume(forEach(src, fn, onError))
 }
+
+export async function* unique<T>(
+    source: AsyncGenerator<T>,
+    getIdentity: (item: T) => string
+): AsyncGenerator<T> {
+    const seenIdentities = new Set<string>()
+    for await (const item of source) {
+        const identity = getIdentity(item)
+        if (!seenIdentities.has(identity)) {
+            seenIdentities.add(identity)
+            yield item
+        }
+    }
+}

--- a/packages/client/src/utils/GraphQLClient.ts
+++ b/packages/client/src/utils/GraphQLClient.ts
@@ -44,4 +44,29 @@ export class GraphQLClient {
         }
         return resJson.data
     }
+
+    async* fetchPaginatedResults<T extends { id: string }>(
+        createQuery: (lastId: string, pageSize: number) => string,
+        pageSize = 1000
+    ): AsyncGenerator<T, void, undefined> {
+        let lastResultSet: T[] | undefined
+        do {
+            const lastId = (lastResultSet !== undefined) ? lastResultSet[lastResultSet.length - 1].id : ''
+            const query = createQuery(lastId, pageSize)
+            // eslint-disable-next-line no-await-in-loop
+            const response = await this.sendQuery(query)
+            const rootKey = Object.keys(response)[0] // there is a always a one root level property, e.g. "streams" or "permissions"
+            const items: T[] = (response as any)[rootKey] as T[]
+            yield* items
+            lastResultSet = items
+        } while (lastResultSet.length === pageSize)
+    }
+
+    static createWhereClause(variables: Record<string, any>): string {
+        const parameterList = Object.keys(variables)
+            .filter((k) => variables[k] !== undefined)
+            .map((k) => k + ': $' + k)
+            .join(' ')
+        return `where: { ${parameterList} }`
+    }
 }

--- a/packages/client/src/utils/GraphQLClient.ts
+++ b/packages/client/src/utils/GraphQLClient.ts
@@ -1,0 +1,47 @@
+import fetch from 'node-fetch'
+import { scoped, Lifecycle, inject } from 'tsyringe'
+import { instanceId } from './index'
+import { Config, StrictStreamrClientConfig } from '../Config'
+import { Context } from './Context'
+import { Debugger } from 'debug'
+
+@scoped(Lifecycle.ContainerScoped)
+export class GraphQLClient {
+
+    private debug: Debugger
+
+    constructor(
+        context: Context,
+        @inject(Config.Root) private config: StrictStreamrClientConfig
+    ) {
+        this.debug = context.debug.extend(instanceId(this))
+    }
+
+    async sendQuery(gqlQuery: string): Promise<Object> {
+        this.debug('GraphQL query: %s', gqlQuery)
+        const res = await fetch(this.config.theGraphUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                accept: '*/*',
+            },
+            body: gqlQuery
+        })
+        const resText = await res.text()
+        let resJson
+        try {
+            resJson = JSON.parse(resText)
+        } catch {
+            throw new Error(`GraphQL query failed with "${resText}", check that your theGraphUrl="${this.config.theGraphUrl}" is correct`)
+        }
+        this.debug('GraphQL response: %o', resJson)
+        if (!resJson.data) {
+            if (resJson.errors && resJson.errors.length > 0) {
+                throw new Error('GraphQL query failed: ' + JSON.stringify(resJson.errors.map((e: any) => e.message)))
+            } else {
+                throw new Error('GraphQL query failed')
+            }
+        }
+        return resJson.data
+    }
+}

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -1,0 +1,201 @@
+import { Wallet } from 'ethers'
+import StreamrClient, { ConfigTest, SearchStreamsPermissionFilter, Stream, StreamPermission } from '../../src'
+import { until } from '../../src/utils'
+import { collect } from '../../src/utils/GeneratorUtils'
+import { fakeAddress, getPrivateKey } from '../utils'
+
+jest.setTimeout(30 * 1000)
+
+const SEARCH_TERM = `mock-search-term-${Date.now()}`
+
+describe('SearchStreams', () => {
+
+    let client: StreamrClient
+    let streamWithoutPermission: Stream
+    let streamWithUserPermission: Stream
+    let streamWithPublicPermission: Stream
+    let streamWithUserAndPublicPermission: Stream
+    let streamWithGrantedAndRevokedPermission: Stream
+    const searcher = Wallet.createRandom()
+
+    const waitUntilStreamsExistOnTheGraph = async (streams: Stream[]) => {
+        return Promise.all(streams.map((stream: Stream) => {
+            return until(
+                () => { return client.streamExistsOnTheGraph(stream.id) },
+                20000,
+                500,
+                () => `timed out while waiting for streamrClient.streamExistsOnTheGraph(${stream.id})`
+            )
+        }))
+    }
+
+    const searchStreamIds = async (searchTerm: string, permissionFilter?: SearchStreamsPermissionFilter) => {
+        const streams = client.searchStreams(searchTerm, permissionFilter)
+        const ids = (await collect(streams)).map((stream) => stream.id)
+        ids.sort()
+        return ids
+    }
+
+    beforeAll(async () => {
+        client = new StreamrClient({
+            ...ConfigTest,
+            auth: {
+                privateKey: await getPrivateKey(),
+            },
+            autoConnect: false
+        })
+        streamWithoutPermission = await client.createStream(`/${SEARCH_TERM}/1-no-permissions`)
+        streamWithUserPermission = await client.createStream(`/${SEARCH_TERM}/2-user-permission`)
+        await streamWithUserPermission.grantUserPermission(StreamPermission.SUBSCRIBE, searcher.address)
+        streamWithPublicPermission = await client.createStream(`/${SEARCH_TERM}/3-public-permissions`)
+        await streamWithPublicPermission.grantPublicPermission(StreamPermission.SUBSCRIBE)
+        streamWithUserAndPublicPermission = await client.createStream(`/${SEARCH_TERM}/4-user-and-public-permission`)
+        await streamWithUserAndPublicPermission.grantUserPermission(StreamPermission.SUBSCRIBE, searcher.address)
+        await streamWithUserAndPublicPermission.grantPublicPermission(StreamPermission.SUBSCRIBE)
+        streamWithGrantedAndRevokedPermission = await client.createStream(`/${SEARCH_TERM}/5-granted-and-revoked-permission`)
+        await streamWithGrantedAndRevokedPermission.grantUserPermission(StreamPermission.SUBSCRIBE, searcher.address)
+        await streamWithGrantedAndRevokedPermission.grantPublicPermission(StreamPermission.SUBSCRIBE)
+        await streamWithGrantedAndRevokedPermission.revokeUserPermission(StreamPermission.SUBSCRIBE, searcher.address)
+        await streamWithGrantedAndRevokedPermission.revokePublicPermission(StreamPermission.SUBSCRIBE)
+        const noSearchTermMatchStream = await client.createStream(`/${Date.now()}`)
+        await waitUntilStreamsExistOnTheGraph([
+            streamWithoutPermission,
+            streamWithUserPermission,
+            streamWithPublicPermission,
+            streamWithUserAndPublicPermission,
+            streamWithGrantedAndRevokedPermission,
+            noSearchTermMatchStream
+        ])
+    })
+
+    afterAll(async () => {
+        await client?.destroy()
+    })
+
+    it('search term matches', async () => {
+        const streamIds = await searchStreamIds(SEARCH_TERM)
+        expect(streamIds).toEqual([
+            streamWithoutPermission.id,
+            streamWithUserPermission.id,
+            streamWithPublicPermission.id,
+            streamWithUserAndPublicPermission.id,
+            streamWithGrantedAndRevokedPermission.id,
+        ])
+    })
+
+    it('no search term matches', async () => {
+        const streamIds = await searchStreamIds(`no-matches-${Date.now()}`)
+        expect(streamIds).toEqual([])
+    })
+
+    it('no filters', async () => {
+        const iterable = client.searchStreams()
+        // most likely many items created by various tests, check that we can read some item
+        const firstItem = (await iterable[Symbol.asyncIterator]().next()).value
+        expect(firstItem.id).toBeDefined()
+    })
+
+    describe('permission filter', () => {
+
+        it('user permissions', async () => {
+            const streamIds = await searchStreamIds(SEARCH_TERM, {
+                user: searcher.address,
+                allowPublic: false
+            })
+            expect(streamIds).toEqual([
+                streamWithUserPermission.id,
+                streamWithUserAndPublicPermission.id
+            ])
+        })
+
+        it('user permissions and public permissions', async () => {
+            const streamIds = await searchStreamIds(SEARCH_TERM, {
+                user: searcher.address,
+                allowPublic: true
+            })
+            expect(streamIds).toEqual([
+                streamWithUserPermission.id,
+                streamWithPublicPermission.id,
+                streamWithUserAndPublicPermission.id
+            ])
+        })
+
+        it('public permissions', async () => {
+            const streamIds = await searchStreamIds(SEARCH_TERM, {
+                user: fakeAddress(),
+                allowPublic: true
+            })
+            expect(streamIds).toEqual([
+                streamWithPublicPermission.id,
+                streamWithUserAndPublicPermission.id
+            ])
+        })
+
+        describe('all of', () => {
+            it('match', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    allOf: [StreamPermission.SUBSCRIBE],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([
+                    streamWithUserPermission.id,
+                    streamWithUserAndPublicPermission.id
+                ])
+            })
+
+            it('no match', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    allOf: [StreamPermission.SUBSCRIBE, StreamPermission.PUBLISH],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([])
+            })
+
+            it('all permission types match', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    allOf: [],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([
+                    streamWithUserPermission.id,
+                    streamWithUserAndPublicPermission.id
+                ])
+            })
+        })
+
+        describe('any of', () => {
+            it('match', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    anyOf: [StreamPermission.SUBSCRIBE, StreamPermission.PUBLISH],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([
+                    streamWithUserPermission.id,
+                    streamWithUserAndPublicPermission.id
+                ])
+            })
+
+            it('no match', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    anyOf: [StreamPermission.GRANT],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([])
+            })
+
+            it('no possible results', async () => {
+                const streamIds = await searchStreamIds(SEARCH_TERM, {
+                    user: searcher.address,
+                    anyOf: [],
+                    allowPublic: false
+                })
+                expect(streamIds).toEqual([])
+            })
+        })
+    })
+})

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -4,7 +4,7 @@ import { until } from '../../src/utils'
 import { collect } from '../../src/utils/GeneratorUtils'
 import { fakeAddress, getPrivateKey } from '../utils'
 
-jest.setTimeout(30 * 1000)
+jest.setTimeout(2 * 60 * 1000)
 
 const SEARCH_TERM = `mock-search-term-${Date.now()}`
 
@@ -89,7 +89,7 @@ describe('SearchStreams', () => {
     })
 
     it('no filters', async () => {
-        const iterable = client.searchStreams()
+        const iterable = client.searchStreams(undefined, undefined)
         // most likely many items created by various tests, check that we can read some item
         const firstItem = (await iterable[Symbol.asyncIterator]().next()).value
         expect(firstItem.id).toBeDefined()

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -1,12 +1,10 @@
 import { Wallet } from 'ethers'
-import { v4 as uuid } from 'uuid'
 
 import { clientOptions, createTestStream, until, fakeAddress, createRelativeTestStreamId, getPrivateKey } from '../utils'
 import { NotFoundError } from '../../src/authFetch'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
 import { storageNodeTestConfig } from './devEnvironment'
-import { SearchStreamsOptions } from '../../src/StreamRegistry'
 import { StreamPartIDUtils, toStreamID, toStreamPartID } from 'streamr-client-protocol'
 
 jest.setTimeout(40000)
@@ -181,68 +179,6 @@ describe('StreamEndpoints', () => {
                     id: `${otherAddress}${newPath}`,
                 })
             }).rejects.toThrow(`stream id "${otherAddress}${newPath}" not in namespace of authenticated user "${wallet.address.toLowerCase()}"`)
-        })
-    })
-
-    describe('searchStreams', () => {
-        it('filters by given criteria (match)', async () => {
-            const result = await client.searchStreams(createdStream.id)
-            expect(result.length).toBe(1)
-            return expect(result[0].id).toBe(createdStream.id)
-        })
-
-        it('escaped char', async () => {
-            const description = 'searchStreams.escapedChar"' + Date.now()
-            await createTestStream(client, module, {
-                description
-            })
-            // the content is escaped twice because it is stored in a JSON field ("description")
-            // in a strigifyed JSON ("metadata" object)
-            const result = await client.searchStreams(description.replace('"', '\\\\"'))
-            expect(result.length).toBe(1)
-        })
-
-        it('filters by given criteria (no match)', async () => {
-            const result = await client.searchStreams(`non-existent-${Date.now()}`)
-            return expect(result.length).toBe(0)
-        })
-
-        /* eslint-disable no-await-in-loop */
-        it('max and offset', async () => {
-            const streamIds = []
-            const searchTerm = `searchStreams-${Date.now()}`
-            for (let i = 0; i < 3; i++) {
-                const orderSuffix = uuid()
-                const path = await createRelativeTestStreamId(module, orderSuffix)
-                const stream = await client.createStream({
-                    id: path,
-                    description: searchTerm
-                })
-                streamIds.push(stream.id)
-            }
-            streamIds.sort()
-            await until(async () => {
-                const streams = await client.searchStreams(searchTerm)
-                return streams.length === streamIds.length
-            }, 20000, 1000)
-
-            const searchStreamsIds = async (query: SearchStreamsOptions) => {
-                const streams = await client.searchStreams(searchTerm, {
-                    order: 'asc',
-                    ...query
-                })
-                return streams.map((s) => s.id)
-            }
-
-            const resultList1 = await searchStreamsIds({
-                max: 2
-            })
-            expect(resultList1).toEqual([streamIds[0], streamIds[1]])
-            const resultList2 = await searchStreamsIds({
-                max: 2,
-                offset: 1
-            })
-            expect(resultList2).toEqual([streamIds[1], streamIds[2]])
         })
     })
 

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -6,6 +6,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
 import { storageNodeTestConfig } from './devEnvironment'
 import { StreamPartIDUtils, toStreamID, toStreamPartID } from 'streamr-client-protocol'
+import { toArray } from '../../src/utils/iterators'
 
 jest.setTimeout(40000)
 


### PR DESCRIPTION
The `client.searchStreams` can now search over the id field and stream permissions using the following API:

```ts
searchStreams(term: string | undefined, permissionFilter: SearchStreamsPermissionFilter | undefined): AsyncGenerator<Stream>

export interface SearchStreamsPermissionFilter {
    user: EthereumAddress
    allOf?: StreamPermission[]
    anyOf?: StreamPermission[]
    allowPublic: boolean
}
```

The new return type is `AsyncGenerator` instead of `Promise<Stream[]>`. 

Changed also return types of `getAllStreams`, `getStreamPublishers`, and `getStreamSubscribers` to `AsyncGenerators` as paging is now done automatically.

Updated CLI-tool command `stream search` to use the new search method.