### PR TITLE
client: validate searchStreams params

### DIFF
--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -40,10 +40,6 @@ createClientCommand(async (client: StreamrClient, term: string | undefined, opti
         options.any,
         client
     )
-    if ((term === undefined) && (permissionFilter === undefined)) {
-        console.error('specify a search term or a permission filter')
-        process.exit(1)
-    }
     const streams = client.searchStreams(term, permissionFilter)
     for await (const stream of streams) {
         console.log(stream.id)

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -40,6 +40,10 @@ createClientCommand(async (client: StreamrClient, term: string | undefined, opti
         options.any,
         client
     )
+    if ((term === undefined) && (permissionFilter === undefined)) {
+        console.error('specify a search term or a permission filter')
+        process.exit(1)
+    }
     const streams = client.searchStreams(term, permissionFilter)
     for await (const stream of streams) {
         console.log(stream.id)

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -257,6 +257,9 @@ export class StreamRegistry implements Context {
     }
 
     searchStreams(term: string | undefined, permissionFilter: SearchStreamsPermissionFilter | undefined): AsyncGenerator<Stream> {
+        if ((term === undefined) && (permissionFilter === undefined)) {
+            throw new Error('Requires a search term or a permission filter')
+        }
         this.debug('Search streams term=%s permissions=%j', term, permissionFilter)
         return map(
             fetchSearchStreamsResultFromTheGraph(term, permissionFilter, this.graphQLClient),

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -122,10 +122,9 @@ describe('SearchStreams', () => {
     })
 
     it('no filters', async () => {
-        const iterable = client.searchStreams(undefined, undefined)
-        // most likely many items created by various tests, check that we can read some item
-        const firstItem = (await iterable[Symbol.asyncIterator]().next()).value
-        expect(firstItem.id).toBeDefined()
+        return expect(async () => {
+            await client.searchStreams(undefined, undefined)
+        }).rejects.toThrow('Requires a search term or a permission filter')
     })
 
     describe('permission filter', () => {


### PR DESCRIPTION
If there is no search term or permission filter, `client.searchStream` throws an `Error`. 

It could return all streams from the registry, but maybe it is better to an error. In an earlier PR we removed the `client.getAllStreams()` method -> it doesn't make sense that we'd support the "search all streams" functionality via this method.