### PR TITLE
[NET-698]: Config wizard: only write non-default values

### DIFF
--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -45,11 +45,6 @@ const PRIVATE_KEY_SOURCE_IMPORT = 'Import'
 export const CONFIG_TEMPLATE: any = {
     client: {
         auth: {
-        },
-        network: {
-            stunUrls: [
-                "stun:stun.streamr.network:5349"
-            ]
         }
     },
     plugins: {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -46,7 +46,6 @@ export const CONFIG_TEMPLATE: any = {
     client: {
         auth: {
         },
-        restUrl: 'https://streamr.network/api/v2',
         network: {
             stunUrls: [
                 "stun:stun.streamr.network:5349"

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -49,12 +49,7 @@ export const CONFIG_TEMPLATE: any = {
     },
     plugins: {
         brubeckMiner: {},
-        metrics: {
-            consoleAndPM2IntervalInSeconds: 0,
-            nodeMetrics: {
-                streamIdPrefix: 'streamr.eth/metrics/nodes/firehose/'
-            }
-        },
+        metrics: {}
     },
     apiAuthentication: {
         keys: [generateApiKey()]

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -48,7 +48,6 @@ export const CONFIG_TEMPLATE: any = {
         },
         restUrl: 'https://streamr.network/api/v2',
         network: {
-            name: 'miner-node',
             trackers: [
                 {
                     "id": "0xFBB6066c44bc8132bA794C73f58F391273E3bdA1",

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -48,22 +48,7 @@ export const CONFIG_TEMPLATE: any = {
         }
     },
     plugins: {
-        brubeckMiner: {
-            rewardStreamIds: [
-                'streamr.eth/brubeck-mainnet/rewards/001ae9',
-                'streamr.eth/brubeck-mainnet/rewards/b82a43',
-                'streamr.eth/brubeck-mainnet/rewards/d72f1a',
-                'streamr.eth/brubeck-mainnet/rewards/d1aed2',
-                'streamr.eth/brubeck-mainnet/rewards/14aptk',
-                'streamr.eth/brubeck-mainnet/rewards/b2ab22',
-                'streamr.eth/brubeck-mainnet/rewards/7cd249',
-                'streamr.eth/brubeck-mainnet/rewards/af81e2',
-                'streamr.eth/brubeck-mainnet/rewards/52ada6',
-                'streamr.eth/brubeck-mainnet/rewards/cbab52'
-            ],
-            claimServerUrl: "http://brubeck1.streamr.network:3011",
-            stunServerHost: "stun.sipgate.net"
-        },
+        brubeckMiner: {},
         metrics: {
             consoleAndPM2IntervalInSeconds: 0,
             nodeMetrics: {

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -48,58 +48,6 @@ export const CONFIG_TEMPLATE: any = {
         },
         restUrl: 'https://streamr.network/api/v2',
         network: {
-            trackers: [
-                {
-                    "id": "0xFBB6066c44bc8132bA794C73f58F391273E3bdA1",
-                    "ws": "wss://brubeck3.streamr.network:30401",
-                    "http": "https://brubeck3.streamr.network:30401"
-                },
-                {
-                    "id": "0x3D61bFeFA09CEAC1AFceAA50c7d79BE409E1ec24",
-                    "ws": "wss://brubeck3.streamr.network:30402",
-                    "http": "https://brubeck3.streamr.network:30402"
-                },
-                {
-                    "id": "0xE80FB5322231cBC1e761A0F896Da8E0CA2952A66",
-                    "ws": "wss://brubeck3.streamr.network:30403",
-                    "http": "https://brubeck3.streamr.network:30403"
-                },
-                {
-                    "id": "0xf626285C6AACDE39ae969B9Be90b1D9855F186e0",
-                    "ws": "wss://brubeck3.streamr.network:30404",
-                    "http": "https://brubeck3.streamr.network:30404"
-                },
-                {
-                    "id": "0xce88Da7FE0165C8b8586aA0c7C4B26d880068219",
-                    "ws": "wss://brubeck3.streamr.network:30405",
-                    "http": "https://brubeck3.streamr.network:30405"
-                },
-                {
-                    "id": "0x05e7a0A64f88F84fB1945a225eE48fFC2c48C38E",
-                    "ws": "wss://brubeck4.streamr.network:30401",
-                    "http": "https://brubeck4.streamr.network:30401"
-                },
-                {
-                    "id": "0xF15784106ACd35b0542309CDF2b35cb5BA642C4F",
-                    "ws": "wss://brubeck4.streamr.network:30402",
-                    "http": "https://brubeck4.streamr.network:30402"
-                },
-                {
-                    "id": "0x77FA7Af34108abdf8e92B8f4C4AeC7CbfD1d6B09",
-                    "ws": "wss://brubeck4.streamr.network:30403",
-                    "http": "https://brubeck4.streamr.network:30403"
-                },
-                {
-                    "id": "0x7E83e0bdAF1eF06F31A02f35A07aFB48179E536B",
-                    "ws": "wss://brubeck4.streamr.network:30404",
-                    "http": "https://brubeck4.streamr.network:30404"
-                },
-                {
-                    "id": "0x2EeF37180691c75858Bf1e781D13ae96943Dd388",
-                    "ws": "wss://brubeck4.streamr.network:30405",
-                    "http": "https://brubeck4.streamr.network:30405"
-                }
-            ],
             stunUrls: [
                 "stun:stun.streamr.network:5349"
             ]

--- a/packages/broker/src/ConfigWizard.ts
+++ b/packages/broker/src/ConfigWizard.ts
@@ -234,7 +234,6 @@ export const storagePathPrompts = [{
 export const getConfig = (privateKey: string, pluginsAnswers: inquirer.Answers): any => {
     const config = { ... CONFIG_TEMPLATE, plugins: { ... CONFIG_TEMPLATE.plugins } }
     config.client.auth.privateKey = privateKey
-    config.client.network.id = new Wallet(privateKey).address
 
     const pluginKeys = Object.keys(PLUGIN_NAMES)
     pluginKeys.forEach((pluginKey) => {

--- a/packages/broker/src/plugins/brubeckMiner/config.schema.json
+++ b/packages/broker/src/plugins/brubeckMiner/config.schema.json
@@ -9,11 +9,22 @@
             "type": "array",
             "items": { "type": "string" },
             "uniqueItems": true,
-            "default": ["streamr.eth/brubeck/brubeck-rewards"]
+            "default": [
+                "streamr.eth/brubeck-mainnet/rewards/001ae9",
+                "streamr.eth/brubeck-mainnet/rewards/b82a43",
+                "streamr.eth/brubeck-mainnet/rewards/d72f1a",
+                "streamr.eth/brubeck-mainnet/rewards/d1aed2",
+                "streamr.eth/brubeck-mainnet/rewards/14aptk",
+                "streamr.eth/brubeck-mainnet/rewards/b2ab22",
+                "streamr.eth/brubeck-mainnet/rewards/7cd249",
+                "streamr.eth/brubeck-mainnet/rewards/af81e2",
+                "streamr.eth/brubeck-mainnet/rewards/52ada6",
+                "streamr.eth/brubeck-mainnet/rewards/cbab52"
+            ]
         },
         "claimServerUrl": {
             "type": "string",
-            "default": "https://brubeck-rewards.streamr.network"
+            "default": "http://brubeck1.streamr.network:3011"
         },
         "maxClaimDelay": {
             "type": "number",
@@ -25,7 +36,7 @@
                 "string",
                 "null"
             ],
-            "default": "stun.streamr.network:5349"
+            "default": "stun.sipgate.net"
         }
     }
 }

--- a/packages/broker/src/plugins/metrics/config.schema.json
+++ b/packages/broker/src/plugins/metrics/config.schema.json
@@ -12,7 +12,8 @@
     "consoleAndPM2IntervalInSeconds": {
       "type": "integer",
       "description": "Interval (in seconds) in which to collect and report metrics (0 = disable)",
-      "minimum": 0
+      "minimum": 0,
+      "default": 0
     },
     "nodeMetrics" : {
       "type": [
@@ -20,6 +21,7 @@
         "null"
       ],
       "additionalProperties": false,
+      "default": {},
       "properties": {
         "streamIdPrefix": {
           "type": "string",

--- a/packages/client/src/ConfigBase.ts
+++ b/packages/client/src/ConfigBase.ts
@@ -98,7 +98,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
     auth: {},
 
     // Streamr Core options
-    restUrl: 'https://streamr.network/api/v2/',
+    restUrl: 'https://streamr.network/api/v2',
     theGraphUrl: 'https://api.thegraph.com/subgraphs/name/streamr-dev/streams',
     streamrNodeAddress: '0xf3E5A65851C3779f468c9EcB32E6f25D9D68601a',
     // storageNodeAddressDev = new StorageNode('0xde1112f631486CfC759A50196853011528bC5FA0', '')

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -39,7 +39,7 @@ export const createNetworkNode = ({
     rttUpdateTimeout,
     webrtcDatachannelBufferThresholdLow,
     webrtcDatachannelBufferThresholdHigh,
-    stunUrls = ['stun:stun.l.google.com:19302'],
+    stunUrls = ['stun:stun.streamr.network:5349'],
     trackerConnectionMaintenanceInterval,
     webrtcDisallowPrivateAddresses = false,
     acceptProxyConnections


### PR DESCRIPTION
Config wizard creates a minimal configuration file as it doesn't write a values if that value is a default value of the property.

Also changed some defaults, most importantly network `stunUrls`. @juslesan Is it ok that we have the `stunUrl` default has been changed in `network`-repo, affecting all use cases of network package?

### Details 
- We don't write `network.id`, because by default we derive that information from the private key. Note: now when an explicit id is not set, the network id will use session id suffix. Trackers and miner plugins should be compatible with that.
- We don't write `network.name`. The intention is that all Brubeck nodes won't be miners and therefore the name could be misleading. The name is used to give name to the MetricsContext (`BrubeckNode.ts:67`), but it is maybe ok that we change that? Note that network.id now includes a sessionId and therefore it is not the same in two consecutive runs. Therefore is some use case needs to have deterministic name for the metrics context, the user should set an explicit network.id. (If we don't change the functionality, e.g. by removing the sessionId suffix.)
- Updated the defaults of `brubeckMiner` plugin to reflect what was earlier defined in config wizard.
- Client restUrl doesn't have an `/` character at the of the url definition. Maybe fixes something, or is just more accurate value?