### PR TITLE
refactor: remove redundant dependency injections

### DIFF
--- a/packages/client/src/LoginEndpoints.ts
+++ b/packages/client/src/LoginEndpoints.ts
@@ -2,10 +2,9 @@
  * Login Endpoints Wrapper.
  */
 import { scoped, Lifecycle, inject, delay } from 'tsyringe'
-import Ethereum, { AuthConfig } from './Ethereum'
+import Ethereum from './Ethereum'
 import { instanceId } from './utils'
 import { Context } from './utils/Context'
-import { ConfigInjectionToken } from './Config'
 import { Rest } from './Rest'
 import { EthereumAddress } from 'streamr-client-protocol'
 
@@ -32,8 +31,7 @@ export class LoginEndpoints implements Context {
     constructor(
         context: Context,
         private ethereum: Ethereum,
-        @inject(delay(() => Rest)) private rest: Rest,
-        @inject(ConfigInjectionToken.Auth) private authConfig: AuthConfig,
+        @inject(delay(() => Rest)) private rest: Rest
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -90,7 +90,7 @@ class StreamrStream implements StreamMetadata {
     /** @internal */
     constructor(
         props: StreamrStreamConstructorOptions,
-        @inject(BrubeckContainer) private _container: DependencyContainer
+        @inject(BrubeckContainer) _container: DependencyContainer
     ) {
         Object.assign(this, props)
         this.id = props.id

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -3,7 +3,7 @@
  */
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
-import { scoped, Lifecycle, inject, DependencyContainer, delay } from 'tsyringe'
+import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import {
     ContentType,
     EncryptionType,
@@ -18,10 +18,7 @@ import { Context } from './utils/Context'
 
 import { Stream } from './Stream'
 import { ErrorCode, NotFoundError } from './authFetch'
-import { BrubeckContainer } from './Container'
-import { ConfigInjectionToken, ConnectionConfig } from './Config'
 import { Rest } from './Rest'
-import StreamrEthereum from './Ethereum'
 import { StreamRegistry } from './StreamRegistry'
 import { StorageNodeRegistry } from './StorageNodeRegistry'
 import { StreamIDBuilder } from './StreamIDBuilder'
@@ -82,13 +79,10 @@ export class StreamEndpoints implements Context {
     /** @internal */
     constructor(
         context: Context,
-        @inject(BrubeckContainer) private container: DependencyContainer,
-        @inject(ConfigInjectionToken.Connection) private readonly options: ConnectionConfig,
         @inject(delay(() => Rest)) private readonly rest: Rest,
         @inject(delay(() => StorageNodeRegistry)) private readonly storageNodeRegistry: StorageNodeRegistry,
         @inject(StreamRegistry) private readonly streamRegistry: StreamRegistry,
         @inject(StreamIDBuilder) private readonly streamIdBuilder: StreamIDBuilder,
-        private readonly ethereum: StreamrEthereum
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import './utils/PatchTsyringe'
-import { container as rootContainer, DependencyContainer, inject } from 'tsyringe'
+import { container as rootContainer, DependencyContainer } from 'tsyringe'
 
 import Ethereum from './Ethereum'
 import { uuid, counterId, pOnce } from './utils'
@@ -66,14 +66,12 @@ class StreamrClientBase implements Context {
 
     constructor(
         private container: DependencyContainer,
-        private context: Context,
-        @inject(ConfigInjectionToken.Root) private options: StrictStreamrClientConfig,
+        context: Context,
         private node: BrubeckNode,
         private ethereum: Ethereum,
         private session: Session,
         private loginEndpoints: LoginEndpoints,
         private streamEndpoints: StreamEndpoints,
-        private cached: StreamEndpointsCached,
         private resends: Resends,
         private publisher: Publisher,
         private subscriber: Subscriber,
@@ -241,13 +239,11 @@ export class StreamrClient extends StreamrClientBase {
         super(
             c,
             c.resolve<Context>(Context as any),
-            config,
             c.resolve<BrubeckNode>(BrubeckNode),
             c.resolve<Ethereum>(Ethereum),
             c.resolve<Session>(Session),
             c.resolve<LoginEndpoints>(LoginEndpoints),
             c.resolve<StreamEndpoints>(StreamEndpoints),
-            c.resolve<StreamEndpointsCached>(StreamEndpointsCached),
             c.resolve<Resends>(Resends),
             c.resolve<Publisher>(Publisher),
             c.resolve<Subscriber>(Subscriber),

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -13,7 +13,6 @@ import { StreamEndpoints } from '../StreamEndpoints'
 import PublishPipeline, { PublishMetadata } from './PublishPipeline'
 import { Stoppable } from '../utils/Stoppable'
 import { PublisherKeyExchange } from '../encryption/KeyExchangePublisher'
-import Validator from '../Validator'
 import BrubeckNode from '../BrubeckNode'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
@@ -37,7 +36,6 @@ export default class BrubeckPublisher implements Context, Stoppable {
         context: Context,
         private pipeline: PublishPipeline,
         private node: BrubeckNode,
-        private validator: Validator,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(delay(() => PublisherKeyExchange)) private keyExchange: PublisherKeyExchange,
         @inject(delay(() => StreamEndpoints)) private streamEndpoints: StreamEndpoints,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -12,7 +12,6 @@ import { MessageStream, MessageStreamOnMessage } from './MessageStream'
 import SubscribePipeline from './SubscribePipeline'
 
 import { StorageNodeRegistry } from '../StorageNodeRegistry'
-import { StreamEndpoints } from '../StreamEndpoints'
 import { BrubeckContainer } from '../Container'
 import { createQueryString, Rest } from '../Rest'
 import { StreamIDBuilder } from '../StreamIDBuilder'
@@ -76,7 +75,6 @@ export default class Resend implements Context {
         context: Context,
         @inject(delay(() => StorageNodeRegistry)) private storageNodeRegistry: StorageNodeRegistry,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
-        @inject(delay(() => StreamEndpoints)) private streamEndpoints: StreamEndpoints,
         @inject(Rest) private rest: Rest,
         @inject(BrubeckContainer) private container: DependencyContainer
     ) {

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -106,9 +106,6 @@ describe('MemoryLeaks', () => {
                     maxRetries: 2,
                     ...opts,
                 })
-                // ignore stuff captured by leaking network node
-                // @ts-expect-error
-                leaksDetector.ignoreAll(c.options.network)
                 return c
             }
         })

--- a/packages/client/test/end-to-end/StreamrClient.test.ts
+++ b/packages/client/test/end-to-end/StreamrClient.test.ts
@@ -37,6 +37,7 @@ describeRepeats('StreamrClient', () => {
 
     let onError = jest.fn()
     let client: StreamrClient
+    let privateKey: string
     const createClient = getCreateClient()
     let publishTestMessages: ReturnType<typeof getPublishTestMessages>
 
@@ -62,9 +63,10 @@ describeRepeats('StreamrClient', () => {
     })
 
     beforeEach(async () => {
+        privateKey = fastPrivateKey()
         client = await createClient({
             auth: {
-                privateKey: fastPrivateKey()
+                privateKey
             }
         })
         await client.connect()
@@ -235,8 +237,9 @@ describeRepeats('StreamrClient', () => {
 
         it('destroying stops publish', async () => {
             const subscriber = await createClient({
-                // @ts-expect-error
-                auth: client.options.auth,
+                auth: {
+                    privateKey
+                }
             })
             const sub = await subscriber.subscribe(streamDefinition)
 
@@ -283,8 +286,9 @@ describeRepeats('StreamrClient', () => {
             // that subscriber will actually get something.
             // Probably needs to wait for propagation.
             const subscriber = await createClient({
-                // @ts-expect-error
-                auth: client.options.auth,
+                auth: {
+                    privateKey
+                }
             })
 
             const received: any[] = []

--- a/packages/client/test/end-to-end/Subscriber.test.ts
+++ b/packages/client/test/end-to-end/Subscriber.test.ts
@@ -25,6 +25,7 @@ describeRepeats('Subscriber', () => {
     let expectErrors = 0 // check no errors by default
     let onError = jest.fn()
     let client: StreamrClient
+    let privateKey: string
     let streamParts: AsyncGenerator<StreamPartID>
     let streamDefinition: StreamDefinition
     let M: Subscriber
@@ -44,11 +45,11 @@ describeRepeats('Subscriber', () => {
     })
 
     beforeEach(async () => {
-        // eslint-disable-next-line require-atomic-updates
+        privateKey = fastPrivateKey()
         client = new StreamrClient({
             ...ConfigTest,
             auth: {
-                privateKey: fastPrivateKey()
+                privateKey
             }
         })
         // @ts-expect-error private
@@ -403,8 +404,9 @@ describeRepeats('Subscriber', () => {
                 sub2.onError(onSuppressError)
 
                 const client2 = await createClient({
-                    // @ts-expect-error
-                    auth: client.options.auth,
+                    auth: {
+                        privateKey
+                    }
                 })
 
                 const publishTestMessages2 = getPublishTestMessages(client2, streamDefinition)

--- a/packages/client/test/integration/BrubeckNode.test.ts
+++ b/packages/client/test/integration/BrubeckNode.test.ts
@@ -1,7 +1,7 @@
 import { StreamrClient } from '../../src/StreamrClient'
 import { ConfigTest } from '../../src/ConfigTest'
 import { getCreateClient } from '../test-utils/utils'
-import { fastWallet } from 'streamr-test-utils'
+import { fastPrivateKey, fastWallet } from 'streamr-test-utils'
 
 describe('BrubeckNode', () => {
     const createClient = getCreateClient()
@@ -16,9 +16,17 @@ describe('BrubeckNode', () => {
         })
 
         it('generates different ids for different clients with same private key', async () => {
-            const client1 = await createClient()
-            // @ts-expect-error
-            const client2 = await createClient({ auth: client1.options.auth })
+            const privateKey = fastPrivateKey()
+            const client1 = await createClient({
+                auth: {
+                    privateKey
+                }
+            })
+            const client2 = await createClient({
+                auth: {
+                    privateKey
+                }
+            })
             // same key, same address
             expect(await client1.getAddress()).toEqual(await client2.getAddress())
             const expectedPrefix = `${await client1.getAddress()}#`

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -1,4 +1,4 @@
-import { wait } from 'streamr-test-utils'
+import { fastPrivateKey, wait } from 'streamr-test-utils'
 import { StreamMessage } from 'streamr-client-protocol'
 import {
     describeRepeats,
@@ -29,7 +29,9 @@ describeRepeats('decryption', () => {
     let errors: Error[] = []
 
     let publisher: StreamrClient
+    let publisherPrivateKey: string
     let subscriber: StreamrClient
+    let subscriberPrivateKey: string
     let stream: Stream
     let clientFactory: ClientFactory
 
@@ -90,10 +92,24 @@ describeRepeats('decryption', () => {
             await subscriber.destroy()
         }
 
+        publisherPrivateKey = fastPrivateKey()
+        subscriberPrivateKey = fastPrivateKey()
         // eslint-disable-next-line require-atomic-updates, semi-style, no-extra-semi
         ;[publisher, subscriber] = await Promise.all([
-            setupClient({ id: 'publisher', ...opts }),
-            setupClient({ id: 'subscriber', ...opts }),
+            setupClient({
+                id: 'publisher',
+                auth: {
+                    privateKey: publisherPrivateKey
+                },
+                ...opts
+            }),
+            setupClient({
+                id: 'subscriber',
+                auth: {
+                    privateKey: subscriberPrivateKey
+                },
+                ...opts
+            })
         ])
     }
 
@@ -374,18 +390,19 @@ describeRepeats('decryption', () => {
                         }
                     }
                 }
-
                 // eslint-disable-next-line require-atomic-updates
                 publisher = await setupClient({
-                    // @ts-expect-error
-                    auth: publisher.options.auth,
+                    auth: {
+                        privateKey: publisherPrivateKey
+                    },
                     groupKeys,
                 })
 
                 // eslint-disable-next-line require-atomic-updates
                 subscriber = await setupClient({
-                    // @ts-expect-error
-                    auth: subscriber.options.auth,
+                    auth: {
+                        privateKey: subscriberPrivateKey
+                    },
                     groupKeys,
                 })
 

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,5 +1,5 @@
 import { StreamrClient } from '../../src/StreamrClient'
-import { STREAM_CLIENT_DEFAULTS } from '../../src/Config'
+import { createStrictConfig, STREAM_CLIENT_DEFAULTS } from '../../src/Config'
 import { ConfigTest } from '../../src/ConfigTest'
 import { SmartContractRecord } from 'streamr-client-protocol'
 
@@ -7,7 +7,7 @@ describe('Config', () => {
     describe('validate', () => {
         it('additional property', () => {
             expect(() => {
-                return new StreamrClient({
+                return createStrictConfig({
                     network: {
                         foo: 'bar'
                     }
@@ -17,7 +17,7 @@ describe('Config', () => {
 
         it('missing property', () => {
             expect(() => {
-                return new StreamrClient({
+                return createStrictConfig({
                     network: {
                         trackers: [{
                             id: '0x1234567890123456789012345678901234567890',
@@ -31,7 +31,7 @@ describe('Config', () => {
         describe('invalid property format', () => {
             it('primitive', () => {
                 expect(() => {
-                    return new StreamrClient({
+                    return createStrictConfig({
                         network: {
                             acceptProxyConnections: 123
                         }
@@ -41,7 +41,7 @@ describe('Config', () => {
 
             it('enum', () => {
                 expect(() => {
-                    return new StreamrClient({
+                    return createStrictConfig({
                         verifySignatures: 'foo'
                     } as any)
                 }).toThrow('verifySignatures must be equal to one of the allowed values')
@@ -49,7 +49,7 @@ describe('Config', () => {
 
             it('ajv-format', () => {
                 expect(() => {
-                    return new StreamrClient({
+                    return createStrictConfig({
                         theGraphUrl: 'foo'
                     } as any)
                 }).toThrow('/theGraphUrl must match format "uri"')
@@ -57,7 +57,7 @@ describe('Config', () => {
 
             it('ethereum address', () => {
                 expect(() => {
-                    return new StreamrClient({
+                    return createStrictConfig({
                         auth: {
                             address: 'foo'
                         }
@@ -67,7 +67,7 @@ describe('Config', () => {
 
             it('ethereum private key', () => {
                 expect(() => {
-                    return new StreamrClient({
+                    return createStrictConfig({
                         auth: {
                             privateKey: 'foo'
                         }
@@ -92,23 +92,19 @@ describe('Config', () => {
         })
 
         it('can override network.trackers arrays', () => {
-            const clientDefaults = new StreamrClient()
-            const clientOverrides = new StreamrClient(ConfigTest)
-            // @ts-expect-error private
-            expect(clientOverrides.options.network.trackers).not.toEqual(clientDefaults.options.network.trackers)
-            // @ts-expect-error private
-            expect(clientOverrides.options.network.trackers).toEqual(ConfigTest.network.trackers)
+            const clientDefaults = createStrictConfig()
+            const clientOverrides = createStrictConfig(ConfigTest)
+            expect(clientOverrides.network.trackers).not.toEqual(clientDefaults.network.trackers)
+            expect(clientOverrides.network.trackers).toEqual(ConfigTest.network.trackers)
         })
 
         it('network can be empty', () => {
-            const clientDefaults = new StreamrClient()
-            const clientOverrides = new StreamrClient({
+            const clientDefaults = createStrictConfig()
+            const clientOverrides = createStrictConfig({
                 network: {}
             })
-            // @ts-expect-error
-            expect(clientOverrides.options.network).toEqual(clientDefaults.options.network)
-            // @ts-expect-error private
-            expect(clientOverrides.options.network.trackers).toEqual(STREAM_CLIENT_DEFAULTS.network.trackers)
+            expect(clientOverrides.network).toEqual(clientDefaults.network)
+            expect(clientOverrides.network.trackers).toEqual(STREAM_CLIENT_DEFAULTS.network.trackers)
         })
 
         it('can override trackers', () => {
@@ -119,17 +115,14 @@ describe('Config', () => {
                     http: 'https://brubeck3.streamr.network:30401'
                 },
             ]
-            const clientOverrides = new StreamrClient({
+            const clientOverrides = createStrictConfig({
                 network: {
                     trackers,
                 }
             })
-            // @ts-expect-error
-            expect(clientOverrides.options.network.trackers).toEqual(trackers)
-            // @ts-expect-error
-            expect(clientOverrides.options.network.trackers).not.toBe(trackers)
-            // @ts-expect-error
-            expect((clientOverrides.options.network.trackers as SmartContractRecord[])[0]).not.toBe(trackers[0])
+            expect(clientOverrides.network.trackers).toEqual(trackers)
+            expect(clientOverrides.network.trackers).not.toBe(trackers)
+            expect((clientOverrides.network.trackers as SmartContractRecord[])[0]).not.toBe(trackers[0])
         })
 
         it('can override debug settings', () => {
@@ -145,30 +138,24 @@ describe('Config', () => {
                 }
             }
 
-            const clientDefaults = new StreamrClient()
-            const clientOverrides1 = new StreamrClient({
+            const clientDefaults = createStrictConfig()
+            const clientOverrides1 = createStrictConfig({
                 debug: debugPartial,
             })
-            const clientOverrides2 = new StreamrClient({
+            const clientOverrides2 = createStrictConfig({
                 debug: debugFull,
             })
-            // @ts-expect-error
-            expect(clientOverrides1.options.debug).toEqual({
-                // @ts-expect-error
-                ...clientDefaults.options.debug,
+            expect(clientOverrides1.debug).toEqual({
+                ...clientDefaults.debug,
                 inspectOpts: {
-                    // @ts-expect-error
-                    ...clientDefaults.options.debug.inspectOpts,
+                    ...clientDefaults.debug.inspectOpts,
                     ...debugPartial.inspectOpts,
                 }
             })
-            // @ts-expect-error
-            expect(clientOverrides2.options.debug).toEqual({
-                // @ts-expect-error
-                ...clientDefaults.options.debug,
+            expect(clientOverrides2.debug).toEqual({
+                ...clientDefaults.debug,
                 inspectOpts: {
-                    // @ts-expect-error
-                    ...clientDefaults.options.debug.inspectOpts,
+                    ...clientDefaults.debug.inspectOpts,
                     ...debugFull.inspectOpts,
                 }
             })

--- a/packages/client/test/unit/Session.test.ts
+++ b/packages/client/test/unit/Session.test.ts
@@ -59,14 +59,14 @@ describe('Session', () => {
 
     describe('instantiation', () => {
         it('should get token if set with a token', async () => {
+            const SESSION_TOKEN = 'test'
             const clientNone = createClient({
                 auth: {
-                    sessionToken: 'test'
+                    sessionToken: SESSION_TOKEN
                 },
             })
             const sessionToken = await clientNone.getSessionToken()
-            // @ts-expect-error
-            expect(sessionToken).toBe(clientNone.options.auth.sessionToken)
+            expect(sessionToken).toBe(SESSION_TOKEN)
         })
 
         it('should return empty string with no authentication', async () => {


### PR DESCRIPTION
Remove injected objects which were not used by the client. 

One of the fields is `client.options`, which contains e.g. the private key. The removal also enhances security. If we pass a `StreamrClient` instance to some external component, that component shouldn't be able to read the private key.

Refactor some test which used `client.options` directly. In `MemoryLeak.test.ts` there was a leak detection exception for `client.config.network`, but that is maybe not needed anymore? The `client.config.network` object contains just the configuration options, not e.g. a `NetworkNode` instance.