### PR TITLE
NET-812: Configurable metrics periods

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -58,9 +58,6 @@
     },
     "apiAuthentication": null,
     "plugins": {
-        "metrics": {
-            "nodeMetrics": null
-        },
         "storage": {
             "cassandra": {
                 "hosts": [

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -57,9 +57,5 @@
         "port": 8791
     },
     "apiAuthentication": null,
-    "plugins": {
-        "metrics": {
-            "nodeMetrics": null
-        }
-    }
+    "plugins": {}
 }

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -57,9 +57,5 @@
         "port": 8691
     },
     "apiAuthentication": null,
-    "plugins": {
-        "metrics": {
-            "nodeMetrics": null
-        }
-    }
+    "plugins": {}
 }

--- a/packages/broker/configs/development-prod-resend.env.json
+++ b/packages/broker/configs/development-prod-resend.env.json
@@ -20,9 +20,5 @@
         "port": 8791
     },
     "apiAuthentication": null,
-    "plugins": {
-        "metrics": {
-            "nodeMetrics": null
-        }
-    }
+    "plugins": {}
 }

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -141,8 +141,6 @@ const convertV1ToV2 = (source: any): Config => {
     return target as Config
 }
 
-// const streamId = `${this.streamIdPrefix}${streamIdSuffix}`
-
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createMigratedConfig = (source: any): Config | never => {
     const version = getVersion(source)

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -113,11 +113,35 @@ const convertV1ToV2 = (source: any): Config => {
         }
         delete target.plugins.metrics.consoleAndPM2IntervalInSeconds
     }
+    const metricsPluginStreamIdPrefix = source.plugins.metrics?.streamIdPrefix
+    if (metricsPluginStreamIdPrefix !== undefined) {
+        target.plugins.metrics.periods = [
+            {
+                duration: 5000,
+                streamId: `${metricsPluginStreamIdPrefix}/sec`
+            },
+            {
+                duration: 60000,
+                streamId: `${metricsPluginStreamIdPrefix}/min`
+            },
+            {
+                duration: 3600000,
+                streamId: `${metricsPluginStreamIdPrefix}/hour`
+            },
+            {
+                duration: 86400000,
+                streamId: `${metricsPluginStreamIdPrefix}/day`
+            }
+        ]
+        delete target.plugins.metrics.streamIdPrefix
+    }
     if (target.client?.network?.name !== undefined) {
         delete target.client.network.name 
     }
     return target as Config
 }
+
+// const streamId = `${this.streamIdPrefix}${streamIdSuffix}`
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createMigratedConfig = (source: any): Config | never => {

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -113,7 +113,7 @@ const convertV1ToV2 = (source: any): Config => {
         }
         delete target.plugins.metrics.consoleAndPM2IntervalInSeconds
     }
-    const metricsPluginStreamIdPrefix = source.plugins.metrics?.streamIdPrefix
+    const metricsPluginStreamIdPrefix = source.plugins.metrics?.nodeMetrics?.streamIdPrefix
     if (metricsPluginStreamIdPrefix !== undefined) {
         target.plugins.metrics.periods = [
             {
@@ -133,7 +133,7 @@ const convertV1ToV2 = (source: any): Config => {
                 streamId: `${metricsPluginStreamIdPrefix}/day`
             }
         ]
-        delete target.plugins.metrics.streamIdPrefix
+        delete target.plugins.metrics.nodeMetrics
     }
     if (target.client?.network?.name !== undefined) {
         delete target.client.network.name 

--- a/packages/broker/src/plugins/metrics/config.schema.json
+++ b/packages/broker/src/plugins/metrics/config.schema.json
@@ -3,25 +3,43 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "Metrics plugin configuration",
-  "required": [
-    "nodeMetrics"
-  ],
   "additionalProperties": false,
   "properties": {
-    "nodeMetrics" : {
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": false,
-      "default": {},
-      "properties": {
-        "streamIdPrefix": {
-          "type": "string",
-          "description": "Base streamId before granularities (sec, min, hour) for the firehose metrics stream",
-          "default": "streamr.eth/metrics/nodes/firehose/"
+    "periods": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "streamId",
+          "duration"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number"
+          }
+        } 
+      },
+      "default": [
+        {
+          "duration": 5000,
+          "streamId": "streamr.eth/metrics/nodes/firehose/sec"
+        },
+        {
+          "duration": 60000,
+          "streamId": "streamr.eth/metrics/nodes/firehose/min"
+        },
+        {
+          "duration": 3600000,
+          "streamId": "streamr.eth/metrics/nodes/firehose/hour"
+        },
+        {
+          "duration": 86400000,
+          "streamId": "streamr.eth/metrics/nodes/firehose/day"
         }
-      }
+      ]
     }
   }
 }

--- a/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
+++ b/packages/broker/test/integration/plugins/metrics/node/NodeMetrics.test.ts
@@ -1,9 +1,8 @@
-import StreamrClient, { StreamPermission } from 'streamr-client'
+import StreamrClient, { Stream, StreamPermission } from 'streamr-client'
 import { Tracker } from '@streamr/network-tracker'
 import { Wallet } from 'ethers'
 import { createClient, fetchPrivateKeyWithGas, startBroker, startTestTracker, STREAMR_DOCKER_DEV_HOST } from '../../../../utils'
 import { Broker } from '../../../../../src/broker'
-import { v4 as uuid } from 'uuid'
 import { EthereumAddress, keyToArrayIndex } from 'streamr-client-protocol'
 import { MetricsReport } from 'streamr-network'
 import { waitForCondition } from 'streamr-test-utils'
@@ -17,7 +16,7 @@ describe('NodeMetrics', () => {
     let metricsGeneratingBroker: Broker
     let nodeAddress: EthereumAddress
     let client: StreamrClient
-    let streamIdPrefix: string
+    let stream: Stream
 
     beforeAll(async () => {
         const brokerWallet = new Wallet(await fetchPrivateKeyWithGas())
@@ -26,12 +25,11 @@ describe('NodeMetrics', () => {
         tracker = await startTestTracker(trackerPort)
         client = await createClient(tracker, brokerWallet.privateKey)
 
-        const stream = await client.createStream({
-            id: `/metrics/nodes/${uuid()}/sec`,
+        stream = await client.createStream({
+            id: `/metrics/${Date.now()}`,
             partitions: NUM_OF_PARTITIONS
         })
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user: nodeAddress })
-        streamIdPrefix = stream.id.replace('sec', '')
         // a previous test run may have created the assignment stream
         await client.getOrCreateStream({
             id: '/assignments'
@@ -42,9 +40,12 @@ describe('NodeMetrics', () => {
             trackerPort,
             extraPlugins: {
                 metrics: {
-                    nodeMetrics: {
-                        streamIdPrefix
-                    }
+                    periods: [
+                        {
+                            duration: 100,
+                            streamId: stream.id
+                        }
+                    ]
                 },
                 storage: {
                     cassandra: {
@@ -73,18 +74,17 @@ describe('NodeMetrics', () => {
     it('should retrieve the a `sec` metrics', async () => {
         let report: MetricsReport | undefined
 
-        const id = `${streamIdPrefix}sec`
         const nodeId = (await metricsGeneratingBroker.getNode()).getNodeId()
         const partition = keyToArrayIndex(NUM_OF_PARTITIONS, nodeId.toLowerCase())
 
-        await client.subscribe({ id, partition }, (content: any) => {
+        await client.subscribe({ id: stream.id, partition }, (content: any) => {
             const isReady = content.node.connectionAverageCount > 0
             if (isReady && (report === undefined)) {
                 report = content
             }
         })
 
-        await waitForCondition(() => report !== undefined, 15000, 100)
+        await waitForCondition(() => report !== undefined)
         expect(report!).toMatchObject({
             node: {
                 publishMessagesPerSecond: expect.any(Number),
@@ -115,5 +115,5 @@ describe('NodeMetrics', () => {
                 end: expect.any(Number)
             }
         })
-    }, 35000)
+    })
 })

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -241,6 +241,7 @@ describe('Config migration', () => {
             city: null
         }
         source.plugins.metrics.consoleAndPM2IntervalInSeconds = 123
+        source.plugins.metrics.nodeMetrics.streamIdPrefix = 'mock-prefix'
         testMigration(source, (target: any) => {
             expect(target.client.network.name).toBeUndefined()
             expect(target.client.network.location).toStrictEqual({
@@ -249,6 +250,26 @@ describe('Config migration', () => {
                 country: 'mock-country'
             })
             expect(target.plugins.consoleMetrics.interval).toBe(123)
+            expect(target.plugins.metrics).toEqual({
+                periods: [
+                    {
+                        duration: 5000,
+                        streamId: 'mock-prefix/sec'
+                    },
+                    {
+                        duration: 60000,
+                        streamId: 'mock-prefix/min'
+                    },
+                    {
+                        duration: 3600000,
+                        streamId: 'mock-prefix/hour'
+                    },
+                    {
+                        duration: 86400000,
+                        streamId: 'mock-prefix/day'
+                    }
+                ]
+            })
         })
     })
 


### PR DESCRIPTION
Report periods for `metrics` plugin can be defined in the config file. Each period definition is a pair of `duration` + `streamId`.

The previously hardcoded periods are now used as defaults (`config.schema.json`).