### PR TITLE
client: remove strict-event-emitter-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28274,7 +28274,6 @@
                 "sqlite3": "^5.0.2",
                 "streamr-client-protocol": "^12.0.0",
                 "streamr-network": "^35.0.0",
-                "strict-event-emitter-types": "^2.0.0",
                 "ts-toolbelt": "^9.6.0",
                 "tsyringe": "^4.6.0",
                 "uuid": "^8.3.2"
@@ -48700,7 +48699,6 @@
                 "streamr-client-protocol": "^12.0.0",
                 "streamr-network": "^35.0.0",
                 "streamr-test-utils": "^2.0.0",
-                "strict-event-emitter-types": "^2.0.0",
                 "terser-webpack-plugin": "^5.2.5",
                 "ts-jest": "^27.0.5",
                 "ts-loader": "^9.2.6",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -165,7 +165,6 @@
         "sqlite3": "^5.0.2",
         "streamr-client-protocol": "^12.0.0",
         "streamr-network": "^35.0.0",
-        "strict-event-emitter-types": "^2.0.0",
         "ts-toolbelt": "^9.6.0",
         "tsyringe": "^4.6.0",
         "uuid": "^8.3.2"

--- a/packages/client/src/Session.ts
+++ b/packages/client/src/Session.ts
@@ -23,7 +23,7 @@ enum State {
 export default class Session {
     private state: State
     private sessionTokenPromise?: Promise<string>
-    private eventEmitter: EventEmitter
+    private eventEmitter: EventEmitter<State>
 
     constructor(
         @inject(BrubeckContainer) private container: DependencyContainer,
@@ -31,7 +31,7 @@ export default class Session {
     ) {
         this.state = State.LOGGED_OUT
         this.options = options
-        this.eventEmitter = new EventEmitter()
+        this.eventEmitter = new EventEmitter<State>()
         if (!this.options.sessionToken) {
             this.options.unauthenticated = true
         }


### PR DESCRIPTION
Use `EventEmitter3` with generics instead of `strict-event-emitter-types`. That way we get type safety without additional external library. 

Improved browser compatibility in `contracts.ts`: it used NodeJS's `EventEmitter` instead of `EventEmitter3`.
