### PR TITLE
Port 2.0 admin fee support from v5, expose DU address calculation methods to public API

### DIFF
--- a/packages/client/src/dataunion/DataUnion.ts
+++ b/packages/client/src/dataunion/DataUnion.ts
@@ -16,6 +16,7 @@ import { erc20AllowanceAbi } from './abi'
 
 import DataUnionAPI from './index'
 import { EthereumAddress } from 'streamr-client-protocol'
+import type { TransactionReceipt } from '@ethersproject/providers'
 
 export interface DataUnionDeployOptions {
     owner?: EthereumAddress,
@@ -731,7 +732,7 @@ export class DataUnion {
     }
 
     /** @internal */
-    static async _setBinanceDepositAddress(binanceRecipient: EthereumAddress, client: DataUnionAPI) {
+    static async _setBinanceDepositAddress(binanceRecipient: EthereumAddress, client: DataUnionAPI): Promise<TransactionReceipt> {
         const contracts = new Contracts(client)
         const adapter = await contracts.getBinanceAdapter()
         const ethersOverrides = client.ethereum.getDataUnionOverrides()
@@ -745,7 +746,7 @@ export class DataUnion {
         binanceRecipient: EthereumAddress,
         signature: BytesLike,
         client: DataUnionAPI
-    ) {
+    ): Promise<TransactionReceipt> {
         const contracts = new Contracts(client)
         const adapter = await contracts.getBinanceAdapter()
         const ethersOverrides = client.ethereum.getDataUnionOverrides()

--- a/packages/client/src/dataunion/abi.ts
+++ b/packages/client/src/dataunion/abi.ts
@@ -48,6 +48,18 @@ export const dataUnionMainnetABI = [{
     outputs: [{ type: 'address' }],
     stateMutability: 'view',
     type: 'function'
+}, {
+    name: 'setAdminFee', // NOT AVAILABLE since v2.2, moved to sidechain (see below)
+    inputs: [{ type: 'uint256' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+}, {
+    name: 'adminFeeFraction', // NOT AVAILABLE since v2.2, moved to sidechain (see below)
+    inputs: [],
+    outputs: [{ type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
 }]
 
 // In DU v2.2, fees were moved to the sidechain (admin fee and added DU fee that goes to the DU DAO)

--- a/packages/client/src/dataunion/index.ts
+++ b/packages/client/src/dataunion/index.ts
@@ -1,16 +1,27 @@
 import { inject, scoped, Lifecycle } from 'tsyringe'
 
+import { BigNumber } from '@ethersproject/bignumber'
+import { BytesLike, hexZeroPad } from '@ethersproject/bytes'
+import { Contract } from '@ethersproject/contracts'
+import { keccak256 } from '@ethersproject/keccak256'
+
+import { EthereumAddress } from 'streamr-client-protocol'
+
 import Ethereum from '../Ethereum'
 import { Rest } from '../Rest'
 import { StrictBrubeckClientConfig, Config } from '../Config'
 import { DataUnion, DataUnionDeployOptions } from './DataUnion'
-import { BigNumber } from '@ethersproject/bignumber'
-import { getAddress, isAddress } from '@ethersproject/address'
-import { Contract } from '@ethersproject/contracts'
+import { getAddress, getCreate2Address, isAddress } from '@ethersproject/address'
 import Contracts from './Contracts'
+import { defaultAbiCoder } from '@ethersproject/abi'
 
-import { BytesLike } from '@ethersproject/bytes'
-import { EthereumAddress } from 'streamr-client-protocol'
+import { factoryMainnetABI } from './abi'
+
+import { Debug } from '../utils/log'
+import { parseEther } from '@ethersproject/units'
+import { until } from '../utils'
+
+const log = Debug('DataUnionAPI')
 
 const balanceOfAbi = [{
     name: 'balanceOf',
@@ -53,7 +64,30 @@ export default class DataUnionAPI {
         return token.balanceOf(addr)
     }
 
-    async getDataUnion(contractAddress: EthereumAddress) {
+    /**
+     * NOTE: if template address is not given, calculation only works for the newest currently deployed factory,
+     *       i.e. can be used for "future deployments" but NOT for old deployments
+     * For old deployments, please use getDataUnion
+     */
+    calculateDataUnionAddresses(
+        dataUnionName: string,
+        deployerAddress: EthereumAddress
+    ): { mainnetAddress: EthereumAddress, sidechainAddress: EthereumAddress } {
+        const deployer = getAddress(deployerAddress)
+        const {
+            templateMainnetAddress,
+            factoryMainnetAddress,
+            factorySidechainAddress,
+        } = this.options.dataUnion
+        // These magic hex comes from https://github.com/streamr-dev/data-union-solidity/blob/master/contracts/CloneLib.sol#L19
+        const codeHash = keccak256(`0x3d602d80600a3d3981f3363d3d373d3d3d363d73${templateMainnetAddress.slice(2)}5af43d82803e903d91602b57fd5bf3`)
+        const salt = keccak256(defaultAbiCoder.encode(['string', 'address'], [dataUnionName, deployer]))
+        const mainnetAddress = getCreate2Address(factoryMainnetAddress, salt, codeHash)
+        const sidechainAddress = getCreate2Address(factorySidechainAddress, hexZeroPad(mainnetAddress, 32), codeHash)
+        return { mainnetAddress, sidechainAddress }
+    }
+
+    async getDataUnion(contractAddress: EthereumAddress): Promise<DataUnion> {
         if (!isAddress(contractAddress)) {
             throw new Error(`Can't get Data Union, invalid Ethereum address: ${contractAddress}`)
         }
@@ -70,8 +104,77 @@ export default class DataUnionAPI {
         throw new Error(`${contractAddress} is an unknown Data Union version "${version}"`)
     }
 
-    async deployDataUnion(options?: DataUnionDeployOptions) {
-        return DataUnion._deploy(options, this) // eslint-disable-line no-underscore-dangle
+    /**
+     * Create a new DataUnionMainnet contract to mainnet with DataUnionFactoryMainnet
+     * This triggers DataUnionSidechain contract creation in sidechain, over the bridge (AMB)
+     * @return Promise<DataUnion> that resolves when the new DU is deployed over the bridge to side-chain
+     */
+    async deployDataUnion(options: DataUnionDeployOptions = {}): Promise<DataUnion> {
+        const deployerAddress = await this.ethereum.getAddress()
+        const mainnetProvider = this.ethereum.getMainnetProvider()
+        const mainnetWallet = this.ethereum.getSigner()
+        const duChainProvider = this.ethereum.getDataUnionChainProvider()
+
+        const {
+            factoryMainnetAddress
+        } = this.options.dataUnion
+
+        const {
+            owner = deployerAddress,
+            joinPartAgents = [owner, this.options.streamrNodeAddress],
+            dataUnionName = `DataUnion-${Date.now()}`, // TODO: use uuid
+            adminFee = 0,
+            sidechainPollingIntervalMs = 1000,
+            sidechainRetryTimeoutMs = 600000,
+            confirmations = 1,
+            gasPrice
+        } = options
+
+        log(`Going to deploy Data Union with name: ${dataUnionName}`)
+
+        if (adminFee < 0 || adminFee > 1) { throw new Error('options.adminFeeFraction must be a number between 0...1, got: ' + adminFee) }
+        const adminFeeBN = BigNumber.from((adminFee * 1e18).toFixed()) // last 2...3 decimals are going to be gibberish
+
+        const ownerAddress = getAddress(owner)
+        const agentAddressList = joinPartAgents.map(getAddress)
+
+        const {
+            mainnetAddress,
+            sidechainAddress,
+        } = this.calculateDataUnionAddresses(dataUnionName, deployerAddress)
+
+        if (await mainnetProvider.getCode(mainnetAddress) !== '0x') {
+            throw new Error(`Mainnet data union "${dataUnionName}" contract ${mainnetAddress} already exists!`)
+        }
+
+        if (await mainnetProvider.getCode(factoryMainnetAddress) === '0x') {
+            throw new Error(`Contract not found at ${factoryMainnetAddress}, check StreamrClient.options.dataUnion.factoryMainnetAddress!`)
+        }
+
+        const factoryMainnet = new Contract(factoryMainnetAddress, factoryMainnetABI, mainnetWallet)
+        const ethersOptions: any = {}
+        if (gasPrice) { ethersOptions.gasPrice = gasPrice }
+        const duFeeFraction = parseEther('0') // TODO: decide what the default values should be
+        const duBeneficiary = '0x0000000000000000000000000000000000000000' // TODO: decide what the default values should be
+        const tx = await factoryMainnet.deployNewDataUnion(
+            ownerAddress,
+            adminFeeBN,
+            duFeeFraction,
+            duBeneficiary,
+            agentAddressList,
+            dataUnionName,
+            ethersOptions
+        )
+        await tx.wait(confirmations)
+
+        log(`Data Union deployed to mainnet: ${mainnetAddress}, waiting for sidechain: ${sidechainAddress}`)
+        await until(
+            async () => await duChainProvider.getCode(sidechainAddress) !== '0x',
+            sidechainRetryTimeoutMs,
+            sidechainPollingIntervalMs
+        )
+
+        return new DataUnion(mainnetAddress, sidechainAddress, this)
     }
 
     async setBinanceDepositAddress(binanceRecipient: EthereumAddress) {

--- a/packages/client/src/dataunion/index.ts
+++ b/packages/client/src/dataunion/index.ts
@@ -76,14 +76,16 @@ export default class DataUnionAPI {
         const deployer = getAddress(deployerAddress)
         const {
             templateMainnetAddress,
+            templateSidechainAddress,
             factoryMainnetAddress,
             factorySidechainAddress,
         } = this.options.dataUnion
-        // These magic hex comes from https://github.com/streamr-dev/data-union-solidity/blob/master/contracts/CloneLib.sol#L19
-        const codeHash = keccak256(`0x3d602d80600a3d3981f3363d3d373d3d3d363d73${templateMainnetAddress.slice(2)}5af43d82803e903d91602b57fd5bf3`)
+        // The magic hex strings come from https://github.com/streamr-dev/data-union-solidity/blob/master/contracts/CloneLib.sol#L19
         const salt = keccak256(defaultAbiCoder.encode(['string', 'address'], [dataUnionName, deployer]))
-        const mainnetAddress = getCreate2Address(factoryMainnetAddress, salt, codeHash)
-        const sidechainAddress = getCreate2Address(factorySidechainAddress, hexZeroPad(mainnetAddress, 32), codeHash)
+        const codeHashM = keccak256(`0x3d602d80600a3d3981f3363d3d373d3d3d363d73${templateMainnetAddress.slice(2)}5af43d82803e903d91602b57fd5bf3`)
+        const mainnetAddress = getCreate2Address(factoryMainnetAddress, salt, codeHashM)
+        const codeHashS = keccak256(`0x3d602d80600a3d3981f3363d3d373d3d3d363d73${templateSidechainAddress.slice(2)}5af43d82803e903d91602b57fd5bf3`)
+        const sidechainAddress = getCreate2Address(factorySidechainAddress, hexZeroPad(mainnetAddress, 32), codeHashS)
         return { mainnetAddress, sidechainAddress }
     }
 

--- a/packages/client/test/integration/dataunion/calculate.test.ts
+++ b/packages/client/test/integration/dataunion/calculate.test.ts
@@ -2,11 +2,8 @@ import { Wallet } from 'ethers'
 import debug from 'debug'
 
 import { StreamrClient } from '../../../src/StreamrClient'
-import Contracts from '../../../src/dataunion/Contracts'
-import DataUnionAPI from '../../../src/dataunion'
 import { clientOptions, providerMainnet, providerSidechain } from '../devEnvironment'
 import { getRandomClient, expectInvalidAddress } from '../../utils'
-import BrubeckConfig from '../../../src/Config'
 
 const log = debug('StreamrClient::DataUnion::integration-test-calculate')
 

--- a/packages/client/test/integration/dataunion/calculate.test.ts
+++ b/packages/client/test/integration/dataunion/calculate.test.ts
@@ -25,18 +25,17 @@ describe('DataUnion calculate', () => {
         log('Connected to sidechain network: ', JSON.stringify(network2))
 
         const adminClient = new StreamrClient(clientOptions as any)
-
         const dataUnionName = 'test-' + Date.now()
-
-        const contracts = new Contracts(new DataUnionAPI(adminClient, null!, BrubeckConfig(clientOptions)))
-        const mainnetAddressPredicted = contracts.calculateDataUnionMainnetAddress(dataUnionName, adminWalletMainnet.address)
-        const sidechainAddressPredicted = contracts.calculateDataUnionSidechainAddress(mainnetAddressPredicted)
+        const {
+            mainnetAddress,
+            sidechainAddress,
+        } = adminClient.calculateDataUnionAddresses(dataUnionName, adminWalletMainnet.address)
 
         const dataUnionDeployed = await adminClient.deployDataUnion({ dataUnionName })
         const version = await dataUnionDeployed.getVersion()
 
-        expect(dataUnionDeployed.getAddress()).toBe(mainnetAddressPredicted)
-        expect(dataUnionDeployed.getSidechainAddress()).toBe(sidechainAddressPredicted)
+        expect(dataUnionDeployed.getAddress()).toBe(mainnetAddress)
+        expect(dataUnionDeployed.getSidechainAddress()).toBe(sidechainAddress)
         expect(version).toBe(2)
     }, 60000)
 


### PR DESCRIPTION
I didn't add them to README because they're kind of special-use; they shouldn't be used for existing DUs, only future DUs

2.0 admin fee (handled in mainnet) was needed because many prominent DUs listed on the Marketplace still use the 2.0 contracts.

Both ETH-232 and ETH-231 were included here