### PR TITLE
Remove incorrect information from broker readme

### DIFF
--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -123,15 +123,3 @@ https://semver.org/. Files package.json and package-lock.json will be automatica
 3. `git push --follow-tags`
 4. Wait for GitHub Actions to run tests
 5. If tests passed, GitHub Actions will publish the new version to NPM
-
-## Misc
-
-
-### Special considerations for using MQTT plugin
-- For authentication put private key in the password connection field
-- MQTT clients can send plain text, but their payload will be transformed to a JSON object accordingly:
-`{"mqttPayload":"ORIGINAL_PLAINTEXT_PAYLOAD}`
-
-#### Error handling
-- If private key is not correct, client will receive "Connection refused, bad user name or password" (returnCode: 4)
-- If stream is not found, client will receive "Connection refused, not authorized" (returnCode: 5)


### PR DESCRIPTION
The broker readme seemed to contain incorrect info about the MQTT plugin:
- You shouldn't pass the private key as the password, but the API key
- Published plaintext messages don't seem to be wrapped to JSON as described

The functionality of the MQTT plugin is described in the Plugins markdown, so no reason to duplicate it here (even if the info was correct, which it isn't)
