### PR TITLE
Add command `npm run check` to check types without emitting files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "streamr-monorepo",
     "private": true,
     "scripts": {
+        "check": "npm run --workspaces --if-present check",
         "prepare": "husky install && npm run versions",
         "bootstrap": "npm ci --no-audit",
         "bootstrap-pkg": "npm ci --no-audit --include-workspace-root --workspace",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -15,6 +15,7 @@
   },
   "main": "bin/broker.js",
   "scripts": {
+    "check": "tsc -p ./tsconfig.json --noEmit",
     "prepare": "npm run build",
     "test": "jest --forceExit test/unit test/integration && npm run test-sequential",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -6,6 +6,7 @@
     "streamr": "dist/bin/streamr.js"
   },
   "scripts": {
+    "check": "tsc -p ./tsconfig.json --noEmit",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepare": "npm run eslint && npm run build",
     "build": "tsc -b tsconfig.json",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "build": "npm run bootstrap-dist && npm run build-node",
         "build-production": "npm run clean; npm run bootstrap-dist && NODE_ENV=production npm run build-node && npm run build-browser-production",
+        "check": "tsc -p ./tsconfig.json --noEmit",
         "prepare": "npm run build",
         "vendor": "SRCDIR=`node -p \"path.dirname(require.resolve('quick-lru'))\"` bash -c 'mkdir -p vendor/quick-lru; cp -n $SRCDIR/index.d.ts vendor/quick-lru; cp -n $SRCDIR/index.js vendor/quick-lru'; true",
         "copy-package": "mkdir -p dist/; node copy-package.js; cp -f README.md LICENSE readme-header-img.png dist; mkdir -p dist/src/encryption/migrations; cp -f ./src/encryption/migrations/* dist/src/encryption/migrations; true",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "npm run prepare",
     "build-browser": "webpack --mode=development --progress",
+    "check": "tsc -p ./tsconfig.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
@@ -38,7 +39,7 @@
     "test-flakey": "jest test/flakey",
     "test-integration": "jest test/integration/",
     "test-simulator": "jest --projects simulator.jest.config.js -- test/",
-    "test-types": "tsc --noEmit -b ./tsconfig.json ",
+    "test-types": "npm run check",
     "test-unit": "jest test/unit",
     "tracker": "node $NODE_DEBUG_OPTION bin/tracker.js"
   },

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -10,6 +10,7 @@
         "test/**/*"
     ],
     "exclude": [
+        "src/**/BrowserWebRtcConnection.ts",
         "test/**/BrowserWebRtcConnection.test.ts",
         "test/**/IntegrationBrowserWebRtcConnection.test.ts"
     ],

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.node.json",
     "prepublishOnly": "npm run clean && NODE_ENV=production npm run build",
+    "check": "tsc -p ./tsconfig.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "watch": "tsc --watch",
     "benchmark": "jest test/benchmarks --detectOpenHandles",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/src/utils.js",
   "types": "./dist/src/utils.d.ts",
   "scripts": {
+    "check": "tsc -p ./tsconfig.json --noEmit",
     "test": "jest",
     "test-unit": "npm run test",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",


### PR DESCRIPTION
Add command `npm run check` to compile both src _and_ test files without emitting any files.