### PR TITLE
NET-615: Client: remove duplicate id field from Stream class

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -79,7 +79,6 @@ function getFieldType(value: any): (Field['type'] | undefined) {
 }
 
 class StreamrStream implements StreamMetadata {
-    streamId: StreamID
     id: StreamID
     description?: string
     config: {
@@ -105,7 +104,6 @@ class StreamrStream implements StreamMetadata {
     ) {
         Object.assign(this, props)
         this.id = props.id
-        this.streamId = this.id
         this.partitions = props.partitions ? props.partitions : 1
         this._rest = _container.resolve<Rest>(Rest)
         this._resends = _container.resolve<Resends>(Resends)

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -87,7 +87,7 @@ describe('PubSub with proxy connections', () => {
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.streamId, 0), proxyNodeId1))
+            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
     }, 15000)
 
@@ -103,7 +103,7 @@ describe('PubSub with proxy connections', () => {
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.streamId, 0), proxyNodeId1))
+            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         await publishingClient.removePublishProxy(stream, proxyNodeId1)
@@ -112,7 +112,7 @@ describe('PubSub with proxy connections', () => {
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.isSetUp(toStreamPartID(stream.streamId, 0)))
+            .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
     }, 15000)
 
@@ -132,13 +132,13 @@ describe('PubSub with proxy connections', () => {
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.streamId, 0), proxyNodeId1))
+            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.streamId, 0), proxyNodeId2))
+            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId2))
             .toEqual(true)
 
         await publishingClient.removePublishProxies(stream, [proxyNodeId1, proxyNodeId2])
@@ -147,13 +147,13 @@ describe('PubSub with proxy connections', () => {
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.isSetUp(toStreamPartID(stream.streamId, 0)))
+            .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 
         // @ts-expect-error private
         expect((await publishingClient.publisher.node.getNode())
             // @ts-expect-error private
-            .streamPartManager.isSetUp(toStreamPartID(stream.streamId, 0)))
+            .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 
     }, 15000)

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -56,7 +56,7 @@ describe('StreamEndpoints', () => {
                 id: path,
                 requireSignedData: true
             })
-            await until(async () => { return client.streamExistsOnTheGraph(stream.streamId) }, 100000, 1000)
+            await until(async () => { return client.streamExistsOnTheGraph(stream.id) }, 100000, 1000)
             expect(stream.id).toBe(toStreamID(path, await client.getAddress()))
             expect(stream.requireSignedData).toBe(true)
         })


### PR DESCRIPTION
Removed the legacy `streamId` field from `Stream` class. The `id` should be used instead of that.