### PR TITLE
build: specify exact npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16-bullseye as build
 WORKDIR /usr/src/monorepo
 RUN npm set unsafe-perm true && \
 	# explicitly use npm v8
-	npm install -g npm@8 --no-audit
+	npm install -g npm@8.4.1 --no-audit
 COPY . .
 RUN npm config set python "$(which python3)" && npm run bootstrap-pkg -- streamr-broker
 


### PR DESCRIPTION
Fixes oom-killer issue with docker build.

```
[  544.917991] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=14026f2afa01b7a214a20371d296eb22f4bf862805a09a8272848d1a27b6c76e,mems_allowed=0,global_oom,task_memcg=/docker/buildx/14026f2afa01b7a214a20371d296eb22f4bf862805a09a8272848d1a27b6c76e,task=npm ci,pid=2592,uid=0
[  544.922131] Out of memory: Killed process 2592 (npm ci) total-vm:1099676kB, anon-rss:18456kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:3964kB oom_score_adj:0
[  544.940426] oom_reaper: reaped process 2592 (npm ci), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
```