### PR TITLE
Post launch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ as you expect e.g. `^X.Y.Z` vs `X.Y.Z`
 | `npm run fix`                                                      | Runs `eslint --fix` in all packages and `manypkg fix`.                                                                                                                                        |
 | `npm run clean-package-locks`                                      | Removes only top-level package-lock.  There should only be a single top-level package-lock.                                                                                                   |
 
+## Releasing
+
+### Client
+```
+git checkout main
+cd packages/client
+npm version <SEMVER_OPTION>
+git add package.json
+git commit -m "release(client): vX.Y.Z"
+git tag client/vX.Y.Z
+git push origin
+git push origin client/vX.Y.Z
+```
 
 ## Important changes to the bootstrap/install scripts as of 48e165f:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ git commit -m "release(client): vX.Y.Z"
 git tag client/vX.Y.Z
 git push origin
 git push origin client/vX.Y.Z
+
+# If everything above went thru
+npm run build-production
+cd dist
+npm publish
 ```
 
 ## Important changes to the bootstrap/install scripts as of 48e165f:

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,34 +1,12 @@
-## 6.0
-### Features
+# Changelog
+All notable changes to this project will be documented in this file.
 
-* Deprecated `safeGetDataUnion`, it's now called just `getDataUnion`; but unlike the old `getDataUnion`, it returns a promise so getting a data union is now `const dataUnion = await getDataUnion(address)`.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+As this is still empty, see [cli-tool CHANGELOG](../cli-tools/CHANGELOG.md) for example.
+Remove this paragraph when content has been added.
 
-## [Unreleased](https://github.com/streamr-dev/streamr-client/compare/v5.3.0-beta.0...c98b04415cdf558b483f70a838e58b2a5321ffed) (2021-05-01)
+## [Unreleased]
 
-### Bug Fixes
-
-* Don't use waitForCondition outside test, doesn't wait for async, uses browser-incompatible setImmediate. ([c98b044](https://github.com/streamr-dev/streamr-client/commit/c98b04415cdf558b483f70a838e58b2a5321ffed))
-* **login:** Remove apiKey login support, no longer supported by core-api. ([f37bac5](https://github.com/streamr-dev/streamr-client/commit/f37bac53972ed9dc429ffdbd1567172d6e502801))
-
-### Features
-
-* Don't clear message chains on disconnect, allows continued publishing to same chain. ([df64089](https://github.com/streamr-dev/streamr-client/commit/df6408985d0001a88d118d9712c2cc92f595748d))
-
-
-## [5.2.1](https://github.com/streamr-dev/streamr-client/compare/v5.1.0...v5.2.1) (2021-03-29)
-
-This release fixes a subtle but serious memleak in all previous 5.x
-versions. Upgrading immediately is highly recommended.
-
-### Bug Fixes
-
-* **dataunions:** Withdraw amount can be a string ([bccebcb](https://github.com/streamr-dev/streamr-client/commit/bccebcb580e91f55a68a0aae864dcc48cf370bfa))
-* **keyexchange:** Remove bad call to cancelTask. ([cb576fd](https://github.com/streamr-dev/streamr-client/commit/cb576fdccbbf2600011c89a151cb15a3870a258a))
-* **pipeline:** Fix memleak in pipeline. ([86fcb83](https://github.com/streamr-dev/streamr-client/commit/86fcb833d74df267ad538fc37cf76c4f95c9462c))
-* **pushqueue:** Empty pending promises array in cleanup, prevents memleak. ([1e4892c](https://github.com/streamr-dev/streamr-client/commit/1e4892ccabd6853c59648fc025bc8be1fd630e55))
-* **pushqueue:** Transform was doing something unusual. ([27dbb05](https://github.com/streamr-dev/streamr-client/commit/27dbb05612a2d838e4ce399fb643d6ca00c1af74))
-* **subscribe:** Clean up type errors. ([1841741](https://github.com/streamr-dev/streamr-client/commit/184174127835a3d11160acbe4804b621e4480a86))
-* **util:** Clean up dangling Defers in LimitAsyncFnByKey. ([1eaa55a](https://github.com/streamr-dev/streamr-client/commit/1eaa55a9b51f44e055148ba80fa51e1d63fe2a77))
-* **util/defer:** Rejig exposed functions so resolve/reject can be gc'ed. ([2638f2b](https://github.com/streamr-dev/streamr-client/commit/2638f2b164455b6c45f3c6e9d3d6b297669ebc7a))
-* **validator:** Only keep a small message validator cache. ([de7b689](https://github.com/streamr-dev/streamr-client/commit/de7b68953dd52f8fbdf4bee4dff2ba6b3bd02545))
+[Unreleased]: https://github.com/streamr-dev/network-monorepo/compare/client/v6.0.0...HEAD

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -18,7 +18,6 @@ This library allows you to easily interact with the [Streamr Network](https://st
 Please see the [Streamr project docs](https://streamr.network/docs) for more detailed documentation.
 
 ## Contents
-- [Important information](#important-information)
 - [Getting started](#getting-started)
     - [Subscribing](#subscribing)
     - [Publishing](#publishing)
@@ -39,14 +38,6 @@ Please see the [Streamr project docs](https://streamr.network/docs) for more det
     - [Disable message ordering and gap filling](#disable-message-ordering-and-gap-filling)
     - [Proxy publishing](#proxy-publishing)
     - [Logging](#logging)
-
-## Important information
-> ⚠️ This section is to be removed before launch 
-
-The current stable version of the Streamr Client is `5.x` (at the time of writing, February 2022) which is connected to the [Corea Network](https://streamr.network/roadmap). The Brubeck Network Streamr Client is the [6.0.0-beta.4](https://www.npmjs.com/package/streamr-client/v/6.0.0-beta.4) build along with the `testnet` builds of the Broker node. The developer experience of the two networks is the same, however, the `6.0.0-beta.4` client also runs as a light node in the network, whereas the `5.x` era client communicates remotely to a Streamr run node. When the Streamr Network transitions into the Brubeck era (ETA Jan/Feb 2022), data guarantees of `5.x` clients will need to be reassessed. Publishing messages to the Brubeck network will only be visible in the [Brubeck Core UI](https://brubeck.streamr.network). The Marketplace, Core app and CLI tool are currently all configured to interact with the Corea Network only. Take care not to mix networks during this transition period.
-
----
-
 
 ## Getting started
 
@@ -100,7 +91,7 @@ const { StreamrClient } = require('streamr-client')
 For usage in the browser include the latest build, e.g. by including a `<script>` tag pointing at a CDN:
 
 ```html
-<script src="https://unpkg.com/streamr-client@beta/streamr-client.web.js"></script>
+<script src="https://unpkg.com/streamr-client@latest/streamr-client.web.js"></script>
 ```
 ___
 ## Usage


### PR DESCRIPTION
- Remove references to beta (and beta information) from client/README.md
- Add releasing instructions (for client) to root-level README.md
- Add client/CHANGELOG.md skeleton 