### PR TITLE
fix: add default config for client RPC timeout null cases

### DIFF
--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -352,7 +352,8 @@
                                 "type": "boolean"
                             },
                             "timeout": {
-                                "type": "number"
+                                "type": "number",
+                                "default": 120000
                             },
                             "headers": {
                                 "type": "object"


### PR DESCRIPTION
- Required after [NET-697](https://github.com/streamr-dev/network-monorepo/commit/09ae1bebb6c083768fbc800db6a7a5b6d43cc510) to ensure that the default timeout is set for each separately configured RPC-endpoint