### PR TITLE
fix: WebRTC compatibility in Firefox

### DIFF
--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -75,7 +75,9 @@ export class BrowserWebRtcConnection extends WebRtcConnection {
     }
 
     protected doClose(err?: Error): void {
+        if (err !== undefined) {
         this.logger.warn('Closing BrowserWebRTCConnection with error: %s', err)
+        }
         if (this.dataChannel) {
             try {
                 this.dataChannel.close()

--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -76,7 +76,7 @@ export class BrowserWebRtcConnection extends WebRtcConnection {
 
     protected doClose(err?: Error): void {
         if (err !== undefined) {
-        this.logger.warn('Closing BrowserWebRTCConnection with error: %s', err)
+            this.logger.warn('Closing BrowserWebRTCConnection with error: %s', err)
         }
         if (this.dataChannel) {
             try {

--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -42,20 +42,6 @@ export class BrowserWebRtcConnection extends WebRtcConnection {
             this.lastGatheringState = this.peerConnection?.iceGatheringState
         }
 
-        this.peerConnection.onconnectionstatechange = () => {
-            const state = this.peerConnection?.connectionState
-            this.logger.trace('conn.onStateChange: %s -> %s', this.lastState, state)
-            this.lastState = state
-
-            if (state === 'disconnected' || state === 'closed') {
-                this.close()
-            } else if (state === 'failed') {
-                this.close(new Error('connection failed'))
-            } else if (state === 'connecting') {
-                this.restartConnectionTimeout()
-            }
-        }
-
         if (this.isOffering()) {
             this.peerConnection.onnegotiationneeded = async () => {
                 try {
@@ -209,7 +195,13 @@ export class BrowserWebRtcConnection extends WebRtcConnection {
     }
 
     private openDataChannel(dataChannel: RTCDataChannel): void {
+        this.lastState = 'connected'
         this.dataChannel = dataChannel
         this.emitOpen()
+    }
+
+    close(err?: Error): void {
+        this.lastState = 'close'
+        super.close(err)
     }
 }


### PR DESCRIPTION
Improve WebRTC connection handling to be compatible with Firefox. 

We used `peerConnection.connectionState` to determine the state of a WebRTC connection, however this is not supported in some browsers, such as Firefox (See: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState#browser_compatibility and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionstatechange_event). 

If it is not supported, it will have value undefined, which will trip up the logic to throw an error on 2nd access to the connection in https://github.com/streamr-dev/network-monorepo/blob/main/packages/network/src/connection/webrtc/WebRtcEndpoint.ts#L354. The 2nd access is typically made when a stream is encrypted as we deliver the group keys via the same connection.