### PR TITLE
refactor(network): MetricsContext without id

### DIFF
--- a/packages/broker/test/unit/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/unit/plugins/metrics/node/NodeMetrics.test.ts
@@ -23,7 +23,7 @@ describe('NodeMetrics', () => {
     let updateMockMetricsData: any
 
     beforeEach(() => {
-        const metricsContext = new MetricsContext('')
+        const metricsContext = new MetricsContext()
         const webRtcMetricsProducer = metricsContext.create('WebRtcEndpoint')
             .addRecordedMetric('inSpeed')
             .addRecordedMetric('outSpeed')

--- a/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
@@ -48,7 +48,7 @@ describe('DataQueryEndpoints', () => {
     beforeEach(() => {
         app = express()
         storage = {} as Storage
-        app.use(restEndpointRouter(storage, new MetricsContext(null as any)))
+        app.use(restEndpointRouter(storage, new MetricsContext()))
     })
 
     describe('Getting last events', () => {

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -102,7 +102,7 @@ export class BrubeckNode implements Context {
             name: id,
             ...networkOptions,
             id,
-            metricsContext: new MetricsContext(options.name ?? id)
+            metricsContext: new MetricsContext()
         })
 
         if (!this.destroySignal.isDestroyed()) {

--- a/packages/network-tracker/src/logic/Tracker.ts
+++ b/packages/network-tracker/src/logic/Tracker.ts
@@ -120,7 +120,7 @@ export class Tracker extends EventEmitter {
             throw new Error('Provided protocols are not correct')
         }
 
-        const metricsContext = opts.metricsContext || new MetricsContext('')
+        const metricsContext = opts.metricsContext || new MetricsContext()
         this.maxNeighborsPerNode = opts.maxNeighborsPerNode
         this.trackerServer = opts.protocols.trackerServer
         this.peerInfo = opts.peerInfo

--- a/packages/network-tracker/src/startTracker.ts
+++ b/packages/network-tracker/src/startTracker.ts
@@ -28,7 +28,7 @@ export const startTracker = async ({
     location,
     attachHttpEndpoints = true,
     maxNeighborsPerNode = DEFAULT_MAX_NEIGHBOR_COUNT,
-    metricsContext = new MetricsContext(id),
+    metricsContext = new MetricsContext(),
     trackerPingInterval,
     privateKeyFileName,
     certFileName,

--- a/packages/network-tracker/test/integration/tracker-endpoints.test.ts
+++ b/packages/network-tracker/test/integration/tracker-endpoints.test.ts
@@ -311,8 +311,6 @@ describe('tracker endpoint', () => {
     it('/metrics/', async () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/metrics/`)
         expect(status).toEqual(200)
-        expect(jsonResult.peerId).toEqual(tracker.getTrackerId())
-        expect(jsonResult.startTime).toBeGreaterThan(1600000000000)
         expect(jsonResult.metrics).not.toBeUndefined()
     })
 

--- a/packages/network-tracker/test/unit/InstructionSender.test.ts
+++ b/packages/network-tracker/test/unit/InstructionSender.test.ts
@@ -29,7 +29,7 @@ describe('InstructionSender', () => {
     beforeEach(() => {
         jest.useFakeTimers()
         jest.setSystemTime(STARTUP_TIME)
-        metrics = new MetricsContext('').create('test')
+        metrics = new MetricsContext().create('test')
         send = jest.fn().mockResolvedValue(true)
         sender = new InstructionSender({
             debounceWait: DEBOUNCE_WAIT,

--- a/packages/network/bin/publisher.js
+++ b/packages/network/bin/publisher.js
@@ -47,7 +47,7 @@ function generateString(length) {
     return result
 }
 
-const metricsContext = new MetricsContext(id)
+const metricsContext = new MetricsContext()
 const publisher = createNetworkNode({
     name,
     id,

--- a/packages/network/bin/subscriber.js
+++ b/packages/network/bin/subscriber.js
@@ -21,7 +21,7 @@ program
 const id = program.opts().id || 'SU'
 const name = program.opts().nodeName || id
 const logger = new Logger(module)
-const metricsContext = new MetricsContext(id)
+const metricsContext = new MetricsContext()
 
 const trackerInfos = program.opts().trackers.map((ws, i) => {
     return {

--- a/packages/network/bin/tracker.js
+++ b/packages/network/bin/tracker.js
@@ -43,7 +43,7 @@ const getTopologyStabilization = () => {
 }
 
 async function main() {
-    const metricsContext = new MetricsContext(id)
+    const metricsContext = new MetricsContext()
     try {
         await startTracker({
             listen,

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -31,7 +31,7 @@ export const createNetworkNode = ({
     name,
     location,
     trackers,
-    metricsContext = new MetricsContext(id),
+    metricsContext = new MetricsContext(),
     peerPingInterval,
     trackerPingInterval,
     disconnectionWaitTime,

--- a/packages/network/src/helpers/MetricsContext.ts
+++ b/packages/network/src/helpers/MetricsContext.ts
@@ -1,4 +1,3 @@
-import { PeerId } from '../connection/PeerInfo'
 import { Speedometer } from './Speedometer'
 
 type QueryFn = () => (Promise<number> | number | Promise<Record<string, unknown>> | Record<string, unknown>)
@@ -12,7 +11,6 @@ interface IndividualReport {
 }
 
 interface Report {
-    peerId: PeerId
     startTime: number
     currentTime: number
     metrics: {
@@ -120,14 +118,12 @@ export class Metrics {
 }
 
 export class MetricsContext {
-    private readonly peerId: PeerId
     private readonly startTime: number
     private readonly metrics: {
         [key: string]: Metrics
     }
 
-    constructor(peerId: PeerId) {
-        this.peerId = peerId
+    constructor() {
         this.startTime = Date.now()
         this.metrics = {}
     }
@@ -149,7 +145,6 @@ export class MetricsContext {
             Object.values(this.metrics).forEach((metrics) => metrics.clearLast())
         }
         return {
-            peerId: this.peerId,
             startTime: this.startTime,
             currentTime: Date.now(),
             metrics: Object.fromEntries(entries),

--- a/packages/network/src/helpers/MetricsContext.ts
+++ b/packages/network/src/helpers/MetricsContext.ts
@@ -11,8 +11,6 @@ interface IndividualReport {
 }
 
 interface Report {
-    startTime: number
-    currentTime: number
     metrics: {
         [key: string]: IndividualReport
     }
@@ -118,13 +116,11 @@ export class Metrics {
 }
 
 export class MetricsContext {
-    private readonly startTime: number
     private readonly metrics: {
         [key: string]: Metrics
     }
 
     constructor() {
-        this.startTime = Date.now()
         this.metrics = {}
     }
 
@@ -145,8 +141,6 @@ export class MetricsContext {
             Object.values(this.metrics).forEach((metrics) => metrics.clearLast())
         }
         return {
-            startTime: this.startTime,
-            currentTime: Date.now(),
             metrics: Object.fromEntries(entries),
         }
     }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -96,7 +96,7 @@ export class Node extends EventEmitter {
         this.started = new Date().toLocaleString()
         this.acceptProxyConnections = opts.acceptProxyConnections || false
 
-        this.metricsContext = opts.metricsContext || new MetricsContext('')
+        this.metricsContext = opts.metricsContext || new MetricsContext()
         this.metrics = this.metricsContext.create('node')
             .addFixedMetric('latency')
         this.publishMetrics = this.metricsContext.create('node/publish')

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -52,7 +52,7 @@ describe('delivery of messages in protocol layer', () => {
             peerInfo1,
             [],
             new RtcSignaller(peerInfo1, nodeToTracker),
-            new MetricsContext('node1'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory
         )
@@ -60,7 +60,7 @@ describe('delivery of messages in protocol layer', () => {
             peerInfo2,
             [],
             new RtcSignaller(peerInfo2, nodeToTracker2),
-            new MetricsContext('node2'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
         )

--- a/packages/network/test/integration/latency.test.ts
+++ b/packages/network/test/integration/latency.test.ts
@@ -18,7 +18,7 @@ describe('latency metrics', () => {
             }
         })
         const trackerInfo = tracker.getConfigRecord()
-        metricsContext = new MetricsContext('node1')
+        metricsContext = new MetricsContext()
         node = createNetworkNode({
             id: 'node1',
             trackers: [trackerInfo],

--- a/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
+++ b/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
@@ -52,7 +52,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             peerInfo1,
             [],
             new RtcSignaller(peerInfo1, nodeToTracker1),
-            new MetricsContext('node-endpoint1'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory,
             5000
@@ -61,7 +61,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             peerInfo2,
             [],
             new RtcSignaller(peerInfo2, nodeToTracker2),
-            new MetricsContext('node-endpoint2'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory,
             5000
@@ -70,7 +70,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             peerInfo3,
             [],
             new RtcSignaller(peerInfo3, nodeToTracker3),
-            new MetricsContext('node-endpoint3'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo3),
             NodeWebRtcConnectionFactory,
             5000

--- a/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -41,7 +41,7 @@ describe('WebRtcEndpoint: back pressure handling', () => {
             peerInfo1,
             ['stun:stun.l.google.com:19302'],
             new RtcSignaller(peerInfo1, nodeToTracker1),
-            new MetricsContext('ep1'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory
         )
@@ -49,7 +49,7 @@ describe('WebRtcEndpoint: back pressure handling', () => {
             peerInfo2,
             ['stun:stun.l.google.com:19302'],
             new RtcSignaller(peerInfo2, nodeToTracker2),
-            new MetricsContext('ep'),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
         )

--- a/packages/network/test/integration/webrtc-multi-signaller.test.ts
+++ b/packages/network/test/integration/webrtc-multi-signaller.test.ts
@@ -64,7 +64,7 @@ describe('WebRTC multisignaller test', () => {
             peerInfo1,
             ['stun:stun.l.google.com:19302'],
             new RtcSignaller(peerInfo1, nodeToTracker1),
-            new MetricsContext(''),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
             NodeWebRtcConnectionFactory
         )
@@ -72,7 +72,7 @@ describe('WebRTC multisignaller test', () => {
             peerInfo2,
             ['stun:stun.l.google.com:19302'],
             new RtcSignaller(peerInfo2, nodeToTracker2),
-            new MetricsContext(''),
+            new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
             NodeWebRtcConnectionFactory
         )

--- a/packages/network/test/unit/MetricsContext.test.ts
+++ b/packages/network/test/unit/MetricsContext.test.ts
@@ -19,9 +19,6 @@ describe('metrics', () => {
     it('empty report', async () => {
         const rep = await context.report(false)
         expect(rep).toEqual({
-            peerId: 'peerId',
-            startTime: 100,
-            currentTime: 100,
             metrics: {}
         })
     })
@@ -33,9 +30,6 @@ describe('metrics', () => {
 
         const rep = await context.report()
         expect(rep).toEqual({
-            peerId: 'peerId',
-            startTime: 100,
-            currentTime: 100,
             metrics: {
                 metricOne: {},
                 metricTwo: {},
@@ -63,9 +57,6 @@ describe('metrics', () => {
 
         const rep = await context.report()
         expect(rep).toEqual({
-            peerId: 'peerId',
-            startTime: 100,
-            currentTime: 100,
             metrics: {
                 metricOne: {
                     a: 666,

--- a/packages/network/test/unit/MetricsContext.test.ts
+++ b/packages/network/test/unit/MetricsContext.test.ts
@@ -8,7 +8,7 @@ describe('metrics', () => {
     beforeEach(() => {
         jest.useFakeTimers('modern')
         jest.setSystemTime(STARTUP_TIME)
-        context = new MetricsContext('peerId')
+        context = new MetricsContext()
     })
 
     afterEach(() => {

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -48,7 +48,7 @@ describe('WebRtcEndpoint', () => {
                 peerInfo1,
                 ["stun:stun.l.google.com:19302"],
                 new RtcSignaller(peerInfo1, nodeToTracker1),
-                new MetricsContext(''),
+                new MetricsContext(),
                 new NegotiatedProtocolVersions(peerInfo1),
                 factory
             )
@@ -56,7 +56,7 @@ describe('WebRtcEndpoint', () => {
                 peerInfo2,
                 ["stun:stun.l.google.com:19302"],
                 new RtcSignaller(peerInfo2, nodeToTracker2),
-                new MetricsContext(''),
+                new MetricsContext(),
                 new NegotiatedProtocolVersions(peerInfo2),
                 factory
             )
@@ -453,7 +453,7 @@ describe('WebRtcEndpoint', () => {
                 peerInfo,
                 [],
                 new RtcSignaller(peerInfo, nodeToTracker),
-                new MetricsContext(''),
+                new MetricsContext(),
                 new NegotiatedProtocolVersions(peerInfo),
                 NodeWebRtcConnectionFactory,
                 15000,    // newConnectionTimeout


### PR DESCRIPTION
Do not store `peerId` and `startTime` for `MetricsContext`.

Remove also `currentTime` from `context.report()` output.

## Future improvements

- After this PR `client.network.name` is not used anymore. Note that in `BrubeckNode.ts` we pass `id` instead of `name` as an argument to `createNetworkNode()`. We could use `client.name ?? client.id` there, or remove the `name` config option. https://github.com/streamr-dev/network-monorepo/blob/2e789c6c6513c684e41505741bf8777a28c4b763/packages/client/src/BrubeckNode.ts#L102