### PR TITLE
Client storage node method names

### DIFF
--- a/packages/broker/src/plugins/storage/StoragePoller.ts
+++ b/packages/broker/src/plugins/storage/StoragePoller.ts
@@ -37,7 +37,7 @@ export class StoragePoller {
 
     async poll(): Promise<void> {
         logger.info('polling...')
-        const { streams, blockNumber } = await this.streamrClient.getStoredStreamsOf(this.clusterId)
+        const { streams, blockNumber } = await this.streamrClient.getStoredStreams(this.clusterId)
         logger.info('found %d streams at block %d', streams.length, blockNumber)
         this.onNewSnapshot(streams, blockNumber)
     }

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -21,10 +21,10 @@ function makeStubStream(streamId: string): Stream {
 }
 
 describe(StorageConfig, () => {
-    let getStoredStreamsOf: jest.Mock<Promise<{ streams: Stream[], blockNumber: number }>, [nodeAddress: EthereumAddress]>
+    let getStoredStreams: jest.Mock<Promise<{ streams: Stream[], blockNumber: number }>, [nodeAddress: EthereumAddress]>
     let storageEventListener: ((event: StorageNodeAssignmentEvent) => any) | undefined
     let stubClient: Pick<StreamrClient, 'getStream'
-        | 'getStoredStreamsOf'
+        | 'getStoredStreams'
         | 'registerStorageEventListener'
         | 'unregisterStorageEventListeners' >
     let onStreamPartAdded: jest.Mock<void, [StreamPartID]>
@@ -32,10 +32,10 @@ describe(StorageConfig, () => {
     let storageConfig: StorageConfig
 
     beforeEach(async () => {
-        getStoredStreamsOf = jest.fn()
+        getStoredStreams = jest.fn()
         storageEventListener = undefined
         stubClient = {
-            getStoredStreamsOf,
+            getStoredStreams,
             async getStream(streamIdOrPath: string) {
                 return makeStubStream(streamIdOrPath, )
             },
@@ -52,7 +52,7 @@ describe(StorageConfig, () => {
             onStreamPartAdded,
             onStreamPartRemoved
         })
-        getStoredStreamsOf.mockRejectedValue(new Error('results not available'))
+        getStoredStreams.mockRejectedValue(new Error('results not available'))
     })
 
     afterEach(async () => {
@@ -65,7 +65,7 @@ describe(StorageConfig, () => {
 
     describe('on polled results', () => {
         beforeEach(async () => {
-            getStoredStreamsOf.mockResolvedValue({
+            getStoredStreams.mockResolvedValue({
                 streams: [
                     makeStubStream('stream-1'),
                     makeStubStream('stream-2')
@@ -140,7 +140,7 @@ describe(StorageConfig, () => {
     })
 
     it('updates do not occur if start has not been invoked', async () => {
-        getStoredStreamsOf.mockResolvedValue({
+        getStoredStreams.mockResolvedValue({
             streams: [
                 makeStubStream('stream-1'),
                 makeStubStream('stream-2')
@@ -150,7 +150,7 @@ describe(StorageConfig, () => {
         await wait(POLL_TIME * 2)
 
         expect(storageEventListener).toBeUndefined()
-        expect(getStoredStreamsOf).toHaveBeenCalledTimes(0)
+        expect(getStoredStreams).toHaveBeenCalledTimes(0)
         expect(onStreamPartAdded).toHaveBeenCalledTimes(0)
         expect(onStreamPartRemoved).toHaveBeenCalledTimes(0)
     })
@@ -160,8 +160,8 @@ describe(StorageConfig, () => {
         await wait(POLL_TIME)
         await storageConfig.destroy()
 
-        getStoredStreamsOf.mockClear()
-        getStoredStreamsOf.mockResolvedValue({
+        getStoredStreams.mockClear()
+        getStoredStreams.mockResolvedValue({
             streams: [
                 makeStubStream('stream-1'),
                 makeStubStream('stream-2')
@@ -171,7 +171,7 @@ describe(StorageConfig, () => {
         expect(storageEventListener).toBeUndefined()
         await wait(POLL_TIME * 2)
 
-        expect(getStoredStreamsOf).toHaveBeenCalledTimes(0)
+        expect(getStoredStreams).toHaveBeenCalledTimes(0)
         expect(onStreamPartAdded).toHaveBeenCalledTimes(0)
         expect(onStreamPartRemoved).toHaveBeenCalledTimes(0)
     })

--- a/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
@@ -5,7 +5,7 @@ import StreamrClient from 'streamr-client'
 import { createClientCommand } from '../src/command'
 
 createClientCommand((async (client: StreamrClient, storageNodeAddress: string) => {
-    const { streams } = await client.getStoredStreamsOf(storageNodeAddress)
+    const { streams } = await client.getStoredStreams(storageNodeAddress)
     if (streams.length > 0) {
         console.info(EasyTable.print(streams.map((stream) => {
             return {

--- a/packages/cli-tools/bin/streamr-storage-node-list.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list.ts
@@ -4,18 +4,9 @@ import { StreamrClient } from 'streamr-client'
 import EasyTable from 'easy-table'
 import { createClientCommand } from '../src/command'
 
-const getStorageNodes = async (streamId: string | undefined, client: StreamrClient): Promise<string[]> => {
-    if (streamId !== undefined) {
-        const stream = await client.getStream(streamId)
-        return stream.getStorageNodes()
-    } else {
-        return client.getAllStorageNodes()
-    }
-}
-
 createClientCommand(async (client: StreamrClient, options: any) => {
     const streamId = options.stream
-    const addresses = await getStorageNodes(streamId, client)
+    const addresses = await client.getStorageNodes(streamId)
     if (addresses.length > 0) {
         console.info(EasyTable.print(addresses.map((address: string) => ({
             address

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Method `getStorageNodesOf()` renamed to `getStorageNodes()`
+- Method `getStoredStreamsOf()` renamed to `getStoredStreams()`
+- Method `isStreamStoredInStorageNode()` renamed to `isStoredStream()`
 - Method `stream.update()` now requires a parameter `props`
 - Method `unRegisterStorageEventListeners()` renamed to `unregisterStorageEventListeners()`
 
@@ -20,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove method `getAllStorageNodes()`, use `getStorageNodes()` without arguments instead
 - Remove (non-functional) client configuration options `autoConnect` and `autoDisconnect`
 - Remove method `disconnect()`, use `destroy()` instead
 - Remove method `unsubscribeAll()`, use `unsubscribe()` without arguments instead

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -175,7 +175,7 @@ export class StorageNodeRegistry {
         return this.streamStorageRegistryContractReadonly.isStorageNodeOf(streamId, nodeAddress.toLowerCase())
     }
 
-    async getStoredStreamsOf(nodeAddress: EthereumAddress): Promise<{ streams: Stream[], blockNumber: number }> {
+    async getStoredStreams(nodeAddress: EthereumAddress): Promise<{ streams: Stream[], blockNumber: number }> {
         log('Getting stored streams of node %s', nodeAddress)
         const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStorageNodeQuery(nodeAddress.toLowerCase())) as StorageNodeQueryResult
         const streams = res.node.storedStreams.map((stream) => {

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -175,16 +175,6 @@ export class StorageNodeRegistry {
         return this.streamStorageRegistryContractReadonly.isStorageNodeOf(streamId, nodeAddress.toLowerCase())
     }
 
-    async getStorageNodesOf(streamIdOrPath: string): Promise<EthereumAddress[]> {
-        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        log('Getting storage nodes of stream %s', streamId)
-        const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStoredStreamQuery(streamId)) as StoredStreamQueryResult
-        if (res.stream === null) {
-            return []
-        }
-        return res.stream.storageNodes.map((node) => node.id)
-    }
-
     async getStoredStreamsOf(nodeAddress: EthereumAddress): Promise<{ streams: Stream[], blockNumber: number }> {
         log('Getting stored streams of node %s', nodeAddress)
         const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStorageNodeQuery(nodeAddress.toLowerCase())) as StorageNodeQueryResult
@@ -197,6 +187,16 @@ export class StorageNodeRegistry {
             // eslint-disable-next-line no-underscore-dangle
             blockNumber: res._meta.block.number
         }
+    }
+
+    async getStorageNodes(streamIdOrPath: string): Promise<EthereumAddress[]> {
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        log('Getting storage nodes of stream %s', streamId)
+        const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStoredStreamQuery(streamId)) as StoredStreamQueryResult
+        if (res.stream === null) {
+            return []
+        }
+        return res.stream.storageNodes.map((node) => node.id)
     }
 
     async getAllStorageNodes(): Promise<EthereumAddress[]> {

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -169,7 +169,7 @@ export class StorageNodeRegistry {
         return metadata.http
     }
 
-    async isStreamStoredInStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
+    async isStoredStream(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         log('Checking if stream %s is stored in storage node %s', streamId, nodeAddress)
         return this.streamStorageRegistryContractReadonly.isStorageNodeOf(streamId, nodeAddress.toLowerCase())

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -189,20 +189,20 @@ export class StorageNodeRegistry {
         }
     }
 
-    async getStorageNodes(streamIdOrPath: string): Promise<EthereumAddress[]> {
-        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        log('Getting storage nodes of stream %s', streamId)
-        const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStoredStreamQuery(streamId)) as StoredStreamQueryResult
-        if (res.stream === null) {
-            return []
+    async getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
+        if (streamIdOrPath !== undefined) {
+            const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+            log('Getting storage nodes of stream %s', streamId)
+            const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildStoredStreamQuery(streamId)) as StoredStreamQueryResult
+            if (res.stream === null) {
+                return []
+            }
+            return res.stream.storageNodes.map((node) => node.id)
+        } else {
+            log('Getting all storage nodes')
+            const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildAllNodesQuery()) as AllNodesQueryResult
+            return res.nodes.map((node) => node.id)
         }
-        return res.stream.storageNodes.map((node) => node.id)
-    }
-
-    async getAllStorageNodes(): Promise<EthereumAddress[]> {
-        log('Getting all storage nodes')
-        const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildAllNodesQuery()) as AllNodesQueryResult
-        return res.nodes.map((node) => node.id)
     }
 
     async registerStorageEventListener(callback: (event: StorageNodeAssignmentEvent) => any) {

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -198,6 +198,7 @@ export class StorageNodeRegistry {
                 return []
             }
             return res.stream.storageNodes.map((node) => node.id)
+            // eslint-disable-next-line no-else-return
         } else {
             log('Getting all storage nodes')
             const res = await this.graphQLClient.sendQuery(StorageNodeRegistry.buildAllNodesQuery()) as AllNodesQueryResult

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -235,7 +235,7 @@ class StreamrStream implements StreamMetadata {
     }
 
     async getStorageNodes() {
-        return this._nodeRegistry.getStorageNodesOf(this.id)
+        return this._nodeRegistry.getStorageNodes(this.id)
     }
 
     /**

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -162,7 +162,7 @@ export default class Resend implements Context {
     ) {
         const debug = this.debug.extend(counterId(`resend-${endpointSuffix}`))
         debug('fetching resend %s %s %o', endpointSuffix, streamPartId, query)
-        const nodeAdresses = await this.storageNodeRegistry.getStorageNodesOf(StreamPartIDUtils.getStreamID(streamPartId))
+        const nodeAdresses = await this.storageNodeRegistry.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
         if (!nodeAdresses.length) {
             const err = new ContextError(this, `no storage assigned: ${inspect(streamPartId)}`)
             err.code = 'NO_STORAGE_NODES'

--- a/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
@@ -85,7 +85,7 @@ describe('createNode', () => {
             expect(storageNodeUrls.length).toEqual(1)
             return expect(storageNodeUrls[0]).toEqual(nodeAddress.toLowerCase())
         })
-    
+
         it('all', async () => {
             const storageNodeUrls: EthereumAddress[] = await client.getStorageNodes()
             expect(storageNodeUrls.length).toBeGreaterThan(0)

--- a/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
@@ -94,8 +94,8 @@ describe('createNode', () => {
 
     })
 
-    it('getStoredStreamsOf', async () => {
-        const { streams, blockNumber } = await client.getStoredStreamsOf(nodeAddress)
+    it('getStoredStreams', async () => {
+        const { streams, blockNumber } = await client.getStoredStreams(nodeAddress)
         expect(blockNumber).toBeGreaterThanOrEqual(0)
         expect(streams.length).toBeGreaterThan(0)
         return expect(streams.find((el) => { return el.id === createdStream.id })).toBeDefined()

--- a/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
@@ -87,7 +87,7 @@ describe('createNode', () => {
         })
     
         it('all', async () => {
-            const storageNodeUrls: EthereumAddress[] = await client.getAllStorageNodes()
+            const storageNodeUrls: EthereumAddress[] = await client.getStorageNodes()
             expect(storageNodeUrls.length).toBeGreaterThan(0)
             return expect(storageNodeUrls).toContain(nodeAddress.toLowerCase())
         })

--- a/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
@@ -78,10 +78,20 @@ describe('createNode', () => {
         await client.unregisterStorageEventListeners()
     })
 
-    it('getStorageNodesOf', async () => {
-        const storageNodeUrls: EthereumAddress[] = await client.getStorageNodesOf(createdStream.id)
-        expect(storageNodeUrls.length).toEqual(1)
-        return expect(storageNodeUrls[0]).toEqual(nodeAddress.toLowerCase())
+    describe('getStorageNodes', () => {
+
+        it('id', async () => {
+            const storageNodeUrls: EthereumAddress[] = await client.getStorageNodes(createdStream.id)
+            expect(storageNodeUrls.length).toEqual(1)
+            return expect(storageNodeUrls[0]).toEqual(nodeAddress.toLowerCase())
+        })
+    
+        it('all', async () => {
+            const storageNodeUrls: EthereumAddress[] = await client.getAllStorageNodes()
+            expect(storageNodeUrls.length).toBeGreaterThan(0)
+            return expect(storageNodeUrls).toContain(nodeAddress.toLowerCase())
+        })
+
     })
 
     it('getStoredStreamsOf', async () => {
@@ -89,12 +99,6 @@ describe('createNode', () => {
         expect(blockNumber).toBeGreaterThanOrEqual(0)
         expect(streams.length).toBeGreaterThan(0)
         return expect(streams.find((el) => { return el.id === createdStream.id })).toBeDefined()
-    })
-
-    it('getAllStorageNodes', async () => {
-        const storageNodeUrls: EthereumAddress[] = await client.getAllStorageNodes()
-        expect(storageNodeUrls.length).toBeGreaterThan(0)
-        return expect(storageNodeUrls).toContain(nodeAddress.toLowerCase())
     })
 
     it('removeStreamFromStorageNode', async () => {

--- a/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeEndpoints.test.ts
@@ -52,13 +52,13 @@ describe('createNode', () => {
         return expect(createdNodeUrl).toEqual('http://10.200.10.1:8891')
     })
 
-    it('addStreamToStorageNode, isStreamStoredInStorageNode', async () => {
+    it('addStreamToStorageNode, isStoredStream', async () => {
         await client.addStreamToStorageNode(createdStream.id, nodeAddress)
-        await until(async () => { return client.isStreamStoredInStorageNode(createdStream.id, nodeAddress) }, 100000, 1000)
-        return expect(await client.isStreamStoredInStorageNode(createdStream.id, nodeAddress)).toEqual(true)
+        await until(async () => { return client.isStoredStream(createdStream.id, nodeAddress) }, 100000, 1000)
+        return expect(await client.isStoredStream(createdStream.id, nodeAddress)).toEqual(true)
     })
 
-    it('addStreamToStorageNode, isStreamStoredInStorageNode, eventlistener', async () => {
+    it('addStreamToStorageNode, isStoredStream, eventlistener', async () => {
         const promise = Promise
         const callback = (event: StorageNodeAssignmentEvent) => {
             // check if they are values from this test and not other test running in parallel
@@ -103,14 +103,14 @@ describe('createNode', () => {
 
     it('removeStreamFromStorageNode', async () => {
         await client.removeStreamFromStorageNode(createdStream.id, nodeAddress)
-        await until(async () => { return !(await client.isStreamStoredInStorageNode(createdStream.id, nodeAddress)) }, 100000, 1000)
-        return expect(await client.isStreamStoredInStorageNode(createdStream.id, nodeAddress)).toEqual(false)
+        await until(async () => { return !(await client.isStoredStream(createdStream.id, nodeAddress)) }, 100000, 1000)
+        return expect(await client.isStoredStream(createdStream.id, nodeAddress)).toEqual(false)
     })
 
     it('addStreamToStorageNode through stream object', async () => {
         const stream = await createTestStream(client, module)
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
-        const isStored = await client.isStreamStoredInStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)
+        const isStored = await client.isStoredStream(stream.id, DOCKER_DEV_STORAGE_NODE)
         expect(isStored).toEqual(true)
     })
 

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -50,7 +50,7 @@ describe('StorageNodeRegistry', () => {
         expect(stored.streams.some((s) => s.id === stream.id)).toBe(true)
 
         await stream.removeFromStorageNode(DOCKER_DEV_STORAGE_NODE)
-        await until(async () => { return !(await creatorClient.isStreamStoredInStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)) }, 100000, 1000)
+        await until(async () => { return !(await creatorClient.isStoredStream(stream.id, DOCKER_DEV_STORAGE_NODE)) }, 100000, 1000)
         storageNodes = await stream.getStorageNodes()
         expect(storageNodes).toHaveLength(0)
         stored = await creatorClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -46,14 +46,14 @@ describe('StorageNodeRegistry', () => {
         let storageNodes = await stream.getStorageNodes()
         expect(storageNodes.length).toBe(1)
         expect(storageNodes[0]).toStrictEqual(DOCKER_DEV_STORAGE_NODE.toLowerCase())
-        let stored = await creatorClient.getStoredStreamsOf(DOCKER_DEV_STORAGE_NODE)
+        let stored = await creatorClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
         expect(stored.streams.some((s) => s.id === stream.id)).toBe(true)
 
         await stream.removeFromStorageNode(DOCKER_DEV_STORAGE_NODE)
         await until(async () => { return !(await creatorClient.isStreamStoredInStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)) }, 100000, 1000)
         storageNodes = await stream.getStorageNodes()
         expect(storageNodes).toHaveLength(0)
-        stored = await creatorClient.getStoredStreamsOf(DOCKER_DEV_STORAGE_NODE)
+        stored = await creatorClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
         expect(stored.streams.some((s) => s.id === stream.id)).toBe(false)
     })
 
@@ -81,8 +81,8 @@ describe('StorageNodeRegistry', () => {
         })
     }, TEST_TIMEOUT)
 
-    it('getStoredStreamsOf', async () => {
-        const result = await listenerClient.getStoredStreamsOf(DOCKER_DEV_STORAGE_NODE)
+    it('getStoredStreams', async () => {
+        const result = await listenerClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
         expect(result.blockNumber).toBeGreaterThanOrEqual(0)
         expect(result.streams.length).toBeGreaterThanOrEqual(0)
         result.streams.forEach((s) => expect(s).toBeInstanceOf(Stream))

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -109,7 +109,7 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getStoredStreamsOf(_nodeAddress: EthereumAddress): Promise<{ streams: Stream[]; blockNumber: number }> {
+    getStoredStreams(_nodeAddress: EthereumAddress): Promise<{ streams: Stream[]; blockNumber: number }> {
         throw new Error('not implemented')
     }
 

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -28,17 +28,17 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
 
     private async hasAssignment(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
         const normalizedNodeAddress = nodeAddress.toLowerCase()
-        const assignments = await this.getStorageNodesOf(streamIdOrPath)
+        const assignments = await this.getStorageNodes(streamIdOrPath)
         return assignments.includes(normalizedNodeAddress)
     }
 
-    async getStorageNodesOf(streamIdOrPath: string): Promise<EthereumAddress[]> {
+    async getStorageNodes(streamIdOrPath: string): Promise<EthereumAddress[]> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         return this.assignments.get(streamId)
     }
 
     async getRandomStorageNodeFor(streamPartId: StreamPartID): Promise<FakeStorageNode> {
-        const nodeAddresses = await this.getStorageNodesOf(StreamPartIDUtils.getStreamID(streamPartId))
+        const nodeAddresses = await this.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
         if (nodeAddresses.length > 0) {
             const chosenAddress = nodeAddresses[Math.floor(Math.random() * nodeAddresses.length)]
             const storageNode = this.activeNodes.getNode(chosenAddress)

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -84,11 +84,6 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    isStreamStoredInStorageNodeFromContract(_streamIdOrPath: string, _nodeAddress: EthereumAddress): Promise<boolean> {
-        throw new Error('not implemented')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
     createOrUpdateNodeInStorageNodeRegistry(_nodeMetadata: string): Promise<void> {
         throw new Error('not implemented')
     }
@@ -104,7 +99,7 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    isStreamStoredInStorageNode(_streamIdOrPath: string, _nodeAddress: string): Promise<boolean> {
+    isStoredStream(_streamIdOrPath: string, _nodeAddress: string): Promise<boolean> {
         throw new Error('not implemented')
     }
 

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -36,6 +36,7 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
         if (streamIdOrPath !== undefined) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
             return this.assignments.get(streamId)
+            // eslint-disable-next-line no-else-return
         } else {
             throw new Error('not implemented')
         }

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -32,9 +32,13 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
         return assignments.includes(normalizedNodeAddress)
     }
 
-    async getStorageNodes(streamIdOrPath: string): Promise<EthereumAddress[]> {
-        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        return this.assignments.get(streamId)
+    async getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
+        if (streamIdOrPath !== undefined) {
+            const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+            return this.assignments.get(streamId)
+        } else {
+            throw new Error('not implemented')
+        }
     }
 
     async getRandomStorageNodeFor(streamPartId: StreamPartID): Promise<FakeStorageNode> {
@@ -106,11 +110,6 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
 
     // eslint-disable-next-line class-methods-use-this
     getStoredStreamsOf(_nodeAddress: EthereumAddress): Promise<{ streams: Stream[]; blockNumber: number }> {
-        throw new Error('not implemented')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    getAllStorageNodes(): Promise<string[]> {
         throw new Error('not implemented')
     }
 


### PR DESCRIPTION
Rename some client methods related to storage node handling: 
- rename `getStorageNodesOf(stream)` -> `getStorageNodes(stream)` (consistent with `stream#getStorageNodes()`)
- remove `getAllStorageNodes()` -> use `getStorageNodes()` without parameters
- rename `getStoredStreamsOf()` -> `getStoredStreams()`
- rename `isStreamStoredInStorageNode()` -> `isStoredStream()`