### PR TITLE
ci: add latest tag for broker Docker

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -193,6 +193,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern=v{{version}}
             type=raw,value=dev
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && startsWith(github.ref, 'refs/tags/v') }}
             type=schedule,pattern=nightly
       - name: Setup qemu
         uses: docker/setup-qemu-action@v1.2.0


### PR DESCRIPTION
Add `latest` tag to broker Docker build.

- Applies `latest` conditionally when `refs/tag/v` and `main` branch are present.

Check for more information: https://github.com/docker/metadata-action/issues/171
