### PR TITLE
client: Storage node assignment event listeners

### DIFF
--- a/packages/broker/src/plugins/storage/StorageEventListener.ts
+++ b/packages/broker/src/plugins/storage/StorageEventListener.ts
@@ -4,13 +4,15 @@ import { Logger } from 'streamr-network'
 const logger = new Logger(module)
 
 /**
- * Hooks up to `StreamrClient#registerStorageEventListener` to learn about
+ * Hooks up to StreamrClient event listener to learn about
  * stream assignment and removal events in real-time.
  */
 export class StorageEventListener {
     private readonly clusterId: string
     private readonly streamrClient: StreamrClient
     private readonly onEvent: (stream: Stream, type: 'added' | 'removed', block: number) => void
+    private readonly onAddToStorageNode: (event: StorageNodeAssignmentEvent) => void
+    private readonly onRemoveFromStorageNode: (event: StorageNodeAssignmentEvent) => void
 
     constructor(
         clusterId: string,
@@ -20,26 +22,30 @@ export class StorageEventListener {
         this.clusterId = clusterId.toLowerCase()
         this.streamrClient = streamrClient
         this.onEvent = onEvent
+        this.onAddToStorageNode = (event: StorageNodeAssignmentEvent) => this.handleEvent(event, 'added')
+        this.onRemoveFromStorageNode = (event: StorageNodeAssignmentEvent) => this.handleEvent(event, 'removed')
+    }
+
+    private async handleEvent(event: StorageNodeAssignmentEvent, type: 'added' | 'removed') {
+        if (event.nodeAddress.toLowerCase() !== this.clusterId) {
+            return
+        }
+        logger.info('received StorageNodeAssignmentEvent type=%s: %j', type, event)
+        try {
+            const stream = await this.streamrClient.getStream(event.streamId)
+            this.onEvent(stream, type, event.blockNumber)
+        } catch (e) {
+            logger.warn('chainEventsListener: %s', e)
+        }
     }
 
     async start(): Promise<void> {
-        this.streamrClient.registerStorageEventListener(
-            async (event: StorageNodeAssignmentEvent) => {
-                if (event.nodeAddress.toLowerCase() !== this.clusterId) {
-                    return
-                }
-                logger.info('received StorageNodeAssignmentEvent: %j', event)
-                try {
-                    const stream = await this.streamrClient.getStream(event.streamId)
-                    this.onEvent(stream, event.type, event.blockNumber)
-                } catch (e) {
-                    logger.warn('chainEventsListener: %s', e)
-                }
-            }
-        )
+        this.streamrClient.on('addToStorageNode', this.onAddToStorageNode)
+        this.streamrClient.on('removeFromStorageNode', this.onRemoveFromStorageNode)
     }
 
     async destroy(): Promise<void> {
-        await this.streamrClient.unregisterStorageEventListeners()
+        this.streamrClient.off('addToStorageNode', this.onAddToStorageNode)
+        this.streamrClient.off('removeFromStorageNode', this.onRemoveFromStorageNode)
     }
 }

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -1,5 +1,5 @@
 import { StorageConfig } from '../../../../src/plugins/storage/StorageConfig'
-import { StorageNodeAssignmentEvent, Stream, StreamrClient } from 'streamr-client'
+import { StorageNodeAssignmentEvent, Stream, StreamrClient, StreamrClientEvents } from 'streamr-client'
 import { EthereumAddress, StreamPartID, StreamPartIDUtils, toStreamID} from 'streamr-client-protocol'
 import { wait } from 'streamr-test-utils'
 
@@ -22,28 +22,25 @@ function makeStubStream(streamId: string): Stream {
 
 describe(StorageConfig, () => {
     let getStoredStreams: jest.Mock<Promise<{ streams: Stream[], blockNumber: number }>, [nodeAddress: EthereumAddress]>
-    let storageEventListener: ((event: StorageNodeAssignmentEvent) => any) | undefined
-    let stubClient: Pick<StreamrClient, 'getStream'
-        | 'getStoredStreams'
-        | 'registerStorageEventListener'
-        | 'unregisterStorageEventListeners' >
+    let storageEventListeners: Map<keyof StreamrClientEvents, ((event: StorageNodeAssignmentEvent) => any)>
+    let stubClient: Pick<StreamrClient, 'getStream' | 'getStoredStreams' | 'on' | 'off' >
     let onStreamPartAdded: jest.Mock<void, [StreamPartID]>
     let onStreamPartRemoved: jest.Mock<void, [StreamPartID]>
     let storageConfig: StorageConfig
 
     beforeEach(async () => {
         getStoredStreams = jest.fn()
-        storageEventListener = undefined
+        storageEventListeners = new Map()
         stubClient = {
             getStoredStreams,
             async getStream(streamIdOrPath: string) {
                 return makeStubStream(streamIdOrPath, )
             },
-            async registerStorageEventListener(cb: (event: StorageNodeAssignmentEvent) => any) {
-                storageEventListener = cb
+            on(eventName: keyof StreamrClientEvents, listener: any) {
+                storageEventListeners.set(eventName, listener)
             },
-            unregisterStorageEventListeners: async () => {
-                storageEventListener = undefined
+            off(eventName: keyof StreamrClientEvents) {
+                storageEventListeners.delete(eventName)
             }
         }
         onStreamPartAdded = jest.fn()
@@ -97,24 +94,23 @@ describe(StorageConfig, () => {
     describe('on event-based results', () => {
         beforeEach(async () => {
             await storageConfig.start()
-            storageEventListener!({
+            const addToStorageNodeListener = storageEventListeners.get('addToStorageNode')!
+            const removeFromStorageNodeListener = storageEventListeners.get('removeFromStorageNode')!
+            addToStorageNodeListener({
                 streamId: 'stream-1',
                 nodeAddress: 'clusterId',
-                type: 'added',
                 blockNumber: 10,
             })
             await wait(0)
-            storageEventListener!({
+            addToStorageNodeListener({
                 streamId: 'stream-3',
                 nodeAddress: 'clusterId',
-                type: 'added',
                 blockNumber: 15,
             })
             await wait(0)
-            storageEventListener!({
+            removeFromStorageNodeListener({
                 streamId: 'stream-1',
                 nodeAddress: 'clusterId',
-                type: 'removed',
                 blockNumber: 13,
             })
             await wait(0)
@@ -149,7 +145,7 @@ describe(StorageConfig, () => {
         })
         await wait(POLL_TIME * 2)
 
-        expect(storageEventListener).toBeUndefined()
+        expect(storageEventListeners.size).toBe(0)
         expect(getStoredStreams).toHaveBeenCalledTimes(0)
         expect(onStreamPartAdded).toHaveBeenCalledTimes(0)
         expect(onStreamPartRemoved).toHaveBeenCalledTimes(0)
@@ -168,7 +164,7 @@ describe(StorageConfig, () => {
             ],
             blockNumber: 10
         })
-        expect(storageEventListener).toBeUndefined()
+        expect(storageEventListeners.size).toBe(0)
         await wait(POLL_TIME * 2)
 
         expect(getStoredStreams).toHaveBeenCalledTimes(0)

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -22,7 +22,7 @@ function makeStubStream(streamId: string): Stream {
 
 describe(StorageConfig, () => {
     let getStoredStreams: jest.Mock<Promise<{ streams: Stream[], blockNumber: number }>, [nodeAddress: EthereumAddress]>
-    let storageEventListeners: Map<keyof StreamrClientEvents, ((event: StorageNodeAssignmentEvent) => any)>
+    let storageEventListeners: Map<keyof StreamrClientEvents, ((event: StorageNodeAssignmentEvent) => void)>
     let stubClient: Pick<StreamrClient, 'getStream' | 'getStoredStreams' | 'on' | 'off' >
     let onStreamPartAdded: jest.Mock<void, [StreamPartID]>
     let onStreamPartRemoved: jest.Mock<void, [StreamPartID]>

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Method `getStoredStreamsOf()` renamed to `getStoredStreams()`
 - Method `isStreamStoredInStorageNode()` renamed to `isStoredStream()`
 - Method `stream.update()` now requires a parameter `props`
-- Method `unRegisterStorageEventListeners()` renamed to `unregisterStorageEventListeners()`
+- Storage node assignment events:
+  - add a listener with `on('addToStorageNode')` / `on('removeFromStorageNode')` instead of `registerStorageEventListeners()`
+  - remove a listener with `off('addToStorageNode')` / `off('removeFromStorageNode')` instead of `unRegisterStorageEventListeners()`
 
 ### Deprecated
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Method `isStreamStoredInStorageNode()` renamed to `isStoredStream()`
 - Method `stream.update()` now requires a parameter `props`
 - Storage node assignment events:
-  - add a listener with `on('addToStorageNode')` / `on('removeFromStorageNode')` instead of `registerStorageEventListeners()`
-  - remove a listener with `off('addToStorageNode')` / `off('removeFromStorageNode')` instead of `unRegisterStorageEventListeners()`
+  - method `registerStorageEventListeners(listener)` replaced with `on('addToStorageNode', listener)` and `on('removeFromStorageNode', listener)`
+  - method `unRegisterStorageEventListeners()` replaced with `off('addToStorageNode', listener)` and `off('removeFromStorageNode', listener)`
 
 ### Deprecated
 

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -92,14 +92,13 @@ export class StorageNodeRegistry {
         type Listener = (streamId: string, nodeAddress: string, extra: any) => void
         initEventGateway<StreamrClientEvents, Listener>(
             clientEvent,
-            () => {
+            (emit: (payload: StorageNodeAssignmentEvent) => void) => {
                 const listener = (streamId: string, nodeAddress: string, extra: any) => {
-                    const payload = {
+                    emit({
                         streamId,
                         nodeAddress,
                         blockNumber: extra.blockNumber
-                    }
-                    eventEmitter.emit(clientEvent, payload)
+                    })
                 }
                 this.streamStorageRegistryContractReadonly.on(contractEvent, listener)
                 return listener

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -16,7 +16,7 @@ import { EthereumAddress, StreamID, toStreamID } from 'streamr-client-protocol'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { waitForTx, withErrorHandlingAndLogging } from './utils/contract'
 import { SynchronizedGraphQLClient, createWriteContract } from './utils/SynchronizedGraphQLClient'
-import { StreamrClientEventEmitter, StreamrClientEvents, EventEmitterInjectionToken, initEventGateway } from './events'
+import { StreamrClientEventEmitter, StreamrClientEvents, initEventGateway } from './events'
 
 const log = debug('StreamrClient:StorageNodeRegistry')
 
@@ -76,7 +76,7 @@ export class StorageNodeRegistry {
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(SynchronizedGraphQLClient) private graphQLClient: SynchronizedGraphQLClient,
         @inject(ConfigInjectionToken.Root) clientConfig: StrictStreamrClientConfig,
-        @inject(EventEmitterInjectionToken) eventEmitter: StreamrClientEventEmitter
+        @inject(StreamrClientEventEmitter) eventEmitter: StreamrClientEventEmitter
     ) {
         this.clientConfig = clientConfig
         this.chainProvider = this.ethereum.getStreamRegistryChainProvider()
@@ -90,7 +90,7 @@ export class StorageNodeRegistry {
 
     initStreamAssignmentEventListener(clientEvent: keyof StreamrClientEvents, contractEvent: string, eventEmitter: StreamrClientEventEmitter) {
         type Listener = (streamId: string, nodeAddress: string, extra: any) => void
-        initEventGateway<Listener>(
+        initEventGateway<StreamrClientEvents, Listener>(
             clientEvent,
             () => {
                 const listener = (streamId: string, nodeAddress: string, extra: any) => {

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -90,7 +90,7 @@ export class StorageNodeRegistry {
 
     initStreamAssignmentEventListener(clientEvent: keyof StreamrClientEvents, contractEvent: string, eventEmitter: StreamrClientEventEmitter) {
         type Listener = (streamId: string, nodeAddress: string, extra: any) => void
-        initEventGateway<StreamrClientEvents, Listener>(
+        initEventGateway(
             clientEvent,
             (emit: (payload: StorageNodeAssignmentEvent) => void) => {
                 const listener = (streamId: string, nodeAddress: string, extra: any) => {

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -98,7 +98,6 @@ class StreamrClientBase implements Context {
         Plugin(this, this.dataunions)
         Plugin(this, this.streamRegistry)
         Plugin(this, this.storageNodeRegistry)
-        Plugin(this, this.eventEmitter)
 
         this.onDestroy = this.destroySignal.onDestroy.bind(this.destroySignal)
         this.isDestroyed = this.destroySignal.isDestroyed.bind(this.destroySignal)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -27,7 +27,7 @@ import { Methods, Plugin } from './utils/Plugin'
 import { StreamDefinition } from './types'
 import { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
 import { StreamIDBuilder } from './StreamIDBuilder'
-import { EventEmitterInjectionToken, StreamrClientEventEmitter, StreamrClientEvents } from './events'
+import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
 
 let uid: string = process.pid != null
     // Use process id in node uid.
@@ -192,8 +192,6 @@ class StreamrClientBase implements Context {
  */
 export function initContainer(config: StrictStreamrClientConfig, parentContainer = rootContainer) {
     const c = parentContainer.createChildContainer()
-    const eventEmitter = new StreamrClientEventEmitter()
-    c.register(EventEmitterInjectionToken, { useValue: eventEmitter } as any)
     uid = uid || `${uuid().slice(-4)}${uuid().slice(0, 4)}`
     const id = counterId(`StreamrClient:${uid}${config.id ? `:${config.id}` : ''}`)
     const debug = Debug(id)
@@ -270,7 +268,7 @@ export class StreamrClient extends StreamrClientBase {
             c.resolve<StreamRegistry>(StreamRegistry),
             c.resolve<StorageNodeRegistry>(StorageNodeRegistry),
             c.resolve<StreamIDBuilder>(StreamIDBuilder),
-            c.resolve(EventEmitterInjectionToken)
+            c.resolve<StreamrClientEventEmitter>(StreamrClientEventEmitter)
         )
     }
 }

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -1,0 +1,80 @@
+import EventEmitter3, { EventNames, EventListener } from 'eventemitter3'
+import { StorageNodeAssignmentEvent } from './StorageNodeRegistry'
+
+export interface StreamrClientEvents {
+    addToStorageNode: (payload: StorageNodeAssignmentEvent) => void,
+    removeFromStorageNode: (payload: StorageNodeAssignmentEvent) => void
+}
+
+interface ObservableEventEmitterEvents {
+    addEventListener: (eventName: keyof StreamrClientEvents) => void
+    removeEventListener: (eventName: keyof StreamrClientEvents) => void
+}
+
+/*
+ * An observable EventEmitter: emits an addEventListener/removeEventListener event when a listener
+ * is added or removed
+ */
+export class StreamrClientEventEmitter<C = any> extends EventEmitter3<StreamrClientEvents & ObservableEventEmitterEvents> {
+
+    on<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
+        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
+    ) {
+        super.on(event, fn, context)
+        this.emitListenerEvent('addEventListener', event)
+        return this
+    }
+
+    once<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
+        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
+    ) {
+        const wrappedFn: any = (...args: any[]) => {
+            (fn as any).apply(context, args)
+            this.emitListenerEvent('removeEventListener', event)
+        }
+        super.once(event, wrappedFn, context)
+        this.emitListenerEvent('addEventListener', event)
+        return this
+    }
+
+    off<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
+        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
+    ) {
+        super.off(event, fn, context)
+        this.emitListenerEvent('removeEventListener', event)
+        return this
+    }
+
+    private emitListenerEvent(
+        eventName: keyof ObservableEventEmitterEvents, sourceEvent: keyof StreamrClientEvents | keyof ObservableEventEmitterEvents
+    ) {
+        if ((sourceEvent !== 'addEventListener') && (sourceEvent !== 'removeEventListener')) {
+            this.emit(eventName, sourceEvent)
+        }
+    }
+}
+
+export const initEventGateway = <L extends (...args: any[]) => void>(
+    eventName: keyof StreamrClientEvents,
+    start: () => L,
+    stop: (listener: L) => void,
+    emitter: StreamrClientEventEmitter
+) => {
+    let listener: L | undefined
+    emitter.on('addEventListener', (sourceEvent: keyof StreamrClientEvents) => {
+        if ((sourceEvent === eventName) && (listener === undefined)) {
+            listener = start()
+        }
+    })
+    emitter.on('removeEventListener', (sourceEvent: keyof StreamrClientEvents) => {
+        if ((sourceEvent === eventName) && (listener !== undefined) && (emitter.listenerCount(eventName) === 0)) {
+            stop(listener)
+            listener = undefined
+        }
+    })
+    if (emitter.listenerCount(eventName) > 0) {
+        listener = start()
+    }
+}
+
+export const EventEmitterInjectionToken = Symbol('EventEmitterInjectionToken')

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -69,14 +69,14 @@ export class ObservableEventEmitter<E extends Events<E>> {
  * when a first event listener for the event name is added, and the stop() callback is called
  * when the last event listener is removed.
  */
-export const initEventGateway = <E extends Events<E>, P>(
-    eventName: keyof E,
-    start: <T extends keyof E>(emit: (payload: Parameters<E[T]>[0]) => void) => P,
+export const initEventGateway = <E extends Events<E>, T extends keyof E, P>(
+    eventName: T,
+    start: (emit: (payload: Parameters<E[T]>[0]) => void) => P,
     stop: (listener: P) => void,
     emitter: ObservableEventEmitter<E>
 ) => {
     const observer = emitter.getObserver()
-    const emit = <T extends keyof E>(payload: Parameters<E[T]>[0]) => emitter.emit(eventName, payload)
+    const emit = (payload: Parameters<E[T]>[0]) => emitter.emit(eventName, payload)
     let producer: P | undefined
     observer.on('addEventListener', (sourceEvent: keyof E) => {
         if ((sourceEvent === eventName) && (producer === undefined)) {

--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -1,4 +1,5 @@
-import EventEmitter3, { EventNames, EventListener } from 'eventemitter3'
+import { Lifecycle, scoped } from 'tsyringe'
+import EventEmitter3 from 'eventemitter3'
 import { StorageNodeAssignmentEvent } from './StorageNodeRegistry'
 
 export interface StreamrClientEvents {
@@ -6,75 +7,84 @@ export interface StreamrClientEvents {
     removeFromStorageNode: (payload: StorageNodeAssignmentEvent) => void
 }
 
-interface ObservableEventEmitterEvents {
-    addEventListener: (eventName: keyof StreamrClientEvents) => void
-    removeEventListener: (eventName: keyof StreamrClientEvents) => void
+interface ObserverEvents<E extends object> {
+    addEventListener: (eventName: keyof E) => void
+    removeEventListener: (eventName: keyof E) => void
 }
 
 /*
- * An observable EventEmitter: emits an addEventListener/removeEventListener event when a listener
- * is added or removed
+ * Emits an addEventListener/removeEventListener event to a separate EventEmitter
+ * whenever a listener is added or removed
  */
-export class StreamrClientEventEmitter<C = any> extends EventEmitter3<StreamrClientEvents & ObservableEventEmitterEvents> {
+export class ObservableEventEmitter<E extends object> {
 
-    on<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
-        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
-    ) {
-        super.on(event, fn, context)
-        this.emitListenerEvent('addEventListener', event)
-        return this
+    private delegate: EventEmitter3<E> = new EventEmitter3()
+    private observer: EventEmitter3<ObserverEvents<E>> = new EventEmitter3()
+
+    on<T extends keyof E>(eventName: T, listener: E[T]) {
+        this.delegate.on(eventName as any, listener as any)
+        this.observer.emit('addEventListener', eventName)
     }
 
-    once<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
-        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
-    ) {
-        const wrappedFn: any = (...args: any[]) => {
-            (fn as any).apply(context, args)
-            this.emitListenerEvent('removeEventListener', event)
+    once<T extends keyof E>(eventName: T, listener: E[T]) {
+        const wrappedFn = (payload: any) => {
+            (listener as any)(payload)
+            this.observer.emit('removeEventListener', eventName)
         }
-        super.once(event, wrappedFn, context)
-        this.emitListenerEvent('addEventListener', event)
-        return this
+        this.delegate.once(eventName as any, wrappedFn as any)
+        this.observer.emit('addEventListener', eventName)
     }
 
-    off<T extends EventNames<StreamrClientEvents & ObservableEventEmitterEvents>>(
-        event: T, fn: EventListener<StreamrClientEvents & ObservableEventEmitterEvents, T>, context?: C
-    ) {
-        super.off(event, fn, context)
-        this.emitListenerEvent('removeEventListener', event)
-        return this
+    off<T extends keyof E>(eventName: T, listener: E[T]) {
+        this.delegate.off(eventName as any, listener as any)
+        this.observer.emit('removeEventListener', eventName)
     }
 
-    private emitListenerEvent(
-        eventName: keyof ObservableEventEmitterEvents, sourceEvent: keyof StreamrClientEvents | keyof ObservableEventEmitterEvents
-    ) {
-        if ((sourceEvent !== 'addEventListener') && (sourceEvent !== 'removeEventListener')) {
-            this.emit(eventName, sourceEvent)
+    removeAllListeners() {
+        const eventNames = this.delegate.eventNames()
+        this.delegate.removeAllListeners()
+        for (const eventName of eventNames) {
+            this.observer.emit('removeEventListener', eventName)
         }
+    }
+
+    emit<T extends keyof E>(eventName: T, payload: any) {
+        (this.delegate.emit as any)(eventName, payload)
+    }
+
+    getListenerCount<T extends keyof E>(eventName: T) {
+        return this.delegate.listenerCount(eventName as any)
+    }
+
+    getObserver() {
+        return this.observer
     }
 }
 
-export const initEventGateway = <L extends (...args: any[]) => void>(
+export const initEventGateway = <E extends object, L extends (...args: any[]) => void>(
     eventName: keyof StreamrClientEvents,
     start: () => L,
     stop: (listener: L) => void,
-    emitter: StreamrClientEventEmitter
+    emitter: ObservableEventEmitter<E>
 ) => {
+    const observer = emitter.getObserver()
     let listener: L | undefined
-    emitter.on('addEventListener', (sourceEvent: keyof StreamrClientEvents) => {
+    observer.on('addEventListener', (sourceEvent: keyof E) => {
         if ((sourceEvent === eventName) && (listener === undefined)) {
             listener = start()
         }
     })
-    emitter.on('removeEventListener', (sourceEvent: keyof StreamrClientEvents) => {
-        if ((sourceEvent === eventName) && (listener !== undefined) && (emitter.listenerCount(eventName) === 0)) {
+    observer.on('removeEventListener', (sourceEvent: keyof E) => {
+        if ((sourceEvent === eventName) && (listener !== undefined) && (emitter.getListenerCount(eventName as any) === 0)) {
             stop(listener)
             listener = undefined
         }
     })
-    if (emitter.listenerCount(eventName) > 0) {
+    if (emitter.getListenerCount(eventName as any) > 0) {
         listener = start()
     }
 }
 
-export const EventEmitterInjectionToken = Symbol('EventEmitterInjectionToken')
+@scoped(Lifecycle.ContainerScoped)
+export class StreamrClientEventEmitter extends ObservableEventEmitter<StreamrClientEvents> {
+}

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -4,6 +4,7 @@
 export * from './StreamrClient'
 export * from './Stream'
 export * from './encryption/Encryption'
+export { StreamrClientEvents } from './events'
 export { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
 export { MessageStreamOnMessage } from './subscribe/MessageStream'
 export type { MessageStream } from './subscribe/MessageStream'

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -59,24 +59,24 @@ describe('StorageNodeRegistry2', () => {
 
     it('storage event listener', async () => {
         const promise = Promise
-        const callback = (event: StorageNodeAssignmentEvent) => {
+        const onAddToStorageNode = (event: StorageNodeAssignmentEvent) => {
             // check if they are values from this test and not other test running in parallel
             if (event.streamId === createdStream.id && event.nodeAddress === storageNodeAddress) {
                 expect(event).toEqual({
                     blockNumber: expect.any(Number),
                     streamId: createdStream.id,
-                    nodeAddress: storageNodeAddress,
-                    type: 'added'
+                    nodeAddress: storageNodeAddress
                 })
                 promise.resolve()
             }
         }
         try {
-            await client.registerStorageEventListener(callback)
+            client.on('addToStorageNode', onAddToStorageNode)
             await client.addStreamToStorageNode(createdStream.id, storageNodeAddress)
             await promise
+            expect(onAddToStorageNode).toBeCalledTimes(1)
         } finally {
-            await client?.unregisterStorageEventListeners()
+            client.off('addToStorageNode', onAddToStorageNode)
         }
     })
 

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -59,7 +59,7 @@ describe('StorageNodeRegistry2', () => {
 
     it('storage event listener', async () => {
         const promise = Promise
-        const onAddToStorageNode = (event: StorageNodeAssignmentEvent) => {
+        const onAddToStorageNode = jest.fn().mockImplementation((event: StorageNodeAssignmentEvent) => {
             // check if they are values from this test and not other test running in parallel
             if (event.streamId === createdStream.id && event.nodeAddress === storageNodeAddress) {
                 expect(event).toEqual({
@@ -69,7 +69,7 @@ describe('StorageNodeRegistry2', () => {
                 })
                 promise.resolve()
             }
-        }
+        })
         try {
             client.on('addToStorageNode', onAddToStorageNode)
             await client.addStreamToStorageNode(createdStream.id, storageNodeAddress)

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -4,13 +4,14 @@ import { StreamIDBuilder } from '../../../src/StreamIDBuilder'
 import { DOCKER_DEV_STORAGE_NODE } from '../../../src/ConfigTest'
 import { FakeStorageNode } from './FakeStorageNode'
 import { ActiveNodes } from './ActiveNodes'
-import { StorageNodeAssignmentEvent, StorageNodeRegistry } from '../../../src/StorageNodeRegistry'
+import { StorageNodeRegistry } from '../../../src/StorageNodeRegistry'
 import { Stream } from '../../../src/Stream'
 import { Multimap } from '../utils'
 import { StreamRegistry } from '../../../src/StreamRegistry'
 
 @scoped(Lifecycle.ContainerScoped)
 export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
+    'initStreamAssignmentEventListener' |
     'clientConfig' | 'chainProvider' | 'streamStorageRegistryContractReadonly' |
     'chainSigner' | 'nodeRegistryContract' | 'streamStorageRegistryContract'> {
 
@@ -108,16 +109,6 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
 
     // eslint-disable-next-line class-methods-use-this
     getStoredStreams(_nodeAddress: EthereumAddress): Promise<{ streams: Stream[]; blockNumber: number }> {
-        throw new Error('not implemented')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    registerStorageEventListener(_listener: (event: StorageNodeAssignmentEvent) => any): Promise<void> {
-        throw new Error('not implemented')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    unregisterStorageEventListeners(): Promise<void> {
         throw new Error('not implemented')
     }
 }

--- a/packages/client/test/unit/events.test.ts
+++ b/packages/client/test/unit/events.test.ts
@@ -1,20 +1,29 @@
 import 'reflect-metadata'
-import { initEventGateway, StreamrClientEventEmitter } from '../../src/events'
+import { initEventGateway, ObservableEventEmitter } from '../../src/events'
+
+interface FooPayload {
+    x: string,
+    y: number
+}
+
+interface MockEvents {
+    foo: (payload: FooPayload) => void
+    bar: (payload: number) => void
+}
 
 type MockGatewayListener = () => void
 
-const MOCK_EVENT_NAME = 'addToStorageNode'
+const MOCK_EVENT_NAME = 'foo'
 const MOCK_EVENT_PAYLOAD = {
-    streamId: '',
-    nodeAddress: '',
-    blockNumber: 123
+    x: 'mock',
+    y: 123
 }
-const OTHER_EVENT_NAME = 'removeFromStorageNode'
+const OTHER_EVENT_NAME = 'bar'
 
 describe('events', () => {
 
     it('observable listeners', () => {
-        const emitter = new StreamrClientEventEmitter()
+        const emitter = new ObservableEventEmitter<MockEvents>()
         const listenerCounts: number[] = []
         const onEventEmitterChange = (name: string) => {
             if (name === MOCK_EVENT_NAME) {
@@ -36,12 +45,12 @@ describe('events', () => {
 
     describe('gateway', () => {
 
-        let emitter: StreamrClientEventEmitter
+        let emitter: ObservableEventEmitter<MockEvents>
         let start: () => MockGatewayListener
         let stop: (listener: MockGatewayListener) => void
 
         beforeEach(() => {
-            emitter = new StreamrClientEventEmitter()
+            emitter = new ObservableEventEmitter<MockEvents>()
             start = jest.fn().mockReturnValue(() => {})
             stop = jest.fn()
         })

--- a/packages/client/test/unit/events.test.ts
+++ b/packages/client/test/unit/events.test.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata'
 import { initEventGateway, StreamrClientEventEmitter } from '../../src/events'
 
 type MockGatewayListener = () => void
@@ -17,11 +18,11 @@ describe('events', () => {
         const listenerCounts: number[] = []
         const onEventEmitterChange = (name: string) => {
             if (name === MOCK_EVENT_NAME) {
-                listenerCounts.push(emitter.listenerCount(MOCK_EVENT_NAME))
+                listenerCounts.push(emitter.getListenerCount(MOCK_EVENT_NAME))
             }
         }
-        emitter.on('addEventListener', onEventEmitterChange)
-        emitter.on('removeEventListener', onEventEmitterChange)
+        emitter.getObserver().on('addEventListener', onEventEmitterChange)
+        emitter.getObserver().on('removeEventListener', onEventEmitterChange)
         const listener1 = () => {}
         const listener2 = () => {}
         emitter.on(MOCK_EVENT_NAME, listener1)

--- a/packages/client/test/unit/events.test.ts
+++ b/packages/client/test/unit/events.test.ts
@@ -1,0 +1,118 @@
+import { initEventGateway, StreamrClientEventEmitter } from '../../src/events'
+
+type MockGatewayListener = () => void
+
+const MOCK_EVENT_NAME = 'addToStorageNode'
+const MOCK_EVENT_PAYLOAD = {
+    streamId: '',
+    nodeAddress: '',
+    blockNumber: 123
+}
+const OTHER_EVENT_NAME = 'removeFromStorageNode'
+
+describe('events', () => {
+
+    it('observable listeners', () => {
+        const emitter = new StreamrClientEventEmitter()
+        const listenerCounts: number[] = []
+        const onEventEmitterChange = (name: string) => {
+            if (name === MOCK_EVENT_NAME) {
+                listenerCounts.push(emitter.listenerCount(MOCK_EVENT_NAME))
+            }
+        }
+        emitter.on('addEventListener', onEventEmitterChange)
+        emitter.on('removeEventListener', onEventEmitterChange)
+        const listener1 = () => {}
+        const listener2 = () => {}
+        emitter.on(MOCK_EVENT_NAME, listener1)
+        emitter.on(MOCK_EVENT_NAME, listener2)
+        emitter.once(MOCK_EVENT_NAME, () => {})
+        emitter.emit(MOCK_EVENT_NAME, MOCK_EVENT_PAYLOAD)
+        emitter.off(MOCK_EVENT_NAME, listener1)
+        emitter.off(MOCK_EVENT_NAME, listener2)
+        expect(listenerCounts).toEqual([1, 2, 3, 2, 1, 0])
+    })
+
+    describe('gateway', () => {
+
+        let emitter: StreamrClientEventEmitter
+        let start: () => MockGatewayListener
+        let stop: (listener: MockGatewayListener) => void
+
+        beforeEach(() => {
+            emitter = new StreamrClientEventEmitter()
+            start = jest.fn().mockReturnValue(() => {})
+            stop = jest.fn()
+        })
+
+        it('happy path', () => {
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            const listener = () => {}
+            expect(start).toBeCalledTimes(0)
+            expect(stop).toBeCalledTimes(0)
+            emitter.on(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(1)
+            expect(stop).toBeCalledTimes(0)
+            emitter.off(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(1)
+            expect(stop).toBeCalledTimes(1)
+        })
+
+        it('multiple listeners', () => {
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            const listener1 = () => {}
+            const listener2 = () => {}
+            expect(start).toBeCalledTimes(0)
+            emitter.on(MOCK_EVENT_NAME, listener1)
+            expect(start).toBeCalledTimes(1)
+            emitter.on(MOCK_EVENT_NAME, listener2)
+            expect(start).toBeCalledTimes(1)
+            emitter.off(MOCK_EVENT_NAME, listener1)
+            expect(stop).toBeCalledTimes(0)
+            emitter.off(MOCK_EVENT_NAME, listener2)
+            expect(stop).toBeCalledTimes(1)
+        })
+
+        it('once', () => {
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            const listener = () => {}
+            expect(start).toBeCalledTimes(0)
+            emitter.once(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(1)
+            expect(stop).toBeCalledTimes(0)
+            emitter.emit(MOCK_EVENT_NAME, MOCK_EVENT_PAYLOAD)
+            expect(stop).toBeCalledTimes(1)
+        })
+
+        it('ignorable event', () => {
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            emitter.on(OTHER_EVENT_NAME, () => {})
+            expect(start).toBeCalledTimes(0)
+        })
+
+        it('start if initial listeners', () => {
+            emitter.on(MOCK_EVENT_NAME, () => {})
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            expect(start).toBeCalledTimes(1)
+        })
+
+        it('restart', () => {
+            initEventGateway(MOCK_EVENT_NAME, start, stop, emitter)
+            const listener = () => {}
+            expect(start).toBeCalledTimes(0)
+            expect(stop).toBeCalledTimes(0)
+            emitter.on(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(1)
+            expect(stop).toBeCalledTimes(0)
+            emitter.off(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(1)
+            expect(stop).toBeCalledTimes(1)
+            emitter.on(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(2)
+            expect(stop).toBeCalledTimes(1)
+            emitter.off(MOCK_EVENT_NAME, listener)
+            expect(start).toBeCalledTimes(2)
+            expect(stop).toBeCalledTimes(2)
+        })
+    })
+})


### PR DESCRIPTION
Refactor storage node assignment event listeners to use EventEmitter style:
-  add a listener with `on('addToStorageNode')` / `on('removeFromStorageNode')` instead of `registerStorageEventListeners()`
- remove a listener with `off('addToStorageNode')` / `off('removeFromStorageNode')` instead of `unregisterStorageEventListeners()`

The `unRegisterStorageEventListeners()` removed all listeners. The `off('...', listener)` call always removes a specific listener.

Previously there was only one event, which had a field to indicate whether the event is an addition or a removal. Now it is possible to listen either or both of the events.

## Implementation

We get storage node events from the StorageNode contract by adding a listener to that contract. Adding a listener starts a poller which queries the blockchain state in 4 second intervals. 

To avoid unnecessary polling, we add a contract listener only when `StreamrClient` needs the event information. That is, when `client.on('addToStorageNode')` or `client.on('removeFromStorageNode)` is called.  

To support that kind of dynamic listener binding, there is an observable `StreamrClientEventEmitter` which emits an event whenever new listeners are added to a `StreamrClient` instance. The `initEventGateway` helper method is used to do the actual binding (binding the listener in `start` callback, and unbinding it in `stop` callback).

## Future improvements

- refactor `onResent` to use EventEmitter style
- automatically remove listeners when `destroy()` is called (e.g. by using `destroySignal.onDestroy()`)
- use generics in `EventEmitter3` instead of `strict-event-emitter-types` in client

## Checklist

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog
