### PR TITLE
cli-tools: change log for 5.0.1 and 6.0.0 releases

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.0.0] - 2022-02-23
 - Add new command `stream wallet whoami` to display Ethereum address
-- Add permission commands: `stream grant-permission` and `stream revoke-permission`
-- Remove `typescript` and `ts-node` as run-time dependencies
-- (Breaking) Remove `--msg-chain-id` parameter from `stream resend from`
 - (Breaking) `stream create` argument is a stream ID, not a name
 - Support path notation when defining a stream ID
 - (Breaking) Remove `misc get-session-token` command
@@ -27,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Breaking) Rename `--partition-key` argument to `--partition-key-field` in `stream publish`
 - Bump dependency streamr-client to 6.1.0
 - Bump dependency commander to 8.3.0
+
+## 5.0.1 - 2021-06-04
+
+- Add permission commands: `stream grant-permission` and `stream revoke-permission`
+- Remove `typescript` and `ts-node` as run-time dependencies
+- (Breaking) Remove `--msg-chain-id` parameter from `stream resend from`
 
 ## [5.0.0] - 2021-05-05
 ### Added
@@ -88,7 +93,8 @@ ordering and gap filling.
 - Bump dependency commander to ^4.0.1.
 - Re-organize README.md and a few touches to Developing section paragraphs.
 
-[Unreleased]: https://github.com/streamr-dev/cli-tools/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/streamr-dev/network-monorepo/compare/cli-tools%2fv6.0.0...HEAD
+[6.0.0]: https://github.com/streamr-dev/network-monorepo/compare/cli-tools%2fv5.0.1...cli-tools%2fv6.0.0
 [5.0.0]: https://github.com/streamr-dev/cli-tools/compare/v4.1.1...v5.0.0
 [4.1.1]: https://github.com/streamr-dev/cli-tools/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/streamr-dev/cli-tools/compare/v4.0.0...v4.1.0


### PR DESCRIPTION
Update cli-tools change log about v5.0.1 and v6.0.0 releases.

To support this PR git tags `cli-tools/v6.0.0` and `cli-tools/v5.0.0` were added (there was already a git tag for v5.0.1).

The 5.0.0 version was originally created in another repository, and maybe that is the reason why comparison between 5.0.0 and 5.0.1 doesn't work (https://github.com/streamr-dev/network-monorepo/compare/cli-tools%2fv5.0.0...cli-tools%2fv5.0.1). Therefore that comparison is not included in the change log.