### PR TITLE
client tests: simplify dev environment storage node handling

### DIFF
--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -59,3 +59,5 @@ export default {
     autoDisconnect: false,
     maxRetries: 2,
 }
+
+export const DOCKER_DEV_STORAGE_NODE = '0xde1112f631486CfC759A50196853011528bC5FA0'

--- a/packages/client/test/flakey/Resends.test.ts
+++ b/packages/client/test/flakey/Resends.test.ts
@@ -4,9 +4,8 @@ import { getPublishTestMessages, describeRepeats, createTestStream, getPrivateKe
 import { StreamrClient } from '../../src/StreamrClient'
 import { Defer, pTimeout } from '../../src/utils'
 
-import config from '../../src/ConfigTest'
+import config, { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
-import { storageNodeTestConfig } from '../integration/devEnvironment'
 
 /* eslint-disable no-await-in-loop */
 
@@ -61,7 +60,7 @@ describeRepeats('StreamrClient resends', () => {
             beforeEach(async () => {
                 stream = await createTestStream(client, module)
 
-                await stream.addToStorageNode(storageNodeTestConfig.address)
+                await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
                 publishTestMessages = getPublishTestMessages(client, stream)
             }, 300000)

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -15,7 +15,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/Encryption'
 import { Stream, StreamPermission } from '../../src/Stream'
 import Subscription from '../../src/Subscription'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 const debug = Debug('StreamrClient::test')
 const TIMEOUT = 15 * 1000
@@ -72,13 +72,8 @@ describeRepeats('decryption', () => {
     }
 
     async function setupStream() {
-        const storageNodeClient = await createClient({ auth: {
-            privateKey: storageNodeTestConfig.privatekey
-        } })
-
         stream = await createTestStream(publisher, module)
-
-        await stream.addToStorageNode(await storageNodeClient.getAddress())
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         publishTestMessages = getPublishTestStreamMessages(publisher, stream)
     }
 

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -8,7 +8,7 @@ import Subscriber from '../../src/Subscriber'
 import Subscription from '../../src/Subscription'
 
 import { getPublishTestStreamMessages, createTestStream, getCreateClient, describeRepeats, Msg } from '../utils'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 const MAX_MESSAGES = 10
 jest.setTimeout(50000)
@@ -52,11 +52,7 @@ describeRepeats('GapFill', () => {
         stream = await createTestStream(client, module, {
             requireSignedData: true
         })
-        // const storageNodeClient = await createClient({ auth: {
-        //     privateKey: storageNodeTestConfig.privatekey
-        // } })
-        // await storageNodeClient.setNode(storageNodeTestConfig.url)
-        await stream.addToStorageNode(storageNodeTestConfig.address)
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         client.debug('connecting before test <<')
         publishTestMessages = getPublishTestStreamMessages(client, stream.id, { waitForLast: true })
         return client

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -3,8 +3,7 @@ import { describeRepeats, getCreateClient, getPublishTestStreamMessages, createT
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
 import { GroupKey } from '../../src/encryption/Encryption'
-import { Wallet } from 'ethers'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 const TIMEOUT = 30 * 1000
 jest.setTimeout(60000)
@@ -30,8 +29,7 @@ describeRepeats('Group Key Persistence', () => {
             stream = await createTestStream(client, module, {
                 ...streamOpts,
             })
-            const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-            await stream.addToStorageNode(await storageNodeWallet.getAddress())
+            await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
             publishTestMessages = getPublishTestStreamMessages(client, stream)
             return client
         }
@@ -72,8 +70,7 @@ describeRepeats('Group Key Persistence', () => {
                 // subscriber will need to ask new publisher
                 // for group keys, which the new publisher will have to read from
                 // persistence
-                const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-                await stream.addToStorageNode(await storageNodeWallet.getAddress())
+                await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
                 published = await publishTestMessages(5, {
                     waitForLast: true,
@@ -304,8 +301,7 @@ describeRepeats('Group Key Persistence', () => {
                 for (let i = 0; i < NUM_STREAMS; i++) {
 
                     const s = await createTestStream(publisher, module)
-                    const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-                    await s.addToStorageNode(await storageNodeWallet.getAddress())
+                    await s.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
                     // eslint-disable-next-line no-loop-func
                     streams.push(s)
                 }

--- a/packages/client/test/integration/MultipleClients.test.ts
+++ b/packages/client/test/integration/MultipleClients.test.ts
@@ -6,9 +6,8 @@ import {
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils'
 import { Stream, StreamPermission } from '../../src/Stream'
-import { Wallet } from '@ethersproject/wallet'
 import { StreamMessage } from 'streamr-client-protocol'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 jest.setTimeout(50000)
 // this number should be at least 10, otherwise late subscribers might not join
@@ -33,10 +32,8 @@ describeRepeats('PubSub with multiple clients', () => {
                 privateKey
             }
         })
-
-        const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
         stream = await createTestStream(mainClient, module)
-        await stream.addToStorageNode(await storageNodeWallet.getAddress())
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
     })
 
     afterEach(async () => {

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -12,8 +12,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import Resend from '../../src/Resends'
 
 import { Stream } from '../../src/Stream'
-import { Wallet } from 'ethers'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 // import { EthereumAddress } from '../types'
 
 /* eslint-disable no-await-in-loop */
@@ -31,7 +30,6 @@ describeRepeats('resends', () => {
     let publishTestMessages: ReturnType<typeof getPublishTestStreamMessages>
     let waitForStorage: (...args: any[]) => Promise<void>
     let subscriber: Resend
-    let storageNodeAddress: string
 
     beforeAll(async () => {
         client = new StreamrClient({
@@ -52,9 +50,7 @@ describeRepeats('resends', () => {
         stream = await createTestStream(client, module)
         client.debug('createStream <<')
         client.debug('addToStorageNode >>')
-        const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-        storageNodeAddress = await storageNodeWallet.getAddress()
-        await stream.addToStorageNode(await storageNodeWallet.getAddress())
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         client.debug('addToStorageNode <<')
 
         publishTestMessages = getPublishTestStreamMessages(client, stream.id)
@@ -129,7 +125,7 @@ describeRepeats('resends', () => {
         describe('resendSubscribe', () => {
             it('sees realtime when no resend', async () => {
                 const stream2 = await createTestStream(client, module)
-                await stream2.addToStorageNode(storageNodeAddress)
+                await stream2.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
                 const publishTestMessagesStream2 = getPublishTestStreamMessages(client, stream2.id)
 
@@ -161,7 +157,7 @@ describeRepeats('resends', () => {
 
             it('handles errors in resend', async () => {
                 const stream2 = await createTestStream(client, module)
-                await stream2.addToStorageNode(storageNodeAddress)
+                await stream2.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
                 const publishTestMessagesStream2 = getPublishTestStreamMessages(client, stream2.id)
 
@@ -192,7 +188,7 @@ describeRepeats('resends', () => {
 
             it('can ignore errors in resend', async () => {
                 const stream2 = await createTestStream(client, module)
-                await stream2.addToStorageNode(storageNodeAddress)
+                await stream2.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
                 const publishTestMessagesStream2 = getPublishTestStreamMessages(client, stream2.id)
 

--- a/packages/client/test/integration/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/integration/StorageNodeEndpoints.test.ts
@@ -6,7 +6,7 @@ import { until } from '../../src/utils'
 import { StorageNodeAssignmentEvent } from '../../src/StorageNodeRegistry'
 import { createTestStream, getCreateClient, getPrivateKey } from '../utils'
 
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { EthereumAddress } from 'streamr-client-protocol'
 
 jest.setTimeout(30000)
@@ -103,13 +103,11 @@ describe('createNode', () => {
         return expect(await client.isStreamStoredInStorageNode(createdStream.id, nodeAddress)).toEqual(false)
     })
 
-    it('addStreamToStorageNode through streamobject', async () => {
-        const storageNodeClientFromDevEnv = await createClient({ auth: {
-            privateKey: storageNodeTestConfig.privatekey
-        } })
-        await storageNodeClientFromDevEnv.createOrUpdateNodeInStorageNodeRegistry(storageNodeTestConfig.url)
-        await createdStream.addToStorageNode(storageNodeTestConfig.address)
-        return expect(await client.isStreamStoredInStorageNode(createdStream.id, storageNodeTestConfig.address)).toEqual(true)
+    it('addStreamToStorageNode through stream object', async () => {
+        const stream = await createTestStream(client, module)
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+        const isStored = await client.isStreamStoredInStorageNode(createdStream.id, DOCKER_DEV_STORAGE_NODE)
+        expect(isStored).toEqual(true)
     })
 
     it('delete a node ', async () => {

--- a/packages/client/test/integration/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/integration/StorageNodeEndpoints.test.ts
@@ -106,7 +106,7 @@ describe('createNode', () => {
     it('addStreamToStorageNode through stream object', async () => {
         const stream = await createTestStream(client, module)
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
-        const isStored = await client.isStreamStoredInStorageNode(createdStream.id, DOCKER_DEV_STORAGE_NODE)
+        const isStored = await client.isStreamStoredInStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)
         expect(isStored).toEqual(true)
     })
 

--- a/packages/client/test/integration/StorageNodeRegistry.test.ts
+++ b/packages/client/test/integration/StorageNodeRegistry.test.ts
@@ -3,7 +3,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { Wallet } from 'ethers'
 import { clientOptions, createTestStream, getPrivateKey, until } from '../utils'
 import { Stream } from '../../src'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { afterAll } from 'jest-circus'
 
 const TEST_TIMEOUT = 60 * 1000
@@ -45,28 +45,28 @@ describe('StorageNodeRegistry', () => {
         const cb = jest.fn()
         listenerClient.registerStorageEventListener(cb)
 
-        await stream.addToStorageNode(storageNodeTestConfig.address)
-        await stream.removeFromStorageNode(storageNodeTestConfig.address)
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+        await stream.removeFromStorageNode(DOCKER_DEV_STORAGE_NODE)
 
         await until(() => cb.mock.calls.length >= 2)
 
         expect(cb).toHaveBeenCalledTimes(2)
         expect(cb).toHaveBeenNthCalledWith(1, {
             blockNumber: expect.any(Number),
-            nodeAddress: storageNodeTestConfig.address,
+            nodeAddress: DOCKER_DEV_STORAGE_NODE,
             streamId: stream.id,
             type: 'added'
         })
         expect(cb).toHaveBeenNthCalledWith(2, {
             blockNumber: expect.any(Number),
-            nodeAddress: storageNodeTestConfig.address,
+            nodeAddress: DOCKER_DEV_STORAGE_NODE,
             streamId: stream.id,
             type: 'removed'
         })
     }, TEST_TIMEOUT)
 
     it('getStoredStreamsOf', async () => {
-        const result = await listenerClient.getStoredStreamsOf(storageNodeTestConfig.address)
+        const result = await listenerClient.getStoredStreamsOf(DOCKER_DEV_STORAGE_NODE)
         expect(result.blockNumber).toBeGreaterThanOrEqual(0)
         expect(result.streams.length).toBeGreaterThanOrEqual(0)
         result.streams.forEach((s) => expect(s).toBeInstanceOf(Stream))

--- a/packages/client/test/integration/Stream.test.ts
+++ b/packages/client/test/integration/Stream.test.ts
@@ -2,8 +2,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { getPublishTestMessages, getCreateClient, createTestStream } from '../utils'
 
-import { Wallet } from 'ethers'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 jest.setTimeout(30000)
 
@@ -17,8 +16,7 @@ describe('Stream', () => {
         await client.connect()
 
         stream = await createTestStream(client, module)
-        const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-        await stream.addToStorageNode(await storageNodeWallet.getAddress())
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
     })
 
     describe('detectFields()', () => {

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -4,7 +4,7 @@ import { clientOptions, createTestStream, until, fakeAddress, createRelativeTest
 import { NotFoundError } from '../../src/authFetch'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { StreamPartIDUtils, toStreamID, toStreamPartID } from 'streamr-client-protocol'
 import { collect } from '../../src/utils/GeneratorUtils'
 
@@ -19,7 +19,6 @@ describe('StreamEndpoints', () => {
     let wallet: Wallet
     let createdStream: Stream
     let otherWallet: Wallet
-    let storageNodeAddress: string
 
     beforeAll(async () => {
         wallet = new Wallet(await getPrivateKey())
@@ -36,16 +35,6 @@ describe('StreamEndpoints', () => {
         createdStream = await createTestStream(client, module, {
             requireSignedData: true
         })
-        const storageNodeWallet = new Wallet(storageNodeTestConfig.privatekey)
-        // const storageNodeClient = new StreamrClient({
-        //     ...clientOptions,
-        //     auth: {
-        //         privateKey: storageNodeWallet.privateKey,
-        //     },
-        // })
-        // await storageNodeClient.setNode(storageNodeTestConfig.url)
-        storageNodeAddress = storageNodeWallet.address
-        // storageNode = await client.getStorageNode(await storageNodeWallet.getAddress())
     })
 
     describe('createStream', () => {
@@ -195,8 +184,7 @@ describe('StreamEndpoints', () => {
             const stream = await client.createStream({
                 id: await createRelativeTestStreamId(module),
             })
-            await stream.addToStorageNode(storageNodeAddress)
-            await until(async () => { return client.isStreamStoredInStorageNode(stream.id, storageNodeAddress) }, 100000, 1000)
+            await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
             const result = await client.getStreamLast(stream.id)
             expect(result).toEqual([])
         })
@@ -574,25 +562,23 @@ describe('StreamEndpoints', () => {
         it('add', async () => {
             // await stream.addToStorageNode(node.getAddress())// use actual storage nodes Address, actually register it
             const stream = await createTestStream(client, module)
-            await stream.addToStorageNode(storageNodeAddress)
-            await until(async () => { return client.isStreamStoredInStorageNode(stream.id, storageNodeAddress) }, 100000, 1000)
+            await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
             const storageNodes = await stream.getStorageNodes()
             expect(storageNodes.length).toBe(1)
-            expect(storageNodes[0]).toStrictEqual(storageNodeAddress.toLowerCase())
-            const storedStreamParts = await client.getStreamPartsByStorageNode(storageNodeAddress)
+            expect(storageNodes[0]).toStrictEqual(DOCKER_DEV_STORAGE_NODE.toLowerCase())
+            const storedStreamParts = await client.getStreamPartsByStorageNode(DOCKER_DEV_STORAGE_NODE)
             const expectedStreamPartId = toStreamPartID(stream.id, 0)
             return expect(storedStreamParts.some((sp) => sp === expectedStreamPartId)).toBeTruthy()
         })
 
         it('remove', async () => {
             const stream = await createTestStream(client, module)
-            await stream.addToStorageNode(storageNodeAddress)
-            await until(async () => { return client.isStreamStoredInStorageNode(stream.id, storageNodeAddress) }, 100000, 1000)
-            await stream.removeFromStorageNode(storageNodeAddress)
-            await until(async () => { return !(await client.isStreamStoredInStorageNode(stream.id, storageNodeAddress)) }, 100000, 1000)
+            await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+            await stream.removeFromStorageNode(DOCKER_DEV_STORAGE_NODE)
+            await until(async () => { return !(await client.isStreamStoredInStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)) }, 100000, 1000)
             const storageNodes = await stream.getStorageNodes()
             expect(storageNodes).toHaveLength(0)
-            const storedStreamParts = await client.getStreamPartsByStorageNode(storageNodeAddress)
+            const storedStreamParts = await client.getStreamPartsByStorageNode(DOCKER_DEV_STORAGE_NODE)
             return expect(storedStreamParts.some((sp) => (StreamPartIDUtils.getStreamID(sp) === stream.id))).toBeFalsy()
         })
     })

--- a/packages/client/test/integration/StreamrClient.test.ts
+++ b/packages/client/test/integration/StreamrClient.test.ts
@@ -21,7 +21,7 @@ import { Defer } from '../../src/utils'
 import * as G from '../../src/utils/GeneratorUtils'
 
 import { Stream } from '../../src/Stream'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 jest.setTimeout(60000)
 
@@ -529,8 +529,7 @@ describeRepeats('StreamrClient', () => {
         })
 
         it('decodes resent messages correctly', async () => {
-            await stream.addToStorageNode(storageNodeTestConfig.address)// use actual storage nodes Address, actually register it
-            await until(async () => { return client.isStreamStoredInStorageNode(stream.id, storageNodeTestConfig.address) }, 100000, 1000)
+            await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)// use actual storage nodes Address, actually register it
 
             const publishedMessage = Msg({
                 content: fs.readFileSync(path.join(__dirname, 'utf8Example.txt'), 'utf8')

--- a/packages/client/test/integration/SubscriberResendsSequential.test.ts
+++ b/packages/client/test/integration/SubscriberResendsSequential.test.ts
@@ -8,7 +8,7 @@ import {
     createTestStream,
 } from '../utils'
 import { StreamrClient } from '../../src/StreamrClient'
-import { storageNodeTestConfig } from './devEnvironment'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 
 import { Stream, StreamPermission } from '../../src/Stream'
 
@@ -46,7 +46,7 @@ describeRepeats('sequential resend subscribe', () => {
         })
 
         stream = await createTestStream(publisher, module)
-        await stream.addToStorageNode(storageNodeTestConfig.address)
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
         publishTestMessages = getPublishTestStreamMessages(publisher, stream)
         await stream.grantUserPermission(StreamPermission.SUBSCRIBE, await subscriber.getAddress())

--- a/packages/client/test/integration/devEnvironment.ts
+++ b/packages/client/test/integration/devEnvironment.ts
@@ -63,9 +63,3 @@ export const relayTokensAbi = [
         type: 'function'
     }
 ]
-
-export const storageNodeTestConfig = {
-    privatekey: 'aa7a3b3bb9b4a662e756e978ad8c6464412e7eef1b871f19e5120d4747bce966',
-    address: '0xde1112f631486CfC759A50196853011528bC5FA0',
-    url: `{"http": "http://${process.env.STREAMR_DOCKER_DEV_HOST || '10.200.10.1'}:8891/api/v1"}`
-}


### PR DESCRIPTION
Modified the configuration of the storage node which is available when running the stack in `streamer-docker-dev `environment. 

The address is now configured as `DOCKER_DEV_STORAGE_NODE` in` ConfigTest.ts`. Other aspects of the storage node configs (url and private key) are not needed in tests. 

Removed also some unnecessary client instances which were created for storage node initialization.