### PR TITLE
Add log level adjusting for node-datachannel

### DIFF
--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -92,6 +92,12 @@ To disable all logs
 
     NOLOG=true
 
+To get logs from the internal node-datachannel library:
+
+    NODE_DATACHANNEL_LOG_LEVEL=[Verbose|Debug|Info|Warning|Error|Fatal]
+
+    By default: NODE_DATACHANNEL_LOG_LEVEL=Fatal
+
 ### Regenerate self-signed certificate fixture
 To regenerate self signed certificate in `./test/fixtures` run:
 

--- a/packages/network/src/connection/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/NodeWebRtcConnection.ts
@@ -6,7 +6,8 @@ import { Logger } from "../helpers/Logger"
 import { NameDirectory } from "../NameDirectory"
 import { WebRtcConnectionFactory } from "./WebRtcEndpoint"
 
-nodeDataChannel.initLogger("Error" as LogLevel)
+const loggerLevel = process.env.NODE_DATACHANNEL_LOG_LEVEL || 'Fatal'
+nodeDataChannel.initLogger(loggerLevel as LogLevel)
 
 /**
  * Parameters that would be passed to an event handler function


### PR DESCRIPTION
<!--- Provide a general summary of the changes -->

- Change default node-datachannel log level to 'Fatal'
- Add new env variable (NODE_DATACHANNEL_LOG_LEVEL) to adjust node-datachannel logging


## Checklist

<!--- Feel free to remove any that are not relevant -->

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog
- [x] Updated Documentation
