### PR TITLE
feat: add installation instructions for m1 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Monorepo for Streamr Network packages.
 | NodeJS version `16.13.x` and NPM version `8.x` is required |
 | --- |
 
-Installation on m1 Macs requires additional steps, see [install-on-m1.md](/install-on-m1)
+Installation on an M1 Mac requires additional steps, see [install-on-m1.md](/install-on-m1)
 
 Uses [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to manage monorepo.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Monorepo for Streamr Network packages.
 | NodeJS version `16.13.x` and NPM version `8.x` is required |
 | --- |
 
+Installation on m1 Macs requires additional steps, see [install-on-m1.md](/install-on-m1)
+
 Uses [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to manage monorepo.
 
 **Important:** Do not use `npm ci` or `npm install` directly in the sub-package directories.

--- a/install-on-m1.md
+++ b/install-on-m1.md
@@ -1,4 +1,4 @@
-#  Starting network-monorepo development from scratch on M1 Macs 
+#  Starting network-monorepo development from scratch on an M1 Mac
 
 These instructions were tested on 
 

--- a/install-on-m1.md
+++ b/install-on-m1.md
@@ -44,7 +44,7 @@ export OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1n/
 export OPENSSL_INCLUDE_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1n/include
 ```
 
-* Install networ-monorepo from scratch: 
+* Install network-monorepo from scratch: 
 ```
 npm install
 ```

--- a/install-on-m1.md
+++ b/install-on-m1.md
@@ -16,7 +16,7 @@ The current (April 19th 2022) main branch of streamr-network-monorepo  does not 
 
 Running `npm install` also requires a couple of preparations, because 
 
-* Python 2 is not avaialable by default on macOS 12.3 (which prevents the package weak-napi from compiling)
+* Python 2 is not available by default on macOS 12.3 (which prevents the package weak-napi from compiling)
 * Package node-datachannel does not come with pre-compiled M1 binaries, and gets recompiled
 
 

--- a/install-on-m1.md
+++ b/install-on-m1.md
@@ -1,0 +1,50 @@
+#  Starting network-monorepo development from scratch on M1 Macs 
+
+These instructions were tested on 
+
+```
+macOS Monterey Version 12.3
+Apple M1 Max
+nodejs v16.14.2
+npm 8.5.0
+```
+
+## Introduction
+
+The current (April 19th 2022) main branch of streamr-network-monorepo  does not install out-of-the-box on M1 macs using `npm ci`, but rather requires deleting the 
+`package-lock.json` file, and installing from scratch using `npm install`. 
+
+Running `npm install` also requires a couple of preparations, because 
+
+* Python 2 is not avaialable by default on macOS 12.3 (which prevents the package weak-napi from compiling)
+* Package node-datachannel does not come with pre-compiled M1 binaries, and gets recompiled
+
+
+## Installation
+
+* Install Homebrew with XCode command line tools: https://mac.install.guide/commandlinetools/3.html
+* Install python 2.7:
+```
+brew install pyenv
+pyenv install 2.7.18
+cat 2.7.18 > ~/.pyenv/version
+```
+
+Make sure that the python installation works:
+```
+% python --version
+Python 2.7.18
+```
+
+* Install the prerequsites for compiling node-datachannel:
+```
+brew install openssl
+brew install cmake
+export OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1n/  
+export OPENSSL_INCLUDE_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1n/include
+```
+
+* Install networ-monorepo from scratch: 
+```
+npm install
+```

--- a/install-on-m1.md
+++ b/install-on-m1.md
@@ -11,7 +11,7 @@ npm 8.5.0
 
 ## Introduction
 
-The current (April 19th 2022) main branch of streamr-network-monorepo  does not install out-of-the-box on M1 macs using `npm ci`, but rather requires deleting the 
+The current (April 19th 2022) main branch of streamr-network-monorepo does not install out-of-the-box on an M1 Mac using `npm ci`, but rather requires deleting the 
 `package-lock.json` file, and installing from scratch using `npm install`. 
 
 Running `npm install` also requires a couple of preparations, because 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "check": "npm run --workspaces --if-present check",
-        "prepare": "husky install && npm run versions",
+        "prepare": "chmod a+x node_modules/.bin/husky && husky install && npm run versions",
         "bootstrap": "npm ci --no-audit",
         "bootstrap-pkg": "npm ci --no-audit --include-workspace-root --workspace",
         "versions": "zx ./show-versions.mjs && manypkg check",

--- a/packages/network/src/connection/MessageQueue.ts
+++ b/packages/network/src/connection/MessageQueue.ts
@@ -81,11 +81,11 @@ export class MessageQueue<M> {
     }
 
     peek(): QueueItem<M> {
-        return this.heap.peek()
+        return this.heap.peek() as QueueItem<M>
     }
 
     pop(): QueueItem<M> {
-        return this.heap.pop()
+        return this.heap.pop() as QueueItem<M>
     }
 
     size(): number {

--- a/packages/protocol/src/utils/OrderedMsgChain.ts
+++ b/packages/protocol/src/utils/OrderedMsgChain.ts
@@ -74,7 +74,7 @@ class MsgChainQueue {
     peek() {
         if (this.isEmpty()) { return }
         const ref = this.queue.peek()
-        return this.pendingMsgs.get(ref)
+        return this.pendingMsgs.get(ref as MessageRef)
     }
 
     /**


### PR DESCRIPTION
* Added a new readme file containing instructions for running npm install on M1 Macs
* Linked the new readme file from the main README.md
* Added type-casting to a couple of places in MessageQueue.ts and OrderedMsgChain.ts in order to accommodate changes that have happened the latest versions of the types file for the 'heap' package
* Added to package.json the forcing of the executable flag on the 'husky' binary, which has apparently been dropped in some later version of husky