### PR TITLE
client: Remove StorageNode event cleanup

### DIFF
--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -216,13 +216,6 @@ export class StorageNodeRegistry {
         }
     }
 
-    async stop() {
-        if (this.nodeRegistryContract) {
-            this.nodeRegistryContract.removeAllListeners()
-            this.nodeRegistryContract.provider.removeAllListeners()
-        }
-    }
-
     // --------------------------------------------------------------------------------------------
     // GraphQL queries
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -155,7 +155,6 @@ class StreamrClientBase implements Context {
         this.connect.reset() // reset connect (will error on next call)
         const tasks = [
             this.destroySignal.destroy().then(() => undefined),
-            this.resends.stop(),
             this.publisher.stop(),
             this.subscriber.stop(),
         ]

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -248,9 +248,4 @@ export default class Resend implements Context {
             msgChainId,
         })
     }
-
-    /** @internal */
-    async stop() {
-        await this.storageNodeRegistry.stop()
-    }
 }


### PR DESCRIPTION
No need to stop `StorageNode` because:
- the only way to add contract listeners is to add client event listeners (`addToStorageNode`, `removeFromStorageNode`)
- when client event listeners are removed, the contract event listeners are also automatically removed (https://github.com/streamr-dev/network-monorepo/pull/531)
- all client event handlers are removed when `client.destroy()` is called (https://github.com/streamr-dev/network-monorepo/pull/536)