### PR TITLE
NET-783: Remove obsolete encryption / signature flags 

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -36,7 +36,6 @@ export interface StreamProperties {
         fields: Field[];
     }
     partitions?: number
-    requireSignedData?: boolean
     storageDays?: number
     inactivityThresholdHours?: number
 }
@@ -82,7 +81,6 @@ class StreamrStream implements StreamMetadata {
         fields: Field[];
     } = { fields: [] }
     partitions!: number
-    requireSignedData!: boolean
     storageDays?: number
     inactivityThresholdHours?: number
     protected _rest: Rest

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -18,7 +18,6 @@ import { StreamIDBuilder } from './StreamIDBuilder'
 export interface StreamValidationInfo {
     id: string
     partitions: number
-    requireSignedData: boolean
     storageDays: number
 }
 

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -142,15 +142,13 @@ describe('MemoryLeaks', () => {
 
             test('create', async () => {
                 await client.createStream({
-                    id: `/${counterId('stream')}-${Date.now()}`,
-                    requireSignedData: true,
+                    id: `/${counterId('stream')}-${Date.now()}`
                 })
             })
 
             test('publish', async () => {
                 const stream = await client.createStream({
-                    id: `/${counterId('stream')}-${Date.now()}`,
-                    requireSignedData: true,
+                    id: `/${counterId('stream')}-${Date.now()}`
                 })
                 const publishTestMessages = getPublishTestMessages(client, stream, {
                     retainMessages: false,
@@ -165,8 +163,7 @@ describe('MemoryLeaks', () => {
             describe('publish + subscribe', () => {
                 it('does not leak subscription', async () => {
                     const stream = await client.createStream({
-                        id: `/${counterId('stream')}-${Date.now()}`,
-                        requireSignedData: true,
+                        id: `/${counterId('stream')}-${Date.now()}`
                     })
                     const sub = await client.subscribe(stream)
                     leaksDetector.addAll(sub.id, sub)
@@ -179,8 +176,7 @@ describe('MemoryLeaks', () => {
 
                 test('subscribe using async iterator', async () => {
                     const stream = await client.createStream({
-                        id: `/${counterId('stream')}-${Date.now()}`,
-                        requireSignedData: true,
+                        id: `/${counterId('stream')}-${Date.now()}`
                     })
                     const sub = await client.subscribe(stream)
                     leaksDetector.addAll(sub.id, sub)
@@ -201,8 +197,7 @@ describe('MemoryLeaks', () => {
 
                 test('subscribe using onMessage callback', async () => {
                     const stream = await client.createStream({
-                        id: `/${counterId('stream')}-${Date.now()}`,
-                        requireSignedData: true,
+                        id: `/${counterId('stream')}-${Date.now()}`
                     })
 
                     const publishTestMessages = getPublishTestMessages(client, stream, {
@@ -227,8 +222,7 @@ describe('MemoryLeaks', () => {
                 test('subscriptions can be collected before all subscriptions removed', async () => {
                     // leaksDetector = new LeaksDetector()
                     const stream = await client.createStream({
-                        id: `/${counterId('stream')}-${Date.now()}`,
-                        requireSignedData: true,
+                        id: `/${counterId('stream')}-${Date.now()}`
                     })
 
                     const publishTestMessages = getPublishTestMessages(client, stream, {

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -10,6 +10,7 @@ import { collect } from '../../src/utils/GeneratorUtils'
 import { randomEthereumAddress } from 'streamr-test-utils'
 
 jest.setTimeout(40000)
+const PARTITION_COUNT = 3
 
 /**
  * These tests should be run in sequential order!
@@ -32,7 +33,7 @@ describe('StreamRegistry', () => {
 
     beforeAll(async () => {
         createdStream = await createTestStream(client, module, {
-            requireSignedData: true
+            partitions: PARTITION_COUNT
         })
     })
 
@@ -40,11 +41,9 @@ describe('StreamRegistry', () => {
         it('creates a stream with correct values', async () => {
             const path = await createRelativeTestStreamId(module)
             const stream = await client.createStream({
-                id: path,
-                requireSignedData: true
+                id: path
             })
             expect(stream.id).toBe(toStreamID(path, await client.getAddress()))
-            expect(stream.requireSignedData).toBe(true)
         })
 
         it('valid id', async () => {
@@ -224,7 +223,7 @@ describe('StreamRegistry', () => {
             }, 100000, 1000)
             // check that other fields not overwritten
             const updatedStream = await client.getStream(createdStream.id)
-            expect(updatedStream.requireSignedData).toBe(true)
+            expect(updatedStream.partitions).toBe(PARTITION_COUNT)
         })
     })
 

--- a/packages/client/test/end-to-end/Validation.test.ts
+++ b/packages/client/test/end-to-end/Validation.test.ts
@@ -23,9 +23,7 @@ describe('Validation', () => {
         // @ts-expect-error
         subscriber = client.subscriber
         client.debug('connecting before test >>')
-        stream = await createTestStream(client, module, {
-            requireSignedData: true
-        })
+        stream = await createTestStream(client, module)
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         client.debug('connecting before test <<')
         publishTestMessages = getPublishTestMessages(client, stream.id)

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -52,9 +52,7 @@ describe('GapFill', () => {
         // @ts-expect-error
         subscriber = client.subscriber
         client.debug('connecting before test >>')
-        stream = await createTestStream(client, module, {
-            requireSignedData: true
-        })
+        stream = await createTestStream(client, module)
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         client.debug('connecting before test <<')
@@ -248,9 +246,7 @@ describe('GapFill', () => {
 
             it('rejects resend if no storage assigned', async () => {
                 // new stream, assign to storage node not called
-                stream = await createTestStream(client, module, {
-                    requireSignedData: true,
-                })
+                stream = await createTestStream(client, module)
 
                 await expect(async () => {
                     await client.resend(

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -22,14 +22,10 @@ describe('Resends', () => {
 
         it('happy path', async () => {
             await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
-            const mockId = Date.now()
-            const msg = new StreamMessage({
-                messageId: new MessageID(stream.id, 0, Date.now(), 0, 'publisherId', 'msgChainId'),
-                content: {
-                    mockId
-                }
-            })
-            const publishedMsg = await client.publish(stream.id, msg.getParsedContent())
+            const content = {
+                foo: Date.now()
+            }
+            const publishedMsg = await client.publish(stream.id, content)
             await client.waitForStorage(publishedMsg)
         })
 
@@ -38,13 +34,9 @@ describe('Resends', () => {
             const content = {
                 foo: Date.now()
             }
-            const msg = new StreamMessage({
-                messageId: new MessageID(stream.id, 0, Date.now(), 0, 'publisherId', 'msgChainId'),
-                content
-            })
-            await client.publish(stream.id, msg.getParsedContent())
+            const publishedMsg = await client.publish(stream.id, content)
             const messageMatchFn = jest.fn().mockReturnValue(false)
-            await expect(() => client.waitForStorage(msg, {
+            await expect(() => client.waitForStorage(publishedMsg, {
                 interval: 50,
                 timeout: 100,
                 count: 1,

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 import { MessageID, StreamMessage } from 'streamr-client-protocol'
 import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { StreamPermission } from '../../src/permission'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { createClientFactory } from '../test-utils/fake/fakeEnvironment'
@@ -18,6 +19,7 @@ describe('Resends', () => {
             stream = await client.createStream({
                 id: await createRelativeTestStreamId(module),
             })
+            await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         })
 
         it('happy path', async () => {

--- a/packages/client/test/memory/Leaks.test.ts
+++ b/packages/client/test/memory/Leaks.test.ts
@@ -90,8 +90,7 @@ describeRepeats('Leaks', () => {
                 if (!client) { return }
 
                 await client.createStream({
-                    id: `/${counterId('stream')}`,
-                    requireSignedData: true,
+                    id: `/${counterId('stream')}`
                 })
             })
 
@@ -99,8 +98,7 @@ describeRepeats('Leaks', () => {
                 if (!client) { return }
 
                 const stream = await client.createStream({
-                    id: `/${counterId('stream')}`,
-                    requireSignedData: true,
+                    id: `/${counterId('stream')}`
                 })
                 const ethAddress = await client.getAddress()
                 await client.cached.isStreamPublisher(stream.id, ethAddress)
@@ -112,8 +110,7 @@ describeRepeats('Leaks', () => {
                 if (!client) { return }
 
                 const stream = await client.createStream({
-                    id: `/${counterId('stream')}`,
-                    requireSignedData: true,
+                    id: `/${counterId('stream')}`
                 })
                 const publishTestMessages = getPublishTestMessages(client, stream, {
                     retainMessages: false,
@@ -129,8 +126,7 @@ describeRepeats('Leaks', () => {
                     if (!client) { return }
 
                     const stream = await client.createStream({
-                        id: `/${counterId('stream')}`,
-                        requireSignedData: true,
+                        id: `/${counterId('stream')}`
                     })
                     let sub: Subscription | undefined = await client.subscribe(stream)
                     if (!sub) { throw new Error('no sub') }
@@ -157,8 +153,7 @@ describeRepeats('Leaks', () => {
 
                         leaksDetector = new LeaksDetector()
                         const stream = await client.createStream({
-                            id: `/${counterId('stream')}`,
-                            requireSignedData: true,
+                            id: `/${counterId('stream')}`
                         })
                         const sub = await client.subscribe(stream)
                         subLeak = new LeakDetector(sub)
@@ -194,8 +189,7 @@ describeRepeats('Leaks', () => {
 
                         leaksDetector = new LeaksDetector()
                         const stream = await client.createStream({
-                            id: `/${counterId('stream')}`,
-                            requireSignedData: true,
+                            id: `/${counterId('stream')}`
                         })
 
                         const publishTestMessages = getPublishTestMessages(client, stream, {
@@ -233,8 +227,7 @@ describeRepeats('Leaks', () => {
 
                         // leaksDetector = new LeaksDetector()
                         const stream = await client.createStream({
-                            id: `/${counterId('stream')}`,
-                            requireSignedData: true,
+                            id: `/${counterId('stream')}`
                         })
 
                         const publishTestMessages = getPublishTestMessages(client, stream, {

--- a/packages/client/test/memory/Publishing.test.ts
+++ b/packages/client/test/memory/Publishing.test.ts
@@ -56,8 +56,7 @@ describe.skip('no memleaks when publishing a high quantity of large messages', (
         client.onError = jest.fn()
         client.on('error', onError)
         stream = await client.createStream({
-            id: `/${counterId('stream')}`,
-            requireSignedData: true,
+            id: `/${counterId('stream')}`
         })
         publishTestMessages = getPublishTestMessages(client, {
             stream

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -49,9 +49,11 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
         this.ethereum = ethereum
         this.container = container
         this.streamEndpointsCached = streamEndpointsCached
+        const storageNodeAssignmentStreamPermissions = new Multimap<string,StreamPermission>()
+        storageNodeAssignmentStreamPermissions.add(DOCKER_DEV_STORAGE_NODE.toLowerCase(), StreamPermission.PUBLISH)
         this.registryItems.set(formStorageNodeAssignmentStreamId(DOCKER_DEV_STORAGE_NODE), {
             metadata: {},
-            permissions: new Multimap()
+            permissions: storageNodeAssignmentStreamPermissions
         })
     }
 

--- a/packages/protocol/src/utils/StreamMessageValidator.ts
+++ b/packages/protocol/src/utils/StreamMessageValidator.ts
@@ -19,8 +19,6 @@ export interface Options {
     verify?: (address: EthereumAddress, payload: string, signature: string) => Promise<boolean>
 }
 
-const PUBLIC_USER = '0x0000000000000000000000000000000000000000'
-
 /**
  * Validates observed StreamMessages according to protocol rules, regardless of observer.
  * Functions needed for external interactions are injected as constructor args.
@@ -142,13 +140,6 @@ export default class StreamMessageValidator {
         // Checks against stream metadata
         if (!streamMessage.signature) {
             throw new StreamMessageError('Stream data is required to be signed.', streamMessage)
-        }
-
-        if (streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE){
-            const isPublicStream = await this.isSubscriber(PUBLIC_USER, streamMessage.getStreamId())
-            if (!isPublicStream){
-                throw new StreamMessageError('Non-public streams require data to be encrypted.', streamMessage)
-            }
         }
 
         if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= stream.partitions) {

--- a/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
@@ -141,27 +141,6 @@ describe('StreamMessageValidator', () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
 
-        it ('rejects unsigned messages', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse
-            })
-
-            msg.signature = null
-            msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
-
-            await assert.rejects(getValidator({
-                getStream,
-                isPublisher,
-                isSubscriber,
-                verify
-            }).validate(msg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                assert((getStream as any).calledOnce, 'getStream not called once!')
-                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
-                return true
-            })
-        })
-
         it('rejects unsigned messages', async () => {
             msg.signature = null
             msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE

--- a/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
@@ -32,8 +32,7 @@ describe('StreamMessageValidator', () => {
     let groupKeyErrorResponse: StreamMessage
 
     const defaultGetStreamResponse = {
-        partitions: 10,
-        requireSignedData: true
+        partitions: 10
     }
 
     const getValidator = (customConfig?: any) => {
@@ -41,7 +40,7 @@ describe('StreamMessageValidator', () => {
             return new StreamMessageValidator(customConfig)
         } else {
             return new StreamMessageValidator({
-                getStream, isPublisher, isSubscriber, verify, requireBrubeckValidation: false
+                getStream, isPublisher, isSubscriber, verify
             })
         }
     }
@@ -142,10 +141,9 @@ describe('StreamMessageValidator', () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
 
-        it ('rejects unsigned messages when Brubeck validation is required', async () => {
+        it ('rejects unsigned messages', async () => {
             getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse,
-                requireSignedData: false,
+                ...defaultGetStreamResponse
             })
 
             msg.signature = null
@@ -155,8 +153,7 @@ describe('StreamMessageValidator', () => {
                 getStream,
                 isPublisher,
                 isSubscriber,
-                verify,
-                requireBrubeckValidation: true
+                verify
             }).validate(msg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 assert((getStream as any).calledOnce, 'getStream not called once!')
@@ -167,8 +164,7 @@ describe('StreamMessageValidator', () => {
 
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse,
-                requireSignedData: false,
+                ...defaultGetStreamResponse
             })
 
             msg.signature = null
@@ -197,7 +193,7 @@ describe('StreamMessageValidator', () => {
             await getValidator().validate(msg)
         })
 
-        it('accepts unencrypted messages if Brubeck validation is required and the stream public', async () => {
+        it('accepts unencrypted messages if stream is public', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
             })
@@ -209,8 +205,7 @@ describe('StreamMessageValidator', () => {
                 getStream,
                 isPublisher,
                 isSubscriber,
-                verify,
-                requireBrubeckValidation: true
+                verify
             }).validate(msg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 assert((getStream as any).calledOnce, 'getStream not called once!')
@@ -219,7 +214,7 @@ describe('StreamMessageValidator', () => {
             })
         })
 
-        it('rejects unencrypted messages if Brubeck validation is required', async () => {
+        it('rejects unencrypted messages if stream is not public', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
             })
@@ -230,8 +225,7 @@ describe('StreamMessageValidator', () => {
                 getStream,
                 isPublisher,
                 isSubscriber,
-                verify,
-                requireBrubeckValidation: true
+                verify
             }).validate(msg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 assert((getStream as any).calledOnce, 'getStream not called once!')

--- a/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
@@ -162,71 +162,11 @@ describe('StreamMessageValidator', () => {
             })
         })
 
-        it('accepts unsigned messages that dont need to be signed', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse
-            })
-
-            msg.signature = null
-            msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
-
-            await getValidator().validate(msg)
-        })
-
-        it('rejects unsigned messages that should be signed', async () => {
+        it('rejects unsigned messages', async () => {
             msg.signature = null
             msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
 
             await assert.rejects(getValidator().validate(msg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                assert((getStream as any).calledOnce, 'getStream not called once!')
-                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
-                return true
-            })
-        })
-
-        it('accepts valid encrypted messages', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse
-            })
-            msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
-            await getValidator().validate(msg)
-        })
-
-        it('accepts unencrypted messages if stream is public', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse,
-            })
-
-            msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
-            //msg.getPublisherId = () => { return '0x0000000000000000000000000000000000000000' }
-
-            await assert.rejects(getValidator({
-                getStream,
-                isPublisher,
-                isSubscriber,
-                verify
-            }).validate(msg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                assert((getStream as any).calledOnce, 'getStream not called once!')
-                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
-                return true
-            })
-        })
-
-        it('rejects unencrypted messages if stream is not public', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse,
-            })
-
-            msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
-
-            await assert.rejects(getValidator({
-                getStream,
-                isPublisher,
-                isSubscriber,
-                verify
-            }).validate(msg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 assert((getStream as any).calledOnce, 'getStream not called once!')
                 assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)


### PR DESCRIPTION
Behavior changes:
- Always require that messages are signed
- Encryption plays no role in stream message validation

Clean-up:
- Remove `requireSignedData` obsolete stream property
- Remove obsolete `requireBrubeckValidation` flag