### PR TITLE
feat(client): Remove state metrics

### DIFF
--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -46,8 +46,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
         let storageWriteCountPerSecond = 0
         let storageReadKbPerSecond = 0
         let storageWriteKbPerSecond = 0
-        let totalBatches = 0
-        let meanBatchAge = 0
         let resendRate = {
             last: 0,
             from: 0,
@@ -62,10 +60,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
             storageReadKbPerSecond = report.metrics['broker/cassandra'].readBytes.rate / 1000
             // @ts-expect-error not enough typing info available
             storageWriteKbPerSecond = report.metrics['broker/cassandra'].writeBytes.rate / 1000
-            // @ts-expect-error not enough typing info available
-            totalBatches = report.metrics['broker/cassandra'].batchManager.totalBatches
-            // @ts-expect-error not enough typing info available
-            meanBatchAge = report.metrics['broker/cassandra'].batchManager.meanBatchAge
         }
 
         const networkConnectionCount = report.metrics.WebRtcEndpoint.connections
@@ -97,8 +91,7 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
             + '\tResends:\n'
             + '\t- last: %d requests/s\n'
             + '\t- from: %d requests/s\n'
-            + '\t- range: %d requests/s\n'
-            + '\tTotal batches: %d (mean age %d ms)\n',
+            + '\t- range: %d requests/s\n',
             networkConnectionCount,
             formatNumber(networkInPerSecond),
             formatNumber(networkKbInPerSecond),
@@ -111,8 +104,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
             resendRate.last,
             resendRate.from,
             resendRate.range,
-            totalBatches,
-            meanBatchAge
         )
     }
 

--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -77,7 +77,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
         const networkKbInPerSecond = report.metrics.WebRtcEndpoint.inSpeed.rate / 1000
         // @ts-expect-error not enough typing info available
         const networkKbOutPerSecond = report.metrics.WebRtcEndpoint.outSpeed.rate / 1000
-        const { messageQueueSize } = report.metrics.WebRtcEndpoint
 
         const storageQueryMetrics = report.metrics['broker/storage/query']
         if (storageQueryMetrics !== undefined) {
@@ -91,7 +90,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
         logger.info(
             'Report\n'
             + '\tNetwork connections %d\n'
-            + '\tQueued messages: %d\n'
             + '\tNetwork in: %d events/s, %d kb/s\n'
             + '\tNetwork out: %d events/s, %d kb/s\n'
             + '\tStorage read: %d events/s, %d kb/s\n'
@@ -102,7 +100,6 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
             + '\t- range: %d requests/s\n'
             + '\tTotal batches: %d (mean age %d ms)\n',
             networkConnectionCount,
-            messageQueueSize,
             formatNumber(networkInPerSecond),
             formatNumber(networkKbInPerSecond),
             formatNumber(networkOutPerSecond),

--- a/packages/broker/src/plugins/storage/BatchManager.ts
+++ b/packages/broker/src/plugins/storage/BatchManager.ts
@@ -155,19 +155,4 @@ export class BatchManager extends EventEmitter {
             batch.scheduleInsert()
         }
     }
-
-    metrics(): { totalBatches: number, meanBatchAge: number } {
-        const now = Date.now()
-        const { batches, pendingBatches } = this
-        const totalBatches = Object.values(batches).length + Object.values(pendingBatches).length
-        const meanBatchAge = totalBatches === 0 ? 0
-            : [
-                ...Object.values(batches),
-                ...Object.values(pendingBatches)
-            ].reduce((acc, batch) => acc + (now - batch.createdAt), 0) / totalBatches
-        return {
-            totalBatches,
-            meanBatchAge
-        }
-    }
 }

--- a/packages/broker/src/plugins/storage/Storage.ts
+++ b/packages/broker/src/plugins/storage/Storage.ts
@@ -236,7 +236,6 @@ export class Storage extends EventEmitter {
             .addRecordedMetric('readBytes')
             .addRecordedMetric('writeCount')
             .addRecordedMetric('writeBytes')
-            .addQueriedMetric('batchManager', () => this.batchManager.metrics())
         this.on('read', (streamMessage: StreamMessage) => {
             cassandraMetrics.record('readCount', 1)
             cassandraMetrics.record('readBytes', streamMessage.getContent(false).length)

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -110,9 +110,6 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             .addRecordedMetric('msgOutSpeed')
             .addRecordedMetric('failedConnection')
             .addQueriedMetric('connections', () => Object.keys(this.connections).length)
-            .addQueriedMetric('messageQueueSize', () => {
-                return Object.values(this.connections).reduce((total, c) => total + c.getQueueSize(), 0)
-            })
 
         this.startConnectionStatusReport()
     }


### PR DESCRIPTION
Remove some metrics from consoleMetrics plugin:
- `WebRtcEndpoint.messageQueueSize`
- `broker/cassandra.totalBatches`
- `broker/cassandra.meanBatchAge`

These metrics represent a snapshot state of a node. That kind of state data could be queried e.g. via `info` plugin in the future. 