### PR TITLE
refactor(network): Remove PeerInfo.peerName

### DIFF
--- a/packages/network-tracker/src/startTracker.ts
+++ b/packages/network-tracker/src/startTracker.ts
@@ -24,6 +24,7 @@ export interface TrackerOptions extends AbstractNodeOptions {
 export const startTracker = async ({
     listen,
     id = uuidv4(),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     name,
     location,
     attachHttpEndpoints = true,
@@ -34,7 +35,7 @@ export const startTracker = async ({
     certFileName,
     topologyStabilization
 }: TrackerOptions): Promise<Tracker> => {
-    const peerInfo = PeerInfo.newTracker(id, name, undefined, undefined, location)
+    const peerInfo = PeerInfo.newTracker(id, undefined, undefined, location)
     const httpServer = await startHttpServer(listen, privateKeyFileName, certFileName)
     const endpoint = new ServerWsEndpoint(listen, privateKeyFileName !== undefined, httpServer, peerInfo, trackerPingInterval)
 

--- a/packages/network/src/connection/PeerInfo.ts
+++ b/packages/network/src/connection/PeerInfo.ts
@@ -14,7 +14,6 @@ interface ObjectRepresentation {
     peerType: string
     controlLayerVersions: number[] | null
     messageLayerVersions: number[] | null
-    peerName?: string | null | undefined
     location?: Location | null | undefined
 }
 
@@ -24,7 +23,6 @@ const defaultMessageLayerVersions = MessageLayer.StreamMessage.getSupportedVersi
 export class PeerInfo {
     static newTracker(
         peerId: TrackerId,
-        peerName?: string | null | undefined,
         controlLayerVersions?: number[],
         messageLayerVersions?: number[],
         location?: Location
@@ -34,14 +32,12 @@ export class PeerInfo {
             PeerType.Tracker,
             controlLayerVersions || defaultControlLayerVersions,
             messageLayerVersions || defaultMessageLayerVersions,
-            peerName,
             location
         )
     }
 
     static newNode(
         peerId: NodeId,
-        peerName?: string | null | undefined,
         controlLayerVersions?: number[] | undefined,
         messageLayerVersions?: number[] | undefined,
         location?: Location
@@ -51,7 +47,6 @@ export class PeerInfo {
             PeerType.Node,
             controlLayerVersions || defaultControlLayerVersions,
             messageLayerVersions || defaultMessageLayerVersions,
-            peerName,
             location
         )
     }
@@ -60,13 +55,12 @@ export class PeerInfo {
         return new PeerInfo(peerId, PeerType.Unknown, defaultControlLayerVersions, defaultMessageLayerVersions)
     }
 
-    static fromObject({ peerId, peerType, peerName, location, controlLayerVersions, messageLayerVersions }: ObjectRepresentation): PeerInfo  {
+    static fromObject({ peerId, peerType, location, controlLayerVersions, messageLayerVersions }: ObjectRepresentation): PeerInfo  {
         return new PeerInfo(
             peerId,
             peerType as PeerType,
             controlLayerVersions || defaultControlLayerVersions,
             messageLayerVersions || defaultMessageLayerVersions,
-            peerName,
             location ?? undefined
         )
     }
@@ -75,7 +69,6 @@ export class PeerInfo {
     readonly peerType: PeerType
     readonly controlLayerVersions: number[]
     readonly messageLayerVersions: number[]
-    readonly peerName: string | null
     readonly location: Location | undefined
 
     constructor(
@@ -83,7 +76,6 @@ export class PeerInfo {
         peerType: PeerType,
         controlLayerVersions?: number[],
         messageLayerVersions?: number[],
-        peerName?: string | null | undefined,
         location?: Location
     ) {
         if (!peerId) {
@@ -106,7 +98,6 @@ export class PeerInfo {
         this.peerType = peerType
         this.controlLayerVersions = controlLayerVersions
         this.messageLayerVersions = messageLayerVersions
-        this.peerName = peerName ? peerName : null
         this.location = location
     }
 
@@ -119,6 +110,6 @@ export class PeerInfo {
     }
 
     toString(): string {
-        return (this.peerName ? `${this.peerName}` : '') + `<${this.peerId.slice(0, 8)}>`
+        return `<${this.peerId.slice(0, 8)}>`
     }
 }

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -28,6 +28,7 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
 
 export const createNetworkNode = ({
     id = uuidv4(),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     name,
     location,
     trackers,
@@ -44,7 +45,7 @@ export const createNetworkNode = ({
     webrtcDisallowPrivateAddresses = true,
     acceptProxyConnections
 }: NetworkNodeOptions): NetworkNode => {
-    const peerInfo = PeerInfo.newNode(id, name, undefined, undefined, location)
+    const peerInfo = PeerInfo.newNode(id, undefined, undefined, location)
     const endpoint = new NodeClientWsEndpoint(peerInfo, trackerPingInterval)
     const nodeToTracker = new NodeToTracker(endpoint)
 

--- a/packages/network/test/unit/NegotiatedProtocolVersions.test.ts
+++ b/packages/network/test/unit/NegotiatedProtocolVersions.test.ts
@@ -5,7 +5,7 @@ describe('NegotiatedProtocolVersions', () => {
     let negotiatedProtocolVersions: NegotiatedProtocolVersions
 
     beforeEach(() => {
-        const peerInfo = PeerInfo.newNode('node', null, [1,2], [30,31,32])
+        const peerInfo = PeerInfo.newNode('node', [1,2], [30,31,32])
         negotiatedProtocolVersions = new NegotiatedProtocolVersions(peerInfo)
         negotiatedProtocolVersions.negotiateProtocolVersion('peer2', [1,2,3,4,5], [29,30,31,32,33])
         negotiatedProtocolVersions.negotiateProtocolVersion('peer3', [1,5], [29,31])

--- a/packages/network/test/unit/PeerInfo.test.ts
+++ b/packages/network/test/unit/PeerInfo.test.ts
@@ -24,7 +24,7 @@ describe('PeerInfo', () => {
     })
 
     it('toString', () => {
-        expect(nodeInfo.toString()).toEqual('NetworkNode<0x215836>')
+        expect(nodeInfo.toString()).toEqual('<0x215836>')
         expect(trackerInfo.toString()).toEqual('<0x4c56db>')
         expect(unknownInfo.toString()).toEqual('<0xeba138>')
     })

--- a/packages/network/test/unit/PeerInfo.test.ts
+++ b/packages/network/test/unit/PeerInfo.test.ts
@@ -6,7 +6,7 @@ describe('PeerInfo', () => {
     let unknownInfo: PeerInfo
 
     beforeEach(() => {
-        nodeInfo = PeerInfo.newNode('0x21583691f17b9e36a4577520f8db04a19a2f2a0d', 'NetworkNode')
+        nodeInfo = PeerInfo.newNode('0x21583691f17b9e36a4577520f8db04a19a2f2a0d')
         trackerInfo = PeerInfo.newTracker('0x4c56dbe52abb0878ee05dc15b86d660e7ef3329e')
         unknownInfo = PeerInfo.newUnknown('0xeba1386b00de68dcc514ac5d7de7fcb48495c4c7')
     })
@@ -44,13 +44,8 @@ describe('PeerInfo', () => {
         expect(peerInfo.isTracker()).toEqual(true)
     })
 
-    it('id is null if not given', () => {
-        const peerInfo = PeerInfo.newNode('nodeId')
-        expect(peerInfo.peerName).toEqual(null)
-    })
-
     it('use default location if not given', () => {
-        const peerInfo = PeerInfo.newNode('nodeId', 'nodeName',undefined , undefined, undefined)
+        const peerInfo = PeerInfo.newNode('nodeId', undefined, undefined, undefined)
         expect(peerInfo.location).toEqual(undefined)
     })
 })

--- a/packages/protocol/src/protocol/tracker_layer/Originator.ts
+++ b/packages/protocol/src/protocol/tracker_layer/Originator.ts
@@ -3,6 +3,5 @@ export interface Originator {
     peerType: string
     controlLayerVersions: number[]
     messageLayerVersions: number[]
-    peerName: string | null
     location: any
 }

--- a/packages/protocol/test/unit/protocol/tracker_layer/RelayMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/tracker_layer/RelayMessage.test.ts
@@ -11,7 +11,6 @@ describe('RelayMessage', () => {
                 requestId: 'requestId',
                 originator: {
                     peerId: 'peerId',
-                    peerName: 'peerName',
                     peerType: 'node',
                     controlLayerVersions: [2],
                     messageLayerVersions: [32],
@@ -27,7 +26,6 @@ describe('RelayMessage', () => {
                 requestId: 'requestId',
                 originator: {
                     peerId: 'peerId',
-                    peerName: 'peerName',
                     peerType: 'node',
                     controlLayerVersions: [2],
                     messageLayerVersions: [32],
@@ -45,7 +43,6 @@ describe('RelayMessage', () => {
                 requestId: 'requestId',
                 originator: {
                     peerId: 'peerId',
-                    peerName: 'peerName',
                     peerType: 'node',
                     controlLayerVersions: [2],
                     messageLayerVersions: [32],
@@ -74,7 +71,6 @@ describe('RelayMessage', () => {
                 requestId: null as any,
                 originator: {
                     peerId: 'peerId',
-                    peerName: 'peerName',
                     peerType: 'node',
                     controlLayerVersions: [2],
                     messageLayerVersions: [32],
@@ -92,7 +88,6 @@ describe('RelayMessage', () => {
                 requestId: 'requestId',
                 originator: {
                     peerId: 'peerId',
-                    peerName: 'peerName',
                     peerType: 'node',
                     controlLayerVersions: [2],
                     messageLayerVersions: [32],
@@ -109,7 +104,6 @@ describe('RelayMessage', () => {
             assert.strictEqual(msg.requestId, 'requestId')
             assert.deepStrictEqual(msg.originator, {
                 peerId: 'peerId',
-                peerName: 'peerName',
                 peerType: 'node',
                 controlLayerVersions: [2],
                 messageLayerVersions: [32],

--- a/packages/protocol/test/unit/protocol/tracker_layer/RelayMessageSerializerV2.test.ts
+++ b/packages/protocol/test/unit/protocol/tracker_layer/RelayMessageSerializerV2.test.ts
@@ -10,7 +10,6 @@ const message = new RelayMessage({
     requestId: 'requestId',
     originator: {
         peerId: 'peerId',
-        peerName: 'peerName',
         peerType: 'node',
         controlLayerVersions: [2],
         messageLayerVersions: [32],
@@ -28,7 +27,6 @@ const serializedMessage = JSON.stringify([
     'requestId',
     {
         peerId: 'peerId',
-        peerName: 'peerName',
         peerType: 'node',
         controlLayerVersions: [2],
         messageLayerVersions: [32],


### PR DESCRIPTION
Remove `PeerInfo.peerName` as we use `peerInfo.id` to identify peers. We can later add support for human-readable peer names e.g. by supporting ENS names as peer ids. 