### PR TITLE
broker: remove /api/v1 prefix from Metrics plugin /volume endpoint

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -104,7 +104,7 @@ jobs:
           services-to-start: "nginx trackers parity-node0 parity-sidechain-node0 broker-node-no-storage-1 graph-deploy-streamregistry-subgraph"
       - run: |
           for (( i=0; i < 5; i=i+1 )); do
-              curl -s http://localhost:8791/api/v1/volume;
+              curl -s http://localhost:8791/volume;
               res=$?;
               if test "$res" != "0"; then
                   echo "Attempting to connect to broker retrying in $wait_time seconds";

--- a/packages/broker/src/httpServer.ts
+++ b/packages/broker/src/httpServer.ts
@@ -10,8 +10,6 @@ import { ApiAuthenticator } from './apiAuthenticator'
 
 const logger = new Logger(module)
 
-export const LEGACY_API_ROUTE_PREFIX = '/api/v1'
-
 const HTTP_STATUS_UNAUTHORIZED = 401
 const HTTP_STATUS_FORBIDDEN = 403
 

--- a/packages/broker/src/plugins/metrics/VolumeEndpoint.ts
+++ b/packages/broker/src/plugins/metrics/VolumeEndpoint.ts
@@ -1,6 +1,5 @@
 import express, { Request, Response, Router } from 'express'
 import { MetricsContext } from 'streamr-network'
-import { LEGACY_API_ROUTE_PREFIX } from '../../httpServer'
 
 /**
  * Endpoint for GETing volume metrics
@@ -12,7 +11,7 @@ export const router = (metricsContext: MetricsContext): Router => {
 
     const router = express.Router()
 
-    router.get(`${LEGACY_API_ROUTE_PREFIX}/volume`, async (req: Request, res: Response) => {
+    router.get('/volume', async (req: Request, res: Response) => {
         const report = await metricsContext.report()
         res.status(200).send(report)
     })


### PR DESCRIPTION
Changed the url of Metrics plugin: `/api/v1/volume` -> `/volume`. Now the url mapping is consistent with other plugin endpoints (https://github.com/streamr-dev/network-monorepo/pull/408).