### PR TITLE
feat(broker): Console resend metrics

### DIFF
--- a/packages/broker/src/plugins/metrics/ConsoleMetrics.ts
+++ b/packages/broker/src/plugins/metrics/ConsoleMetrics.ts
@@ -64,8 +64,6 @@ export class ConsoleMetrics {
             meanBatchAge = report.metrics['broker/cassandra'].batchManager.meanBatchAge
         }
 
-        const brokerConnectionCount = (report.metrics['broker/ws'] ? report.metrics['broker/ws'].connections : 0)
-
         const networkConnectionCount = report.metrics.WebRtcEndpoint.connections
         // @ts-expect-error not enough typing info available
         const networkInPerSecond = report.metrics.WebRtcEndpoint.msgInSpeed.rate
@@ -88,7 +86,6 @@ export class ConsoleMetrics {
 
         logger.info(
             'Report\n'
-            + '\tBroker connections: %d\n'
             + '\tNetwork connections %d\n'
             + '\tQueued messages: %d\n'
             + '\tNetwork in: %d events/s, %d kb/s\n'
@@ -100,7 +97,6 @@ export class ConsoleMetrics {
             + '\t- from: %d requests/s\n'
             + '\t- range: %d requests/s\n'
             + '\tTotal batches: %d (mean age %d ms)\n',
-            brokerConnectionCount,
             networkConnectionCount,
             messageQueueSize,
             formatNumber(networkInPerSecond),

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -131,8 +131,6 @@ type RangeRequest = BaseRequest<{
 export const router = (storage: Storage, metricsContext: MetricsContext): Router => {
     const router = express.Router()
     const metrics = metricsContext.create('broker/storage/query')
-        .addRecordedMetric('outBytes')
-        .addRecordedMetric('outMessages')
         .addRecordedMetric('lastRequests')
         .addRecordedMetric('fromRequests')
         .addRecordedMetric('rangeRequests')

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -130,7 +130,7 @@ type RangeRequest = BaseRequest<{
 
 export const router = (storage: Storage, metricsContext: MetricsContext): Router => {
     const router = express.Router()
-    const metrics = metricsContext.create('broker/http')
+    const metrics = metricsContext.create('broker/storage/query')
         .addRecordedMetric('outBytes')
         .addRecordedMetric('outMessages')
         .addRecordedMetric('lastRequests')


### PR DESCRIPTION
Update `ConsoleMetrics` to read the resend metrics from the data provided by `DataQueryEndpoints`. The previous implementation used websocket connection data, and it was always empty as `legacyWebsocket` plugin has been removed.

Previous data:
```
Total ongoing resends: %d (mean age %d ms)
```
Current data:
```
Resends:
- last: %d requests/s
- from: %d requests/s
- range: %d requests/s
```

The `outBytes` and `outMessages` metrics from `DataQueryEndpoints` aren't included as no data was produced for those metrics. 

Remove also broker connections count metrics in `ConsoleMetrics` as the non-existing websocket data was used there, too. 