### PR TITLE
refactor: Search streams error handling

### DIFF
--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -236,17 +236,9 @@ export class StreamRegistry implements Context {
         }
         this.debug('Search streams term=%s permissions=%j', term, permissionFilter)
         return map(
-            filter(fetchSearchStreamsResultFromTheGraph(term, permissionFilter, this.graphQLClient),
-                (item: SearchStreamsResultItem) => {
-                    try {
-                        Stream.parsePropertiesFromMetadata(item.stream.metadata)
-                        return true
-                    } catch (err) {
-                        this.debug('Omitting stream %s from result because %s', item.stream.id, err.message)
-                        return false
-                    }
-                }),
-            (item: SearchStreamsResultItem) => this.parseStream(toStreamID(item.stream.id), item.stream.metadata)
+            fetchSearchStreamsResultFromTheGraph(term, permissionFilter, this.graphQLClient),
+            (item: SearchStreamsResultItem) => this.parseStream(toStreamID(item.stream.id), item.stream.metadata),
+            (err: Error, item: SearchStreamsResultItem) => this.debug('Omitting stream %s from result because %s', item.stream.id, err.message)
         )
     }
 

--- a/packages/client/test/unit/SearchStreams.test.ts
+++ b/packages/client/test/unit/SearchStreams.test.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata'
+import { BigNumber } from '@ethersproject/bignumber'
+import { StreamID, StreamIDUtils, toStreamID } from 'streamr-client-protocol'
+import { SearchStreamsResultItem } from '../../src/searchStreams'
+import { StreamRegistry } from '../../src/StreamRegistry'
+import { collect } from '../../src/utils/GeneratorUtils'
+import { createMockAddress } from '../test-utils/utils'
+
+const MOCK_USER = createMockAddress()
+
+const createMockResultItem = (streamId: StreamID, metadata: string): SearchStreamsResultItem => {
+    return {
+        id: streamId,
+        userAddress: StreamIDUtils.getDomain(streamId)!,
+        stream: {
+            id: streamId,
+            metadata
+        },
+        canEdit: true,
+        canDelete: true,
+        publishExpiration: BigNumber.from(0),
+        subscribeExpiration: BigNumber.from(0),
+        canGrant: true
+    }
+}
+
+const createMockStreamRegistry = (resultItems: SearchStreamsResultItem[], debugLog: jest.Mock<void, []>) => {
+    return new StreamRegistry(
+        {
+            debug: {
+                extend: () => debugLog
+            }
+        } as any,
+        {
+            getAllStreamRegistryChainProviders: () => []
+        } as any,
+        undefined as any,
+        {
+            resolve: () => undefined
+        } as any,
+        undefined as any,
+        {
+            // eslint-disable-next-line generator-star-spacing
+            async *fetchPaginatedResults() {
+                yield* resultItems
+            }
+        } as any,
+        undefined as any
+    )
+}
+
+describe('SearchStreams', () => {
+    it('invalid metadata', async () => {
+        const stream1 = toStreamID('/1', MOCK_USER)
+        const stream2 = toStreamID('/2', MOCK_USER)
+        const stream3 = toStreamID('/3', MOCK_USER)
+        const debugLog = jest.fn()
+        const registry = createMockStreamRegistry([
+            createMockResultItem(stream1, JSON.stringify({ partitions: 11 })),
+            createMockResultItem(stream2, 'invalid-json'),
+            createMockResultItem(stream3, JSON.stringify({ partitions: 33 }))
+        ], debugLog)
+        const streams = await collect(registry.searchStreams('/', undefined))
+        expect(streams).toHaveLength(2)
+        expect(streams[0].id).toBe(stream1)
+        expect(streams[0].partitions).toBe(11)
+        expect(streams[1].id).toBe(stream3)
+        expect(streams[1].partitions).toBe(33)
+        expect(debugLog).toBeCalledWith(
+            'Omitting stream %s from result because %s',
+            stream2,
+            'Could not parse properties from onchain metadata: invalid-json'
+        )
+    })
+})


### PR DESCRIPTION
Implement error handling in `StreamRegistry.searchStreams` using `GeneratorUtils.map`'s `onError` callback . This is simpler and more efficient, as we don't need to parse the `metadata` JSON twice.

- [x] Has passing tests that demonstrate this change works
