### PR TITLE
fix(broker): Use streamr user inside Docker container instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16.14-bullseye as build
-WORKDIR /usr/src/monorepo
+WORKDIR /usr/src/network
 RUN npm config set \
 	unsafe-perm=true \
 	python="$(which python3)"
@@ -13,8 +13,10 @@ RUN apt-get update && apt-get --assume-yes --no-install-recommends install \
 	curl=7.74.0-1.3+deb11u1 \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-COPY --from=build /usr/src/monorepo /usr/src/monorepo
-WORKDIR /usr/src/monorepo
+RUN usermod -d /home/streamr -l streamr node && groupmod -n streamr node
+USER streamr
+WORKDIR /home/streamr/network
+COPY --chown=streamr:streamr --from=build /usr/src/network/ .
 
 ENV LOG_LEVEL=info
 
@@ -24,7 +26,7 @@ EXPOSE 1883/tcp
 EXPOSE 7170/tcp
 EXPOSE 7171/tcp
 
-WORKDIR /usr/src/monorepo/packages/broker
+WORKDIR /home/streamr/network/packages/broker
 
 # start broker from default config
 CMD ["./bin/broker.js"]


### PR DESCRIPTION
Broker doesn't need root permissions to run.

BREAKING CHANGE: Changes file system path internal to Docker container
from `/root` to `/home/streamr`. Affects Docker volume mappings when
starting/running container.

<!--- Provide a general summary of the changes -->

## Checklist

<!--- Feel free to remove any that are not relevant -->

- [ ] Has passing tests that demonstrate this change works
- [ ] Updated Changelog
- [x] Updated Documentation https://github.com/streamr-dev/core-frontend/pull/1337/files
