### PR TITLE
fix: network options in tests

### DIFF
--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -141,15 +141,18 @@ export const createClient = async (
     privateKey: string,
     clientOptions?: StreamrClientConfig
 ): Promise<StreamrClient> => {
+    const networkOptions = {
+        ...ConfigTest?.network,
+        trackers: [tracker.getConfigRecord()],
+        ...clientOptions?.network
+    }
     return new StreamrClient({
         ...ConfigTest,
         auth: {
             privateKey
         },
         restUrl: `http://${STREAMR_DOCKER_DEV_HOST}/api/v2`,
-        network: {
-            trackers: [tracker.getConfigRecord()]
-        },
+        network: networkOptions,
         ...clientOptions,
     })
 }

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -47,7 +47,8 @@ export const ConfigTest = {
                 http: `http://${process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'}:30303`
             }
         ],
-        webrtcDisallowPrivateAddresses: false
+        webrtcDisallowPrivateAddresses: false,
+        stunUrls: []
     },
     mainChainRPCs: {
         name: 'dev_ethereum',


### PR DESCRIPTION
- Broker tests: use network options from `ConfigTest`
- empty `stunUrls` in `ConfigTest` (as not needed in CI or in local tests) 