### PR TITLE
Lazy start up of KeyServer

### DIFF
--- a/packages/broker/jest.config.js
+++ b/packages/broker/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
     // The directory where Jest should output its coverage files
     coverageDirectory: 'coverage',
 
-    globalSetup: './jest.setup.js',
+    globalTeardown: './jest.teardown.js',
    
     preset: 'ts-jest/presets/js-with-ts',
 

--- a/packages/broker/jest.setup.js
+++ b/packages/broker/jest.setup.js
@@ -1,5 +1,0 @@
-import { KeyServer } from 'streamr-test-utils'
-
-export default async () => {
-    global.__StreamrKeyserver = new KeyServer()
-}

--- a/packages/broker/jest.teardown.js
+++ b/packages/broker/jest.teardown.js
@@ -1,5 +1,5 @@
+const { KeyServer } = require('streamr-test-utils')
+
 export default async () => {
-    if (global.__StreamrKeyserver) {
-        await global.__StreamrKeyserver.destroy()
-    }
+    await KeyServer.stopIfRunning()
 }

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -4,7 +4,7 @@ import StreamrClient, { Stream, StreamPermission } from 'streamr-client'
 import { Tracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Broker } from '../../src/broker'
-import { startBroker, createClient, createTestStream, getPrivateKey, getStreamParts, startTestTracker } from '../utils'
+import { startBroker, createClient, createTestStream, fetchPrivateKeyWithGas, getStreamParts, startTestTracker } from '../utils'
 
 jest.setTimeout(50000)
 
@@ -39,8 +39,8 @@ describe('broker subscriptions', () => {
     let mqttClient2: AsyncMqttClient
 
     beforeEach(async () => {
-        const broker1User = new Wallet(await getPrivateKey())
-        const broker2User = new Wallet(await getPrivateKey())
+        const broker1User = new Wallet(await fetchPrivateKeyWithGas())
+        const broker2User = new Wallet(await fetchPrivateKeyWithGas())
         tracker = await startTestTracker(trackerPort)
         broker1 = await startBroker({
             name: 'broker1',
@@ -65,11 +65,11 @@ describe('broker subscriptions', () => {
 
         await wait(2000)
 
-        client1 = await createClient(tracker, await getPrivateKey())
-        client2 = await createClient(tracker, await getPrivateKey())
+        client1 = await createClient(tracker, await fetchPrivateKeyWithGas())
+        client2 = await createClient(tracker, await fetchPrivateKeyWithGas())
 
-        client1 = await createClient(tracker, await getPrivateKey())
-        client2 = await createClient(tracker, await getPrivateKey())
+        client1 = await createClient(tracker, await fetchPrivateKeyWithGas())
+        client2 = await createClient(tracker, await fetchPrivateKeyWithGas())
 
         mqttClient1 = await createMqttClient(mqttPort1)
         mqttClient2 = await createMqttClient(mqttPort2)

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -3,7 +3,7 @@ import { Stream, StreamrClient } from 'streamr-client'
 import { Tracker } from 'streamr-network'
 import { Broker } from '../../src/broker'
 import { Message } from '../../src/helpers/PayloadFormat'
-import { createClient, startBroker, createTestStream, Queue, getPrivateKey, startTestTracker } from '../utils'
+import { createClient, startBroker, createTestStream, Queue, fetchPrivateKeyWithGas, startTestTracker } from '../utils'
 
 interface MessagingPluginApi<T> {
     createClient: (action: 'publish'|'subscribe', streamId: string, apiKey: string) => Promise<T>
@@ -55,7 +55,7 @@ export const createMessagingPluginTest = <T>(
         let messageQueue: Queue<Message>
 
         beforeAll(async () => {
-            brokerUser = new Wallet(await getPrivateKey())
+            brokerUser = new Wallet(await fetchPrivateKeyWithGas())
             tracker = await startTestTracker(ports.tracker)
             broker = await startBroker({
                 name: 'broker',

--- a/packages/broker/test/integration/local-propagation.test.ts
+++ b/packages/broker/test/integration/local-propagation.test.ts
@@ -3,7 +3,7 @@ import StreamrClient, { Stream, StreamPermission } from 'streamr-client'
 import { Tracker } from 'streamr-network'
 import { wait, waitForCondition } from 'streamr-test-utils'
 import { Broker } from '../../src/broker'
-import { startBroker, createClient, createTestStream, getPrivateKey, startTestTracker } from '../utils'
+import { startBroker, createClient, createTestStream, fetchPrivateKeyWithGas, startTestTracker } from '../utils'
 
 jest.setTimeout(30000)
 
@@ -21,9 +21,9 @@ describe('local propagation', () => {
     let brokerWallet: Wallet
 
     beforeAll(async () => {
-        privateKey = await getPrivateKey()
+        privateKey = await fetchPrivateKeyWithGas()
         tracker = await startTestTracker(trackerPort)
-        brokerWallet = new Wallet(await getPrivateKey())
+        brokerWallet = new Wallet(await fetchPrivateKeyWithGas())
 
         broker = await startBroker({
             name: 'broker1',

--- a/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
@@ -1,7 +1,7 @@
 import StreamrClient, { StreamPermission } from 'streamr-client'
 import { Tracker } from 'streamr-network'
 import { Wallet } from 'ethers'
-import { createClient, getPrivateKey, Queue, startBroker, startTestTracker } from '../../../../utils'
+import { createClient, fetchPrivateKeyWithGas, Queue, startBroker, startTestTracker } from '../../../../utils'
 import { Broker } from '../../../../../src/broker'
 import { v4 as uuid } from 'uuid'
 import { keyToArrayIndex } from 'streamr-client-protocol'
@@ -18,7 +18,7 @@ describe('NodeMetrics', () => {
     let streamIdPrefix: string
 
     beforeAll(async () => {
-        const tmpAccount = new Wallet(await getPrivateKey())
+        const tmpAccount = new Wallet(await fetchPrivateKeyWithGas())
 
         nodeAddress = tmpAccount.address
         tracker = await startTestTracker(trackerPort)

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -2,7 +2,7 @@ import { Stream, StreamrClient } from 'streamr-client'
 import { Tracker } from 'streamr-network'
 import mqtt from 'async-mqtt'
 import { Broker } from '../../../../src/broker'
-import { createClient, startBroker, createTestStream, Queue, getPrivateKey, startTestTracker } from '../../../utils'
+import { createClient, startBroker, createTestStream, Queue, fetchPrivateKeyWithGas, startTestTracker } from '../../../utils'
 import { wait } from 'streamr-test-utils'
 import { Wallet } from '@ethersproject/wallet'
 
@@ -30,7 +30,7 @@ describe('MQTT Bridge', () => {
     }
 
     beforeAll(async () => {
-        brokerUser = new Wallet(await getPrivateKey())
+        brokerUser = new Wallet(await fetchPrivateKeyWithGas())
         tracker = await startTestTracker(TRACKER_PORT)
         broker = await startBroker({
             name: 'broker',

--- a/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
+++ b/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
@@ -6,7 +6,7 @@ import {
     startBroker,
     createClient,
     createTestStream,
-    getPrivateKey,
+    fetchPrivateKeyWithGas,
     startTestTracker
 } from '../../../utils'
 import { Broker } from "../../../../src/broker"
@@ -35,7 +35,7 @@ describe('DataMetadataEndpoints', () => {
     let storageNodeAccount: Wallet
 
     beforeAll(async () => {
-        storageNodeAccount = new Wallet(await getPrivateKey())
+        storageNodeAccount = new Wallet(await fetchPrivateKeyWithGas())
         tracker = await startTestTracker(trackerPort)
         const storageNodeClient = new StreamrClient({
             ...ConfigTest,
@@ -51,7 +51,7 @@ describe('DataMetadataEndpoints', () => {
             httpPort: httpPort1,
             enableCassandra: true,
         })
-        client1 = await createClient(tracker, await getPrivateKey())
+        client1 = await createClient(tracker, await fetchPrivateKeyWithGas())
     })
 
     afterAll(async () => {

--- a/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
@@ -9,7 +9,7 @@ import {
     createClient,
     STREAMR_DOCKER_DEV_HOST,
     createTestStream,
-    getPrivateKey,
+    fetchPrivateKeyWithGas,
     startTestTracker
 } from '../../../utils'
 import { Broker } from '../../../../src/broker'
@@ -36,9 +36,9 @@ describe('StorageConfig', () => {
     let brokerAccount: Wallet
 
     beforeAll(async () => {
-        publisherAccount = new Wallet(await getPrivateKey())
-        storageNodeAccount = new Wallet(await getPrivateKey())
-        brokerAccount = new Wallet(await getPrivateKey())
+        publisherAccount = new Wallet(await fetchPrivateKeyWithGas())
+        storageNodeAccount = new Wallet(await fetchPrivateKeyWithGas())
+        brokerAccount = new Wallet(await fetchPrivateKeyWithGas())
         cassandraClient = new cassandra.Client({
             contactPoints,
             localDataCenter,

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -1,6 +1,6 @@
 import { Tracker } from 'streamr-network'
 import { Wallet } from 'ethers'
-import { createClient, getPrivateKey, startBroker, startTestTracker } from '../../../utils'
+import { createClient, fetchPrivateKeyWithGas, startBroker, startTestTracker } from '../../../utils'
 import { Broker } from "../../../../src/broker"
 import StreamrClient from 'streamr-client'
 
@@ -18,7 +18,7 @@ describe('StorageNode', () => {
     })
 
     beforeAll(async () => {
-        storageNodeAccount = new Wallet(await getPrivateKey())
+        storageNodeAccount = new Wallet(await fetchPrivateKeyWithGas())
         const storageNodeClient = await createClient(tracker, storageNodeAccount.privateKey)
         await storageNodeClient.createOrUpdateNodeInStorageNodeRegistry(`{"http": "http://127.0.0.1:${httpPort1}"}`)
 

--- a/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
+++ b/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
@@ -1,7 +1,7 @@
 import { Client, types as cassandraTypes } from 'cassandra-driver'
 import toArray from 'stream-to-array'
 import { BucketId } from '../../../../src/plugins/storage/Bucket'
-import { STREAMR_DOCKER_DEV_HOST, createTestStream, getPrivateKey } from "../../../utils"
+import { STREAMR_DOCKER_DEV_HOST, createTestStream, fetchPrivateKeyWithGas } from "../../../utils"
 import { startCassandraStorage, Storage } from '../../../../src/plugins/storage/Storage'
 import { Protocol } from 'streamr-network'
 import { ConfigTest, StreamrClient } from 'streamr-client'
@@ -103,7 +103,7 @@ describe('CassandraNullPayloads', () => {
         const streamrClient = new StreamrClient({
             ...ConfigTest,
             auth: {
-                privateKey: await getPrivateKey()
+                privateKey: await fetchPrivateKeyWithGas()
             },
             restUrl: `http://${STREAMR_DOCKER_DEV_HOST}/api/v1`,
         })

--- a/packages/broker/test/sequential/plugins/storage/DeleteExpiredCmd.test.ts
+++ b/packages/broker/test/sequential/plugins/storage/DeleteExpiredCmd.test.ts
@@ -3,7 +3,7 @@ import { Client, types as cassandraTypes } from 'cassandra-driver'
 import StreamrClient, { ConfigTest } from 'streamr-client'
 import { BucketId } from '../../../../src/plugins/storage/Bucket'
 import { DeleteExpiredCmd } from "../../../../src/plugins/storage/DeleteExpiredCmd"
-import { STREAMR_DOCKER_DEV_HOST, createTestStream, getPrivateKey } from "../../../utils"
+import { STREAMR_DOCKER_DEV_HOST, createTestStream, fetchPrivateKeyWithGas } from "../../../utils"
 const { TimeUuid } = cassandraTypes
 
 const contactPoints = [STREAMR_DOCKER_DEV_HOST]
@@ -62,7 +62,7 @@ describe('DeleteExpiredCmd', () => {
             localDataCenter,
             keyspace,
         })
-        mockUser = new Wallet(await getPrivateKey())
+        mockUser = new Wallet(await fetchPrivateKeyWithGas())
 
         client = new StreamrClient({
             ...ConfigTest,

--- a/packages/client/jest.setup.js
+++ b/packages/client/jest.setup.js
@@ -1,12 +1,9 @@
 import 'reflect-metadata'
 import { GitRevisionPlugin } from 'git-revision-webpack-plugin'
-import { KeyServer } from 'streamr-test-utils'
 
 const pkg = require('./package.json')
 
 export default async () => {
-    global.__StreamrKeyserver = new KeyServer()
-
     // eslint-disable-next-line
     require('reflect-metadata')
     if (!process.env.GIT_VERSION) {

--- a/packages/client/jest.teardown.js
+++ b/packages/client/jest.teardown.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { KeyServer } = require('streamr-test-utils')
+
 export default async () => {
-    if (global.__StreamrKeyserver) {
-        await global.__StreamrKeyserver.destroy()
-    }
+    await KeyServer.stopIfRunning()
 }

--- a/packages/client/test/flakey/Resends.test.ts
+++ b/packages/client/test/flakey/Resends.test.ts
@@ -1,6 +1,6 @@
 import { wait } from 'streamr-test-utils'
 
-import { getPublishTestMessages, describeRepeats, createTestStream, getPrivateKey } from '../utils'
+import { getPublishTestMessages, describeRepeats, createTestStream, fetchPrivateKeyWithGas } from '../utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Defer, pTimeout } from '../../src/utils'
 
@@ -19,7 +19,7 @@ describeRepeats('StreamrClient resends', () => {
             const c = new StreamrClient({
                 ...config,
                 auth: {
-                    privateKey: await getPrivateKey(),
+                    privateKey: await fetchPrivateKeyWithGas(),
                 },
                 autoConnect: false,
                 autoDisconnect: false,

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -8,7 +8,7 @@ import {
     publishTestMessagesGenerator,
     createTestStream,
     getCreateClient,
-    getPrivateKey
+    fetchPrivateKeyWithGas
 } from '../utils'
 import { Defer, pLimitFn, until } from '../../src/utils'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -96,8 +96,8 @@ describeRepeats('decryption', () => {
 
         // eslint-disable-next-line require-atomic-updates, semi-style, no-extra-semi
         ;[publisher, subscriber] = await Promise.all([
-            setupClient({ id: 'publisher', ...opts, auth: { privateKey: await getPrivateKey() } }),
-            setupClient({ id: 'subscriber', ...opts, auth: { privateKey: await getPrivateKey() } }),
+            setupClient({ id: 'publisher', ...opts, auth: { privateKey: await fetchPrivateKeyWithGas() } }),
+            setupClient({ id: 'subscriber', ...opts, auth: { privateKey: await fetchPrivateKeyWithGas() } }),
         ])
     }
 

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { describeRepeats, getCreateClient, getPublishTestStreamMessages, createTestStream, getPrivateKey } from '../utils'
+import { describeRepeats, getCreateClient, getPublishTestStreamMessages, createTestStream, fetchPrivateKeyWithGas } from '../utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
 import { GroupKey } from '../../src/encryption/Encryption'
@@ -36,8 +36,8 @@ describeRepeats('Group Key Persistence', () => {
             return client
         }
         beforeEach(async () => {
-            publisherPrivateKey = await getPrivateKey()
-            subscriberPrivateKey = await getPrivateKey()
+            publisherPrivateKey = await fetchPrivateKeyWithGas()
+            subscriberPrivateKey = await fetchPrivateKeyWithGas()
 
             publisher = await setupPublisher({
                 id: 'publisher',

--- a/packages/client/test/integration/MemoryLeaks.test.ts
+++ b/packages/client/test/integration/MemoryLeaks.test.ts
@@ -1,5 +1,5 @@
 import { wait } from 'streamr-test-utils'
-import { getPublishTestMessages, getPrivateKey, snapshot, LeaksDetector } from '../utils'
+import { getPublishTestMessages, fetchPrivateKeyWithGas, snapshot, LeaksDetector } from '../utils'
 import { StreamrClient, initContainer, Dependencies } from '../../src/StreamrClient'
 import { container, DependencyContainer } from 'tsyringe'
 import Subscription from '../../src/Subscription'
@@ -41,7 +41,7 @@ describe('MemoryLeaks', () => {
                 return initContainer({
                     ...clientOptions,
                     auth: {
-                        privateKey: await getPrivateKey(),
+                        privateKey: await fetchPrivateKeyWithGas(),
                     },
                     autoConnect: false,
                     autoDisconnect: false,
@@ -101,7 +101,7 @@ describe('MemoryLeaks', () => {
                 const c = new StreamrClient({
                     ...clientOptions,
                     auth: {
-                        privateKey: await getPrivateKey(),
+                        privateKey: await fetchPrivateKeyWithGas(),
                     },
                     autoConnect: false,
                     autoDisconnect: false,

--- a/packages/client/test/integration/MultipleClients.test.ts
+++ b/packages/client/test/integration/MultipleClients.test.ts
@@ -1,7 +1,7 @@
 import { wait, waitForCondition } from 'streamr-test-utils'
 
 import {
-    getCreateClient, getPublishTestMessages, describeRepeats, uid, addAfterFn, createTestStream, getPrivateKey,
+    getCreateClient, getPublishTestMessages, describeRepeats, uid, addAfterFn, createTestStream, fetchPrivateKeyWithGas,
 } from '../utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils'
@@ -26,7 +26,7 @@ describeRepeats('PubSub with multiple clients', () => {
     const addAfter = addAfterFn()
 
     beforeEach(async () => {
-        privateKey = await getPrivateKey()
+        privateKey = await fetchPrivateKeyWithGas()
         mainClient = await createClient({
             id: 'main',
             auth: {
@@ -46,7 +46,7 @@ describeRepeats('PubSub with multiple clients', () => {
     async function createPublisher(opts = {}) {
         const pubClient = await createClient({
             auth: {
-                privateKey: await getPrivateKey(),
+                privateKey: await fetchPrivateKeyWithGas(),
             },
             ...opts
         })
@@ -480,7 +480,7 @@ describeRepeats('PubSub with multiple clients', () => {
 
         otherClient = await createClient({
             auth: {
-                privateKey: await getPrivateKey()
+                privateKey: await fetchPrivateKeyWithGas()
             }
         })
         // otherClient.on('error', getOnError(errors))
@@ -556,7 +556,7 @@ describeRepeats('PubSub with multiple clients', () => {
 
         otherClient = await createClient({
             auth: {
-                privateKey: await getPrivateKey()
+                privateKey: await fetchPrivateKeyWithGas()
             }
         })
         // otherClient.on('error', getOnError(errors))

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -1,4 +1,4 @@
-import { createTestStream, fakePrivateKey, getCreateClient, getPrivateKey } from '../utils'
+import { createTestStream, fakePrivateKey, getCreateClient, fetchPrivateKeyWithGas } from '../utils'
 import { ConfigTest, Stream, StreamPermission, StreamrClient } from '../../src'
 import { wait } from 'streamr-test-utils'
 import { toStreamPartID } from 'streamr-client-protocol'
@@ -18,7 +18,7 @@ describe('PubSub with proxy connections', () => {
     const createClient = getCreateClient()
 
     beforeEach(async () => {
-        pubPrivateKey = await getPrivateKey()
+        pubPrivateKey = await fetchPrivateKeyWithGas()
         proxyPrivateKey1 = fakePrivateKey()
         proxyPrivateKey2 = fakePrivateKey()
 

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import StreamrClient, { ConfigTest, SearchStreamsPermissionFilter, Stream, StreamPermission } from '../../src'
 import { until } from '../../src/utils'
 import { collect } from '../../src/utils/GeneratorUtils'
-import { fakeAddress, getPrivateKey } from '../utils'
+import { fakeAddress, fetchPrivateKeyWithGas } from '../utils'
 
 jest.setTimeout(2 * 60 * 1000)
 
@@ -40,7 +40,7 @@ describe('SearchStreams', () => {
         client = new StreamrClient({
             ...ConfigTest,
             auth: {
-                privateKey: await getPrivateKey(),
+                privateKey: await fetchPrivateKeyWithGas(),
             },
             autoConnect: false
         })

--- a/packages/client/test/integration/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/integration/StorageNodeEndpoints.test.ts
@@ -4,7 +4,7 @@ import { NotFoundError, Stream } from '../../src'
 import { StreamrClient } from '../../src/StreamrClient'
 import { until } from '../../src/utils'
 import { StorageNodeAssignmentEvent } from '../../src/StorageNodeRegistry'
-import { createTestStream, getCreateClient, getPrivateKey } from '../utils'
+import { createTestStream, getCreateClient, fetchPrivateKeyWithGas } from '../utils'
 
 import { storageNodeTestConfig } from './devEnvironment'
 import { EthereumAddress } from 'streamr-client-protocol'
@@ -24,11 +24,11 @@ let nodeAddress: EthereumAddress
 const createClient = getCreateClient()
 
 beforeAll(async () => {
-    const key = await getPrivateKey()
+    const key = await fetchPrivateKeyWithGas()
     client = await createClient({ auth: {
         privateKey: key
     } })
-    const newStorageNodeWallet = new Wallet(await getPrivateKey())
+    const newStorageNodeWallet = new Wallet(await fetchPrivateKeyWithGas())
     newStorageNodeClient = await createClient({ auth: {
         privateKey: newStorageNodeWallet.privateKey
     } })

--- a/packages/client/test/integration/StorageNodeRegistry.test.ts
+++ b/packages/client/test/integration/StorageNodeRegistry.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Wallet } from 'ethers'
-import { clientOptions, createTestStream, getPrivateKey, until } from '../utils'
+import { clientOptions, createTestStream, fetchPrivateKeyWithGas, until } from '../utils'
 import { Stream } from '../../src'
 import { storageNodeTestConfig } from './devEnvironment'
 import { afterAll } from 'jest-circus'
@@ -16,8 +16,8 @@ describe('StorageNodeRegistry', () => {
     let stream: Stream
 
     beforeAll(async () => {
-        creatorWallet = new Wallet(await getPrivateKey())
-        listenerWallet = new Wallet(await getPrivateKey())
+        creatorWallet = new Wallet(await fetchPrivateKeyWithGas())
+        listenerWallet = new Wallet(await fetchPrivateKeyWithGas())
         creatorClient = new StreamrClient({
             ...clientOptions,
             auth: {

--- a/packages/client/test/integration/StreamEndpoints.test.ts
+++ b/packages/client/test/integration/StreamEndpoints.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from 'ethers'
 
-import { clientOptions, createTestStream, until, fakeAddress, createRelativeTestStreamId, getPrivateKey } from '../utils'
+import { clientOptions, createTestStream, until, fakeAddress, createRelativeTestStreamId, fetchPrivateKeyWithGas } from '../utils'
 import { NotFoundError } from '../../src/authFetch'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream, StreamPermission } from '../../src/Stream'
@@ -22,8 +22,8 @@ describe('StreamEndpoints', () => {
     let storageNodeAddress: string
 
     beforeAll(async () => {
-        wallet = new Wallet(await getPrivateKey())
-        otherWallet = new Wallet(await getPrivateKey())
+        wallet = new Wallet(await fetchPrivateKeyWithGas())
+        otherWallet = new Wallet(await fetchPrivateKeyWithGas())
         client = new StreamrClient({
             ...clientOptions,
             auth: {

--- a/packages/client/test/integration/SubscriberResendsSequential.test.ts
+++ b/packages/client/test/integration/SubscriberResendsSequential.test.ts
@@ -2,7 +2,7 @@ import {
     Msg,
     clientOptions,
     describeRepeats,
-    getPrivateKey,
+    fetchPrivateKeyWithGas,
     getWaitForStorage,
     getPublishTestStreamMessages,
     createTestStream,
@@ -33,7 +33,7 @@ describeRepeats('sequential resend subscribe', () => {
             ...clientOptions,
             id: 'TestPublisher',
             auth: {
-                privateKey: await getPrivateKey(),
+                privateKey: await fetchPrivateKeyWithGas(),
             },
         })
 
@@ -41,7 +41,7 @@ describeRepeats('sequential resend subscribe', () => {
             ...clientOptions,
             id: 'TestSubscriber',
             auth: {
-                privateKey: await getPrivateKey(),
+                privateKey: await fetchPrivateKeyWithGas(),
             },
         })
 

--- a/packages/client/test/utils.ts
+++ b/packages/client/test/utils.ts
@@ -3,7 +3,7 @@ import { writeHeapSnapshot } from 'v8'
 import { DependencyContainer } from 'tsyringe'
 
 import fetch from 'node-fetch'
-import { wait } from 'streamr-test-utils'
+import { KeyServer, wait } from 'streamr-test-utils'
 import { Wallet } from 'ethers'
 import { StreamMessage } from 'streamr-client-protocol'
 import LeakDetector from 'jest-leak-detector'
@@ -43,19 +43,24 @@ export function fakeAddress() {
     return crypto.randomBytes(32).toString('hex').slice(0, 40)
 }
 
-export async function getPrivateKey(timeout = 5000): Promise<string> {
-    const response = await new Promise<ReturnType<typeof fetch>>((resolve, reject) => {
-        const t = setTimeout(() => {
-            reject(new Error(`getPrivateKey timed out after ${timeout}ms.`))
-        }, timeout)
-
-        resolve(fetch('http://localhost:45454/key').finally(() => {
-            clearTimeout(t)
-        }))
-    })
+export async function fetchPrivateKeyWithGas(): Promise<string> {
+    let response
+    try {
+        response = await fetch(`http://localhost:${KeyServer.KEY_SERVER_PORT}/key`, {
+            timeout: 5 * 1000
+        })
+    } catch (_e) {
+        try {
+            await KeyServer.startIfNotRunning() // may throw if parallel attempts at starting server
+        } finally {
+            response = await fetch(`http://localhost:${KeyServer.KEY_SERVER_PORT}/key`, {
+                timeout: 5 * 1000
+            })
+        }
+    }
 
     if (!response.ok) {
-        throw new Error(`getPrivateKey failed ${response.status} ${response.statusText}: ${response.text()}`)
+        throw new Error(`fetchPrivateKeyWithGas failed ${response.status} ${response.statusText}: ${response.text()}`)
     }
 
     return response.text()
@@ -188,7 +193,7 @@ export const getCreateClient = (defaultOpts = {}, defaultParentContainer?: Depen
         if (opts.auth && opts.auth.privateKey) {
             key = opts.auth.privateKey
         } else {
-            key = await getPrivateKey()
+            key = await fetchPrivateKeyWithGas()
         }
         const c = new StreamrClient({
             ...clientOptions,

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -281,9 +281,26 @@ export const toReadableStream = (...args: unknown[]): Readable => {
 /* eslint-disable no-console */
 export class KeyServer {
     public static readonly KEY_SERVER_PORT = 45454
-    private readonly server: http.Server
+    private static singleton: KeyServer | undefined
+    private readonly ready: Promise<unknown>
+    private server?: http.Server
 
-    constructor() {
+    public static async startIfNotRunning(): Promise<void> {
+        if (KeyServer.singleton === undefined) {
+            KeyServer.singleton = new KeyServer()
+            await KeyServer.singleton.ready
+        }
+    }
+
+    public static async stopIfRunning(): Promise<void> {
+        if (KeyServer.singleton !== undefined) {
+            const temp = KeyServer.singleton
+            KeyServer.singleton = undefined
+            await temp.destroy()
+        }
+    }
+
+    private constructor() {
         const app = express()
         app.use(cors())
         let c = 1
@@ -305,15 +322,24 @@ export class KeyServer {
             }
         })
         console.info(`starting up keyserver on port ${KeyServer.KEY_SERVER_PORT}...`)
-        this.server = app.listen(KeyServer.KEY_SERVER_PORT)
-            .on('listening', () => {
-                console.info(`keyserver started on port ${KeyServer.KEY_SERVER_PORT}`)
-            })
+        this.ready = new Promise((resolve, reject) => {
+            this.server = app.listen(KeyServer.KEY_SERVER_PORT)
+                .once('listening', () => {
+                    console.info(`keyserver started on port ${KeyServer.KEY_SERVER_PORT}`)
+                    resolve(true)
+                })
+                .once('error', (err) => {
+                    reject(err)
+                })
+        })
     }
 
-    destroy(): Promise<unknown> {
+    private destroy(): Promise<unknown> {
+        if (this.server === undefined) {
+            return Promise.resolve(true)
+        }
         return new Promise((resolve, reject) => {
-            this.server.close((err) => {
+            this.server!.close((err) => {
                 if (err) {
                     reject(err)
                 } else {


### PR DESCRIPTION
Defer starting up `KeyServer` to the first time a private key with gas is request from it. The benefit being that the `KeyServer` doesn't have to be started if the test cases being run don't require it. Often we will want to run some unit test repeatedly when developing a new feature or such. It makes the turn around time faster not to keep starting  / stopping the `KeyServer` for nothing.

Also rename the methods to get private keys from the server as `fetchPrivateKeyWithGas`, clearly revealing the intention that the private key fetched should indeed be one with gas.