### PR TITLE
[NET-711]: Support multiple streams in setPermissions

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -624,10 +624,10 @@ await stream.revokePermissions({
 })
 ```
 
-There is also a `client.setPermissions`. You can use it to set an exact set of permissions for multiple streams. Note that if there are existing permissions for the same users in a stream, the previous permissions are overwritten:
+There is also method `client.setPermissions`. You can use it to set an exact set of permissions for one or more streams. Note that if there are existing permissions for the same users in a stream, the previous permissions are overwritten:
 
 ```js
-await client.setPermissions([{
+await client.setPermissions({
     streamId,
     assignments: [
         {
@@ -641,7 +641,7 @@ await client.setPermissions([{
             permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE]
         }
     ]
-}])
+})
 ```
 
 You can query the existence of a permission with `hasPermission()`. Usually you want to use `allowPublic: true` flag so that also the existence of a public permission is checked:

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -624,19 +624,24 @@ await stream.revokePermissions({
 })
 ```
 
-There is also a `client.setPermissions` method which is otherwise equal to `grantPermission()`, but if there are existing permissions for the same users in that stream, the previous permissions are overwritten:
+There is also a `client.setPermissions`. You can use it to set an exact set of permissions for multiple streams. Note that if there are existing permissions for the same users in a stream, the previous permissions are overwritten:
 
 ```js
-await client.setPermissions(streamId, {
-    user: '0x1111111111111111111111111111111111111111',
-    permissions: [StreamPermission.EDIT]
-}, {
-    user: '0x2222222222222222222222222222222222222222',
-    permissions: [StreamPermission.GRANT]
-}, {
-    public: true,
-    permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE]
-})
+await client.setPermissions([{
+    streamId,
+    assignments: [
+        {
+            user: '0x1111111111111111111111111111111111111111',
+            permissions: [StreamPermission.EDIT]
+        }, {
+            user: '0x2222222222222222222222222222222222222222',
+            permissions: [StreamPermission.GRANT]
+        }, {
+            public: true,
+            permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE]
+        }
+    ]
+}])
 ```
 
 You can query the existence of a permission with `hasPermission()`. Usually you want to use `allowPublic: true` flag so that also the existence of a public permission is checked:

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -423,22 +423,22 @@ export class StreamRegistry implements Context {
         }
     }
 
-    async setPermissions(streams: {
+    async setPermissions(...items: {
         streamId: string,
         assignments: PermissionAssignment[]
     }[]): Promise<void> {
         const streamIds: StreamID[] = []
         const targets: string[][] = []
         const chainPermissions: ChainPermissions[][] = []
-        for (const stream of streams) {
+        for (const item of items) {
             // eslint-disable-next-line no-await-in-loop
-            const streamId = await this.streamIdBuilder.toStreamID(stream.streamId)
+            const streamId = await this.streamIdBuilder.toStreamID(item.streamId)
             this.streamEndpointsCached.clearStream(streamId)
             streamIds.push(streamId)
-            targets.push(stream.assignments.map((assignment) => {
+            targets.push(item.assignments.map((assignment) => {
                 return isPublicPermissionAssignment(assignment) ? PUBLIC_PERMISSION_ADDRESS : assignment.user
             }))
-            chainPermissions.push(stream.assignments.map((assignment) => {
+            chainPermissions.push(item.assignments.map((assignment) => {
                 return convertStreamPermissionsToChainPermission(assignment.permissions)
             }))
         }

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -34,7 +34,8 @@ import {
     PermissionQueryResult,
     PUBLIC_PERMISSION_ADDRESS,
     SingleStreamQueryResult,
-    streamPermissionToSolidityType
+    streamPermissionToSolidityType,
+    ChainPermissions
 } from './permission'
 import { StreamEndpointsCached } from './StreamEndpointsCached'
 
@@ -422,17 +423,29 @@ export class StreamRegistry implements Context {
         }
     }
 
-    async setPermissions(streamIdOrPath: string, ...assignments: PermissionAssignment[]): Promise<void> {
-        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        this.streamEndpointsCached.clearStream(streamId)
+    async setPermissions(streams: {
+        streamId: string,
+        assignments: PermissionAssignment[]
+    }[]): Promise<void> {
+        const streamIds: StreamID[] = []
+        const targets: string[][] = []
+        const chainPermissions: ChainPermissions[][] = []
+        for (const stream of streams) {
+            // eslint-disable-next-line no-await-in-loop
+            const streamId = await this.streamIdBuilder.toStreamID(stream.streamId)
+            this.streamEndpointsCached.clearStream(streamId)
+            streamIds.push(streamId)
+            targets.push(stream.assignments.map((assignment) => {
+                return isPublicPermissionAssignment(assignment) ? PUBLIC_PERMISSION_ADDRESS : assignment.user
+            }))
+            chainPermissions.push(stream.assignments.map((assignment) => {
+                return convertStreamPermissionsToChainPermission(assignment.permissions)
+            }))
+        }
         await this.connectToStreamRegistryContract()
         const ethersOverrides = this.ethereum.getStreamRegistryOverrides()
-        const targets = assignments.map((assignment) => {
-            return isPublicPermissionAssignment(assignment) ? PUBLIC_PERMISSION_ADDRESS : assignment.user
-        })
-        const chainPermissions = assignments.map((assignment) => convertStreamPermissionsToChainPermission(assignment.permissions))
-        const txToSubmit = this.streamRegistryContract!.setPermissions(
-            streamId,
+        const txToSubmit = this.streamRegistryContract!.setPermissionsMultipleStreans(
+            streamIds,
             targets,
             chainPermissions,
             ethersOverrides

--- a/packages/client/test/browser/browser.html
+++ b/packages/client/test/browser/browser.html
@@ -270,10 +270,13 @@
     $('#permissions').on('click', async () => {
         log('Setting Permissions...')
         const subscriberAddress = await subscriber.getAddress()
-        await publisher.setPermissions(stream.id, {
-            user: subscriberAddress,
-            permissions: [StreamrClient.StreamPermission.SUBSCRIBE, StreamrClient.StreamPermission.PUBLISH]
-        })
+        await publisher.setPermissions([{
+            streamId: stream.id,
+            assignments: [{
+                user: subscriberAddress,
+                permissions: [StreamrClient.StreamPermission.SUBSCRIBE, StreamrClient.StreamPermission.PUBLISH]
+            }]
+        }])
         log('Set Permissions.')
         log('Loading permissions...')
         const allAssignments = await stream.getPermissions()

--- a/packages/client/test/browser/browser.html
+++ b/packages/client/test/browser/browser.html
@@ -270,13 +270,13 @@
     $('#permissions').on('click', async () => {
         log('Setting Permissions...')
         const subscriberAddress = await subscriber.getAddress()
-        await publisher.setPermissions([{
+        await publisher.setPermissions({
             streamId: stream.id,
             assignments: [{
                 user: subscriberAddress,
                 permissions: [StreamrClient.StreamPermission.SUBSCRIBE, StreamrClient.StreamPermission.PUBLISH]
             }]
-        }])
+        })
         log('Set Permissions.')
         log('Loading permissions...')
         const allAssignments = await stream.getPermissions()

--- a/packages/client/test/integration/MultipleClients.test.ts
+++ b/packages/client/test/integration/MultipleClients.test.ts
@@ -56,13 +56,13 @@ describeRepeats('PubSub with multiple clients', () => {
 
         // pubClient.on('error', getOnError(errors))
         const pubUser = await pubClient.getAddress()
-        await mainClient.setPermissions([{
+        await mainClient.setPermissions({
             streamId: stream.id,
             assignments: [
                 // StreamPermission.SUBSCRIBE needed to check last
                 { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: pubUser }
             ]
-        }])
+        })
         await pubClient.connect()
         return pubClient
     }

--- a/packages/client/test/integration/MultipleClients.test.ts
+++ b/packages/client/test/integration/MultipleClients.test.ts
@@ -56,11 +56,14 @@ describeRepeats('PubSub with multiple clients', () => {
 
         // pubClient.on('error', getOnError(errors))
         const pubUser = await pubClient.getAddress()
-        await stream.grantPermissions({ permissions: [StreamPermission.PUBLISH], user: pubUser })
-        // needed to check last
-        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user: pubUser })
+        await mainClient.setPermissions([{
+            streamId: stream.id,
+            assignments: [
+                // StreamPermission.SUBSCRIBE needed to check last
+                { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: pubUser }
+            ]
+        }])
         await pubClient.connect()
-
         return pubClient
     }
 

--- a/packages/client/test/integration/Permissions.test.ts
+++ b/packages/client/test/integration/Permissions.test.ts
@@ -168,7 +168,7 @@ describe('Stream permissions', () => {
             user: user2,
             permissions: [StreamPermission.EDIT]
         })
-        await client.setPermissions([{
+        await client.setPermissions({
             streamId: stream.id,
             assignments: [
                 {
@@ -187,7 +187,7 @@ describe('Stream permissions', () => {
                     permissions: [StreamPermission.PUBLISH]
                 }
             ]
-        }])
+        })
         expect(await stream.hasPermission({ permission: StreamPermission.SUBSCRIBE, allowPublic: false, user: user1 })).toBe(true)
         expect(await stream.hasPermission({ permission: StreamPermission.GRANT, allowPublic: false, user: user1 })).toBe(false)
         expect(await stream.hasPermission({ permission: StreamPermission.SUBSCRIBE, allowPublic: false, user: user2 })).toBe(false)

--- a/packages/client/test/integration/Permissions.test.ts
+++ b/packages/client/test/integration/Permissions.test.ts
@@ -33,7 +33,7 @@ describe('Stream permissions', () => {
 
     beforeEach(async () => {
         stream = await client.createStream({
-            id: createRelativeTestStreamId(module),
+            id: createRelativeTestStreamId(module)
         })
     })
 
@@ -155,27 +155,46 @@ describe('Stream permissions', () => {
     })
 
     it('set permissions', async () => {
+        const otherStream = await client.createStream({
+            id: createRelativeTestStreamId(module)
+        })
         const user1 = randomEthereumAddress()
         const user2 = randomEthereumAddress()
         await stream.grantPermissions({
             user: user1,
-            permissions: [StreamPermission.PUBLISH]
+            permissions: [StreamPermission.GRANT]
         })
         await stream.grantPermissions({
             user: user2,
             permissions: [StreamPermission.EDIT]
         })
-        await client.setPermissions(stream.id, {
-            user: user1,
-            permissions: [StreamPermission.SUBSCRIBE]
+        await client.setPermissions([{
+            streamId: stream.id,
+            assignments: [
+                {
+                    user: user1,
+                    permissions: [StreamPermission.SUBSCRIBE]
+                }, {
+                    user: user2,
+                    permissions: []
+                }
+            ]
         }, {
-            user: user2,
-            permissions: []
-        })
+            streamId: otherStream.id,
+            assignments: [
+                {
+                    public: true,
+                    permissions: [StreamPermission.PUBLISH]
+                }
+            ]
+        }])
         expect(await stream.hasPermission({ permission: StreamPermission.SUBSCRIBE, allowPublic: false, user: user1 })).toBe(true)
-        expect(await stream.hasPermission({ permission: StreamPermission.PUBLISH, allowPublic: false, user: user1 })).toBe(false)
+        expect(await stream.hasPermission({ permission: StreamPermission.GRANT, allowPublic: false, user: user1 })).toBe(false)
         expect(await stream.hasPermission({ permission: StreamPermission.SUBSCRIBE, allowPublic: false, user: user2 })).toBe(false)
         expect(await stream.hasPermission({ permission: StreamPermission.EDIT, allowPublic: false, user: user2 })).toBe(false)
+        expect(await otherStream.hasPermission(
+            { permission: StreamPermission.PUBLISH, allowPublic: true, user: randomEthereumAddress() }
+        )).toBe(true)
     })
 
     // TODO: fix flaky test when we have NET-606

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -57,15 +57,15 @@ describe('PubSub with proxy connections', () => {
         proxyNodeId1 = await proxyClient1.node.getNodeId()
         proxyNodeId2 = await proxyClient2.node.getNodeId()
         stream = await createTestStream(publishingClient, module)
-        const pubUser = await publishingClient.getUserInfo()
-        const proxyUser = await proxyClient1.getUserInfo()
-        const proxyUser2 = await proxyClient2.getUserInfo()
-
-        await stream.grantPermissions({ permissions: [StreamPermission.PUBLISH], user: pubUser.username })
-        await stream.grantPermissions({ permissions: [StreamPermission.PUBLISH], user: proxyUser.username })
-        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user: proxyUser.username })
-        await stream.grantPermissions({ permissions: [StreamPermission.PUBLISH], user: proxyUser2.username })
-        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user: proxyUser2.username })
+        const proxyUser1 = await proxyClient1.getAddress()
+        const proxyUser2 = await proxyClient2.getAddress()
+        await publishingClient.setPermissions([{
+            streamId: stream.id,
+            assignments: [
+                { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: proxyUser1 },
+                { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: proxyUser2 }
+            ]
+        }])
     }, 60000)
 
     it('Publish only connections work', async () => {

--- a/packages/client/test/integration/ProxyPublishing.test.ts
+++ b/packages/client/test/integration/ProxyPublishing.test.ts
@@ -59,13 +59,13 @@ describe('PubSub with proxy connections', () => {
         stream = await createTestStream(publishingClient, module)
         const proxyUser1 = await proxyClient1.getAddress()
         const proxyUser2 = await proxyClient2.getAddress()
-        await publishingClient.setPermissions([{
+        await publishingClient.setPermissions({
             streamId: stream.id,
             assignments: [
                 { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: proxyUser1 },
                 { permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE], user: proxyUser2 }
             ]
-        }])
+        })
     }, 60000)
 
     it('Publish only connections work', async () => {

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -29,6 +29,7 @@ describe('SearchStreams', () => {
     }[]) => {
         const streams: Stream[] = []
         for (const item of items) {
+            // eslint-disable-next-line no-await-in-loop
             streams.push(await client.createStream(item.streamId))
         }
         await client.setPermissions(items)
@@ -53,6 +54,7 @@ describe('SearchStreams', () => {
         return ids
     }
 
+    /* eslint-disable prefer-destructuring, object-property-newline */
     beforeAll(async () => {
         client = new StreamrClient({
             ...ConfigTest,
@@ -62,23 +64,22 @@ describe('SearchStreams', () => {
             autoConnect: false
         })
         const streams = await createTestStreams([
-            { streamId: `/${SEARCH_TERM}/1-no-permissions`, assignments: [
-            ]},
+            { streamId: `/${SEARCH_TERM}/1-no-permissions`, assignments: [] },
             { streamId: `/${SEARCH_TERM}/2-user-permission`, assignments: [
                 { user: searcher.address, permissions: [StreamPermission.SUBSCRIBE] }
-            ]},
+            ] },
             { streamId: `/${SEARCH_TERM}/3-public-permissions`, assignments: [
                 { public: true, permissions: [StreamPermission.SUBSCRIBE] }
-            ]},
+            ] },
             { streamId: `/${SEARCH_TERM}/4-user-and-public-permissions`, assignments: [
                 { user: searcher.address, permissions: [StreamPermission.SUBSCRIBE] },
                 { public: true, permissions: [StreamPermission.SUBSCRIBE] }
-            ]},
+            ] },
             { streamId: `/${SEARCH_TERM}/5-granted-and-revoked-permissions`, assignments: [
                 { user: searcher.address, permissions: [StreamPermission.SUBSCRIBE] },
                 { public: true, permissions: [StreamPermission.SUBSCRIBE] }
-            ]},
-            { streamId: `/${Date.now()}`, assignments: []}
+            ] },
+            { streamId: `/${Date.now()}`, assignments: [] }
         ])
         streamWithoutPermission = streams[0]
         streamWithUserPermission = streams[1]

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -32,7 +32,7 @@ describe('SearchStreams', () => {
             // eslint-disable-next-line no-await-in-loop
             streams.push(await client.createStream(item.streamId))
         }
-        await client.setPermissions(items)
+        await client.setPermissions(...items)
         return streams
     }
 

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -161,7 +161,7 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async setPermissions(_streams: {
+    async setPermissions(..._streams: {
         streamId: string,
         assignments: PermissionAssignment[]
     }[]): Promise<void> {

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -161,7 +161,10 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async setPermissions(_streamIdOrPath: string, ..._assignments: PermissionAssignment[]): Promise<void> {
+    async setPermissions(_streams: {
+        streamId: string,
+        assignments: PermissionAssignment[]
+    }[]): Promise<void> {
         throw new Error('not implemented')
     }
 


### PR DESCRIPTION
Modified `client.setPermissions()` to support multiple streams. The method signature was changed, and therefore this is not a backwards-compatible change.

Current API:
```ts
setPermissions(streams:
    {
        streamId: string,
        assignments: PermissionAssignment[]
    }[]
): Promise<void>
```

Previous API:
```ts
setPermissions(
    streamIdOrPath: string,
    ...assignments: PermissionAssignment[]
): Promise<void>
```