### PR TITLE
test: wait for permission propagation

### DIFF
--- a/packages/client/test/browser/browser.html
+++ b/packages/client/test/browser/browser.html
@@ -198,6 +198,10 @@
         $('#result').append($(`<div class="row"><div class="content ${className}">${content}</div><div class='timestamp'>+${duration}ms</div></div>`))
     }
 
+    function wait(ms) { // TODO use from test-utils?
+        return new Promise((resolve) => setTimeout(resolve, ms))
+    }
+
     function logError(content) {
         log(content, 'error')
     }
@@ -279,6 +283,9 @@
         })
         log('Set Permissions.')
         log('Loading permissions...')
+        // we should wait until permissions are propagated to TheGraph
+        // replace the time-based wait in NET-606
+        await wait(5000)
         const allAssignments = await stream.getPermissions()
         const modifiedAssignment = allAssignments.find(p => (p.user.toLowerCase() === subscriberAddress.toLowerCase()))
         log(`Permissions: [${modifiedAssignment.permissions.join(',')}]`, 'permissionsResult')

--- a/packages/client/test/integration/SearchStreams.test.ts
+++ b/packages/client/test/integration/SearchStreams.test.ts
@@ -1,5 +1,5 @@
 import { Wallet } from 'ethers'
-import { randomEthereumAddress } from 'streamr-test-utils'
+import { randomEthereumAddress, wait } from 'streamr-test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { PermissionAssignment, StreamPermission } from '../../src/permission'
@@ -91,6 +91,9 @@ describe('SearchStreams', () => {
             { user: searcher.address, permissions: [StreamPermission.SUBSCRIBE] },
             { public: true, permissions: [StreamPermission.SUBSCRIBE] }
         )
+        // we should wait until revoked permission are propagated to TheGraph
+        // replace the time-based wait in NET-606
+        await wait(5000)
         await waitUntilStreamsExistOnTheGraph([
             streamWithoutPermission,
             streamWithUserPermission,


### PR DESCRIPTION
Wait for permission propagation in `SearchStreams.test.ts` and browser realtime time. 

Now it just waits for 5 seconds. Let's replace it with a better implementation when we can poll The Graph or define a configurable wait parameter for the write transaction (NET-606).