### PR TITLE
fix keyserver test crash

### DIFF
--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -43,6 +43,7 @@ export async function fetchPrivateKeyWithGas(): Promise<string> {
     } catch (_e) {
         try {
             await KeyServer.startIfNotRunning() // may throw if parallel attempts at starting server
+        } catch (_e2) {
         } finally {
             response = await fetch(`http://localhost:${KeyServer.KEY_SERVER_PORT}/key`, {
                 timeout: 5 * 1000


### PR DESCRIPTION
Fix issue where multiple concurrent start ups of `KeyServer` will cause tests to crash.