### PR TITLE
add `npm run build` top-level command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ npm run bootstrap-pkg $PACKAGE_NAME
 
 Examples:
 ```bash
+# from top level
 npm run bootstrap-pkg streamr-client
 npm run bootstrap-pkg streamr-network
+```
+
+## Build all sub-packages
+To build all sub-packages (with dependencies pre-installed beforehand)
+```bash
+# from top level
+npm run build
 ```
 
 ## Regenerate lockfile

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "bootstrap-pkg": "npm ci --no-audit --include-workspace-root --workspace",
         "versions": "zx ./show-versions.mjs && manypkg check",
         "prune-pkg": "npm prune --no-audit --include-workspace-root --production --workspace",
+        "build": "npm run --workspaces --if-present build",
         "clean": "npm run clean-dist && npx --workspaces --include-workspace-root -c 'rm -rf node_modules || true' && npm run bootstrap-root",
         "eslint": "npm run eslint --workspaces --if-present && manypkg check",
         "fix": "manypkg fix; npm run eslint -- --fix",


### PR DESCRIPTION
Add new top-level monorepo command `npm run build` that executes `npm run build` on each sub-package.

Useful when you have the project initialized and packages symlinked  with already before with `npm ci` or `npm run bootstrap`, and are developing and merely want changes made in one sub-package to be available in another sub-package.