### PR TITLE
build(broker): improve Docker build speed by mounting npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN npm config set \
 	unsafe-perm=true \
 	python="$(which python3)"
 COPY . .
-RUN npm run bootstrap-pkg -- streamr-broker && npm run prune-pkg -- streamr-broker
+RUN --mount=type=cache,target=/root/.npm \
+	npm run bootstrap-pkg -- streamr-broker && \
+	npm run prune-pkg -- streamr-broker
 
 FROM --platform=$BUILDPLATFORM node:16.14-bullseye-slim
 ARG NODE_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-bullseye as build
+FROM --platform=$BUILDPLATFORM node:16.14-bullseye as build
 WORKDIR /usr/src/network
 RUN npm config set \
 	unsafe-perm=true \
@@ -6,7 +6,7 @@ RUN npm config set \
 COPY . .
 RUN npm run bootstrap-pkg -- streamr-broker && npm run prune-pkg -- streamr-broker
 
-FROM node:16.14-bullseye-slim
+FROM --platform=$BUILDPLATFORM node:16.14-bullseye-slim
 ARG NODE_ENV
 ENV NODE_ENV=${NODE_ENV:-production}
 RUN apt-get update && apt-get --assume-yes --no-install-recommends install \


### PR DESCRIPTION
Improve Docker build speed by mounting npm cache and prepare for Docker cross compilation.