### PR TITLE
Remove redundant metrics

### DIFF
--- a/packages/broker/src/plugins/storage/BatchManager.ts
+++ b/packages/broker/src/plugins/storage/BatchManager.ts
@@ -156,14 +156,7 @@ export class BatchManager extends EventEmitter {
         }
     }
 
-    metrics(): {
-        totalBatches: number,
-        meanBatchAge: number,
-        meanBatchRetries: number,
-        batchesWithFiveOrMoreRetries: number,
-        batchesWithTenOrMoreRetries: number,
-        batchesWithHundredOrMoreRetries: number,
-        } {
+    metrics(): { totalBatches: number, meanBatchAge: number } {
         const now = Date.now()
         const { batches, pendingBatches } = this
         const totalBatches = Object.values(batches).length + Object.values(pendingBatches).length
@@ -172,32 +165,9 @@ export class BatchManager extends EventEmitter {
                 ...Object.values(batches),
                 ...Object.values(pendingBatches)
             ].reduce((acc, batch) => acc + (now - batch.createdAt), 0) / totalBatches
-        const meanBatchRetries = totalBatches === 0 ? 0
-            : Object.values(pendingBatches).reduce((acc, batch) => acc + batch.retries, 0) / totalBatches
-
-        let batchesWithFiveOrMoreRetries = 0
-        let batchesWithTenOrMoreRetries = 0
-        let batchesWithHundredOrMoreRetries = 0
-
-        Object.values(pendingBatches).forEach((batch) => {
-            if (batch.retries >= 5) {
-                batchesWithFiveOrMoreRetries += 1
-                if (batch.retries >= 10) {
-                    batchesWithTenOrMoreRetries += 1
-                    if (batch.retries >= 100) {
-                        batchesWithHundredOrMoreRetries += 1
-                    }
-                }
-            }
-        })
-
         return {
             totalBatches,
-            meanBatchAge,
-            meanBatchRetries,
-            batchesWithFiveOrMoreRetries,
-            batchesWithTenOrMoreRetries,
-            batchesWithHundredOrMoreRetries,
+            meanBatchAge
         }
     }
 }

--- a/packages/network-tracker/src/logic/InstructionSender.ts
+++ b/packages/network-tracker/src/logic/InstructionSender.ts
@@ -79,7 +79,7 @@ export class InstructionSender {
         this.options = options ?? DEFAULT_TOPOLOGY_STABILIZATION_OPTIONS
         this.sendInstruction = sendInstruction
         this.metrics = metrics
-            .addRecordedMetric('instructionsSent')
+            .addRecordedMetric('instructionSent')
     }
 
     addInstruction(instruction: Instruction): void {
@@ -108,7 +108,7 @@ export class InstructionSender {
     private async sendInstructions(buffer: StreamPartInstructionBuffer): Promise<void> {
         const promises = Array.from(buffer.getInstructions())
             .map(async ({ nodeId, streamPartId, newNeighbors, counterValue }) => {
-                this.metrics.record('instructionsSent', 1)
+                this.metrics.record('instructionSent', 1)
                 try {
                     await this.sendInstruction(
                         nodeId,

--- a/packages/network-tracker/src/logic/Tracker.ts
+++ b/packages/network-tracker/src/logic/Tracker.ts
@@ -158,7 +158,6 @@ export class Tracker extends EventEmitter {
         this.metrics = metricsContext.create('tracker')
             .addRecordedMetric('onNodeDisconnected')
             .addRecordedMetric('processNodeStatus')
-            .addRecordedMetric('_removeNode')
 
         this.instructionSender = new InstructionSender(
             opts.topologyStabilization,
@@ -271,7 +270,6 @@ export class Tracker extends EventEmitter {
     }
 
     private removeNode(node: NodeId): void {
-        this.metrics.record('_removeNode', 1)
         delete this.overlayConnectionRtts[node]
         this.locationManager.removeNode(node)
         delete this.extraMetadatas[node]

--- a/packages/network-tracker/src/logic/Tracker.ts
+++ b/packages/network-tracker/src/logic/Tracker.ts
@@ -156,8 +156,8 @@ export class Tracker extends EventEmitter {
         attachRtcSignalling(this.trackerServer)
 
         this.metrics = metricsContext.create('tracker')
-            .addRecordedMetric('onNodeDisconnected')
-            .addRecordedMetric('processNodeStatus')
+            .addRecordedMetric('nodeDisconnected')
+            .addRecordedMetric('nodeStatusProcessed')
 
         this.instructionSender = new InstructionSender(
             opts.topologyStabilization,
@@ -172,7 +172,7 @@ export class Tracker extends EventEmitter {
 
     onNodeDisconnected(node: NodeId): void {
         this.logger.debug('node %s disconnected', node)
-        this.metrics.record('onNodeDisconnected', 1)
+        this.metrics.record('nodeDisconnected', 1)
         this.removeNode(node)
     }
 
@@ -181,7 +181,7 @@ export class Tracker extends EventEmitter {
             return
         }
 
-        this.metrics.record('processNodeStatus', 1)
+        this.metrics.record('nodeStatusProcessed', 1)
         const status = statusMessage.status as Status
         const isMostRecent = this.instructionCounter.isMostRecent(status, source)
         if (!isMostRecent) {

--- a/packages/network-tracker/src/startTracker.ts
+++ b/packages/network-tracker/src/startTracker.ts
@@ -36,7 +36,7 @@ export const startTracker = async ({
 }: TrackerOptions): Promise<Tracker> => {
     const peerInfo = PeerInfo.newTracker(id, name, undefined, undefined, location)
     const httpServer = await startHttpServer(listen, privateKeyFileName, certFileName)
-    const endpoint = new ServerWsEndpoint(listen, privateKeyFileName !== undefined, httpServer, peerInfo, metricsContext, trackerPingInterval)
+    const endpoint = new ServerWsEndpoint(listen, privateKeyFileName !== undefined, httpServer, peerInfo, trackerPingInterval)
 
     const tracker = new Tracker({
         peerInfo,

--- a/packages/network/bin/tracker.js
+++ b/packages/network/bin/tracker.js
@@ -67,12 +67,19 @@ async function main() {
         })
 
         if (program.opts().metrics) {
+            const previousTotals = {}
             setInterval(async () => {
                 const metrics = await metricsContext.report(true)
-                // output to console
-                if (program.opts().metrics) {
-                    logger.info(JSON.stringify(metrics, null, 4))
+                const output = {
+                    peerId: metrics.peerId,
                 }
+                Object.keys(metrics.metrics.tracker).forEach((key) => {
+                    const currentTotal = metrics.metrics.tracker[key].total
+                    const previousTotal = previousTotals[key] || 0
+                    output[key] = currentTotal - previousTotal
+                    previousTotals[key] = currentTotal
+                })
+                logger.info(JSON.stringify(output, null, 4))
             }, program.opts().metricsInterval)
         }
     } catch (err) {

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -106,20 +106,10 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.metrics = metricsContext.create('WebRtcEndpoint')
             .addRecordedMetric('inSpeed')
             .addRecordedMetric('outSpeed')
-            .addRecordedMetric('msgSpeed')
             .addRecordedMetric('msgInSpeed')
             .addRecordedMetric('msgOutSpeed')
-            .addRecordedMetric('open')
-            .addRecordedMetric('close')
-            .addRecordedMetric('sendFailed')
             .addRecordedMetric('failedConnection')
             .addQueriedMetric('connections', () => Object.keys(this.connections).length)
-            .addQueriedMetric('pendingConnections', () => {
-                return Object.values(this.connections).filter((c) => !c.isOpen()).length
-            })
-            .addQueriedMetric('totalWebSocketBuffer', () => {
-                return Object.values(this.connections).reduce((total, c) => total + c.getBufferedAmount(), 0)
-            })
             .addQueriedMetric('messageQueueSize', () => {
                 return Object.values(this.connections).reduce((total, c) => total + c.getQueueSize(), 0)
             })

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -176,7 +176,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
                 this.attemptProtocolVersionValidation(connection)
             })
         } else {
-            connection.once('localDescription', (type, description) => {
+            connection.once('localDescription', (_type, description) => {
                 this.rtcSignaller.sendRtcAnswer(routerId, connection.getPeerId(), connection.getConnectionId(), description)
                 this.attemptProtocolVersionValidation(connection)
             })
@@ -187,12 +187,10 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         })
         connection.once('open', () => {
             this.emit(Event.PEER_CONNECTED, connection.getPeerInfo())
-            this.metrics.record('open', 1)
         })
         connection.on('message', (message) => {
             this.emit(Event.MESSAGE_RECEIVED, connection.getPeerInfo(), message)
             this.metrics.record('inSpeed', message.length)
-            this.metrics.record('msgSpeed', 1)
             this.metrics.record('msgInSpeed', 1)
         })
         connection.once('close', () => {
@@ -205,7 +203,6 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             this.negotiatedProtocolVersions.removeNegotiatedProtocolVersion(targetPeerId)
             this.emit(Event.PEER_DISCONNECTED, connection.getPeerInfo())
             connection.removeAllListeners()
-            this.metrics.record('close', 1)
         })
         connection.on('bufferLow', () => {
             this.emit(Event.LOW_BACK_PRESSURE, connection.getPeerInfo())
@@ -398,12 +395,10 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         try {
             await this.connections[targetPeerId].send(message)
         } catch (err) {
-            this.metrics.record('sendFailed', 1)
             throw err
         }
 
         this.metrics.record('outSpeed', message.length)
-        this.metrics.record('msgSpeed', 1)
         this.metrics.record('msgOutSpeed', 1)
     }
 

--- a/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
+++ b/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
@@ -1,6 +1,5 @@
 import WebSocket from 'ws'
 import { PeerId, PeerInfo } from '../PeerInfo'
-import { MetricsContext } from '../../helpers/MetricsContext'
 import { AbstractWsEndpoint, DisconnectionCode, DisconnectionReason } from "./AbstractWsEndpoint"
 import { AbstractWsConnection, ReadyState } from "./AbstractWsConnection"
 import { IMessageEvent, w3cwebsocket } from "websocket"
@@ -21,16 +20,13 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
 
     constructor(
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
 
         this.connectionsByServerUrl = new Map()
         this.serverUrlByPeerId = new Map()
         this.pendingConnections = new Map()
-
-        this.metrics.addQueriedMetric('pendingConnections', () => this.pendingConnections.size)
     }
 
     getServerUrlByPeerId(peerId: PeerId): string | undefined {
@@ -127,7 +123,6 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
     }
 
     protected onHandshakeError(serverUrl: string, error: Error, reject: (reason?: any) => void): void {
-        this.metrics.record('webSocketError', 1)
         this.logger.trace('failed to connect to %s, error: %o', serverUrl, error)
         reject(error)
     }
@@ -138,7 +133,6 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
     }
 
     protected ongoingConnectionError(serverPeerId: PeerId, error: Error, connection: AbstractWsConnection): void {
-        this.metrics.record('webSocketError', 1)
         this.logger.trace('Connection to %s failed, error: %o', serverPeerId, error)
         connection.terminate()
     }

--- a/packages/network/src/connection/ws/BrowserClientWsEndpoint.ts
+++ b/packages/network/src/connection/ws/BrowserClientWsEndpoint.ts
@@ -1,6 +1,5 @@
 import { IMessageEvent, w3cwebsocket } from 'websocket'
 import { PeerId, PeerInfo } from '../PeerInfo'
-import { MetricsContext } from '../../helpers/MetricsContext'
 import { DisconnectionCode, DisconnectionReason } from "./AbstractWsEndpoint"
 import { BrowserClientWsConnection, BrowserWebSocketConnectionFactory } from './BrowserClientWsConnection'
 import { AbstractClientWsEndpoint, HandshakeValues } from "./AbstractClientWsEndpoint"
@@ -8,10 +7,9 @@ import { AbstractClientWsEndpoint, HandshakeValues } from "./AbstractClientWsEnd
 export default class BrowserClientWsEndpoint extends AbstractClientWsEndpoint<BrowserClientWsConnection> {
     constructor(
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
     }
 
     protected doConnect(serverUrl: string, serverPeerInfo: PeerInfo): Promise<PeerId> {
@@ -36,7 +34,6 @@ export default class BrowserClientWsEndpoint extends AbstractClientWsEndpoint<Br
                 }
 
             } catch (err) {
-                this.metrics.record('open:failedException', 1)
                 this.logger.trace('failed to connect to %s, error: %o', serverUrl, err)
                 reject(err)
             }

--- a/packages/network/src/connection/ws/NodeClientWsEndpoint.ts
+++ b/packages/network/src/connection/ws/NodeClientWsEndpoint.ts
@@ -1,6 +1,5 @@
 import WebSocket from 'ws'
 import { PeerId, PeerInfo } from '../PeerInfo'
-import { MetricsContext } from '../../helpers/MetricsContext'
 import { DisconnectionCode, DisconnectionReason } from "./AbstractWsEndpoint"
 import { NodeClientWsConnection, NodeWebSocketConnectionFactory } from './NodeClientWsConnection'
 import { AbstractClientWsEndpoint, HandshakeValues, ServerUrl } from "./AbstractClientWsEndpoint"
@@ -8,10 +7,9 @@ import { AbstractClientWsEndpoint, HandshakeValues, ServerUrl } from "./Abstract
 export default class NodeClientWsEndpoint extends AbstractClientWsEndpoint<NodeClientWsConnection> {
     constructor(
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
     }
 
     protected doConnect(serverUrl: ServerUrl, serverPeerInfo: PeerInfo): Promise<PeerId> {
@@ -36,7 +34,6 @@ export default class NodeClientWsEndpoint extends AbstractClientWsEndpoint<NodeC
                 })
 
             } catch (err) {
-                this.metrics.record('open:failedException', 1)
                 this.logger.trace('failed to connect to %s, error: %o', serverUrl, err)
                 reject(err)
             }

--- a/packages/network/src/connection/ws/ServerWsEndpoint.ts
+++ b/packages/network/src/connection/ws/ServerWsEndpoint.ts
@@ -1,5 +1,4 @@
 import { PeerId, PeerInfo } from '../PeerInfo'
-import { MetricsContext } from '../../helpers/MetricsContext'
 import { AbstractWsEndpoint, DisconnectionCode, DisconnectionReason, } from "./AbstractWsEndpoint"
 import { staticLogger, ServerWsConnection } from './ServerWsConnection'
 import fs from 'fs'
@@ -28,10 +27,9 @@ export class ServerWsEndpoint extends AbstractWsEndpoint<ServerWsConnection> {
         sslEnabled: boolean,
         httpServer: http.Server | https.Server,
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
 
         this.httpServer = httpServer
         const protocol = sslEnabled ? 'wss' : 'ws'
@@ -80,7 +78,6 @@ export class ServerWsEndpoint extends AbstractWsEndpoint<ServerWsConnection> {
                         if (!this.getConnectionByPeerId(peerId)) {
                             this.acceptConnection(ws, duplexStream, peerId, this.resolveIP(request))
                         } else {
-                            this.metrics.record('open:duplicateSocket', 1)
                             const failedMessage = `Connection for node: ${peerId} has already been established, rejecting duplicate`
                             ws.close(DisconnectionCode.DUPLICATE_SOCKET, failedMessage)
                             this.logger.warn(failedMessage)

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -45,7 +45,7 @@ export const createNetworkNode = ({
     acceptProxyConnections
 }: NetworkNodeOptions): NetworkNode => {
     const peerInfo = PeerInfo.newNode(id, name, undefined, undefined, location)
-    const endpoint = new NodeClientWsEndpoint(peerInfo, metricsContext, trackerPingInterval)
+    const endpoint = new NodeClientWsEndpoint(peerInfo, trackerPingInterval)
     const nodeToTracker = new NodeToTracker(endpoint)
 
     const webRtcSignaller = new RtcSignaller(peerInfo, nodeToTracker)

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -96,12 +96,6 @@ export class Node extends EventEmitter {
 
         this.metricsContext = opts.metricsContext || new MetricsContext('')
         this.metrics = this.metricsContext.create('node')
-            .addRecordedMetric('onDataReceived')
-            .addRecordedMetric('onDataReceived:invalidNumbering')
-            .addRecordedMetric('onDataReceived:gapMismatch')
-            .addRecordedMetric('onDataReceived:ignoredDuplicate')
-            .addRecordedMetric('propagateMessage')
-            .addRecordedMetric('onNodeDisconnect')
             .addFixedMetric('latency')
         this.publishMetrics = this.metricsContext.create('node/publish')
             .addRecordedMetric('bytes')

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -283,7 +283,6 @@ export class Node extends EventEmitter {
 
     // Null source is used when a message is published by the node itself
     onDataReceived(streamMessage: MessageLayer.StreamMessage, source: NodeId | null = null): void | never {
-        this.metrics.record('onDataReceived', 1)
         const streamPartId = streamMessage.getStreamPartID()
         // Check if the stream is set as one-directional and has inbound connection
         if (source
@@ -309,13 +308,11 @@ export class Node extends EventEmitter {
         } catch (e) {
             if (e instanceof InvalidNumberingError) {
                 logger.trace('received from %s data %j with invalid numbering', source, streamMessage.messageId)
-                this.metrics.record('onDataReceived:invalidNumber', 1)
                 return
             }
             if (e instanceof GapMisMatchError) {
                 logger.warn('received from %s data %j with gap mismatch detected: %j',
                     source, streamMessage.messageId, e)
-                this.metrics.record('onDataReceived:gapMismatch', 1)
                 return
             }
             throw e
@@ -331,7 +328,6 @@ export class Node extends EventEmitter {
             }
         } else {
             logger.trace('ignoring duplicate data %j (from %s)', streamMessage.messageId, source)
-            this.metrics.record('onDataReceived:ignoredDuplicate', 1)
         }
     }
 
@@ -363,7 +359,6 @@ export class Node extends EventEmitter {
     }
 
     private onNodeDisconnected(node: NodeId): void {
-        this.metrics.record('onNodeDisconnect', 1)
         const [streams, proxiedStreams] = this.streamPartManager.removeNodeFromAllStreamParts(node)
         logger.trace('removed all subscriptions of node %s', node)
         streams.forEach((s) => {

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -27,6 +27,7 @@ export enum Event {
     NODE_DISCONNECTED = 'streamr:node:node-disconnected',
     MESSAGE_RECEIVED = 'streamr:node:message-received',
     UNSEEN_MESSAGE_RECEIVED = 'streamr:node:unseen-message-received',
+    DUPLICATE_MESSAGE_RECEIVED = 'streamr:node:duplicate-message-received',
     NODE_SUBSCRIBED = 'streamr:node:subscribed-successfully',
     NODE_UNSUBSCRIBED = 'streamr:node:node-unsubscribed',
     PROXY_CONNECTION_ACCEPTED = 'streamr:node:proxy-connection-accepted',
@@ -55,6 +56,7 @@ export interface Node {
     on(event: Event.NODE_DISCONNECTED, listener: (nodeId: NodeId) => void): this
     on<T>(event: Event.MESSAGE_RECEIVED, listener: (msg: MessageLayer.StreamMessage<T>, nodeId: NodeId) => void): this
     on<T>(event: Event.UNSEEN_MESSAGE_RECEIVED, listener: (msg: MessageLayer.StreamMessage<T>, nodeId: NodeId) => void): this
+    on<T>(event: Event.DUPLICATE_MESSAGE_RECEIVED, listener: (msg: MessageLayer.StreamMessage<T>, nodeId: NodeId) => void): this
     on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, streamPartId: StreamPartID) => void): this
     on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, streamPartId: StreamPartID) => void): this
     on(event: Event.PROXY_CONNECTION_ACCEPTED, listener: (nodeId: NodeId, streamPartId: StreamPartID, direction: ProxyDirection) => void): this
@@ -328,6 +330,7 @@ export class Node extends EventEmitter {
             }
         } else {
             logger.trace('ignoring duplicate data %j (from %s)', streamMessage.messageId, source)
+            this.emit(Event.DUPLICATE_MESSAGE_RECEIVED, streamMessage, source)
         }
     }
 

--- a/packages/network/src/simulator/AbstractClientWsEndpoint_simulator.ts
+++ b/packages/network/src/simulator/AbstractClientWsEndpoint_simulator.ts
@@ -1,6 +1,5 @@
 //import WebSocket from 'ws'
 import { PeerId, PeerInfo } from '../connection/PeerInfo'
-import { MetricsContext } from '../helpers/MetricsContext'
 import { AbstractWsEndpoint, DisconnectionCode, DisconnectionReason } from '../connection/ws/AbstractWsEndpoint'
 import { AbstractWsConnection, ReadyState } from '../connection/ws/AbstractWsConnection'
 import { Simulator, cleanAddress } from './Simulator'
@@ -26,17 +25,14 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
 
     constructor(
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
 
         this.ownAddress = v4()
         this.connectionsByServerUrl = new Map()
         this.serverUrlByPeerId = new Map()
         this.pendingConnections = new Map()
-
-        this.metrics.addQueriedMetric('pendingConnections', () => this.pendingConnections.size)
     }
 
     getServerUrlByPeerId(peerId: PeerId): string | undefined {
@@ -150,7 +146,6 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
     }
 
     protected onHandshakeError(serverUrl: string, error: Error, reject: (reason?: any) => void): void {
-        this.metrics.record('webSocketError', 1)
         this.logger.trace('failed to connect to %s, error: %o', serverUrl, error)
         reject(error)
     }
@@ -161,7 +156,6 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
     }
 
     protected ongoingConnectionError(serverPeerId: PeerId, error: Error, connection: AbstractWsConnection): void {
-        this.metrics.record('webSocketError', 1)
         this.logger.trace('Connection to %s failed, error: %o', serverPeerId, error)
         connection.terminate()
     }

--- a/packages/network/src/simulator/NodeClientWsEndpoint_simulator.ts
+++ b/packages/network/src/simulator/NodeClientWsEndpoint_simulator.ts
@@ -1,5 +1,4 @@
 import { PeerId, PeerInfo } from '../connection/PeerInfo'
-import { MetricsContext } from '../helpers/MetricsContext'
 import { DisconnectionCode, DisconnectionReason } from '../connection/ws/AbstractWsEndpoint'
 import { NodeClientWsConnection } from './NodeClientWsConnection_simulator'
 import { AbstractClientWsEndpoint, HandshakeValues, ServerUrl } from './AbstractClientWsEndpoint_simulator'
@@ -15,10 +14,9 @@ export default class NodeClientWsEndpoint extends AbstractClientWsEndpoint<NodeC
 
     constructor(
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
         Simulator.instance().addClientWsEndpoint(peerInfo, this.ownAddress, this)
     }
 
@@ -30,7 +28,6 @@ export default class NodeClientWsEndpoint extends AbstractClientWsEndpoint<NodeC
                 Simulator.instance().wsConnect(this.ownAddress, this.peerInfo, serverUrl as string)
 
             } catch (err) {
-                this.metrics.record('open:failedException', 1)
                 this.logger.trace('failed to connect to %s, error: %o', serverUrl, err)
                 reject(err)
             }

--- a/packages/network/src/simulator/ServerWsEndpoint_simulator.ts
+++ b/packages/network/src/simulator/ServerWsEndpoint_simulator.ts
@@ -1,6 +1,5 @@
 import { Simulator } from './Simulator'
 import { PeerId, PeerInfo } from '../connection/PeerInfo'
-import { MetricsContext } from '../helpers/MetricsContext'
 import { AbstractWsEndpoint, DisconnectionCode, DisconnectionReason, } from "../connection/ws/AbstractWsEndpoint"
 import { staticLogger, ServerWsConnection } from './ServerWsConnection_simulator'
 import fs from 'fs'
@@ -31,10 +30,9 @@ export class ServerWsEndpoint extends AbstractWsEndpoint<ServerWsConnection> imp
         sslEnabled: boolean,
         httpServer: http.Server | https.Server | null,
         peerInfo: PeerInfo,
-        metricsContext?: MetricsContext,
         pingInterval?: number
     ) {
-        super(peerInfo, metricsContext, pingInterval)
+        super(peerInfo, pingInterval)
         this.httpServer = httpServer
         const protocol = sslEnabled ? 'wss' : 'ws'
         if (typeof listen !== "string") {
@@ -73,7 +71,6 @@ export class ServerWsEndpoint extends AbstractWsEndpoint<ServerWsConnection> imp
                     if (!this.getConnectionByPeerId(peerId)) {
                         this.acceptConnection(peerId, fromAddress)
                     } else {
-                        this.metrics.record('open:duplicateSocket', 1)
                         const failedMessage = `Connection for node: ${peerId} has already been established, rejecting duplicate`
 
                         Simulator.instance().wsDisconnect(this.ownAddress, this.peerInfo, fromAddress, DisconnectionCode.DUPLICATE_SOCKET, 

--- a/packages/network/test/integration/do-not-propagate-to-sender-optimization.test.ts
+++ b/packages/network/test/integration/do-not-propagate-to-sender-optimization.test.ts
@@ -85,11 +85,8 @@ describe('optimization: do not propagate to sender', () => {
             },
         }))
 
-        await waitForCondition(() => onDuplicateMessage.mock.calls.length > 0)
+        await waitForCondition(() => onDuplicateMessage.mock.calls.length >= 2)
 
-        // TODO is it possible that waitForCondition() polls a state where 
-        // onDuplicateMessage.mock.calls.length === 1? (DUPLICATE_MESSAGE_RECEIVED events are 
-        // are usually emitten within few milliseconds)
         expect(onDuplicateMessage.mock.calls.length).toEqual(2)
     })
 })

--- a/packages/network/test/integration/message-duplication.test.ts
+++ b/packages/network/test/integration/message-duplication.test.ts
@@ -16,6 +16,7 @@ describe('duplicate message detection and avoidance', () => {
     let contactNode: NetworkNode
     let otherNodes: NetworkNode[]
     let numOfReceivedMessages: number[]
+    let numOfDuplicateMessages: number[]
 
     beforeAll(async () => {
         tracker = await startTracker({
@@ -86,12 +87,16 @@ describe('duplicate message detection and avoidance', () => {
         // Set up 1st test case
         let totalMessages = 0
         numOfReceivedMessages = [0, 0, 0, 0, 0]
+        numOfDuplicateMessages = [0, 0, 0, 0, 0]
         const updater = (i: number) => () => {
             totalMessages += 1
             numOfReceivedMessages[i] += 1
         }
         for (let i = 0; i < otherNodes.length; ++i) {
             otherNodes[i].addMessageListener(updater(i))
+            otherNodes[i].on(NodeEvent.DUPLICATE_MESSAGE_RECEIVED, () => {
+                numOfDuplicateMessages[i] += 1
+            })
         }
 
         // Produce data
@@ -124,15 +129,8 @@ describe('duplicate message detection and avoidance', () => {
     })
 
     test('maximum times a node receives duplicates of message is bounded by total number of repeaters', async () => {
-        const numOfDuplicates = await Promise.all(otherNodes.map(async (n) => {
-            // @ts-expect-error private field
-            const report = await n.metrics.report()
-            return (report['onDataReceived:ignoredDuplicate'] as any).total
-        }))
-
-        expect(numOfDuplicates).toHaveLength(5)
-        numOfDuplicates.forEach((n) => {
-            expect(n).toBeLessThanOrEqual((otherNodes.length * 2)) // multiplier because 2 separate messages
+        numOfDuplicateMessages.forEach((n) => {
+            expect(n).toBeLessThanOrEqual(otherNodes.length * 2) // multiplier because 2 separate messages
         })
     })
 })

--- a/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
+++ b/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
@@ -36,9 +36,9 @@ describe('Node-to-Node protocol version negotiation', () => {
         const peerInfo3 = new PeerInfo('node-endpoint3', PeerType.Node, [1, 2], [33])
         const trackerPeerInfo = PeerInfo.newTracker(tracker.getTrackerId())
         // Need to set up NodeToTrackers and WsEndpoint(s) to exchange RelayMessage(s) via tracker
-        const wsEp1 = new NodeClientWsEndpoint(peerInfo1, new MetricsContext(peerInfo1.peerId))
-        const wsEp2 = new NodeClientWsEndpoint(peerInfo2, new MetricsContext(peerInfo2.peerId))
-        const wsEp3 = new NodeClientWsEndpoint(peerInfo3, new MetricsContext(peerInfo2.peerId))
+        const wsEp1 = new NodeClientWsEndpoint(peerInfo1)
+        const wsEp2 = new NodeClientWsEndpoint(peerInfo2)
+        const wsEp3 = new NodeClientWsEndpoint(peerInfo3)
         nodeToTracker1 = new NodeToTracker(wsEp1)
         nodeToTracker2 = new NodeToTracker(wsEp2)
         nodeToTracker3 = new NodeToTracker(wsEp3)

--- a/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -29,8 +29,8 @@ describe('WebRtcEndpoint: back pressure handling', () => {
         const peerInfo2 = PeerInfo.newNode('ep2')
 
         // Need to set up NodeToTrackers and WsEndpoint(s) to exchange RelayMessage(s) via tracker
-        const wsEp1 = new NodeClientWsEndpoint(peerInfo1, new MetricsContext(peerInfo1.peerId))
-        const wsEp2 = new NodeClientWsEndpoint(peerInfo2, new MetricsContext(peerInfo2.peerId))
+        const wsEp1 = new NodeClientWsEndpoint(peerInfo1)
+        const wsEp2 = new NodeClientWsEndpoint(peerInfo2)
         nodeToTracker1 = new NodeToTracker(wsEp1)
         nodeToTracker2 = new NodeToTracker(wsEp2)
         await nodeToTracker1.connectToTracker(tracker.getUrl(), PeerInfo.newTracker(tracker.getTrackerId()))

--- a/packages/network/test/integration/webrtc-multi-signaller.test.ts
+++ b/packages/network/test/integration/webrtc-multi-signaller.test.ts
@@ -32,8 +32,8 @@ describe('WebRTC multisignaller test', () => {
             }
         })
 
-        const ep1 = new NodeClientWsEndpoint(PeerInfo.newNode('node-1'), new MetricsContext(''))
-        const ep2 = new NodeClientWsEndpoint(PeerInfo.newNode('node-2'), new MetricsContext(''))
+        const ep1 = new NodeClientWsEndpoint(PeerInfo.newNode('node-1'))
+        const ep2 = new NodeClientWsEndpoint(PeerInfo.newNode('node-2'))
 
         nodeToTracker1 = new NodeToTracker(ep1)
         nodeToTracker2 = new NodeToTracker(ep2)

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -1,5 +1,4 @@
 import { StreamPartID, toStreamID, toStreamPartID } from 'streamr-client-protocol'
-import { MetricsContext } from '../dist/src/helpers/MetricsContext'
 import { Tracker } from '@streamr/network-tracker'
 import { PeerInfo } from '../dist/src/connection/PeerInfo'
 import { startHttpServer } from '../dist/src/connection/ws/ServerWsEndpoint'
@@ -10,7 +9,6 @@ export const startServerWsEndpoint = async (
     host: string,
     port: number,
     peerInfo: PeerInfo,
-    metricsContext?: MetricsContext,
     pingInterval?: number | undefined
 ): Promise<ServerWsEndpoint> => {
     const listen = {
@@ -18,7 +16,7 @@ export const startServerWsEndpoint = async (
         port: port
     }
     const httpServer = await startHttpServer(listen, undefined, undefined)
-    return new ServerWsEndpoint(listen, false, httpServer, peerInfo, metricsContext, pingInterval)
+    return new ServerWsEndpoint(listen, false, httpServer, peerInfo, pingInterval)
 }
 
 export const createStreamPartId = (streamIdAsStr: string, streamPartition: number): StreamPartID => {


### PR DESCRIPTION
Remove metrics which aren't needed in `MetricsPublisher`, `ConsoleMetrics` or Tracker metrics.

In Tracker metrics we don't report `tracker._removeNode` and `WsEndpoint` related metrics. Unify the naming of the remaining tracker metrics.

Add also a new Node event `DUPLICATE_MESSAGE_RECEIVED`. It is used `do-not-propagate-to-sender-optimization.test.ts` and `message-duplication.test.ts` tests to analyze duplicate message processing. Earlier those tests used `onDataReceived:ignoredDuplicate` metrics.

## Tracker metrics comparison

Before this PR:

```
{
    "peerId": "TR30301",
    "startTime": 1641085445000,
    "currentTime": 1641085445000,
    "metrics": {
        "WsEndpoint": {
            "connections": 0,
            "rtts": {},
            "totalWebSocketBuffer": 0,
            "inSpeed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "outSpeed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "msgSpeed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "msgInSpeed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "msgOutSpeed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open:duplicateSocket": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open:failedException": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open:headersNotReceived": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open:missingParameter": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "open:ownAddress": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "close": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "sendFailed": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "webSocketError": {
                "rate": 0,
                "total": 0,
                "last": 0
            }
        },
        "tracker": {
            "onNodeDisconnected": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "processNodeStatus": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "_removeNode": {
                "rate": 0,
                "total": 0,
                "last": 0
            },
            "instructionsSent": {
                "rate": 0,
                "total": 0,
                "last": 0
            }
        }
    }
}
```

After this PR

```
{
    "peerId": "TR30301",
    "nodeDisconnected": 0,
    "nodeStatusProcessed": 0,
    "instructionSent": 0
}
```    



