### PR TITLE
Rework client-layer proxy publishing

### DIFF
--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -9,8 +9,6 @@ import { Config } from './Config'
 import { StreamMessage, StreamPartID } from 'streamr-client-protocol'
 import { DestroySignal } from './DestroySignal'
 import Ethereum from './Ethereum'
-import { node } from 'webpack'
-import { str } from 'ajv'
 
 /**
  * Wrap a network node.
@@ -176,13 +174,13 @@ export default class BrubeckNode implements Context {
             }
             await Promise.all([
                 new Promise<void>((resolve, reject) => {
-                    this.cachedNode!.addPurePublishingAcceptedListener((id, sprt) => {
-                        if (id === nodeId && sprt === streamPartId) {
+                    this.cachedNode!.addPurePublishingAcceptedListener((node, stream) => {
+                        if (node === nodeId && stream === streamPartId) {
                             resolve()
                         }
                     })
-                    this.cachedNode!.addPurePublishingRejectedListener((id, sprt) => {
-                        if (id === nodeId && sprt === streamPartId) {
+                    this.cachedNode!.addPurePublishingRejectedListener((node, stream) => {
+                        if (node === nodeId && stream === streamPartId) {
                             reject()
                         }
                     })

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -9,7 +9,6 @@ import { Config } from './Config'
 import { StreamMessage, StreamPartID } from 'streamr-client-protocol'
 import { DestroySignal } from './DestroySignal'
 import Ethereum from './Ethereum'
-import { Stream } from 'stream'
 
 /**
  * Wrap a network node.
@@ -177,12 +176,12 @@ export default class BrubeckNode implements Context {
             }
             await Promise.all([
                 new Promise<void>((resolve, reject) => {
-                    resolveHandler = (node: NodeID, stream: StreamPartID) => {
+                    resolveHandler = (node: string, stream: StreamPartID) => {
                         if (node === nodeId && stream === streamPartId) {
                             resolve()
                         }
                     }
-                    rejectHandler = (node: NodeID, stream: StreamPartID) => {
+                    rejectHandler = (node: string, stream: StreamPartID) => {
                         if (node === nodeId && stream === streamPartId) {
                             reject()
                         }

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -168,36 +168,13 @@ export default class BrubeckNode implements Context {
     }
 
     async openPublishProxyConnectionOnStreamPart(streamPartId: StreamPartID, nodeId: string): Promise<void> {
-        let resolveHandler
-        let rejectHandler
         try {
             if (!this.cachedNode || !this.startNodeComplete) {
                 await this.startNode()
             }
-            await Promise.all([
-                new Promise<void>((resolve, reject) => {
-                    resolveHandler = (node: string, stream: StreamPartID) => {
-                        if (node === nodeId && stream === streamPartId) {
-                            resolve()
-                        }
-                    }
-                    rejectHandler = (node: string, stream: StreamPartID) => {
-                        if (node === nodeId && stream === streamPartId) {
-                            reject()
-                        }
-                    }
-                    this.cachedNode!.addPurePublishingAcceptedListener(resolveHandler)
-                    this.cachedNode!.addPurePublishingRejectedListener(rejectHandler)
-                }),
-                this.cachedNode!.joinStreamPartAsPurePublisher(streamPartId, nodeId)
-            ])
-
+            await this.cachedNode!.joinStreamPartAsPurePublisher(streamPartId, nodeId)
         } finally {
             this.debug('openProxyConnectionOnStream << %o', streamPartId, nodeId)
-            if (resolveHandler && rejectHandler) {
-                this.cachedNode!.removePurePublishingAcceptedListener(resolveHandler)
-                this.cachedNode!.removePurePublishingRejectedListener(rejectHandler)
-            }
         }
     }
 

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -70,8 +70,14 @@ describe('PubSub with proxy connections', () => {
         await proxyClient1.subscribe(stream, (msg) => {
             receivedMessagesProxy.push(msg)
         })
-        await wait(1000)
+        await wait(2000)
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
+
+        expect((await publishingClient.getNode())
+            // @ts-expect-error private
+            .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
+            .toEqual(true)
+
         await publishingClient.publish(stream, {
             msg: 'hellow'
         })
@@ -84,8 +90,7 @@ describe('PubSub with proxy connections', () => {
         await wait(2500)
         expect(receivedMessagesProxy.length).toEqual(3)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
@@ -98,18 +103,15 @@ describe('PubSub with proxy connections', () => {
         })
         await wait(1000)
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
-        await wait(1000)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         await publishingClient.removePublishProxy(stream, proxyNodeId1)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
@@ -126,30 +128,25 @@ describe('PubSub with proxy connections', () => {
         })
         await wait(1000)
         await publishingClient.setPublishProxies(stream, [proxyNodeId1, proxyNodeId2])
-        await wait(1000)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId2))
             .toEqual(true)
 
         await publishingClient.removePublishProxies(stream, [proxyNodeId1, proxyNodeId2])
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 
-        // @ts-expect-error private
-        expect((await publishingClient.publisher.node.getNode())
+        expect((await publishingClient.getNode())
             // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -74,7 +74,6 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
@@ -91,7 +90,6 @@ describe('PubSub with proxy connections', () => {
         expect(receivedMessagesProxy.length).toEqual(3)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
     }, 15000)
@@ -105,14 +103,12 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         await publishingClient.removePublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
     }, 15000)
@@ -130,24 +126,20 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxies(stream, [proxyNodeId1, proxyNodeId2])
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId2))
             .toEqual(true)
 
         await publishingClient.removePublishProxies(stream, [proxyNodeId1, proxyNodeId2])
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 
         expect((await publishingClient.getNode())
-            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -74,6 +74,7 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
@@ -90,6 +91,7 @@ describe('PubSub with proxy connections', () => {
         expect(receivedMessagesProxy.length).toEqual(3)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
     }, 15000)
@@ -103,12 +105,14 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         await publishingClient.removePublishProxy(stream, proxyNodeId1)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
     }, 15000)
@@ -126,20 +130,24 @@ describe('PubSub with proxy connections', () => {
         await publishingClient.setPublishProxies(stream, [proxyNodeId1, proxyNodeId2])
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId1))
             .toEqual(true)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.hasOutOnlyConnection(toStreamPartID(stream.id, 0), proxyNodeId2))
             .toEqual(true)
 
         await publishingClient.removePublishProxies(stream, [proxyNodeId1, proxyNodeId2])
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 
         expect((await publishingClient.getNode())
+            // @ts-expect-error private
             .streamPartManager.isSetUp(toStreamPartID(stream.id, 0)))
             .toEqual(false)
 

--- a/packages/network/src/logic/node/NetworkNode.ts
+++ b/packages/network/src/logic/node/NetworkNode.ts
@@ -37,6 +37,22 @@ export class NetworkNode extends Node {
         this.off(NodeEvent.UNSEEN_MESSAGE_RECEIVED, cb)
     }
 
+    addPurePublishingAcceptedListener(cb: (nodeId: NodeId, streamPartId: StreamPartID) => void): void {
+        this.on(NodeEvent.PUBLISH_STREAM_ACCEPTED, cb)
+    }
+
+    addPurePublishingRejectedListener(cb: (nodeId: NodeId, streamPartId: StreamPartID) => void): void {
+        this.on(NodeEvent.PUBLISH_STREAM_REJECTED, cb)
+    }
+
+    removePurePublishingAcceptedListener(cb: (nodeId: NodeId, streamPartId: StreamPartID) => void): void {
+        this.off(NodeEvent.PUBLISH_STREAM_ACCEPTED, cb)
+    }
+
+    removePurePublishingRejectedListener(cb: (nodeId: NodeId, streamPartId: StreamPartID) => void): void {
+        this.off(NodeEvent.PUBLISH_STREAM_REJECTED, cb)
+    }
+
     subscribe(streamPartId: StreamPartID): void {
         this.subscribeToStreamIfHaveNotYet(streamPartId)
     }

--- a/packages/network/test/integration/publish-only-stream-connection.test.ts
+++ b/packages/network/test/integration/publish-only-stream-connection.test.ts
@@ -128,6 +128,18 @@ describe('Publish only connection tests', () => {
         await nonContactNode.stop()
     })
 
+    it('Multiple calls to joinStreamPartAsPurePublisher do not cancel the first call', async () => {
+        await Promise.all([
+            waitForEvent(publisherNode, NodeEvent.PUBLISH_STREAM_ACCEPTED),
+            publisherNode.joinStreamPartAsPurePublisher(defaultStreamPartId, 'contact-node'),
+            publisherNode.joinStreamPartAsPurePublisher(defaultStreamPartId, 'contact-node'),
+            publisherNode.joinStreamPartAsPurePublisher(defaultStreamPartId, 'contact-node'),
+            publisherNode.joinStreamPartAsPurePublisher(defaultStreamPartId, 'contact-node'),
+        ])
+        // @ts-expect-error private
+        expect(publisherNode.streamPartManager.getOutboundNodesForStreamPart(defaultStreamPartId)).toContainValue('contact-node')
+    })
+    
     it('Published data is received using one-way stream connections', async () => {
         await publisherNode.joinStreamPartAsPurePublisher(defaultStreamPartId, 'contact-node')
         await Promise.all([


### PR DESCRIPTION
This PR fixes a problem where the client will default to using regular stream connections if the client starts publishing before the proxy connection is formed.

- Add ability to add and remove event listeners for node events related to proxy connections
- When calling `await setPublishProxy()` on the client it will now wait for such an event from the NetworkNode before resolving.