### PR TITLE
broker: use network node via client

### DIFF
--- a/packages/broker/src/Plugin.ts
+++ b/packages/broker/src/Plugin.ts
@@ -2,12 +2,11 @@ import { Config } from './config/config'
 import express from 'express'
 import { validateConfig } from './config/validateConfig'
 import { Schema } from 'ajv'
-import { NetworkNodeStub, StreamrClient } from 'streamr-client'
+import { StreamrClient } from 'streamr-client'
 import { ApiAuthenticator } from './apiAuthenticator'
 
 export interface PluginOptions {
     name: string
-    networkNode: NetworkNodeStub
     streamrClient: StreamrClient
     apiAuthenticator: ApiAuthenticator
     brokerConfig: Config
@@ -17,7 +16,6 @@ export interface PluginOptions {
 export abstract class Plugin<T> {
 
     readonly name: string
-    readonly networkNode: NetworkNodeStub
     readonly streamrClient: StreamrClient
     readonly apiAuthenticator: ApiAuthenticator
     readonly brokerConfig: Config
@@ -27,7 +25,6 @@ export abstract class Plugin<T> {
 
     constructor(options: PluginOptions) {
         this.name = options.name
-        this.networkNode = options.networkNode
         this.streamrClient = options.streamrClient
         this.apiAuthenticator = options.apiAuthenticator
         this.brokerConfig = options.brokerConfig

--- a/packages/broker/src/Plugin.ts
+++ b/packages/broker/src/Plugin.ts
@@ -10,7 +10,6 @@ export interface PluginOptions {
     streamrClient: StreamrClient
     apiAuthenticator: ApiAuthenticator
     brokerConfig: Config
-    nodeId: string
 }
 
 export abstract class Plugin<T> {
@@ -20,7 +19,6 @@ export abstract class Plugin<T> {
     readonly apiAuthenticator: ApiAuthenticator
     readonly brokerConfig: Config
     readonly pluginConfig: T
-    readonly nodeId: string
     private readonly httpServerRouters: express.Router[] = []
 
     constructor(options: PluginOptions) {
@@ -29,7 +27,6 @@ export abstract class Plugin<T> {
         this.apiAuthenticator = options.apiAuthenticator
         this.brokerConfig = options.brokerConfig
         this.pluginConfig = options.brokerConfig.plugins[this.name]
-        this.nodeId = options.nodeId
         const configSchema = this.getConfigSchema()
         if (configSchema !== undefined) {
             validateConfig(this.pluginConfig, configSchema, `${this.name} plugin`)

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -17,9 +17,7 @@ import { StreamPartID } from 'streamr-client-protocol'
 const logger = new Logger(module)
 
 export interface Broker {
-    getNeighbors: () => readonly string[]
     getStreamParts: () => Iterable<StreamPartID>
-    getNodeId: () => string
     start: () => Promise<unknown>
     stop: () => Promise<unknown>
 }
@@ -66,9 +64,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
     let httpServer: HttpServer|HttpsServer|undefined
 
     return {
-        getNeighbors: () => networkNode.getNeighbors(),
         getStreamParts: () => networkNode.getStreamParts(),
-        getNodeId: () => networkNode.getNodeId(),
         start: async () => {
             logger.info(`Starting broker version ${CURRENT_VERSION}`)
             await Promise.all(plugins.map((plugin) => plugin.start()))

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'streamr-network'
-import StreamrClient, { validateConfig as validateClientConfig, getTrackerRegistryFromContract } from 'streamr-client'
+import StreamrClient, { validateConfig as validateClientConfig, getTrackerRegistryFromContract, NetworkNodeStub } from 'streamr-client'
 import * as Protocol from 'streamr-client-protocol'
 import { Wallet } from 'ethers'
 import { Server as HttpServer } from 'http'
@@ -12,12 +12,11 @@ import { Plugin, PluginOptions } from './Plugin'
 import { startServer as startHttpServer, stopServer } from './httpServer'
 import BROKER_CONFIG_SCHEMA from './helpers/config.schema.json'
 import { createApiAuthenticator } from './apiAuthenticator'
-import { StreamPartID } from 'streamr-client-protocol'
 
 const logger = new Logger(module)
 
 export interface Broker {
-    getStreamParts: () => Promise<Iterable<StreamPartID>>
+    getNode: () => Promise<NetworkNodeStub>
     start: () => Promise<unknown>
     stop: () => Promise<unknown>
 }
@@ -98,9 +97,8 @@ export const createBroker = async (config: Config): Promise<Broker> => {
                 await streamrClient.destroy()
             }
         },
-        getStreamParts: async () => {
-            const node = await streamrClient.getNode()
-            return node.getStreamParts()
+        getNode: async () => {
+            return streamrClient.getNode()
         }
     }
 }

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -55,7 +55,6 @@ export const createBroker = async (config: Config): Promise<Broker> => {
     const plugins: Plugin<any>[] = Object.keys(config.plugins).map((name) => {
         const pluginOptions: PluginOptions = {
             name,
-            networkNode,
             streamrClient,
             apiAuthenticator,
             brokerConfig: config,

--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -124,9 +124,10 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
     }
 
     private async claimRewardCode(rewardCode: string, peers: Peer[], delay: number): Promise<void> {
+        const nodeId = await this.streamrClient.getNodeId()
         const body = {
             rewardCode,
-            nodeAddress: this.nodeId,
+            nodeAddress: nodeId,
             streamId: this.streamId,
             clientServerLatency: this.latestLatency,
             waitTime: delay,

--- a/packages/broker/src/plugins/metrics/MetricsPlugin.ts
+++ b/packages/broker/src/plugins/metrics/MetricsPlugin.ts
@@ -32,8 +32,9 @@ export class MetricsPlugin extends Plugin<MetricsPluginConfig> {
         )
 
         if (this.pluginConfig.nodeMetrics !== null) {
+            const nodeId = await this.streamrClient.getNodeId()
             const metricsPublisher = new MetricsPublisher(
-                this.nodeId,
+                nodeId,
                 this.streamrClient!,
                 this.pluginConfig.nodeMetrics.streamIdPrefix
             )

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -93,20 +93,20 @@ describe('broker subscriptions', () => {
         await mqttClient1.subscribe(freshStream1.id)
         await mqttClient2.subscribe(freshStream2.id)
 
-        await waitForCondition(() => getStreamParts(broker1).length === 1)
-        await waitForCondition(() => getStreamParts(broker2).length === 1)
+        await waitForCondition(() => await getStreamParts(broker1).length === 1)
+        await waitForCondition(() => await getStreamParts(broker2).length === 1)
 
-        expect(getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0'])
-        expect(getStreamParts(broker2)).toIncludeSameMembers([freshStream2.id + '#0'])
+        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0'])
+        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream2.id + '#0'])
 
         await mqttClient1.subscribe(freshStream2.id)
         await mqttClient2.subscribe(freshStream1.id)
 
-        await waitForCondition(() => getStreamParts(broker1).length === 2)
-        await waitForCondition(() => getStreamParts(broker2).length === 2)
+        await waitForCondition(() => await getStreamParts(broker1).length === 2)
+        await waitForCondition(() => await getStreamParts(broker2).length === 2)
 
-        expect(getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
-        expect(getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         // client boots own node, so broker streams should not change
         await client1.subscribe(freshStream1, () => {})
@@ -115,21 +115,21 @@ describe('broker subscriptions', () => {
 
         await wait(500) // give some time for client1 to subscribe.
 
-        expect(getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
-        expect(getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         await mqttClient1.unsubscribe(freshStream1.id)
 
-        await waitForCondition(() => getStreamParts(broker2).length === 2)
+        await waitForCondition(() => await getStreamParts(broker2).length === 2)
 
-        expect(getStreamParts(broker1)).toIncludeSameMembers([freshStream2.id + '#0'])
-        expect(getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream2.id + '#0'])
+        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         await mqttClient1.unsubscribe(freshStream2.id)
 
-        await waitForCondition(() => getStreamParts(broker2).length === 2)
+        await waitForCondition(() => await getStreamParts(broker2).length === 2)
 
-        expect(getStreamParts(broker1)).toIncludeSameMembers([])
-        expect(getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect(await getStreamParts(broker1)).toIncludeSameMembers([])
+        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
     })
 })

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -93,20 +93,20 @@ describe('broker subscriptions', () => {
         await mqttClient1.subscribe(freshStream1.id)
         await mqttClient2.subscribe(freshStream2.id)
 
-        await waitForCondition(() => await getStreamParts(broker1).length === 1)
-        await waitForCondition(() => await getStreamParts(broker2).length === 1)
+        await waitForCondition(async () => (await getStreamParts(broker1)).length === 1)
+        await waitForCondition(async () => (await getStreamParts(broker2)).length === 1)
 
-        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0'])
-        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream2.id + '#0'])
+        expect((await getStreamParts(broker1))).toIncludeSameMembers([freshStream1.id + '#0'])
+        expect((await getStreamParts(broker2))).toIncludeSameMembers([freshStream2.id + '#0'])
 
         await mqttClient1.subscribe(freshStream2.id)
         await mqttClient2.subscribe(freshStream1.id)
 
-        await waitForCondition(() => await getStreamParts(broker1).length === 2)
-        await waitForCondition(() => await getStreamParts(broker2).length === 2)
+        await waitForCondition(async () => (await getStreamParts(broker1)).length === 2)
+        await waitForCondition(async () => (await getStreamParts(broker2)).length === 2)
 
-        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
-        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker1))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker2))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         // client boots own node, so broker streams should not change
         await client1.subscribe(freshStream1, () => {})
@@ -115,21 +115,21 @@ describe('broker subscriptions', () => {
 
         await wait(500) // give some time for client1 to subscribe.
 
-        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
-        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker1))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker2))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         await mqttClient1.unsubscribe(freshStream1.id)
 
-        await waitForCondition(() => await getStreamParts(broker2).length === 2)
+        await waitForCondition(async () => (await getStreamParts(broker2)).length === 2)
 
-        expect(await getStreamParts(broker1)).toIncludeSameMembers([freshStream2.id + '#0'])
-        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker1))).toIncludeSameMembers([freshStream2.id + '#0'])
+        expect((await getStreamParts(broker2))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
 
         await mqttClient1.unsubscribe(freshStream2.id)
 
-        await waitForCondition(() => await getStreamParts(broker2).length === 2)
+        await waitForCondition(async () => (await getStreamParts(broker2)).length === 2)
 
-        expect(await getStreamParts(broker1)).toIncludeSameMembers([])
-        expect(await getStreamParts(broker2)).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
+        expect((await getStreamParts(broker1))).toIncludeSameMembers([])
+        expect((await getStreamParts(broker2))).toIncludeSameMembers([freshStream1.id + '#0', freshStream2.id + '#0'])
     })
 })

--- a/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
@@ -58,7 +58,8 @@ describe('NodeMetrics', () => {
         const messageQueue = new Queue<any>()
 
         const id = `${streamIdPrefix}sec`
-        const partition = keyToArrayIndex(NUM_OF_PARTITIONS, metricsGeneratingBroker.getNodeId().toLowerCase())
+        const nodeId = (await metricsGeneratingBroker.getNode()).getNodeId()
+        const partition = keyToArrayIndex(NUM_OF_PARTITIONS, nodeId.toLowerCase())
 
         await client.subscribe({ id, partition }, (content: any) => {
             messageQueue.push({ content })

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -38,6 +38,6 @@ describe('StorageNode', () => {
     })
 
     it('has node id same as address', async () => {
-        expect((await storageNode.getNode()).getNodeId).toEqual(storageNodeAccount.address)
+        expect((await storageNode.getNode()).getNodeId()).toEqual(storageNodeAccount.address)
     })
 })

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -38,6 +38,6 @@ describe('StorageNode', () => {
     })
 
     it('has node id same as address', async () => {
-        expect(storageNode.getNodeId()).toEqual(storageNodeAccount.address)
+        expect((await storageNode.getNode()).getNodeId).toEqual(storageNodeAccount.address)
     })
 })

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -34,11 +34,9 @@ const createMockPlugin = async (tracker: Tracker) => {
     }
     return new SubscriberPlugin({
         name: 'subscriber',
-        networkNode: undefined as any,
         streamrClient: await createClient(tracker, wallet.privateKey),
         apiAuthenticator: undefined as any,
-        brokerConfig,
-        nodeId: wallet.address
+        brokerConfig
     })
 }
 

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -181,8 +181,8 @@ export class Queue<T> {
 }
 
 export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
-    const items = await broker.getStreamParts()
-    return Array.from(items)
+    const node = await broker.getNode()
+    return Array.from(node.getStreamParts())
 }
 
 export async function sleep(ms = 0): Promise<void> {

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -180,8 +180,9 @@ export class Queue<T> {
     }
 }
 
-export const getStreamParts = (broker: Broker): StreamPartID[] => {
-    return Array.from(broker.getStreamParts())
+export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
+    const items = await broker.getStreamParts()
+    return Array.from(items)
 }
 
 export async function sleep(ms = 0): Promise<void> {


### PR DESCRIPTION
Get a node instance and nodeId from a `StreamrClient`. This way we don't need to initialize the Node before `start()` method as each component uses the node lazily.

Removed `broker.getNodeId()` and `broker.getNeighbors()` and `broker.getStreamParts()` helper methods. Instead we have `broker.getNode()`.

### Future improvements

- Expose `broker.getStreamrClient()` instead of `broker.getNode()`?