### PR TITLE
fix: do not log extra fields of publishMetadata object

### DIFF
--- a/packages/client/src/publish/PublishPipeline.ts
+++ b/packages/client/src/publish/PublishPipeline.ts
@@ -186,7 +186,11 @@ export default class PublishPipeline implements Context, Stoppable {
      * Creates a Defer to be resolved when message gets sent to node.
      */
     async publish<T>(publishMetadata: PublishMetadataStrict<T>): Promise<StreamMessage<T>> {
-        this.debug('publish >> %o', publishMetadata)
+        this.debug('publish >> %o', {
+            streamDefinition: formStreamDefinitionDescription(publishMetadata.streamDefinition),
+            timestamp: publishMetadata.timestamp,
+            partitionKey: publishMetadata.partitionKey
+        })
         this.startQueue()
 
         const defer = Defer<StreamMessage<T>>()


### PR DESCRIPTION
The `PublishPipeline#publish` method logs metadata information to the debug log for each message. Reduce the output of that log entry by including only fields, which are defined in `PublishMetadataStrict` type. In practice that object can contain additional fields, e.g. the message payload.

Before this PR:
`publish >> { streamDefinition: { config: { fields: [] }, partitions: 1, id: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foobar' }, content: { foo: 'some-huge-payload' }, timestamp: 1640988000, partitionKey: undefined }`

After this PR:
`publish >> { streamDefinition: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foobar', timestamp: 1640988000, partitionKey: undefined }`
