### PR TITLE
fix(client,broker): fix explicit id problem

### DIFF
--- a/packages/broker/src/helpers/config.schema.json
+++ b/packages/broker/src/helpers/config.schema.json
@@ -21,9 +21,11 @@
                             "type": "string",
                             "pattern": "^(0x)?[a-fA-F0-9]{64}$"
                         }
-                    }
+                    },
+                    "required": ["privateKey"]
                 }
-            }
+            },
+            "required": ["auth"]
         },
         "plugins": {
             "type": "object",

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -49,6 +49,13 @@ export default class BrubeckNode implements Context {
         // generate id if none supplied
         if (id == null || id === '') {
             id = await this.generateId()
+        } else if (!this.ethereum.isAuthenticated()) {
+            throw new Error(`cannot set explicit nodeId ${id} without authentication`)
+        } else {
+            const ethereumAddress = await this.ethereum.getAddress()
+            if (!id.toLowerCase().startsWith(ethereumAddress.toLowerCase())) {
+                throw new Error(`given node id ${id} not compatible with authenticated wallet ${ethereumAddress}`)
+            }
         }
 
         this.debug('initNode', id)


### PR DESCRIPTION
While trying out Brubeck node and new trackers and ConfigWizard with @teogeb, we encountered situations where client and networkNode would be configured with different ids, leading to problems.

Made it so that client checks that the brubeck nodeid prefix matches authenticated wallet address. 