### PR TITLE
NET-753: webrtc peerlist logging to debug

### DIFF
--- a/packages/network/bin/publisher.js
+++ b/packages/network/bin/publisher.js
@@ -52,7 +52,8 @@ const publisher = createNetworkNode({
     name,
     id,
     trackers: trackerInfos,
-    metricsContext
+    metricsContext,
+    webrtcDisallowPrivateAddresses: false
 })
 logger.info('started publisher id: %s, name: %s, ip: %s, trackers: %s, streamId: %s, intervalInMs: %d, metrics: %s',
     id, name, program.opts().ip, program.opts().trackers.join(', '),

--- a/packages/network/bin/subscriber.js
+++ b/packages/network/bin/subscriber.js
@@ -34,7 +34,8 @@ const subscriber = createNetworkNode({
     name,
     id,
     trackers: trackerInfos,
-    metricsContext
+    metricsContext,
+    webrtcDisallowPrivateAddresses: false
 })
 logger.info('started subscriber id: %s, name: %s, ip: %s, trackers: %s, streamId: %s, metrics: %s',
     id, name, program.opts().ip, program.opts().trackers.join(', '), program.opts().streamId, program.opts().metrics)

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -131,7 +131,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         const getPeerNameList = (peerIds: PeerId[]) => {
             return peerIds.map((peerId) => NameDirectory.getName(peerId)).join(',')
         }
-        const STATUS_REPORT_INTERVAL_MS = 5 * 60 * 1000
+        const STATUS_REPORT_INTERVAL_MS = 10 * 1000
         this.statusReportTimer = setInterval(() => {
             const connectedPeerIds = []
             const pendingPeerIds = []
@@ -150,9 +150,11 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             if (connections.length > 0 && connections.length === undefinedStates.length) {
                 this.logger.warn('Cannot determine webrtc datachannel connection states')
             } else {
-                const suffix = (pendingPeerIds.length > 0) ? ', still trying to connect: %s' : ''
-                this.logger.info(`Connected to %d peers (%s)${suffix}`,
-                    connectedPeerIds.length, getPeerNameList(connectedPeerIds), getPeerNameList(pendingPeerIds))
+                const suffix = (pendingPeerIds.length > 0) ? ', trying to connect to %d peers' : ''
+                this.logger.info(`Connected to %d peers${suffix}`,
+                    connectedPeerIds.length, pendingPeerIds.length)
+                this.logger.debug(`Connected to peers: ${getPeerNameList(connectedPeerIds) || '[]'}`)
+                this.logger.debug(`Connecting to peers: ${getPeerNameList(pendingPeerIds) || '[]'}`)
             }
         }, STATUS_REPORT_INTERVAL_MS)
     }

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -131,7 +131,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         const getPeerNameList = (peerIds: PeerId[]) => {
             return peerIds.map((peerId) => NameDirectory.getName(peerId)).join(',')
         }
-        const STATUS_REPORT_INTERVAL_MS = 10 * 1000
+        const STATUS_REPORT_INTERVAL_MS = 5 * 60 * 1000
         this.statusReportTimer = setInterval(() => {
             const connectedPeerIds = []
             const pendingPeerIds = []


### PR DESCRIPTION
Move webrtc peerlist logging level to debug for cleaner logs for the end user.