### PR TITLE
fix: field collision between StreamrClientBase and Session

### DIFF
--- a/packages/client/src/Session.ts
+++ b/packages/client/src/Session.ts
@@ -21,12 +21,12 @@ enum State {
 
 @scoped(Lifecycle.ContainerScoped)
 export default class Session extends EventEmitter {
-    state: State
-    sessionTokenPromise?: Promise<string>
+    private state: State
+    private sessionTokenPromise?: Promise<string>
 
     constructor(
         @inject(BrubeckContainer) private container: DependencyContainer,
-        @inject(Config.Auth) public options: AuthConfig
+        @inject(Config.Auth) private options: AuthConfig
     ) {
         super()
         this.state = State.LOGGED_OUT
@@ -46,7 +46,7 @@ export default class Session extends EventEmitter {
         this.emit(newState)
     }
 
-    get loginEndpoints() {
+    private get loginEndpoints() {
         return this.container.resolve<LoginEndpoints>(LoginEndpoints)
     }
 

--- a/packages/client/test/integration/LoginEndpoints.test.ts
+++ b/packages/client/test/integration/LoginEndpoints.test.ts
@@ -87,9 +87,11 @@ describe('LoginEndpoints', () => {
     describe('logout', () => {
         it('should not be able to use the same session token after logout', async () => {
             await client.getUserInfo() // first fetches the session token, then requests the endpoint
+            // @ts-expect-error private
             const sessionToken1 = client.session.options.sessionToken
             await client.logoutEndpoint() // invalidates the session token in core-api
             await client.getUserInfo() // requests the endpoint with sessionToken1, receives 401, fetches a new session token
+            // @ts-expect-error private
             const sessionToken2 = client.session.options.sessionToken
             assert.notDeepStrictEqual(sessionToken1, sessionToken2)
         })

--- a/packages/client/test/unit/Session.test.ts
+++ b/packages/client/test/unit/Session.test.ts
@@ -100,19 +100,23 @@ describe('Session', () => {
         it('should set sessionToken', async () => {
             await session.getSessionToken()
             expect(loginFunction).toHaveBeenCalledTimes(1)
+            // @ts-expect-error private
             expect(session.options.sessionToken === 'session-token1').toBeTruthy()
         })
 
         it('should not call sendLogin if token set', async () => {
+            // @ts-expect-error private
             session.options.sessionToken = 'session-token1'
             await session.getSessionToken()
             expect(loginFunction).toHaveBeenCalledTimes(0)
         })
 
         it('should call sendLogin if new token required', async () => {
+            // @ts-expect-error private
             session.options.sessionToken = 'expired-session-token'
             await session.getSessionToken(true)
             expect(loginFunction).toHaveBeenCalledTimes(1)
+            // @ts-expect-error private
             expect(session.options.sessionToken === 'session-token1').toBeTruthy()
         })
     })


### PR DESCRIPTION
Annotated some fields of `Session.ts` as private to fix the field collision between `StreamrClientBase` and `Session`. 

Both classes had these fields, and the types are not equal:
- `options` (`StrictBrubeckClientConfig` vs. `AuthConfig`)
- `loginEndpoints` (`LoginEndpoints` vs a function)

Before the fix there was an error in `node_modules/streamr-client/types/src/StreamrClient.d.ts` when the client is used in an external project:

```
Interface 'StreamrClient' cannot simultaneously extend types 'StreamrClientBase' and 'Methods<Session>'.
  Named property 'loginEndpoints' of types 'StreamrClientBase' and 'Methods<Session>' are not identical.ts(2320)
Interface 'StreamrClient' cannot simultaneously extend types 'StreamrClientBase' and 'Methods<Session>'.
  Named property 'options' of types 'StreamrClientBase' and 'Methods<Session>' are not identical.ts(2320)
```