### PR TITLE
feat(broker): Info plugin

### DIFF
--- a/.github/workflows/broker.yml
+++ b/.github/workflows/broker.yml
@@ -82,7 +82,7 @@ jobs:
       build_platforms: linux/amd64
       test_script: |
         for (( i=0; i < 5; i=i+1 )); do
-            curl -s http://localhost:8791/volume;
+            curl -s http://localhost:8791/info;
             res=$?;
             if test "$res" != "0"; then
                 echo "Attempting to connect to broker retrying in $wait_time seconds";

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -63,6 +63,7 @@
             "consoleIntervalInSeconds": 30,
             "nodeMetrics": null
         },
+        "info": {},
         "storage": {
             "cassandra": {
                 "hosts": [

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -62,6 +62,7 @@
       "metrics": {
           "consoleIntervalInSeconds": 30,
           "nodeMetrics": null
-      }
+      },
+      "info": {}
   }
 }

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -62,6 +62,7 @@
       "metrics": {
           "consoleIntervalInSeconds": 30,
           "nodeMetrics": null
-      }
+      },
+      "info": {}
   }
 }

--- a/packages/broker/src/pluginRegistry.ts
+++ b/packages/broker/src/pluginRegistry.ts
@@ -6,6 +6,7 @@ import { MqttPlugin } from './plugins/mqtt/MqttPlugin'
 import { StoragePlugin } from './plugins/storage/StoragePlugin'
 import { BrubeckMinerPlugin } from './plugins/brubeckMiner/BrubeckMinerPlugin'
 import { SubscriberPlugin } from './plugins/subscriber/SubscriberPlugin'
+import { InfoPlugin } from './plugins/info/InfoPlugin'
 
 export const createPlugin = (name: string, pluginOptions: PluginOptions): Plugin<any>|never => {
     switch (name) {
@@ -23,6 +24,8 @@ export const createPlugin = (name: string, pluginOptions: PluginOptions): Plugin
             return new BrubeckMinerPlugin(pluginOptions)
         case 'subscriber':
             return new SubscriberPlugin(pluginOptions)
+        case 'info':
+            return new InfoPlugin(pluginOptions)
         default:
             throw new Error(`Unknown plugin: ${name}`)
     }

--- a/packages/broker/src/plugins/info/InfoPlugin.ts
+++ b/packages/broker/src/plugins/info/InfoPlugin.ts
@@ -1,0 +1,27 @@
+import express, { Request, Response } from 'express'
+import { Plugin, PluginOptions } from '../../Plugin'
+
+export class InfoPlugin extends Plugin<void> {
+
+    constructor(options: PluginOptions) {
+        super(options)
+    }
+
+    async start(): Promise<void> {
+        this.addHttpServerRouter(this.createEndpoint())
+    }
+
+    private createEndpoint(): express.Router {
+        const router = express.Router()
+        router.get('/info', async (_req: Request, res: Response) => {
+            const node = await this.streamrClient.getNode()
+            res.json({
+                nodeId: node.getNodeId()
+            })
+        })
+        return router
+    }
+
+    async stop(): Promise<void> {
+    }
+}


### PR DESCRIPTION
A small plugin which provides the nodeId of the node. Use in "Docker Image: test"  GitHub actions job to ping the node.

Creates a `/info` endpoint which return a JSON:
```
{
    "nodeId": "0xde222e8603fcf641f928e5f66a0cbf4de70d5352#bbce8b3d-6ad8-4de7-bcda-10d93079104d1"
}
```

We can later add more node-related information (e.g. neighbors), if needed.