### PR TITLE
broker [NET-729]: Storage node doesn't close response

### DIFF
--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -81,6 +81,9 @@ const createEndpointRoute = (
                             'Content-Type': format.contentType
                         })
                     })
+                    data.on('close', () => {
+                        res.end()
+                    })
                     data.on('error', (err: any) => {
                         logger.error(`Stream error in DataQueryEndpoints: ${streamId}`, err)
                         if (!res.headersSent) {


### PR DESCRIPTION
We close the the http response stream manually on data `close` event (the `pipe()` method should do this automatically, but it doesn't?)