### PR TITLE
broker: Improve resend error handling in storage node

### DIFF
--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -93,7 +93,7 @@ const createEndpointRoute = (
                         new ResponseTransform(format, version),
                         res,
                         (err) => {
-                            if (err !== undefined) {
+                            if ((err !== undefined) && (err !== null)) {
                                 logger.error(`Pipeline error in DataQueryEndpoints: ${streamId}`, err)
                             }
                         }

--- a/packages/broker/src/plugins/storage/Storage.ts
+++ b/packages/broker/src/plugins/storage/Storage.ts
@@ -340,7 +340,7 @@ export class Storage extends EventEmitter {
                 (err: Error | null) => {
                     if (err) {
                         resultStream.destroy(err)
-                        streams.forEach((s) => s.destroy(err))
+                        streams.forEach((s) => s.destroy(undefined))
                     }
                 }
             )


### PR DESCRIPTION
If we fetch historical data via HTTP, and abort the request (e.g. by pressing ctrl-c while a curl request is active), the storage node crashes:
```
curl 'localhost:8891/streams/.../data/partitions/0/from?format=raw&fromTimestamp=123'
```

The reason was that we emitted errors to Cassandra streams by calling: `streams.forEach((s) => s.destroy(err))`. As there were no `on('error')` handlers for these streams, an `uncaughtException` was throw and the node crashed. The solution was to not emit the error to the Cassandra streams (no need to emit that e.g. for logging purposes as we already log the error in `DataQueryEndpoints.ts`)