### PR TITLE
NET-773: publisher validation issue

### DIFF
--- a/packages/client/src/publish/PublishPipeline.ts
+++ b/packages/client/src/publish/PublishPipeline.ts
@@ -99,12 +99,12 @@ export class PublishPipeline implements Context, Stoppable {
     }
 
     private filterResolved = ([_streamMessage, defer]: PublishQueueOut): boolean => {
-        if (this.isStopped && !defer.isResolved()) {
+        if (this.isStopped && !defer.isSettled()) {
             defer.reject(new ContextError(this, 'Pipeline Stopped. Client probably disconnected'))
             return false
         }
 
-        return !defer.isResolved()
+        return !defer.isSettled()
     }
 
     private async* toStreamMessage(src: AsyncGenerator<PublishQueueIn>): AsyncGenerator<PublishQueueOut> {
@@ -134,7 +134,7 @@ export class PublishPipeline implements Context, Stoppable {
     }
 
     private async signMessage([streamMessage, defer]: PublishQueueOut): Promise<void> {
-        if (defer.isResolved()) { return }
+        if (defer.isSettled()) { return }
         const onError = (err: Error) => {
             defer.reject(err)
         }
@@ -143,7 +143,7 @@ export class PublishPipeline implements Context, Stoppable {
     }
 
     private async validateMessage([streamMessage, defer]: PublishQueueOut): Promise<void> {
-        if (defer.isResolved()) { return }
+        if (defer.isSettled()) { return }
         const onError = (err: Error) => {
             defer.reject(err)
         }
@@ -152,7 +152,7 @@ export class PublishPipeline implements Context, Stoppable {
     }
 
     private async consumeQueue([streamMessage, defer]: PublishQueueOut): Promise<void> {
-        if (defer.isResolved()) { return }
+        if (defer.isSettled()) { return }
 
         try {
             this.check()

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -273,12 +273,13 @@ export type Deferred<T> = ReturnType<DeferredWrapper<T>['wrap']>
 export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => void = noop) {
     let resolveFn: PromiseResolve | undefined
     let rejectFn: PromiseResolve | undefined
-    let isResolved = false
+    let isSettled = false
     const resolve: PromiseResolve = (value) => {
         if (resolveFn) {
             const r = resolveFn
             resolveFn = undefined
             rejectFn = undefined
+            isSettled = true
             r(value)
         }
     }
@@ -287,6 +288,7 @@ export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => 
             const r = rejectFn
             resolveFn = undefined
             rejectFn = undefined
+            isSettled = true
             r(error)
         }
     }
@@ -307,7 +309,7 @@ export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => 
                 reject(err)
                 throw err
             } finally {
-                isResolved = true
+                isSettled = true
             }
         }
     }
@@ -337,8 +339,8 @@ export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => 
         wrap,
         wrapError,
         handleErrBack,
-        isResolved() {
-            return isResolved
+        isSettled() {
+            return isSettled
         },
     })
 }

--- a/packages/client/test/end-to-end/publisher-message-validation.test.ts
+++ b/packages/client/test/end-to-end/publisher-message-validation.test.ts
@@ -5,9 +5,11 @@ import { StreamID } from 'streamr-client-protocol'
 
 const createClient = getCreateClient()
 
-const TIMEOUT = 10 * 1000
+const TIMEOUT = 20 * 1000
 
-describe('publisher message validation', () => {
+const PROPAGATION_WAIT_TIME = 2000
+
+describe('publisher message validation (NET-773)', () => {
     let publisherClient: StreamrClient
     let subscriberClient: StreamrClient
     let streamId: StreamID
@@ -38,7 +40,7 @@ describe('publisher message validation', () => {
         await expect(publisherClient.publish(streamId, { not: 'allowed' }))
             .rejects
             .toThrow(/is not a publisher on stream/)
-        await wait(2000)
+        await wait(PROPAGATION_WAIT_TIME)
         expect(subscriberReceivedMsgs).toEqual(0)
     }, TIMEOUT)
 })

--- a/packages/client/test/end-to-end/publisher-message-validation.test.ts
+++ b/packages/client/test/end-to-end/publisher-message-validation.test.ts
@@ -30,17 +30,15 @@ describe('publisher message validation (NET-773)', () => {
     }, TIMEOUT)
 
     it('publishing message with insufficient permissions prevents message from getting sent to network', async () => {
-        let subscriberReceivedMsgs = 0
-        const subscription = await subscriberClient.subscribe(streamId, () => {
-            subscriberReceivedMsgs += 1
-        })
-        subscription.onError((_err) => {
-            subscriberReceivedMsgs += 1
-        })
+        const onMessage = jest.fn()
+        const onError = jest.fn()
+        const subscription = await subscriberClient.subscribe(streamId, onMessage)
+        subscription.onError(onError)
         await expect(publisherClient.publish(streamId, { not: 'allowed' }))
             .rejects
             .toThrow(/is not a publisher on stream/)
         await wait(PROPAGATION_WAIT_TIME)
-        expect(subscriberReceivedMsgs).toEqual(0)
+        expect(onMessage).not.toHaveBeenCalled()
+        expect(onError).not.toHaveBeenCalled()
     }, TIMEOUT)
 })

--- a/packages/client/test/end-to-end/publisher-message-validation.test.ts
+++ b/packages/client/test/end-to-end/publisher-message-validation.test.ts
@@ -27,7 +27,7 @@ describe('publisher message validation', () => {
         streamId = stream.id
     }, TIMEOUT)
 
-    it('invalid message does not get published', async () => {
+    it('publishing message with insufficient permissions prevents message from getting sent to network', async () => {
         let subscriberReceivedMsgs = 0
         const subscription = await subscriberClient.subscribe(streamId, () => {
             subscriberReceivedMsgs += 1

--- a/packages/client/test/end-to-end/publisher-message-validation.test.ts
+++ b/packages/client/test/end-to-end/publisher-message-validation.test.ts
@@ -1,0 +1,44 @@
+import { StreamrClient } from '../../src'
+import { createTestStream, fetchPrivateKeyWithGas, getCreateClient } from '../test-utils/utils'
+import { fastPrivateKey, wait } from 'streamr-test-utils'
+import { StreamID } from 'streamr-client-protocol'
+
+const createClient = getCreateClient()
+
+const TIMEOUT = 10 * 1000
+
+describe('publisher message validation', () => {
+    let publisherClient: StreamrClient
+    let subscriberClient: StreamrClient
+    let streamId: StreamID
+
+    beforeEach(async () => {
+        publisherClient = await createClient({
+            auth: {
+                privateKey: fastPrivateKey()
+            }
+        })
+        subscriberClient = await createClient({
+            auth: {
+                privateKey: await fetchPrivateKeyWithGas()
+            }
+        })
+        const stream = await createTestStream(subscriberClient, module)
+        streamId = stream.id
+    }, TIMEOUT)
+
+    it('invalid message does not get published', async () => {
+        let subscriberReceivedMsgs = 0
+        const subscription = await subscriberClient.subscribe(streamId, () => {
+            subscriberReceivedMsgs += 1
+        })
+        subscription.onError((_err) => {
+            subscriberReceivedMsgs += 1
+        })
+        await expect(publisherClient.publish(streamId, { not: 'allowed' }))
+            .rejects
+            .toThrow(/is not a publisher on stream/)
+        await wait(2000)
+        expect(subscriberReceivedMsgs).toEqual(0)
+    }, TIMEOUT)
+})


### PR DESCRIPTION
Prevents the publishing of a message to the network if the publisher does not have publish permission on the stream.

### Changes
- Add an end-to-end test that verifies the above statement.
- Modify "class" `Defer` by replacing `isResolved` with `isSettled`, which also covers rejections.

## Checklist

- [ ] Has passing tests that demonstrate this change works
