### PR TITLE
test: maybe fix flaky test for test-utils.wait()

### DIFF
--- a/packages/test-utils/test/utils.test.ts
+++ b/packages/test-utils/test/utils.test.ts
@@ -160,13 +160,10 @@ describe(waitForCondition, () => {
 })
 
 describe(wait, () => {
-    // flaky, fix in NET-645
-    it.skip("waits at least the predetermined time", async () => {
-        // use performance.now instead of Date.now
-        // Date.now may not be accurate enough for low wait values e.g. 10ms
-        const start = performance.now()
+    it("waits at least the predetermined time", async () => {
+        const start = Date.now()
         await wait(20)
-        const end = performance.now()
+        const end = Date.now()
         expect(end - start).toBeGreaterThanOrEqual(20)
     })
 })

--- a/packages/test-utils/test/utils.test.ts
+++ b/packages/test-utils/test/utils.test.ts
@@ -160,7 +160,8 @@ describe(waitForCondition, () => {
 })
 
 describe(wait, () => {
-    it("waits at least the predetermined time", async () => {
+    // flaky, fix in NET-645
+    it.skip("waits at least the predetermined time", async () => {
         // use performance.now instead of Date.now
         // Date.now may not be accurate enough for low wait values e.g. 10ms
         const start = performance.now()

--- a/packages/test-utils/test/utils.test.ts
+++ b/packages/test-utils/test/utils.test.ts
@@ -7,7 +7,6 @@ import {
     waitForCondition,
     eventsToArray, eventsWithArgsToArray
 } from "../src/utils"
-import { performance } from 'perf_hooks'
 import { Readable } from "stream"
 import { EventEmitter } from "events"
 


### PR DESCRIPTION
**Eric's writing:**
I'm gonna go on a gut feeling here and replace this to work with `Date.now()` instead of `performance.now()`. My recollection is that it was like that in the past and was not flaky. I have no idea why taking the time in a more accurate manner causes this, but yeah, if this test stays flaky let's re-look into it.