### PR TITLE
feat(client): Update encryption key api

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add method `subscribeAll` to subscribe to all stream partitions.
 - Add method `resendAll` to resend data from all stream partitions.
+- Method `updateEncryptionKey` to update stream encryption key
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - method `onResent(listener)` replaced with `subscription.once('resendComplete', listener)`
 - Behavior changes: 
   - resends support multiple storage nodes (the data is fetched from a random storage node)
+- Configuration parameter `groupKeys` renamed to `encryptionKeys`
 
 ### Deprecated
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Behavior changes: 
   - resends support multiple storage nodes (the data is fetched from a random storage node)
 - Configuration parameter `groupKeys` renamed to `encryptionKeys`
+- Exported classes `GroupKey` and `GroupKeyId` renamed to `EncryptionKey` and `EncryptionKeyId`
 
 ### Deprecated
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -755,7 +755,8 @@ In practice, the update is needed if:
 Both of the use cases are covered if you call:
 ```
 client.updateEncryptionKey({
-	distributionMethod: 'rekey'
+    streamId,
+    distributionMethod: 'rekey'
 })
 ```
 
@@ -766,7 +767,8 @@ You may want to call that method regularly (e.g. daily/weekly). Or you can call 
 You can optimize the key distribution by using rotate instead of rekey. The optimization is applicable if you don't have subscriptions that can expire. In that situation you can update the key by calling:
 ```
 client.updateEncryptionKey({
-	distributionMethod: 'rotate'
+    streamId,
+    distributionMethod: 'rotate'
 })
 ```
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -47,7 +47,7 @@ Please see the [Streamr project docs](https://streamr.network/docs) for more det
 ## Getting started
 
 ### Subscribing
-```js 
+```js
 const streamId = 'streamr.eth/demos/helsinki-trams'
 
 streamr.subscribe(streamId, (message) => {
@@ -57,7 +57,7 @@ streamr.subscribe(streamId, (message) => {
 ```
 
 ### Publishing
-```js 
+```js
 // Requires MATIC tokens (Polygon blockchain gas token)
 const stream = await streamr.createStream({
     id: '/foo/bar'
@@ -105,7 +105,7 @@ ___
 See https://api-docs.streamr.network
 
 ### Client creation
-In Streamr, Ethereum accounts are used for identity. You can generate an Ethereum private key using any Ethereum wallet, or you can use the utility function [`StreamrClient.generateEthereumAccount()`](#utility-functions), which returns the address and private key of a fresh Ethereum account. A private key is not required if you are only subscribing to public streams on the Network. 
+In Streamr, Ethereum accounts are used for identity. You can generate an Ethereum private key using any Ethereum wallet, or you can use the utility function [`StreamrClient.generateEthereumAccount()`](#utility-functions), which returns the address and private key of a fresh Ethereum account. A private key is not required if you are only subscribing to public streams on the Network.
 
 ```js
 const streamr = new StreamrClient({
@@ -154,13 +154,13 @@ More information on Stream IDs can be found under the [stream creation project d
 ### Subscribing to a stream
 ```js
 const subscription = await streamr.subscribe(
-    streamId, 
+    streamId,
     (content, metadata) => { ... }
 )
 ```
-The callback's first parameter, `content`, will contain the value given to the `publish` method. 
+The callback's first parameter, `content`, will contain the value given to the `publish` method.
 
-The second parameter `metadata` is of type `StreamMessage`. It contains metadata about the message, e.g. timestamp. 
+The second parameter `metadata` is of type `StreamMessage`. It contains metadata about the message, e.g. timestamp.
 
 Unsubscribing from an existent subscription:
 ```js
@@ -209,7 +209,7 @@ const resend1 = await streamr.resend(
     streamId,
     {
         last: 10,
-    }, 
+    },
     onMessage
 )
 ```
@@ -252,8 +252,8 @@ const sub3 = await streamr.resend(
         },
         // when using from and to the following parameters are optional
         // but, if specified, both must be present
-        publisher: '0x12345...', 
-        msgChainId: 'ihuzetvg0c88ydd82z5o', 
+        publisher: '0x12345...',
+        msgChainId: 'ihuzetvg0c88ydd82z5o',
     }
 )
 ```
@@ -266,7 +266,7 @@ sub.once('resendComplete', () => {
 })
 ```
 
-Note that only one of the resend options can be used for a particular subscription. 
+Note that only one of the resend options can be used for a particular subscription.
 
 ### Searching for streams
 You can search for streams by specifying a search term:
@@ -276,7 +276,7 @@ const streams = await streamr.searchStreams('foo')
 Alternatively or additionally to the search term, you can search for streams based on permissions.
 
 To get all streams for which a user has any direct permission:
-```js 
+```js
 const streams = await streamr.searchStreams('foo', {
     user: '0x12345...'
 })
@@ -292,7 +292,7 @@ const streams = await streamr.searchStreams('foo', {
 It is also possible to filter by specific permissions by using `allOf` and `anyOf` properties. The `allOf` property should be preferred over `anyOf` when possible due to better query performance.
 
 If you want to find the streams you can subscribe to:
-```js 
+```js
 const streams = await streamr.searchStreams(undefined, {
     user: '0x12345...',
     allOf: [StreamPermission.SUBSCRIBE],
@@ -361,7 +361,7 @@ await stream.revokePermissions({
     public: true,
     permissions: [StreamPermission.SUBSCRIBE]
 })
-```        
+```
 
 
 The method `streamr.setPermissions` can be used to set an exact set of permissions for one or more streams. Note that if there are existing permissions for the same users in a stream, the previous permissions are overwritten. Note that this method cannot be used from a stream, but via the `StreamrClient` instance:
@@ -516,16 +516,16 @@ const receipt = await dataUnion.withdrawAllToSigned(
 // Or to authorize a fixed amount:
 const receipt = await dataUnion.withdrawAmountToSigned(
     '0x12345...', // member address
-    recipientAddress, 
-    100, // token amount, in wei 
-    signature, 
+    recipientAddress,
+    100, // token amount, in wei
+    signature,
 )
 ```
 
 Setting a new admin fee:
 ```js
 // Any number between 0 and 1, inclusive
-const receipt = await dataUnion.setAdminFee(0.4) 
+const receipt = await dataUnion.setAdminFee(0.4)
 ```
 #### Query functions
 These are available for everyone and anyone, to query publicly available info from a Data Union.
@@ -602,7 +602,7 @@ const dataUnion = await streamr.deployDataUnion({
     owner: ownerAddress, // Owner / admin of the newly created Data Union
     joinPartsAgent: [ownerAddress], // Able to add and remove members to/from the Data Union
     dataUnionName: /* Generated if not provided */, // NOT stored anywhere, only used for address derivation
-    adminFee: 0, // Must be between 0...1 
+    adminFee: 0, // Must be between 0...1
     sidechainPollingIntervalMs: 1000, //How often requests are sent to find out if the deployment has completed
     sidechainRetryTimeoutMs: 60000, // When to give up when waiting for the deployment to complete
     confirmations: 1, // Blocks to wait after Data Union mainnet contract deployment to consider it final
@@ -621,8 +621,8 @@ const dataUnion = await streamr.deployDataUnion({
 `dataUnionName` option exists purely for the purpose of predicting the addresses of Data Unions not yet deployed. Data Union deployment uses the [CREATE2 opcode](https://eips.ethereum.org/EIPS/eip-1014) which means a Data Union deployed by a particular address with particular "name" will have a predictable address.
 
 ### Utility functions
-The static function `StreamrClient.generateEthereumAccount()` generates a new Ethereum private key and returns an object with fields `address` and `privateKey`. 
-```js 
+The static function `StreamrClient.generateEthereumAccount()` generates a new Ethereum private key and returns an object with fields `address` and `privateKey`.
+```js
 const { address, privateKey } = StreamrClient.generateEthereumAccount()
 ```
 In order to retrieve the client's address an async call must me made to `streamr.getAddress`
@@ -645,9 +645,9 @@ const streamId = `${address}/foo/bar`
 const streamId = `${address}/foo/bar#4`
 
 // Stream id + partition as an object
-const streamId = { 
-    id: `${address}/foo/bar`, 
-    partition: 4 
+const streamId = {
+    id: `${address}/foo/bar`,
+    partition: 4
 }
 ```
 
@@ -682,8 +682,8 @@ The partition key can be given as an argument to the `publish` methods, and the 
 
 ```js
 await stream.publish(
-    msg, 
-    Date.now(), 
+    msg,
+    Date.now(),
     msg.vehicleId // msg.vehicleId is the partition key here
 )
 ```
@@ -733,21 +733,21 @@ By disabling message ordering your application won't perform any filling nor sor
 
 ### Encryption keys
 
-Messages published to a non-public stream are always encrypted. The publishing client creates the encryption keys and delivers the keys to the subscribers automatically. In typical use cases, there is no need to manage encryption keys manually.
+Messages published to a non-public stream are always encrypted. The publishing client creates the encryption keys and delivers them to the subscribers automatically. In most use cases, there is no need to manage encryption keys manually.
 
 #### Typical use cases
 
-A new encryption key is generated when a client is started. The key doesn't change during the lifetime of the client unless you explicitly update it.
+A new encryption key is generated when publishing activity to a stream starts. The keys don't change during the lifetime of a client unless explicitly updated.
 
-At any given time a subscriber can request a key from the publisher. When the publisher receives a request, it checks whether the subscriber has valid `StreamPermission.SUBSCRIBE` permission to the stream. If the permission exists, the client sends the encryption key to the subscriber. The subscriber can then use the key to decrypt any message which is encrypted with that key.
+At any given time a subscriber can request a key from a publisher. When the publisher receives a request, it checks whether the subscriber has valid `StreamPermission.SUBSCRIBE` permission to the stream. If a valid permission exists, the client sends the encryption key to the subscriber. The subscriber can then use the key to decrypt messages which are encrypted with that key.
 
-Typically subscribers query the current encryption key. But if they need to access historical data (which is maybe encrypted with a previous encryption key), they may query some previous encryption key. A publisher client stores all previous encryption keys in a local database, and therefore it can respond to those queries automatically (if the client is online when the query happens).
+Typically subscribers query the current encryption key. But if they need to access to historical data, they may query previous encryption keys. A publisher client keeps track of all previous encryption keys in a local database, so it can respond to historical encryption key queries automatically. Therefore the publisher needs to stay online if historical decryption of its data is something that should be supported.
 
 #### Manual key update
 
-You can manually update the encryption key by calling `client.updateEncryptionKey(...)`. That triggers the creation of a new encryption key, and the client starts to use that to encrypt the messages from this moment onwards.
+You can manually update the encryption key by calling `client.updateEncryptionKey(...)`. This triggers the creation of a new encryption key, after which the client starts to use that to encrypt published messages.
 
-In practice, the update is needed if:
+In practice, an update is needed if:
 
 - You want to prevent new subscribers from reading historical messages. When you update the key, the new subscribers get the new key. But as the historical data is encrypted with some previous key, those messages aren't decryptable by the new subscribers.
 - You want to prevent expired subscribers from reading new messages. When you update the key, but you don't distribute the new key to the expired subscribers, they aren't able to decrypt new messages.
@@ -760,11 +760,11 @@ client.updateEncryptionKey({
 })
 ```
 
-You may want to call that method regularly (e.g. daily/weekly). Or you can call it when you observe that you have an expired subscriber (that is, someone bought your data stream for a limited period of time, and that period has now elapsed)
+You may want to call this method regularly (e.g. daily/weekly). Alternatively you can call it anytime you observe new expired subscribers (that is, someone bought your data stream for a limited period of time, and that period has now elapsed).
 
 #### Optimization: key rotation
 
-You can optimize the key distribution by using rotate instead of rekey. The optimization is applicable if you don't have subscriptions that can expire. In that situation you can update the key by calling:
+You can optimize the key distribution by using `rotate` instead of `rekey`. The optimization is applicable if subscriptions haven't expired or been removed. In that situation you can update the key by calling:
 ```
 client.updateEncryptionKey({
     streamId,
@@ -773,8 +773,8 @@ client.updateEncryptionKey({
 ```
 
 In detail, the difference between the methods is:
-- In `rekey` method, the client sends the new key individually to each subscriber. Every subscriber receives a separate message which is encrypted with their public RSA key. The `StreamPermission.SUBSCRIBE` permission is checked for each subscriber before a key is sent. 
-- In `rotate` method, the key is broadcasted to the network in the metadata of the next message. The key is encrypted with the previous encryption key and therefore subscribers can use it only if they know the previous key (https://en.wikipedia.org/wiki/Forward_secrecy). As the key is broadcasted to everyone, no permissions are checked. As recently expired subscribers most likely have the previous key, they can use that new key, too.
+- In `rekey` method, the client sends the new key individually to each subscriber. Every subscriber receives a separate message which is encrypted with their public RSA key. The `StreamPermission.SUBSCRIBE` permission is checked by the publisher for each subscriber before a key is sent.
+- In optimized `rotate` method, the key is broadcasted to the network in the metadata of the next message. The key is encrypted with the previous encryption key and therefore subscribers can use it only if they know the previous key (https://en.wikipedia.org/wiki/Forward_secrecy). As the key is broadcasted to everyone, no permissions are checked. Note that recently expired subscribers most likely have the previous key, therefore they can use that new key, too.
 
 
 ### Proxy publishing and subscribing

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -141,7 +141,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
 
     // Encryption options
     verifySignatures: 'auto',
-    groupKeys: {}, // {streamId: groupKey}
+    encryptionKeys: {}, // {streamId: groupKey}
 
     // Ethereum and Data Union related options
     // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -141,7 +141,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
 
     // Encryption options
     verifySignatures: 'auto',
-    encryptionKeys: {}, // {streamId: groupKey}
+    encryptionKeys: {},
 
     // Ethereum and Data Union related options
     // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -29,7 +29,6 @@ import { StreamDefinition } from './types'
 import { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
-import { toStreamID } from 'streamr-client-protocol'
 
 let uid: string = process.pid != null
     // Use process id in node uid.
@@ -149,7 +148,7 @@ class StreamrClientBase implements Context {
         if (opts.streamId === undefined) {
             throw new Error('streamId required')
         }
-        const streamId = toStreamID(opts.streamId)
+        const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {
                 return this.groupKeyStore.rotateGroupKey(streamId)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -150,10 +150,10 @@ class StreamrClientBase implements Context {
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {
                 return this.groupKeyStore.rotateGroupKey(streamId)
-            } else {
+            } else { // eslint-disable-line no-else-return
                 return this.groupKeyStore.setNextGroupKey(streamId, opts.key)
             }
-        } else if (opts.distributionMethod === 'rekey') {
+        } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
             return this.groupKeyStore.rekey(streamId, opts.key)
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -146,6 +146,9 @@ class StreamrClientBase implements Context {
     }
 
     async updateEncryptionKey(opts: UpdateEncryptionKeyOptions): Promise<void> {
+        if (opts.streamId === undefined) {
+            throw new Error('streamId required')
+        }
         const streamId = toStreamID(opts.streamId)
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -154,11 +154,7 @@ class StreamrClientBase implements Context {
                 return this.groupKeyStore.setNextGroupKey(streamId, opts.key)
             }
         } else if (opts.distributionMethod === 'rekey') {
-            if (opts.key === undefined) {
-                return this.groupKeyStore.rekey(streamId)
-            } else {
-                throw new Error('Explicit key not supported in rekey')
-            }
+            return this.groupKeyStore.rekey(streamId, opts.key)
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
         }

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -192,7 +192,7 @@
         "gapFillTimeout": {
             "type": "number"
         },
-        "groupKeys": {
+        "encryptionKeys": {
             "type": "object"
         },
         "network": {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -198,8 +198,7 @@ export class GroupKeyStore implements Context {
         return this.store.close()
     }
 
-    async rekey() {
-        const newKey = GroupKey.generate()
+    async rekey(newKey = GroupKey.generate()) {
         await this.storeKey(newKey)
         this.currentGroupKeyId = newKey.id
         this.nextGroupKeys.length = 0

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -45,7 +45,7 @@ export class GroupKeyStoreFactory implements Context {
                 return streamId
             }
         })
-        this.initialGroupKeys = encryptionConfig.groupKeys
+        this.initialGroupKeys = encryptionConfig.encryptionKeys
     }
 
     private async getNewStore(streamId: StreamID) {

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -90,9 +90,9 @@ export class GroupKeyStoreFactory implements Context {
     }
 
     /** @internal */
-    async rekey(streamId: StreamID) {
+    async rekey(streamId: StreamID, newKey?: GroupKey) {
         const store = await this.getStore(streamId)
-        return store.rekey()
+        return store.rekey(newKey)
     }
 
     async stop() {

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -11,6 +11,16 @@ import { GroupKeyStore } from './GroupKeyStore'
 import { GroupKey } from './GroupKey'
 import { StreamID } from 'streamr-client-protocol'
 
+// In the client API we use the term EncryptionKey instead of GroupKey.
+// The GroupKey name comes from the protocol. TODO: we could rename all classes
+// and methods to use the term EncryptionKey (except protocol-classes, which
+// should use the protocol level term GroupKey)
+export interface UpdateEncryptionKeyOptions {
+    streamId: string,
+    distributionMethod: 'rotate' | 'rekey',
+    key?: GroupKey
+}
+
 @scoped(Lifecycle.ContainerScoped)
 export class GroupKeyStoreFactory implements Context {
     /** @internal */

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -45,6 +45,7 @@ export class GroupKeyStoreFactory implements Context {
                 return streamId
             }
         })
+        // TODO the streamIds in encryptionConfig.encryptionKeys should support path-format?
         this.initialGroupKeys = encryptionConfig.encryptionKeys
     }
 

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -24,7 +24,7 @@ export type GroupKeyId = string
 export type GroupKeysSerialized = Record<GroupKeyId, GroupKeyish>
 
 export type EncryptionConfig = {
-    groupKeys: Record<string, GroupKeysSerialized>
+    encryptionKeys: Record<string, GroupKeysSerialized>
 }
 
 export function parseGroupKeys(groupKeys: GroupKeysSerialized = {}): Map<GroupKeyId, GroupKey> {

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -51,8 +51,8 @@ export {
     XOR,
     Without
 } from './Ethereum'
-export { EncryptionConfig, GroupKeysSerialized, GroupKeyId } from './encryption/KeyExchangeStream'
-export { GroupKey, GroupKeyish, GroupKeyObject } from './encryption/GroupKey'
+export { EncryptionConfig, GroupKeyId as EncryptionKeyId } from './encryption/KeyExchangeStream'
+export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/GroupKeyStoreFactory'
 
 export { ConfigTest } from './ConfigTest'

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -53,6 +53,7 @@ export {
 } from './Ethereum'
 export { EncryptionConfig, GroupKeysSerialized, GroupKeyId } from './encryption/KeyExchangeStream'
 export { GroupKey, GroupKeyish, GroupKeyObject } from './encryption/GroupKey'
+export { UpdateEncryptionKeyOptions } from './encryption/GroupKeyStoreFactory'
 
 export { ConfigTest } from './ConfigTest'
 export { NetworkNodeStub } from './BrubeckNode'

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -437,7 +437,7 @@ describeRepeats('decryption', () => {
                     auth: {
                         privateKey: subscriberPrivateKey
                     },
-                    groupKeys,
+                    encryptionKeys: groupKeys
                 })
 
                 const contentClear: any[] = []

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -158,7 +158,11 @@ describeRepeats('decryption', () => {
                 }))
 
                 // publisher.once('error', done.reject)
-                await publisher.setNextGroupKey(stream.id, groupKey)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    key: groupKey,
+                    distributionMethod: 'rotate'
+                })
                 // Publish after subscribed
                 await Promise.all([
                     publisher.publish(stream.id, msg),
@@ -174,7 +178,11 @@ describeRepeats('decryption', () => {
                     stream: stream.id,
                 })
 
-                await publisher.setNextGroupKey(stream.id, groupKey)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    key: groupKey,
+                    distributionMethod: 'rotate'
+                })
                 const onEncryptionMessageErr = checkEncryptionMessages(publisher)
 
                 await publisher.publish(stream.id, msg)
@@ -200,7 +208,11 @@ describeRepeats('decryption', () => {
                 // sub.once('error', done.reject)
 
                 const groupKey = GroupKey.generate()
-                await publisher.setNextGroupKey(stream.id, groupKey)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    key: groupKey,
+                    distributionMethod: 'rotate'
+                })
 
                 await publisher.publish(stream.id, msg)
                 const received = await sub.collect(1)
@@ -230,9 +242,17 @@ describeRepeats('decryption', () => {
                 // msg3 gk3 -
                 const groupKey1 = GroupKey.generate()
                 const groupKey2 = GroupKey.generate()
-                await publisher.setNextGroupKey(stream.id, groupKey1)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id, 
+                    key: groupKey1,
+                    distributionMethod: 'rotate'
+                })
                 await publisher.publish(stream.id, msgs[0])
-                await publisher.setNextGroupKey(stream.id, groupKey2)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id, 
+                    key: groupKey2,
+                    distributionMethod: 'rotate'
+                })
                 await publisher.publish(stream.id, msgs[1])
                 await publisher.publish(stream.id, msgs[2])
                 const received = await sub.collect(msgs.length)
@@ -312,7 +332,11 @@ describeRepeats('decryption', () => {
                 const onEncryptionMessageErr = checkEncryptionMessagesPerStream(publisher)
 
                 const groupKey = GroupKey.generate()
-                await publisher.setNextGroupKey(stream.id, groupKey)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    key: groupKey,
+                    distributionMethod: 'rotate'
+                })
 
                 await testSub(stream)
                 await testSub(stream2)
@@ -334,7 +358,11 @@ describeRepeats('decryption', () => {
                 })
 
                 const groupKey = GroupKey.generate()
-                await publisher.setNextGroupKey(stream.id, groupKey)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    key: groupKey,
+                    distributionMethod: 'rotate'
+                })
 
                 const published: any[] = []
                 // @ts-expect-error
@@ -362,13 +390,19 @@ describeRepeats('decryption', () => {
                     stream: stream.id,
                 })
 
-                await publisher.rotateGroupKey(stream.id)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    distributionMethod: 'rotate'
+                })
                 const publishedStreamMessages: any[] = []
                 // @ts-expect-error
                 publisher.publisher.streamMessageQueue.onMessage(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     publishedStreamMessages.push(streamMessage.clone())
-                    await publisher.rotateGroupKey(stream.id)
+                    await publisher.updateEncryptionKey({
+                        streamId: stream.id,
+                        distributionMethod: 'rotate'
+                    })
                 })
                 const published = await getPublishTestStreamMessages(publisher, stream)(NUM_MESSAGES)
 
@@ -421,7 +455,10 @@ describeRepeats('decryption', () => {
 
                 const publishStream = publishTestMessagesGenerator(publisher, stream, NUM_MESSAGES)
                 await publisher.connect()
-                await publisher.rotateGroupKey(stream.id)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    distributionMethod: 'rotate'
+                })
                 const sub = (await subscriber.subscribe({
                     stream: stream.id,
                 }))
@@ -438,10 +475,16 @@ describeRepeats('decryption', () => {
 
             it('client.resend last can get the historical keys for previous encrypted messages', async () => {
                 // Publish encrypted messages with different keys
-                await publisher.rotateGroupKey(stream.id)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    distributionMethod: 'rotate'
+                })
                 // @ts-expect-error
                 publisher.publisher.streamMessageQueue.forEach(async () => {
-                    await publisher.rotateGroupKey(stream.id)
+                    await publisher.updateEncryptionKey({
+                        streamId: stream.id,
+                        distributionMethod: 'rotate'
+                    })
                 })
                 const published: any[] = []
                 // @ts-expect-error
@@ -469,10 +512,16 @@ describeRepeats('decryption', () => {
 
             it('client.subscribe with resend last can get the historical keys for previous encrypted messages', async () => {
                 // Publish encrypted messages with different keys
-                await publisher.rotateGroupKey(stream.id)
+                await publisher.updateEncryptionKey({
+                    streamId: stream.id,
+                    distributionMethod: 'rotate'
+                })
                 // @ts-expect-error
                 publisher.publisher.publishQueue.forEach(async () => {
-                    await publisher.rotateGroupKey(stream.id)
+                    await publisher.updateEncryptionKey({
+                        streamId: stream.id,
+                        distributionMethod: 'rotate'
+                    })
                 })
                 const published = await publishTestMessages(5, {
                     waitForLast: true,
@@ -506,7 +555,11 @@ describeRepeats('decryption', () => {
                         }
                     }
 
-                    await publisher.setNextGroupKey(stream.id, groupKey)
+                    await publisher.updateEncryptionKey({
+                        streamId: stream.id,
+                        key: groupKey,
+                        distributionMethod: 'rotate'
+                    })
                     contentClear = []
 
                     // @ts-expect-error
@@ -517,7 +570,10 @@ describeRepeats('decryption', () => {
 
                     // @ts-expect-error
                     publisher.publisher.publishQueue.forEach(async () => {
-                        await publisher.rotateGroupKey(stream.id)
+                        await publisher.updateEncryptionKey({
+                            streamId: stream.id,
+                            distributionMethod: 'rotate'
+                        })
                     })
 
                     sub = await subscriber.subscribe({
@@ -594,14 +650,18 @@ describeRepeats('decryption', () => {
         it('errors if rotating group key for no stream', async () => {
             await expect(async () => (
                 // @ts-expect-error
-                publisher.rotateGroupKey()
+                publisher.updateEncryptionKey()
             )).rejects.toThrow('streamId')
         })
 
         it('errors if setting group key for no stream', async () => {
             await expect(async () => {
-                // @ts-expect-error
-                await publisher.setNextGroupKey(undefined, GroupKey.generate())
+                await publisher.updateEncryptionKey({
+                    // @ts-expect-error
+                    streamId: undefined,
+                    key: GroupKey.generate(),
+                    distributionMethod: 'rotate'
+                })
             }).rejects.toThrow('streamId')
         })
 
@@ -653,13 +713,19 @@ describeRepeats('decryption', () => {
                     }
                 })
 
-                await publisher.rotateGroupKey(testStream.id)
+                await publisher.updateEncryptionKey({
+                    streamId: testStream.id,
+                    distributionMethod: 'rotate'
+                })
                 const published: any[] = []
                 // @ts-expect-error
                 publisher.publisher.streamMessageQueue.onMessage(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() !== testStream.id) { return }
                     published.push(streamMessage.getParsedContent())
-                    await publisher.rotateGroupKey(testStream.id)
+                    await publisher.updateEncryptionKey({
+                        streamId: testStream.id,
+                        distributionMethod: 'rotate'
+                    })
                 })
 
                 await getPublishTestStreamMessages(publisher, testStream)(NUM_MESSAGES)
@@ -672,7 +738,11 @@ describeRepeats('decryption', () => {
             const onEncryptionMessageErr = checkEncryptionMessagesPerStream(publisher)
 
             const groupKey = GroupKey.generate()
-            await publisher.setNextGroupKey(stream.id, groupKey)
+            await publisher.updateEncryptionKey({
+                streamId: stream.id,
+                key: groupKey,
+                distributionMethod: 'rotate'
+            })
 
             await testSub(stream)
             await testSub(stream2)
@@ -741,9 +811,17 @@ describeRepeats('decryption', () => {
             const onEncryptionMessageErr = checkEncryptionMessagesPerStream(publisher)
 
             const groupKey = GroupKey.generate()
-            await publisher.setNextGroupKey(stream.id, groupKey)
+            await publisher.updateEncryptionKey({
+                streamId: stream.id,
+                key: groupKey,
+                distributionMethod: 'rotate'
+            })
             const groupKey2 = GroupKey.generate()
-            await publisher.setNextGroupKey(stream2.id, groupKey2)
+            await publisher.updateEncryptionKey({
+                streamId: stream2.id,
+                key: groupKey2,
+                distributionMethod: 'rotate'
+            })
 
             await testSub(stream)
             await testSub(stream2)
@@ -774,7 +852,10 @@ describeRepeats('decryption', () => {
             // and subscriber errored with something about group key or
             // permissions
 
-            await publisher.rotateGroupKey(stream.id)
+            await publisher.updateEncryptionKey({
+                streamId: stream.id,
+                distributionMethod: 'rotate'
+            })
 
             await stream.grantPermissions({
                 user: await subscriber.getAddress(),
@@ -809,7 +890,10 @@ describeRepeats('decryption', () => {
                             user: await subscriber.getAddress(),
                             permissions: [StreamPermission.SUBSCRIBE]
                         })
-                        await publisher.rekey(stream.id)
+                        await publisher.updateEncryptionKey({
+                            streamId: stream.id,
+                            distributionMethod: 'rekey'
+                        })
                     }
                 }
             })

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -429,7 +429,7 @@ describeRepeats('decryption', () => {
                     auth: {
                         privateKey: publisherPrivateKey
                     },
-                    groupKeys,
+                    encryptionKeys: groupKeys
                 })
 
                 // eslint-disable-next-line require-atomic-updates

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -243,13 +243,13 @@ describeRepeats('decryption', () => {
                 const groupKey1 = GroupKey.generate()
                 const groupKey2 = GroupKey.generate()
                 await publisher.updateEncryptionKey({
-                    streamId: stream.id, 
+                    streamId: stream.id,
                     key: groupKey1,
                     distributionMethod: 'rotate'
                 })
                 await publisher.publish(stream.id, msgs[0])
                 await publisher.updateEncryptionKey({
-                    streamId: stream.id, 
+                    streamId: stream.id,
                     key: groupKey2,
                     distributionMethod: 'rotate'
                 })

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -61,7 +61,11 @@ describe('Group Key Persistence', () => {
                 permissions: [StreamPermission.SUBSCRIBE]
             })
             const groupKey = GroupKey.generate()
-            await publisher.setNextGroupKey(stream.id, groupKey)
+            await publisher.updateEncryptionKey({
+                streamId: stream.id,
+                key: groupKey,
+                distributionMethod: 'rotate'
+            })
         })
 
         describe('publisher persists group key, can keep serving group key requests (resend)', () => {


### PR DESCRIPTION
Add a public API method to update an encryption key:
```
client.updateEncryptionKey({
    streamId: '/foobar',
    distributionMethod: 'rotate'
})
```

Both `rotate` and `rekey` now support an explicit encryption key (earlier only `rotate` method supported it).

The `groupKeys` config option was renamed to `encryptionKeys`.

### Future improvements

- Rename all client classes/methods to use term `EncryptionKey` instead of `GroupKey` (it is a protocol-level term)
- Support path-format in `encryptionKeys` config option
- Fine-tune encryption key exports or annotations: e.g.  `encryptionKeys` config option uses `GroupKeysSerialized` type which we don't export (we could either export `GroupKeysSerialized`, `GroupKeyish` and `GroupKeyObject` or modify the `encryptionKeys` config option to use `GroupKey` objects) 

### Checklist

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog
- [x] Updated Documentation
