### PR TITLE
feat(client): Resends uses random node address

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - method `unRegisterStorageEventListeners()` replaced with `off('addToStorageNode', listener)` and `off('removeFromStorageNode', listener)`
 - Resent event:
   - method `onResent(listener)` replaced with `subscription.once('resendComplete', listener)`
+- Behavior changes: 
+  - resends support multiple storage nodes (the data is fetched from a random storage node)
 
 ### Deprecated
 

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -17,7 +17,7 @@ import { createQueryString, Rest } from '../Rest'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
 import { StreamEndpointsCached } from '../StreamEndpointsCached'
-import { range } from 'lodash'
+import { random, range } from 'lodash'
 
 const MIN_SEQUENCE_NUMBER_VALUE = 0
 
@@ -162,14 +162,15 @@ export default class Resend implements Context {
     ) {
         const debug = this.debug.extend(counterId(`resend-${endpointSuffix}`))
         debug('fetching resend %s %s %o', endpointSuffix, streamPartId, query)
-        const nodeAdresses = await this.storageNodeRegistry.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
-        if (!nodeAdresses.length) {
+        const nodeAddresses = await this.storageNodeRegistry.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
+        if (!nodeAddresses.length) {
             const err = new ContextError(this, `no storage assigned: ${inspect(streamPartId)}`)
             err.code = 'NO_STORAGE_NODES'
             throw err
         }
 
-        const nodeUrl = await this.storageNodeRegistry.getStorageNodeUrl(nodeAdresses[0]) // TODO: handle multiple nodes
+        const nodeAddress = nodeAddresses[random(0, nodeAddresses.length)]
+        const nodeUrl = await this.storageNodeRegistry.getStorageNodeUrl(nodeAddress)
         const url = createUrl(nodeUrl, endpointSuffix, streamPartId, query)
         const messageStream = SubscribePipeline<T>(
             new MessageStream<T>(this),

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -169,7 +169,7 @@ export default class Resend implements Context {
             throw err
         }
 
-        const nodeAddress = nodeAddresses[random(0, nodeAddresses.length)]
+        const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]
         const nodeUrl = await this.storageNodeRegistry.getStorageNodeUrl(nodeAddress)
         const url = createUrl(nodeUrl, endpointSuffix, streamPartId, query)
         const messageStream = SubscribePipeline<T>(


### PR DESCRIPTION
If there are multiple storage node, `resend()` fetches the data from a random node.
