### PR TITLE
fix(client): Publish encrypted messages

### DIFF
--- a/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
+++ b/packages/broker/test/integration/plugins/storage/DataMetadataEndpoints.test.ts
@@ -99,7 +99,7 @@ describe('DataMetadataEndpoints', () => {
         const res = JSON.parse(json)
 
         expect(status).toEqual(200)
-        expect(res.totalBytes).toEqual(1443)
+        expect(res.totalBytes).toEqual(1775)
         expect(res.totalMessages).toEqual(4)
         expect(
             new Date(res.firstMessage).getTime()

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix stream encryption: messages weren't automatically encrypted if the local database didn't contain pre-existing encryption keys for a stream
 - Fix timeout issue of method `addToStorageNode` when used with storage node cluster
 
 ### Security

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -55,11 +55,6 @@ export class Encrypt implements Stoppable {
 
         const stream = await this.streamEndpoints.getStream(streamId)
 
-        if (!(await (this.keyExchange.hasAnyGroupKey(stream.id)))) {
-            // not needed
-            return
-        }
-
         const [groupKey, nextGroupKey] = await this.keyExchange.useGroupKey(stream.id)
         if (this.isStopped) { return }
 

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -12,7 +12,7 @@ import { Stoppable } from '../utils/Stoppable'
 import { instanceId } from '../utils'
 
 type IDecrypt<T> = {
-    decrypt: (streamMessage: StreamMessage<T>) => Promise<void>
+    decrypt: (streamMessage: StreamMessage<T>) => Promise<StreamMessage<T>>
 }
 
 export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
@@ -36,17 +36,17 @@ export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
         })
     }
 
-    async decrypt(streamMessage: StreamMessage<T>) {
+    async decrypt(streamMessage: StreamMessage<T>): Promise<StreamMessage<T>> {
         if (this.isStopped) {
-            return
+            return streamMessage
         }
 
         if (!streamMessage.groupKeyId) {
-            return
+            return streamMessage
         }
 
         if (streamMessage.encryptionType !== StreamMessage.ENCRYPTION_TYPES.AES) {
-            return
+            return streamMessage
         }
 
         try {
@@ -61,11 +61,17 @@ export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
                 ].join(' '), streamMessage)
             }
 
-            if (this.isStopped) { return }
-            EncryptionUtil.decryptStreamMessage(streamMessage, groupKey)
-            await this.keyExchange.addNewKey(streamMessage)
+            if (this.isStopped) { 
+                return streamMessage
+            }
+            const clone = StreamMessage.deserialize(streamMessage.serialize())
+            EncryptionUtil.decryptStreamMessage(clone, groupKey)
+            await this.keyExchange.addNewKey(clone)
+            return clone as StreamMessage<T>
         } catch (err) {
-            if (this.isStopped) { return }
+            if (this.isStopped) { 
+                return streamMessage
+            }
             this.debug('Decrypt Error', err)
             // clear cached permissions if cannot decrypt, likely permissions need updating
             this.streamEndpoints.clearStream(streamMessage.getStreamId())

--- a/packages/client/src/subscribe/SubscribePipeline.ts
+++ b/packages/client/src/subscribe/SubscribePipeline.ts
@@ -91,7 +91,7 @@ export function SubscribePipeline<T = unknown>(
             await validate.validate(streamMessage)
         })
         // decrypt
-        .forEach(decrypt.decrypt)
+        .map(decrypt.decrypt)
         // parse content
         .forEach(async (streamMessage) => {
             streamMessage.getParsedContent()

--- a/packages/client/test/end-to-end/Basics.test.ts
+++ b/packages/client/test/end-to-end/Basics.test.ts
@@ -1,15 +1,16 @@
 import { wait } from 'streamr-test-utils'
 
-import { describeRepeats, uid, getCreateClient, Msg, publishManyGenerator } from '../test-utils/utils'
+import { getCreateClient, Msg, publishManyGenerator, uid } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
 import { Stream } from '../../src/Stream'
+import { StreamPermission } from '../../src'
 
 const TEST_TIMEOUT = 60 * 1000
 
 jest.setTimeout(TEST_TIMEOUT)
 
-describeRepeats('StreamrClient', () => {
+describe('StreamrClient', () => {
     const MAX_MESSAGES = 10
     let expectErrors = 0 // check no errors by default
     let errors: any[] = []
@@ -52,6 +53,7 @@ describeRepeats('StreamrClient', () => {
         client = await createClient()
         client.debug('create stream >>')
         stream = await createStream()
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         client.debug('create stream <<')
         expect(onError).toHaveBeenCalledTimes(0)
     })
@@ -115,6 +117,8 @@ describeRepeats('StreamrClient', () => {
                 return expect(received.map((streamMessage) => streamMessage.getTimestamp())).toEqual(published.map(() => 1111111))
             }
             const stream2 = await createStream()
+            await stream2.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
+
             const tasks = [
                 testPubSub(stream),
                 testPubSub(stream2),

--- a/packages/client/test/end-to-end/MultipleClients.test.ts
+++ b/packages/client/test/end-to-end/MultipleClients.test.ts
@@ -1,7 +1,12 @@
 import { wait, waitForCondition } from 'streamr-test-utils'
 
 import {
-    getCreateClient, getPublishTestMessages, describeRepeats, uid, addAfterFn, createTestStream, fetchPrivateKeyWithGas,
+    addAfterFn,
+    createTestStream,
+    fetchPrivateKeyWithGas,
+    getCreateClient,
+    getPublishTestMessages,
+    uid,
 } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils'
@@ -15,7 +20,7 @@ jest.setTimeout(50000)
 // in time to see any realtime messages
 const MAX_MESSAGES = 10
 
-describeRepeats('PubSub with multiple clients', () => {
+describe('PubSub with multiple clients', () => {
     let stream: Stream
     let mainClient: StreamrClient
     let otherClient: StreamrClient
@@ -486,9 +491,7 @@ describeRepeats('PubSub with multiple clients', () => {
                 privateKey: await fetchPrivateKeyWithGas()
             }
         })
-        // otherClient.on('error', getOnError(errors))
-        const otherUser = await otherClient.getAddress()
-        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user: otherUser })
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         await otherClient.connect()
 
         const receivedMessagesOther: Record<string, any[]> = {}

--- a/packages/client/test/end-to-end/ResendAll.test.ts
+++ b/packages/client/test/end-to-end/ResendAll.test.ts
@@ -5,11 +5,11 @@ import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import {
     createTestStream,
-    describeRepeats,
     fetchPrivateKeyWithGas,
     getPublishTestStreamMessages,
     getWaitForStorage
 } from '../test-utils/utils'
+import { StreamPermission } from '../../src'
 
 const NUM_MESSAGES = 8
 const PARTITIONS = 3
@@ -17,7 +17,7 @@ const WAIT_FOR_STORAGE_TIMEOUT = process.env.CI ? 20000 : 10000
 
 jest.setTimeout(60000)
 
-describeRepeats('ResendAll', () => {
+describe('ResendAll', () => {
     let client: StreamrClient
     let stream: Stream
     let publishTestMessages: ReturnType<typeof getPublishTestStreamMessages>
@@ -42,6 +42,7 @@ describeRepeats('ResendAll', () => {
         stream = await createTestStream(client, module, {
             partitions: PARTITIONS,
         })
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         client.debug('createStream <<')
         client.debug('addToStorageNode >>')
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)

--- a/packages/client/test/end-to-end/SubscribeAll.test.ts
+++ b/packages/client/test/end-to-end/SubscribeAll.test.ts
@@ -1,6 +1,6 @@
 import { wait, waitForCondition } from 'streamr-test-utils'
 
-import { getPublishTestMessages, createTestStream, getCreateClient, describeRepeats } from '../test-utils/utils'
+import { createTestStream, getCreateClient, getPublishTestMessages } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
 import { Stream } from '../../src/Stream'
@@ -11,7 +11,7 @@ const MAX_MESSAGES = 4
 const PARTITIONS = 3
 jest.setTimeout(60000)
 
-describeRepeats('SubscribeAll', () => {
+describe('SubscribeAll', () => {
     let expectErrors = 0 // check no errors by default
     let onError = jest.fn()
     let client: StreamrClient
@@ -107,10 +107,11 @@ describeRepeats('SubscribeAll', () => {
         const publishedMsgs = pubs.flat()
         expect(publishedMsgs.length).toBe(PARTITIONS * NUM_MESSAGES)
         await sub.onFinally()
+        await wait(500) // TODO: why is this wait needed? wasn't needed before encryption was enabled.
         // got the messages
         expect(subMsgs).toHaveLength(MAX_MESSAGES)
         // unsubscribed from everything
-        expect(client.countAll()).toBe(0)
+        expect(await client.count(stream.id)).toBe(0)
     })
 
     it('stops with unsubscribeAll', async () => {
@@ -149,7 +150,7 @@ describeRepeats('SubscribeAll', () => {
         await waitForCondition(() => subMsgs.length >= (PARTITIONS * NUM_MESSAGES), 25000)
         expect(onFinallyCalled).toHaveBeenCalledTimes(0)
         // unsub from each partition
-        // should only onFinally once all unsubbed
+        // should only call onFinally once all unsubbed
         for (const p of range(PARTITIONS)) {
             expect(onFinallyCalled).toHaveBeenCalledTimes(0)
             // eslint-disable-next-line no-await-in-loop
@@ -165,6 +166,6 @@ describeRepeats('SubscribeAll', () => {
         // got the messages
         expect(subMsgs.length).toBe(PARTITIONS * NUM_MESSAGES)
         // unsubscribed from everything
-        expect(client.countAll()).toBe(0)
+        expect(await client.count(stream.id)).toBe(0)
     })
 })

--- a/packages/client/test/end-to-end/SubscriberResendsSequential.test.ts
+++ b/packages/client/test/end-to-end/SubscriberResendsSequential.test.ts
@@ -1,10 +1,9 @@
 import {
-    Msg,
-    describeRepeats,
-    fetchPrivateKeyWithGas,
-    getWaitForStorage,
-    getPublishTestStreamMessages,
     createTestStream,
+    fetchPrivateKeyWithGas,
+    getPublishTestStreamMessages,
+    getWaitForStorage,
+    Msg,
 } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { ConfigTest, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
@@ -17,7 +16,7 @@ const ITERATIONS = 4
 
 jest.setTimeout(30000)
 
-describeRepeats('sequential resend subscribe', () => {
+describe('sequential resend subscribe', () => {
     let publisher: StreamrClient
     let subscriber: StreamrClient
     let stream: Stream
@@ -45,6 +44,7 @@ describeRepeats('sequential resend subscribe', () => {
         })
 
         stream = await createTestStream(publisher, module)
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
 
         publishTestMessages = getPublishTestStreamMessages(publisher, stream)

--- a/packages/client/test/end-to-end/Validation.test.ts
+++ b/packages/client/test/end-to-end/Validation.test.ts
@@ -1,14 +1,15 @@
-import { getPublishTestMessages, getCreateClient, describeRepeats, createTestStream } from '../test-utils/utils'
+import { createTestStream, getCreateClient, getPublishTestMessages } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
 import { Stream } from '../../src/Stream'
 import { Subscriber } from '../../src/subscribe/Subscriber'
 import { Subscription } from '../../src/subscribe/Subscription'
+import { StreamPermission } from '../../src'
 
 const MAX_MESSAGES = 10
 jest.setTimeout(30000)
 
-describeRepeats('Validation', () => {
+describe('Validation', () => {
     let publishTestMessages: ReturnType<typeof getPublishTestMessages>
     let client: StreamrClient
     let stream: Stream
@@ -25,6 +26,7 @@ describeRepeats('Validation', () => {
         stream = await createTestStream(client, module, {
             requireSignedData: true
         })
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         client.debug('connecting before test <<')
         publishTestMessages = getPublishTestMessages(client, stream.id)
         return client

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -1,0 +1,111 @@
+import { fastPrivateKey, waitForCondition } from 'streamr-test-utils'
+import { createTestStream, fetchPrivateKeyWithGas } from '../test-utils/utils'
+import { ConfigTest, Stream, StreamPermission, StreamrClient } from '../../src'
+import { createNetworkNode, NetworkNode } from 'streamr-network'
+import { toStreamPartID } from 'streamr-client-protocol'
+
+const TIMEOUT = 10 * 1000
+
+const PAYLOAD = { hello: 'world' }
+
+const ENCRYPTED_MESSSAGE_FORMAT = /^[0-9A-Fa-f]+$/
+
+describe('publish-subscribe', () => {
+    let publisherClient: StreamrClient
+    let subscriberClient: StreamrClient
+    let networkNode: NetworkNode
+
+    beforeEach(async () => {
+        publisherClient = new StreamrClient({
+            ...ConfigTest,
+            auth: {
+                privateKey: await fetchPrivateKeyWithGas()
+            }
+        })
+        subscriberClient = new StreamrClient({
+            ...ConfigTest,
+            auth: {
+                privateKey: fastPrivateKey()
+            }
+        })
+        networkNode = await createNetworkNode({
+            ...ConfigTest.network,
+            id: 'networkNode',
+        })
+    }, TIMEOUT)
+
+    afterEach(async () => {
+        await Promise.allSettled([
+            publisherClient?.destroy(),
+            subscriberClient?.destroy(),
+            networkNode?.stop()
+        ])
+    }, TIMEOUT)
+
+    describe('non-public stream', () => {
+        let stream: Stream
+
+        beforeEach(async () => {
+            stream = await createTestStream(publisherClient, module)
+            await stream.grantPermissions({
+                permissions: [StreamPermission.SUBSCRIBE],
+                user: await subscriberClient.getAddress()
+            })
+        }, TIMEOUT)
+
+        it('messages are published encrypted', async () => {
+            const messages: unknown[] = []
+            await networkNode.subscribeAndWaitForJoin(toStreamPartID(stream.id, 0), 4999)
+            networkNode.addMessageListener((msg) => {
+                messages.push(msg.getContent())
+            })
+            await publisherClient.publish(stream.id, PAYLOAD)
+            await waitForCondition(() => messages.length > 0)
+            expect(messages).toHaveLength(1)
+            expect(messages[0]).toMatch(ENCRYPTED_MESSSAGE_FORMAT)
+        }, TIMEOUT)
+
+        it('subscriber is able to receive and decrypt messages', async () => {
+            const messages: unknown[] = []
+            await subscriberClient.subscribe(stream.id, (msg) => {
+                messages.push(msg)
+            })
+            await publisherClient.publish(stream.id, PAYLOAD)
+            await waitForCondition(() => messages.length > 0)
+            expect(messages).toEqual([PAYLOAD])
+        }, TIMEOUT)
+    })
+
+    describe('public stream', () => {
+        let stream: Stream
+
+        beforeEach(async () => {
+            stream = await createTestStream(publisherClient, module)
+            await stream.grantPermissions({
+                permissions: [StreamPermission.SUBSCRIBE],
+                public: true
+            })
+        }, TIMEOUT)
+
+        it('messages are published unencrypted', async () => {
+            const messages: unknown[] = []
+            await networkNode.subscribeAndWaitForJoin(toStreamPartID(stream.id, 0), 4999)
+            networkNode.addMessageListener((msg) => {
+                messages.push(msg.getContent())
+            })
+            await publisherClient.publish(stream.id, PAYLOAD)
+            await waitForCondition(() => messages.length > 0)
+            expect(messages).toEqual([PAYLOAD])
+        }, TIMEOUT)
+
+        it('subscriber is able to receive messages', async () => {
+            const messages: unknown[] = []
+            await subscriberClient.subscribe(stream.id, (msg) => {
+                messages.push(msg)
+            })
+            await publisherClient.publish(stream.id, PAYLOAD)
+            await waitForCondition(() => messages.length > 0)
+            expect(messages).toEqual([PAYLOAD])
+        }, TIMEOUT)
+    })
+})

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -1,66 +1,100 @@
-import { fastPrivateKey, waitForCondition } from 'streamr-test-utils'
+import { waitForCondition } from 'streamr-test-utils'
 import { createTestStream, fetchPrivateKeyWithGas } from '../test-utils/utils'
-import { ConfigTest, Stream, StreamPermission, StreamrClient } from '../../src'
-import { createNetworkNode, NetworkNode } from 'streamr-network'
-import { toStreamPartID } from 'streamr-client-protocol'
+import { ConfigTest, PermissionAssignment, Stream, StreamPermission, StreamrClient } from '../../src'
+import { createNetworkNode } from 'streamr-network'
+import { StreamID, toStreamPartID } from 'streamr-client-protocol'
+import { Wallet } from 'ethers'
 
-const TIMEOUT = 10 * 1000
+const TIMEOUT = 20 * 1000
 
 const PAYLOAD = { hello: 'world' }
 
 const ENCRYPTED_MESSSAGE_FORMAT = /^[0-9A-Fa-f]+$/
 
+async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID): Promise<unknown[]> {
+    const networkNode = await createNetworkNode({
+        ...ConfigTest.network,
+        id: 'networkNode',
+    })
+    try {
+        networkNode.subscribe(toStreamPartID(streamId, 0))
+        const messages: unknown[] = []
+        networkNode.addMessageListener((msg) => {
+            messages.push(msg.getContent())
+        })
+        await waitForCondition(() => messages.length > 0, TIMEOUT - 100)
+        return messages
+    } finally {
+        await networkNode.stop()
+    }
+}
+
+async function createStreamWithPermissions(
+    privateKey: string,
+    ...assignments: PermissionAssignment[]
+): Promise<Stream> {
+    const creatorClient = new StreamrClient({
+        ...ConfigTest,
+        auth: {
+            privateKey
+        }
+    })
+    try {
+        const stream = await createTestStream(creatorClient, module)
+        await stream.grantPermissions(...assignments)
+        return stream
+    } finally {
+        await creatorClient.destroy()
+    }
+}
+
 describe('publish-subscribe', () => {
+    let subscriberWallet: Wallet
+    let publisherPk: string
     let publisherClient: StreamrClient
     let subscriberClient: StreamrClient
-    let networkNode: NetworkNode
+
+    beforeAll(async () => {
+        subscriberWallet = Wallet.createRandom()
+        publisherPk = await fetchPrivateKeyWithGas()
+    })
 
     beforeEach(async () => {
         publisherClient = new StreamrClient({
             ...ConfigTest,
             auth: {
-                privateKey: await fetchPrivateKeyWithGas()
+                privateKey: publisherPk
             }
         })
         subscriberClient = new StreamrClient({
             ...ConfigTest,
             auth: {
-                privateKey: fastPrivateKey()
+                privateKey: subscriberWallet.privateKey
             }
         })
-        networkNode = await createNetworkNode({
-            ...ConfigTest.network,
-            id: 'networkNode',
-        })
+
     }, TIMEOUT)
 
     afterEach(async () => {
         await Promise.allSettled([
             publisherClient?.destroy(),
             subscriberClient?.destroy(),
-            networkNode?.stop()
         ])
     }, TIMEOUT)
 
     describe('non-public stream', () => {
         let stream: Stream
 
-        beforeEach(async () => {
-            stream = await createTestStream(publisherClient, module)
-            await stream.grantPermissions({
+        beforeAll(async () => {
+            stream = await createStreamWithPermissions(publisherPk, {
                 permissions: [StreamPermission.SUBSCRIBE],
-                user: await subscriberClient.getAddress()
+                user: subscriberWallet.address
             })
         }, TIMEOUT)
 
         it('messages are published encrypted', async () => {
-            const messages: unknown[] = []
-            await networkNode.subscribeAndWaitForJoin(toStreamPartID(stream.id, 0), 4999)
-            networkNode.addMessageListener((msg) => {
-                messages.push(msg.getContent())
-            })
             await publisherClient.publish(stream.id, PAYLOAD)
-            await waitForCondition(() => messages.length > 0)
+            const messages = await startNetworkNodeAndListenForAtLeastOneMessage(stream.id)
             expect(messages).toHaveLength(1)
             expect(messages[0]).toMatch(ENCRYPTED_MESSSAGE_FORMAT)
         }, TIMEOUT)
@@ -79,22 +113,16 @@ describe('publish-subscribe', () => {
     describe('public stream', () => {
         let stream: Stream
 
-        beforeEach(async () => {
-            stream = await createTestStream(publisherClient, module)
-            await stream.grantPermissions({
+        beforeAll(async () => {
+            stream = await createStreamWithPermissions(publisherPk, {
                 permissions: [StreamPermission.SUBSCRIBE],
                 public: true
             })
         }, TIMEOUT)
 
         it('messages are published unencrypted', async () => {
-            const messages: unknown[] = []
-            await networkNode.subscribeAndWaitForJoin(toStreamPartID(stream.id, 0), 4999)
-            networkNode.addMessageListener((msg) => {
-                messages.push(msg.getContent())
-            })
             await publisherClient.publish(stream.id, PAYLOAD)
-            await waitForCondition(() => messages.length > 0)
+            const messages = await startNetworkNodeAndListenForAtLeastOneMessage(stream.id)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)
 

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -23,7 +23,7 @@ const NUM_MESSAGES = 5
 
 jest.setTimeout(30000)
 
-describeRepeats('decryption', () => {
+describe('decryption', () => {
     let publishTestMessages: ReturnType<typeof getPublishTestStreamMessages>
     let expectErrors = 0 // check no errors by default
     let errors: Error[] = []
@@ -272,8 +272,9 @@ describeRepeats('decryption', () => {
                 await onEncryptionMessageErr
             }, TIMEOUT * 2)
 
-            it('does not encrypt messages in stream without groupkey', async () => {
+            it('does not encrypt messages for public streams', async () => {
                 const stream2 = await createTestStream(publisher, module)
+                await stream2.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
 
                 let didFindStream2 = false
 
@@ -330,13 +331,6 @@ describeRepeats('decryption', () => {
                 }
 
                 const onEncryptionMessageErr = checkEncryptionMessagesPerStream(publisher)
-
-                const groupKey = GroupKey.generate()
-                await publisher.updateEncryptionKey({
-                    streamId: stream.id,
-                    key: groupKey,
-                    distributionMethod: 'rotate'
-                })
 
                 await testSub(stream)
                 await testSub(stream2)

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -1,7 +1,6 @@
 import { fastPrivateKey, wait } from 'streamr-test-utils'
 import { StreamMessage } from 'streamr-client-protocol'
 import {
-    describeRepeats,
     Msg,
     Debug,
     getPublishTestStreamMessages,

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -7,9 +7,10 @@ import { Stream } from '../../src/Stream'
 import { Subscriber } from '../../src/subscribe/Subscriber'
 import { Subscription } from '../../src/subscribe/Subscription'
 
-import { getPublishTestStreamMessages, createTestStream, Msg } from '../test-utils/utils'
+import { createTestStream, getPublishTestStreamMessages, Msg } from '../test-utils/utils'
 import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { ClientFactory, createClientFactory } from '../test-utils/fake/fakeEnvironment'
+import { StreamPermission } from '../../src'
 
 const MAX_MESSAGES = 10
 jest.setTimeout(50000)
@@ -54,6 +55,7 @@ describe('GapFill', () => {
         stream = await createTestStream(client, module, {
             requireSignedData: true
         })
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         client.debug('connecting before test <<')
         publishTestMessages = getPublishTestStreamMessages(client, stream.id, { waitForLast: true })

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -70,7 +70,8 @@ describe('GapFill', () => {
         if (!subscriber || !stream) { return }
         expect(await subscriber.count(stream.id)).toBe(0)
         if (!client) { return }
-        expect(await subscriber.getSubscriptions()).toEqual([])
+        const subscriptions = await subscriber.getSubscriptions()
+        expect(subscriptions).toHaveLength(0)
     })
 
     afterEach(async () => {

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -35,11 +35,14 @@ describe('Resends', () => {
 
         it('no match', async () => {
             await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+            const content = {
+                foo: Date.now()
+            }
             const msg = new StreamMessage({
                 messageId: new MessageID(stream.id, 0, Date.now(), 0, 'publisherId', 'msgChainId'),
-                content: {}
+                content
             })
-            const publishedMsg = await client.publish(stream.id, msg.getParsedContent())
+            await client.publish(stream.id, msg.getParsedContent())
             const messageMatchFn = jest.fn().mockReturnValue(false)
             await expect(() => client.waitForStorage(msg, {
                 interval: 50,
@@ -47,7 +50,9 @@ describe('Resends', () => {
                 count: 1,
                 messageMatchFn
             })).rejects.toThrow('timed out')
-            expect(messageMatchFn).toHaveBeenCalledWith(expect.anything(), publishedMsg)
+            expect(messageMatchFn).toHaveBeenCalledWith(expect.anything(), expect.anything())
+            expect(messageMatchFn.mock.calls[0][0].getParsedContent()).toEqual(content)
+            expect(messageMatchFn.mock.calls[0][1].getParsedContent()).toEqual(content)
         })
 
         it('no message', async () => {

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -1,18 +1,21 @@
 import 'reflect-metadata'
 import { container } from 'tsyringe'
-import { toStreamID } from 'streamr-client-protocol'
-import { BrubeckNode } from '../../src/BrubeckNode'
+import { StreamMessage, toStreamID } from 'streamr-client-protocol'
+import { BrubeckNode, NetworkNodeStub } from '../../src/BrubeckNode'
 import { Publisher } from '../../src/publish/Publisher'
 import { initContainer } from '../../src'
 import { StreamRegistry } from '../../src/StreamRegistry'
 import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
 import { FakeStreamRegistry } from '../test-utils/fake/FakeStreamRegistry'
 import { createStrictConfig } from '../../src/Config'
+import { GroupKeyStoreFactory } from '../../src/encryption/GroupKeyStoreFactory'
+import { GroupKey } from '../../src/encryption/GroupKey'
 
 const AUTHENTICATED_USER = '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf'
 const PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001'
 const TIMESTAMP = Date.parse('2001-02-03T04:05:06Z')
 const STREAM_ID = toStreamID('/path', AUTHENTICATED_USER)
+const GROUP_KEY = GroupKey.generate()
 
 const createMockContainer = async (
     brubeckNode: Pick<BrubeckNode, 'publishToNode'>,
@@ -22,20 +25,34 @@ const createMockContainer = async (
             privateKey: PRIVATE_KEY
         }
     })
+    const groupKeyStoreFactory = {
+        getStore: () => {
+            return {
+                useGroupKey: async () => [GROUP_KEY, undefined]
+            }
+        }
+    }
     const { childContainer } = initContainer(config, container)
     return childContainer
         .registerSingleton(StreamRegistry, FakeStreamRegistry as any)
         .register(BrubeckNode, { useValue: brubeckNode as any })
+        .register(GroupKeyStoreFactory, { useValue: groupKeyStoreFactory } as any)
 }
 
 describe('Publisher', () => {
 
     let publisher: Pick<Publisher, 'publish' | 'stop'>
-    let brubeckNode: Pick<BrubeckNode, 'publishToNode'>
+    let brubeckNode: Pick<BrubeckNode, 'publishToNode' | 'getNode'>
 
     beforeEach(async () => {
         brubeckNode = {
-            publishToNode: jest.fn()
+            publishToNode: jest.fn(),
+            getNode: async () => {
+                return {
+                    addMessageListener: jest.fn(),
+                    subscribe: jest.fn()
+                } as unknown as NetworkNodeStub
+            } 
         }
         const mockContainer = await createMockContainer(brubeckNode)
         publisher = mockContainer.resolve(Publisher)
@@ -52,8 +69,8 @@ describe('Publisher', () => {
         const actual = (brubeckNode.publishToNode as any).mock.calls[0][0]
         expect(actual).toMatchObject({
             contentType: 0,
-            encryptionType: 0,
-            groupKeyId: null,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.AES,
+            groupKeyId: GROUP_KEY.id,
             messageId: {
                 msgChainId: expect.anything(),
                 publisherId: AUTHENTICATED_USER.toLowerCase(),
@@ -64,9 +81,9 @@ describe('Publisher', () => {
             },
             messageType: 27,
             newGroupKey: null,
-            parsedContent: { foo: 'bar' },
+            parsedContent: undefined,
             prevMsgRef: null,
-            serializedContent: '{"foo":"bar"}',
+            serializedContent: expect.anything(),
             signature: expect.anything(),
             signatureType: 2
         })

--- a/packages/network/src/logic/NetworkNode.ts
+++ b/packages/network/src/logic/NetworkNode.ts
@@ -34,7 +34,7 @@ export class NetworkNode extends Node {
     }
 
     addMessageListener<T>(cb: (msg: StreamMessage<T>) => void): void {
-        this.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, (m) => cb(StreamMessage.deserialize(m.serialize()) as any))
+        this.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, cb)
     }
 
     removeMessageListener<T>(cb: (msg: StreamMessage<T>) => void): void {

--- a/packages/network/src/logic/NetworkNode.ts
+++ b/packages/network/src/logic/NetworkNode.ts
@@ -34,7 +34,7 @@ export class NetworkNode extends Node {
     }
 
     addMessageListener<T>(cb: (msg: StreamMessage<T>) => void): void {
-        this.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, cb)
+        this.on(NodeEvent.UNSEEN_MESSAGE_RECEIVED, (m) => cb(StreamMessage.deserialize(m.serialize()) as any))
     }
 
     removeMessageListener<T>(cb: (msg: StreamMessage<T>) => void): void {


### PR DESCRIPTION
Removed a guard in `Encryption.ts` which caused message encryption to be skipped. The check was modified in https://github.com/streamr-dev/network-monorepo/commit/5d4e11e34a96761c7e7cdc776b559c23ec8f5e47, and it seems that the guard is no longer relevant as all private streams should be encrypted (i.e. stream.requireEncryptedData would be true, it that field still would be available). 

The encryption of public streams is checked separately in line 51:
```
const isPublic = await this.streamEndpoints.isPublic(streamId)
if (isPublic || this.isStopped) {
    return
}
```

## Mutability

When we decrypted message, we would mutate the `StreamMessage` so that its content went from encrypted to decrypted. If that message got sent to further nodes (which could happen if the the decryption process occurred before message propagation), it would go out to neighbors in cleartext. This would mean that upon receiving said message, signature validation would fail on neighbors. 

## Possible future improvements

- Any problems with `WeakSet` in SubscribePipeline class?
- Should we also clone `StreamMessage` before encrypting? It would be symmetrical to the decrypt case, and in a sense, less mutability in system.
- If we make `StreamMessage` to be immutable, the cloning can be removed

## Checklist

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog