### PR TITLE
refactor: move ethersOverrides to Ethereum.ts

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -388,13 +388,12 @@ Adding members using admin functions is not at feature parity with the member fu
 | createSecret(\[name])             | string              | Create a secret for a Data Union                               |
 | addMembers(memberAddressList)     | Transaction receipt | Add members                                                    |
 | removeMembers(memberAddressList)  | Transaction receipt | Remove members from Data Union                                 |
-| setAdminFee(newFeeFraction[, ethersOptions]) `**`                                                     | Transaction receipt     | `newFeeFraction` is a `Number` between 0.0 and 1.0 (inclusive) |
+| setAdminFee(newFeeFraction)       | Transaction receipt | `newFeeFraction` is a `Number` between 0.0 and 1.0 (inclusive) |
 | withdrawAllToMember(memberAddress\[, [options](#withdraw-options)\])                              | Transaction receipt `*` | Send all withdrawable earnings to the member's address |
 | withdrawAllToSigned(memberAddress, recipientAddress, signature\[, [options](#withdraw-options)\]) | Transaction receipt `*` | Send all withdrawable earnings to the address signed off by the member (see [example below](#member-functions)) |
 | withdrawAmountToSigned(memberAddress, recipientAddress, amountTokenWei, signature\[, [options](#withdraw-options)\]) | Transaction receipt `*` | Send some of the withdrawable earnings to the address signed off by the member |
 
 `*` The return value type may vary depending on [the given options](#withdraw-options) that describe the use case.<br>
-`**` `ethersOptions` that `setAdminFee` takes can be found as ["overrides" documented in docs.ethers.io](https://docs.ethers.io/v5/api/contract/contract/#contract-functionsSend).
 
 Here's how to deploy a Data Union contract with 30% Admin fee and add some members:
 

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -254,15 +254,15 @@ class StreamrEthereum {
     }
 
     getBinanceOverrides(): Overrides {
-        return this.getOverrides(this.ethereumConfig?.dataUnionBinanceWithdrawalChainRPC?.name, this.getBinanceProvider())
+        return this.getOverrides(this.ethereumConfig?.dataUnionBinanceWithdrawalChainRPC?.name ?? 'binance', this.getBinanceProvider())
     }
 
     getDataUnionOverrides(): Overrides {
-        return this.getOverrides(this.ethereumConfig?.dataUnionChainRPC?.name, this.getDataUnionChainProvider())
+        return this.getOverrides(this.ethereumConfig?.dataUnionChainRPC?.name ?? 'gnosis', this.getDataUnionChainProvider())
     }
 
     getStreamRegistryOverrides(): Overrides {
-        return this.getOverrides(this.ethereumConfig?.streamRegistryChainRPC?.name, this.getStreamRegistryChainProvider())
+        return this.getOverrides(this.ethereumConfig?.streamRegistryChainRPC?.name ?? 'polygon', this.getStreamRegistryChainProvider())
     }
 
     /**
@@ -270,9 +270,9 @@ class StreamrEthereum {
      * Ethers.js will resolve the gas price promise before sending the tx
      */
     private getOverrides(chainName: string, provider: Provider): Overrides {
-        const chainConfig = this.ethereumConfig.ethereumNetworks[chainName]
+        const chainConfig = this.ethereumConfig?.ethereumNetworks?.[chainName]
         if (!chainConfig) { return {} }
-        const { overrides } = chainConfig
+        const overrides = chainConfig?.overrides ?? {}
         if (chainConfig.gasPriceStrategy) {
             return {
                 ...overrides,

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -248,6 +248,39 @@ class StreamrEthereum {
 
         return new JsonRpcProvider(this.ethereumConfig.streamRegistryChainRPC)
     }
+
+    getMainnetOverrides(): Overrides {
+        return this.getOverrides('ethereum', this.getMainnetProvider())
+    }
+
+    getBinanceOverrides(): Overrides {
+        return this.getOverrides(this.ethereumConfig?.dataUnionBinanceWithdrawalChainRPC?.name, this.getBinanceProvider())
+    }
+
+    getDataUnionOverrides(): Overrides {
+        return this.getOverrides(this.ethereumConfig?.dataUnionChainRPC?.name, this.getDataUnionChainProvider())
+    }
+
+    getStreamRegistryOverrides(): Overrides {
+        return this.getOverrides(this.ethereumConfig?.streamRegistryChainRPC?.name, this.getStreamRegistryChainProvider())
+    }
+
+    /**
+     * Apply the gasPriceStrategy to the estimated gas price, if given
+     * Ethers.js will resolve the gas price promise before sending the tx
+     */
+    private getOverrides(chainName: string, provider: Provider): Overrides {
+        const chainConfig = this.ethereumConfig.ethereumNetworks[chainName]
+        if (!chainConfig) { return {} }
+        const { overrides } = chainConfig
+        if (chainConfig.gasPriceStrategy) {
+            return {
+                ...overrides,
+                gasPrice: provider.getGasPrice().then(chainConfig.gasPriceStrategy)
+            }
+        }
+        return overrides
+    }
 }
 
 export default StreamrEthereum

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -114,8 +114,10 @@ export class StorageNodeRegistry {
     async createOrUpdateNodeInStorageNodeRegistry(nodeMetadata: string): Promise<void> {
         log('setNode %s -> %s', nodeMetadata)
         await this.connectToNodeRegistryContract()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
+        await waitForTx(this.nodeRegistryContract!.createOrUpdateNodeSelf(nodeMetadata, ethersOverrides))
+
         const nodeAddress = await this.ethereum.getAddress()
-        await waitForTx(this.nodeRegistryContract!.createOrUpdateNodeSelf(nodeMetadata))
         await until(async () => {
             try {
                 const url = await this.getStorageNodeUrl(nodeAddress)
@@ -130,14 +132,16 @@ export class StorageNodeRegistry {
     async removeNodeFromStorageNodeRegistry(): Promise<void> {
         log('removeNode called')
         await this.connectToNodeRegistryContract()
-        await waitForTx(this.nodeRegistryContract!.removeNodeSelf())
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
+        await waitForTx(this.nodeRegistryContract!.removeNodeSelf(ethersOverrides))
     }
 
     async addStreamToStorageNode(streamIdOrPath: string, nodeAddress: string): Promise<void> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         log('Adding stream %s to node %s', streamId, nodeAddress)
         await this.connectToNodeRegistryContract()
-        await waitForTx(this.streamStorageRegistryContract!.addStorageNode(streamId, nodeAddress))
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
+        await waitForTx(this.streamStorageRegistryContract!.addStorageNode(streamId, nodeAddress, ethersOverrides))
         await until(async () => { return this.isStreamStoredInStorageNode(streamId, nodeAddress) }, 10000, 500,
             () => `Failed to add stream ${streamId} to storageNode ${nodeAddress}, timed out querying fact from theGraph`)
     }
@@ -146,7 +150,8 @@ export class StorageNodeRegistry {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         log('Removing stream %s from node %s', streamId, nodeAddress)
         await this.connectToNodeRegistryContract()
-        await waitForTx(this.streamStorageRegistryContract!.removeStorageNode(streamId, nodeAddress))
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
+        await waitForTx(this.streamStorageRegistryContract!.removeStorageNode(streamId, nodeAddress, ethersOverrides))
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -1,4 +1,4 @@
-import { Contract, Overrides } from '@ethersproject/contracts'
+import { Contract } from '@ethersproject/contracts'
 import { Signer } from '@ethersproject/abstract-signer'
 import type { StreamRegistry as StreamRegistryContract } from './ethereumArtifacts/StreamRegistry.d'
 import StreamRegistryArtifact from './ethereumArtifacts/StreamRegistryAbi.json'
@@ -79,8 +79,6 @@ export class StreamRegistry implements Context {
     streamRegistryContractReadonly: StreamRegistryContract
     chainProvider: Provider
     chainSigner?: Signer
-    defaultOverrides: Overrides = {}
-    gasPriceStrategy?: (estimatedGasPrice: BigNumber) => BigNumber
 
     constructor(
         context: Context,
@@ -96,25 +94,6 @@ export class StreamRegistry implements Context {
         this.chainProvider = this.ethereum.getStreamRegistryChainProvider()
         this.streamRegistryContractReadonly = new Contract(this.config.streamRegistryChainAddress,
             StreamRegistryArtifact, this.chainProvider) as StreamRegistryContract
-
-        // find chain-specific configs
-        const streamRegistryChainName = this.config.streamRegistryChainRPC?.name
-        if (this.config.ethereumNetworks && streamRegistryChainName) {
-            const chainConfig = this.config.ethereumNetworks[streamRegistryChainName]
-            this.defaultOverrides = chainConfig?.overrides ?? {}
-            this.gasPriceStrategy = chainConfig?.gasPriceStrategy
-        }
-    }
-
-    /**
-     * Apply the gasPriceStrategy to the estimated gas price, if given
-     * Ethers.js will resolve the gas price promise before sending the tx
-     */
-    private getOverrides(): Overrides {
-        return this.gasPriceStrategy ? {
-            ...this.defaultOverrides,
-            gasPrice: this.chainProvider.getGasPrice().then(this.gasPriceStrategy)
-        } : this.defaultOverrides
     }
 
     private parseStream(id: StreamID, metadata: string): Stream {
@@ -186,7 +165,7 @@ export class StreamRegistry implements Context {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
 
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
 
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         const metadata = StreamRegistry.formMetadata(props)
@@ -232,7 +211,7 @@ export class StreamRegistry implements Context {
     async updateStream(props: StreamProperties): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.updateStreamMetadata(
             streamId,
             StreamRegistry.formMetadata(props),
@@ -248,7 +227,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Granting Permission %o for user %s on stream %s', permission, receivingUser, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.grantPermission(
             streamId,
             receivingUser,
@@ -261,7 +240,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Granting PUBLIC Permission %o on stream %s', permission, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.grantPublicPermission(
             streamId,
             StreamRegistry.streamPermissionToSolidityType(permission),
@@ -282,7 +261,7 @@ export class StreamRegistry implements Context {
         this.debug(`Setting permissions for user ${receivingUser} on stream ${streamId}:
         edit: ${edit}, delete: ${deletePermission}, publish: ${publish}, subscribe: ${subscribe}, share: ${share}`)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         const publishExpiration = publish ? MaxInt256 : 0
         const subscribeExpiration = subscribe ? MaxInt256 : 0
         await waitForTx(this.streamRegistryContract!.setPermissionsForUser(
@@ -309,7 +288,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug(`Setting permissions for stream ${streamId} for ${users.length} users`)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         const transformedPermission = permissions.map(StreamRegistry.convertStreamPermissionToChainPermission)
         await waitForTx(this.streamRegistryContract!.setPermissions(
             streamId,
@@ -323,7 +302,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Revoking permission %o for user %s on stream %s', permission, receivingUser, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.revokePermission(
             streamId,
             receivingUser,
@@ -337,7 +316,7 @@ export class StreamRegistry implements Context {
         const address = await this.ethereum.getAddress()
         this.debug('Revoking all permissions user %s on stream %s', address, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.revokeAllPermissionsForUser(
             streamId,
             address,
@@ -349,7 +328,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Revoking all permissions user %s on stream %s', userId, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.revokeAllPermissionsForUser(
             streamId,
             userId,
@@ -361,7 +340,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Revoking PUBLIC Permission %o on stream %s', permission, streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.revokePublicPermission(
             streamId,
             StreamRegistry.streamPermissionToSolidityType(permission),
@@ -373,7 +352,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Revoking all PUBLIC Permissions stream %s', streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.revokeAllPermissionsForUser(
             streamId,
             AddressZero,
@@ -385,7 +364,7 @@ export class StreamRegistry implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Deleting stream %s', streamId)
         await this.connectToStreamRegistryContract()
-        const ethersOverrides = this.getOverrides()
+        const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
         await waitForTx(this.streamRegistryContract!.deleteStream(
             streamId,
             ethersOverrides


### PR DESCRIPTION
also add them to StorageNodeRegistry, so now it seems all Polygon smart contract transactions are covered

The rest don't have overrides for now