### PR TITLE
NET-762: Remove PM2 logging from metrics plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4903,110 +4903,6 @@
                 "@octokit/openapi-types": "^11.2.0"
             }
         },
-        "node_modules/@opencensus/core": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.9.tgz",
-            "integrity": "sha512-31Q4VWtbzXpVUd2m9JS6HEaPjlKvNMOiF7lWKNmXF84yUcgfAFL5re7/hjDmdyQbOp32oGc+RFV78jXIldVz6Q==",
-            "dependencies": {
-                "continuation-local-storage": "^3.2.1",
-                "log-driver": "^1.2.7",
-                "semver": "^5.5.0",
-                "shimmer": "^1.2.0",
-                "uuid": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/@opencensus/core/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/@opencensus/core/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@opencensus/propagation-b3": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@opencensus/propagation-b3/-/propagation-b3-0.0.8.tgz",
-            "integrity": "sha512-PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==",
-            "dependencies": {
-                "@opencensus/core": "^0.0.8",
-                "uuid": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/@opencensus/propagation-b3/node_modules/@opencensus/core": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
-            "integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
-            "dependencies": {
-                "continuation-local-storage": "^3.2.1",
-                "log-driver": "^1.2.7",
-                "semver": "^5.5.0",
-                "shimmer": "^1.2.0",
-                "uuid": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/@opencensus/propagation-b3/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/@opencensus/propagation-b3/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@pm2/io": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.0.tgz",
-            "integrity": "sha512-3rToDVJaRoob5Lq8+7Q2TZFruoEkdORxwzFpZaqF4bmH6Bkd7kAbdPrI/z8X6k1Meq5rTtScM7MmDgppH6aLlw==",
-            "dependencies": {
-                "@opencensus/core": "0.0.9",
-                "@opencensus/propagation-b3": "0.0.8",
-                "async": "~2.6.1",
-                "debug": "~4.3.1",
-                "eventemitter2": "^6.3.1",
-                "require-in-the-middle": "^5.0.0",
-                "semver": "6.3.0",
-                "shimmer": "^1.2.0",
-                "signal-exit": "^3.0.3",
-                "tslib": "1.9.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/@pm2/io/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.21",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -6805,26 +6701,6 @@
                 "lodash": "^4.17.14"
             }
         },
-        "node_modules/async-listener": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-            "dependencies": {
-                "semver": "^5.3.0",
-                "shimmer": "^1.1.0"
-            },
-            "engines": {
-                "node": "<=0.11.8 || >0.11.10"
-            }
-        },
-        "node_modules/async-listener/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/async-mqtt": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/async-mqtt/-/async-mqtt-2.6.1.tgz",
@@ -8548,15 +8424,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/continuation-local-storage": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-            "dependencies": {
-                "async-listener": "^0.6.0",
-                "emitter-listener": "^1.1.1"
-            }
-        },
         "node_modules/conventional-changelog-angular": {
             "version": "5.0.13",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -9950,14 +9817,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/emitter-listener": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-            "dependencies": {
-                "shimmer": "^1.2.0"
-            }
-        },
         "node_modules/emittery": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -11051,11 +10910,6 @@
                 "stream-combiner": "^0.2.2",
                 "through": "^2.3.8"
             }
-        },
-        "node_modules/eventemitter2": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-            "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw=="
         },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
@@ -18398,14 +18252,6 @@
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
-        "node_modules/log-driver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-            "engines": {
-                "node": ">=0.8.6"
-            }
-        },
         "node_modules/log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -19584,11 +19430,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/module-details-from-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-            "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
         },
         "node_modules/morgan": {
             "version": "1.10.0",
@@ -23689,16 +23530,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-in-the-middle": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
-            "integrity": "sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.12.0"
-            }
-        },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -24608,11 +24439,6 @@
                 "vscode-oniguruma": "^1.6.1",
                 "vscode-textmate": "5.2.0"
             }
-        },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "node_modules/side-channel": {
             "version": "1.0.4",
@@ -28132,7 +27958,6 @@
             "version": "31.0.0",
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
-                "@pm2/io": "^5.0.0",
                 "@streamr/network-tracker": "1.0.0",
                 "@streamr/slackbot": "^1.1.0",
                 "@types/cors": "^2.8.12",
@@ -32145,87 +31970,6 @@
                 "@octokit/openapi-types": "^11.2.0"
             }
         },
-        "@opencensus/core": {
-            "version": "0.0.9",
-            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.9.tgz",
-            "integrity": "sha512-31Q4VWtbzXpVUd2m9JS6HEaPjlKvNMOiF7lWKNmXF84yUcgfAFL5re7/hjDmdyQbOp32oGc+RFV78jXIldVz6Q==",
-            "requires": {
-                "continuation-local-storage": "^3.2.1",
-                "log-driver": "^1.2.7",
-                "semver": "^5.5.0",
-                "shimmer": "^1.2.0",
-                "uuid": "^3.2.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-                }
-            }
-        },
-        "@opencensus/propagation-b3": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@opencensus/propagation-b3/-/propagation-b3-0.0.8.tgz",
-            "integrity": "sha512-PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==",
-            "requires": {
-                "@opencensus/core": "^0.0.8",
-                "uuid": "^3.2.1"
-            },
-            "dependencies": {
-                "@opencensus/core": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
-                    "integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
-                    "requires": {
-                        "continuation-local-storage": "^3.2.1",
-                        "log-driver": "^1.2.7",
-                        "semver": "^5.5.0",
-                        "shimmer": "^1.2.0",
-                        "uuid": "^3.2.1"
-                    }
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-                }
-            }
-        },
-        "@pm2/io": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.0.tgz",
-            "integrity": "sha512-3rToDVJaRoob5Lq8+7Q2TZFruoEkdORxwzFpZaqF4bmH6Bkd7kAbdPrI/z8X6k1Meq5rTtScM7MmDgppH6aLlw==",
-            "requires": {
-                "@opencensus/core": "0.0.9",
-                "@opencensus/propagation-b3": "0.0.8",
-                "async": "~2.6.1",
-                "debug": "~4.3.1",
-                "eventemitter2": "^6.3.1",
-                "require-in-the-middle": "^5.0.0",
-                "semver": "6.3.0",
-                "shimmer": "^1.2.0",
-                "signal-exit": "^3.0.3",
-                "tslib": "1.9.3"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-            }
-        },
         "@polka/url": {
             "version": "1.0.0-next.21",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
@@ -33804,22 +33548,6 @@
                 "lodash": "^4.17.14"
             }
         },
-        "async-listener": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-            "requires": {
-                "semver": "^5.3.0",
-                "shimmer": "^1.1.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-            }
-        },
         "async-mqtt": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/async-mqtt/-/async-mqtt-2.6.1.tgz",
@@ -35192,15 +34920,6 @@
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
-        "continuation-local-storage": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-            "requires": {
-                "async-listener": "^0.6.0",
-                "emitter-listener": "^1.1.1"
-            }
-        },
         "conventional-changelog-angular": {
             "version": "5.0.13",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -36295,14 +36014,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "emitter-listener": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-            "requires": {
-                "shimmer": "^1.2.0"
-            }
-        },
         "emittery": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -37138,11 +36849,6 @@
                 "stream-combiner": "^0.2.2",
                 "through": "^2.3.8"
             }
-        },
-        "eventemitter2": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-            "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw=="
         },
         "eventemitter3": {
             "version": "4.0.7",
@@ -43049,11 +42755,6 @@
             "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
-        "log-driver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
-        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -43974,11 +43675,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
             "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
-        },
-        "module-details-from-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-            "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
         },
         "morgan": {
             "version": "1.10.0",
@@ -47124,16 +46820,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
-        "require-in-the-middle": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
-            "integrity": "sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==",
-            "requires": {
-                "debug": "^4.1.1",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.12.0"
-            }
-        },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -47869,11 +47555,6 @@
                 "vscode-oniguruma": "^1.6.1",
                 "vscode-textmate": "5.2.0"
             }
-        },
-        "shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "side-channel": {
             "version": "1.0.4",
@@ -48640,7 +48321,6 @@
         "streamr-broker": {
             "version": "file:packages/broker",
             "requires": {
-                "@pm2/io": "^5.0.0",
                 "@streamr/dev-config": "^1.0.0",
                 "@streamr/network-tracker": "1.0.0",
                 "@streamr/slackbot": "^1.1.0",

--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -66,7 +66,7 @@
   "apiAuthentication": null,
   "plugins": {
       "metrics": {
-        "consoleAndPM2IntervalInSeconds": 0,
+        "consoleIntervalInSeconds": 0,
         "nodeMetrics": null
       },
       "storage": {

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -66,7 +66,7 @@
   "apiAuthentication": null,
   "plugins": {
       "metrics": {
-        "consoleAndPM2IntervalInSeconds": 0,
+        "consoleIntervalInSeconds": 0,
         "nodeMetrics": null
       }
   }

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -66,7 +66,7 @@
   "apiAuthentication": null,
   "plugins": {
       "metrics": {
-        "consoleAndPM2IntervalInSeconds": 0,
+        "consoleIntervalInSeconds": 0,
         "nodeMetrics": null
       }
   }

--- a/packages/broker/configs/development-prod-resend.env.json
+++ b/packages/broker/configs/development-prod-resend.env.json
@@ -24,7 +24,7 @@
     "apiAuthentication": null,
     "plugins": {
         "metrics": {
-            "consoleAndPM2IntervalInSeconds": 0,
+            "consoleIntervalInSeconds": 0,
             "nodeMetrics": null
         }
     }

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -60,7 +60,7 @@
     "apiAuthentication": null,
     "plugins": {
         "metrics": {
-            "consoleAndPM2IntervalInSeconds": 30,
+            "consoleIntervalInSeconds": 30,
             "nodeMetrics": null
         },
         "storage": {

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -60,7 +60,7 @@
   "apiAuthentication": null,
   "plugins": {
       "metrics": {
-          "consoleAndPM2IntervalInSeconds": 30,
+          "consoleIntervalInSeconds": 30,
           "nodeMetrics": null
       }
   }

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -60,7 +60,7 @@
   "apiAuthentication": null,
   "plugins": {
       "metrics": {
-          "consoleAndPM2IntervalInSeconds": 30,
+          "consoleIntervalInSeconds": 30,
           "nodeMetrics": null
       }
   }

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -29,7 +29,6 @@
   "author": "Streamr Network AG <contact@streamr.com>",
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "dependencies": {
-    "@pm2/io": "^5.0.0",
     "@streamr/network-tracker": "1.0.0",
     "@streamr/slackbot": "^1.1.0",
     "@types/cors": "^2.8.12",

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -91,7 +91,7 @@ const convertTestnet3ToV1 = (source: any): Config => {
         } else if (name === 'metrics') {
             const targetConfig: any = {}
             if (sourceConfig.consoleAndPM2IntervalInSeconds !== 0) {
-                targetConfig.consoleAndPM2IntervalInSeconds = sourceConfig.consoleAndPM2IntervalInSeconds
+                targetConfig.consoleIntervalInSeconds = sourceConfig.consoleAndPM2IntervalInSeconds
             }
             target.plugins.metrics = targetConfig
         } else if (['legacyWebsocket', 'legacyMqtt'].includes(name)) {

--- a/packages/broker/src/plugins/metrics/MetricsPlugin.ts
+++ b/packages/broker/src/plugins/metrics/MetricsPlugin.ts
@@ -10,7 +10,7 @@ import { Logger } from 'streamr-network'
 const logger = new Logger(module)
 
 export interface MetricsPluginConfig {
-    consoleAndPM2IntervalInSeconds: number
+    consoleIntervalInSeconds: number
     nodeMetrics: {
         streamIdPrefix: string
     } | null
@@ -27,7 +27,7 @@ export class MetricsPlugin extends Plugin<MetricsPluginConfig> {
     async start(): Promise<void> {
         const metricsContext = (await (this.streamrClient!.getNode())).getMetricsContext()
         this.volumeLogger = new VolumeLogger(
-            this.pluginConfig.consoleAndPM2IntervalInSeconds,
+            this.pluginConfig.consoleIntervalInSeconds,
             metricsContext,
         )
 

--- a/packages/broker/src/plugins/metrics/VolumeLogger.ts
+++ b/packages/broker/src/plugins/metrics/VolumeLogger.ts
@@ -1,19 +1,19 @@
 import { MetricsContext } from 'streamr-network'
-import { ConsoleAndPM2Metrics } from './ConsoleAndPM2Metrics'
+import { ConsoleMetrics } from './ConsoleMetrics'
 
-// TODO remove this class and use ConsoleAndPM2Metrics directly from MetricsPlugin
+// TODO remove this class and use ConsoleMetrics directly from MetricsPlugin
 export class VolumeLogger {
 
     metricsContext: MetricsContext
-    legacyMetrics?: ConsoleAndPM2Metrics
+    legacyMetrics?: ConsoleMetrics
 
     constructor(
-        consoleAndPM2IntervalInSeconds: number,
+        consoleIntervalInSeconds: number,
         metricsContext: MetricsContext,
     ) {
         this.metricsContext = metricsContext
-        if (consoleAndPM2IntervalInSeconds > 0) {
-            this.legacyMetrics = new ConsoleAndPM2Metrics(consoleAndPM2IntervalInSeconds, metricsContext)
+        if (consoleIntervalInSeconds > 0) {
+            this.legacyMetrics = new ConsoleMetrics(consoleIntervalInSeconds, metricsContext)
         }
     }
     

--- a/packages/broker/src/plugins/metrics/config.schema.json
+++ b/packages/broker/src/plugins/metrics/config.schema.json
@@ -4,12 +4,12 @@
   "type": "object",
   "description": "Metrics plugin configuration",
   "required": [
-    "consoleAndPM2IntervalInSeconds",
+    "consoleIntervalInSeconds",
     "nodeMetrics"
   ],
   "additionalProperties": false,
   "properties": {
-    "consoleAndPM2IntervalInSeconds": {
+    "consoleIntervalInSeconds": {
       "type": "integer",
       "description": "Interval (in seconds) in which to collect and report metrics (0 = disable)",
       "minimum": 0,

--- a/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
@@ -37,7 +37,7 @@ describe('NodeMetrics', () => {
             trackerPort,
             extraPlugins: {
                 metrics: {
-                    consoleAndPM2IntervalInSeconds: 0,
+                    consoleIntervalInSeconds: 0,
                     nodeMetrics: {
                         streamIdPrefix
                     },

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -243,7 +243,7 @@ describe('Config migration', () => {
                 longitude: 56.78,
                 country: 'mock-country'
             })
-            expect(target.plugins.metrics.consoleAndPM2IntervalInSeconds).toBe(123)
+            expect(target.plugins.metrics.consoleIntervalInSeconds).toBe(123)
         })
     })
 

--- a/packages/network/webpack.config.js
+++ b/packages/network/webpack.config.js
@@ -50,7 +50,6 @@ const aliases = (env) => {
             path.resolve(__dirname, 'src/connection/ws/BrowserClientWsEndpoint.ts'),
         [path.resolve(__dirname, 'src/connection/ws/NodeClientWsConnection.ts')]:
             path.resolve(__dirname, 'src/connection/ws/BrowserClientWsConnection.ts'),
-        ['@pm2/io']: path.resolve(__dirname, 'src/browser/Pm2Shim.ts'),
     }
     return aliases
 }


### PR DESCRIPTION
Not needed anymore. For storage nodes we can see the stats from the log files.

Also removed an obsolete shim from `network` package.