### PR TITLE
update to node-datachannel 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18183,22 +18183,16 @@
             "license": "MIT"
         },
         "node_modules/node-datachannel": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.2.4.tgz",
-            "integrity": "sha512-EucGuvV8FpzcuZukOB5qHLQm35cUrY2VTUKIB7fvGXgHk3M0PFi190qsq2317ir1Nn3bjT3IQV+cOpPyqEny4g==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.3.2.tgz",
+            "integrity": "sha512-txUzjbqPDtjbxbgnO7PSwqv7KsmUcjIGZBF8zfG+B8oVcZFEPmBfyB4Sf9DBD2SCqGZ+TeZxeS2hmb0M1NUbHA==",
             "bundleDependencies": [
                 "prebuild-install"
             ],
             "hasInstallScript": true,
             "dependencies": {
-                "@types/node": "^17.0.21",
                 "prebuild-install": "^7.0.1"
             }
-        },
-        "node_modules/node-datachannel/node_modules/@types/node": {
-            "version": "17.0.31",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-            "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
         },
         "node_modules/node-datachannel/node_modules/ansi-regex": {
             "version": "2.1.1",
@@ -18417,7 +18411,7 @@
             }
         },
         "node_modules/node-datachannel/node_modules/minimist": {
-            "version": "1.2.5",
+            "version": "1.2.6",
             "inBundle": true,
             "license": "MIT"
         },
@@ -18443,7 +18437,7 @@
             }
         },
         "node_modules/node-datachannel/node_modules/node-abi/node_modules/semver": {
-            "version": "7.3.5",
+            "version": "7.3.7",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18468,7 +18462,7 @@
             }
         },
         "node_modules/node-datachannel/node_modules/npmlog/node_modules/are-we-there-yet": {
-            "version": "1.1.5",
+            "version": "1.1.7",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18708,7 +18702,7 @@
             }
         },
         "node_modules/node-datachannel/node_modules/tar-stream/node_modules/bl": {
-            "version": "4.0.3",
+            "version": "4.1.0",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18747,11 +18741,11 @@
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/wide-align": {
-            "version": "1.1.3",
+            "version": "1.1.5",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "string-width": "^1.0.2 || 2"
+                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "node_modules/node-datachannel/node_modules/wrappy": {
@@ -25872,7 +25866,7 @@
                 "heap": "^0.2.6",
                 "ipaddr.js": "^2.0.1",
                 "lodash": "^4.17.21",
-                "node-datachannel": "^0.2.4",
+                "node-datachannel": "^0.3.2",
                 "pino": "^6.11.3",
                 "setimmediate": "^1.0.5",
                 "streamr-client-protocol": "^12.0.0",
@@ -38320,19 +38314,13 @@
             "dev": true
         },
         "node-datachannel": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.2.4.tgz",
-            "integrity": "sha512-EucGuvV8FpzcuZukOB5qHLQm35cUrY2VTUKIB7fvGXgHk3M0PFi190qsq2317ir1Nn3bjT3IQV+cOpPyqEny4g==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.3.2.tgz",
+            "integrity": "sha512-txUzjbqPDtjbxbgnO7PSwqv7KsmUcjIGZBF8zfG+B8oVcZFEPmBfyB4Sf9DBD2SCqGZ+TeZxeS2hmb0M1NUbHA==",
             "requires": {
-                "@types/node": "^17.0.21",
                 "prebuild-install": "^7.0.1"
             },
             "dependencies": {
-                "@types/node": {
-                    "version": "17.0.31",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-                    "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q=="
-                },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true
@@ -38452,7 +38440,7 @@
                     "bundled": true
                 },
                 "minimist": {
-                    "version": "1.2.5",
+                    "version": "1.2.6",
                     "bundled": true
                 },
                 "mkdirp-classic": {
@@ -38471,7 +38459,7 @@
                     },
                     "dependencies": {
                         "semver": {
-                            "version": "7.3.5",
+                            "version": "7.3.7",
                             "bundled": true,
                             "requires": {
                                 "lru-cache": "^6.0.0"
@@ -38490,7 +38478,7 @@
                     },
                     "dependencies": {
                         "are-we-there-yet": {
-                            "version": "1.1.5",
+                            "version": "1.1.7",
                             "bundled": true,
                             "requires": {
                                 "delegates": "^1.0.0",
@@ -38656,7 +38644,7 @@
                     },
                     "dependencies": {
                         "bl": {
-                            "version": "4.0.3",
+                            "version": "4.1.0",
                             "bundled": true,
                             "requires": {
                                 "buffer": "^5.5.0",
@@ -38687,10 +38675,10 @@
                     "bundled": true
                 },
                 "wide-align": {
-                    "version": "1.1.3",
+                    "version": "1.1.5",
                     "bundled": true,
                     "requires": {
-                        "string-width": "^1.0.2 || 2"
+                        "string-width": "^1.0.2 || 2 || 3 || 4"
                     }
                 },
                 "wrappy": {
@@ -41935,7 +41923,7 @@
                 "karma-spec-reporter": "^0.0.32",
                 "karma-webpack": "^5.0.0",
                 "lodash": "^4.17.21",
-                "node-datachannel": "^0.2.4",
+                "node-datachannel": "^0.3.2",
                 "node-module-polyfill": "^1.0.1",
                 "node-polyfill-webpack-plugin": "^1.1.4",
                 "patch-package": "^6.4.7",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -49,7 +49,7 @@
     "heap": "^0.2.6",
     "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",
-    "node-datachannel": "^0.2.4",
+    "node-datachannel": "^0.3.2",
     "pino": "^6.11.3",
     "setimmediate": "^1.0.5",
     "streamr-client-protocol": "^12.0.0",

--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -6,9 +6,6 @@ import { WebRtcConnectionFactory } from "./WebRtcEndpoint"
 const BrowserWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new BrowserWebRtcConnection(opts)
-    },
-    cleanUp(): void {
-
     }
 })
 

--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -4,7 +4,6 @@ import { NameDirectory } from "../../NameDirectory"
 import { WebRtcConnectionFactory } from "./WebRtcEndpoint"
 
 export const webRtcConnectionFactory = new class implements WebRtcConnectionFactory {
-    activeWebRtcEndpointCount = 0
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new BrowserWebRtcConnection(opts)
     }

--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -3,13 +3,16 @@ import { Logger } from "../../helpers/Logger"
 import { NameDirectory } from "../../NameDirectory"
 import { WebRtcConnectionFactory } from "./WebRtcEndpoint"
 
-const BrowserWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
+export const webRtcConnectionFactory = new class implements WebRtcConnectionFactory {
+    activeWebRtcEndpointCount = 0
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new BrowserWebRtcConnection(opts)
     }
-})
-
-export default BrowserWebRtcConnectionFactory
+    registerWebRtcEndpoint(): void {
+    }
+    unregisterWebRtcEndpoint(): void {
+    }
+}
 
 export class BrowserWebRtcConnection extends WebRtcConnection {
     private readonly logger: Logger

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -70,9 +70,6 @@ function DataChannelEmitter(dataChannel: DataChannel) {
 const NodeWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new NodeWebRtcConnection(opts)
-    },
-    cleanUp(): void {
-        nodeDataChannel.cleanup()
     }
 })
 

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -79,7 +79,7 @@ export const webRtcConnectionFactory = new class implements WebRtcConnectionFact
     unregisterWebRtcEndpoint(): void {
         this.activeWebRtcEndpointCount--
         if (this.activeWebRtcEndpointCount === 0) {
-            this.logger.info('Clean up nodeDataChannel')
+            this.logger.debug('Clean up nodeDataChannel library')
             nodeDataChannel.cleanup()
         }
     }

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -67,13 +67,23 @@ function DataChannelEmitter(dataChannel: DataChannel) {
     return emitter
 }
 
-const NodeWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
+export const webRtcConnectionFactory = new class implements WebRtcConnectionFactory {
+    activeWebRtcEndpointCount = 0
+    logger = new Logger(module)
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new NodeWebRtcConnection(opts)
     }
-})
-
-export default NodeWebRtcConnectionFactory
+    registerWebRtcEndpoint(): void {
+        this.activeWebRtcEndpointCount++
+    }
+    unregisterWebRtcEndpoint(): void {
+        this.activeWebRtcEndpointCount--
+        if (this.activeWebRtcEndpointCount === 0) {
+            this.logger.info('Clean up nodeDataChannel')
+            nodeDataChannel.cleanup()
+        }
+    }
+}
 
 export class NodeWebRtcConnection extends WebRtcConnection {
     private readonly logger: Logger

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -476,6 +476,9 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     }
 
     stop(): void {
+        if (this.stopped === true) {
+            throw new Error('already stopped')
+        }
         this.stopped = true
         const { connections, messageQueues } = this
         this.connections = {}

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -39,7 +39,6 @@ interface WebRtcEndpointMetrics extends MetricsDefinition {
 
 export interface WebRtcConnectionFactory {
     createConnection(opts: ConstructorOptions): WebRtcConnection
-    cleanUp(): void
 }
 
 export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
@@ -493,7 +492,6 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.removeAllListeners()
         Object.values(connections).forEach((connection) => connection.close())
         Object.values(messageQueues).forEach((queue) => queue.clear())
-        this.connectionFactory.cleanUp()
     }
 
     getAllConnectionNodeIds(): PeerId[] {

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -39,6 +39,8 @@ interface WebRtcEndpointMetrics extends MetricsDefinition {
 
 export interface WebRtcConnectionFactory {
     createConnection(opts: ConstructorOptions): WebRtcConnection
+    registerWebRtcEndpoint(): void
+    unregisterWebRtcEndpoint(): void
 }
 
 export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
@@ -90,6 +92,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.bufferThresholdHigh = webrtcDatachannelBufferThresholdHigh
         this.disallowPrivateAddresses = webrtcDisallowPrivateAddresses
         this.maxMessageSize = maxMessageSize
+
+        this.connectionFactory.registerWebRtcEndpoint()
 
         rtcSignaller.setOfferListener(async (options: OfferOptions) => {
             this.onRtcOfferFromSignaller(options)
@@ -492,6 +496,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.removeAllListeners()
         Object.values(connections).forEach((connection) => connection.close())
         Object.values(messageQueues).forEach((queue) => queue.clear())
+        this.connectionFactory.unregisterWebRtcEndpoint()
     }
 
     getAllConnectionNodeIds(): PeerId[] {

--- a/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
+++ b/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
@@ -10,7 +10,6 @@ export type HandshakeValues = { uuid: string, peerId: PeerId }
 
 export interface WebSocketConnectionFactory<C extends AbstractWsConnection> {
     createConnection(socket: SupportedWs, peerInfo: PeerInfo): C
-    cleanUp(): void
 }
 
 export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> extends AbstractWsEndpoint<C> {

--- a/packages/network/src/connection/ws/BrowserClientWsConnection.ts
+++ b/packages/network/src/connection/ws/BrowserClientWsConnection.ts
@@ -10,9 +10,6 @@ const staticLogger = new Logger(module)
 export const BrowserWebSocketConnectionFactory: WebSocketConnectionFactory<BrowserClientWsConnection> = Object.freeze({
     createConnection(socket: w3cwebsocket, peerInfo: PeerInfo): BrowserClientWsConnection {
         return new BrowserClientWsConnection(socket, peerInfo)
-    },
-    cleanUp(): void {
-
     }
 })
 

--- a/packages/network/src/connection/ws/NodeClientWsConnection.ts
+++ b/packages/network/src/connection/ws/NodeClientWsConnection.ts
@@ -11,9 +11,6 @@ const staticLogger = new Logger(module)
 export const NodeWebSocketConnectionFactory: WebSocketConnectionFactory<NodeClientWsConnection> = Object.freeze({
     createConnection(socket: WebSocket, peerInfo: PeerInfo): NodeClientWsConnection {
         return new NodeClientWsConnection(socket, peerInfo)
-    },
-    cleanUp(): void {
-
     }
 })
 

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -10,7 +10,7 @@ import { NegotiatedProtocolVersions } from './connection/NegotiatedProtocolVersi
 import { PeerInfo } from './connection/PeerInfo'
 import NodeClientWsEndpoint from './connection/ws/NodeClientWsEndpoint'
 import { WebRtcEndpoint } from './connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from './connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory} from './connection/webrtc/NodeWebRtcConnection'
 
 export interface NetworkNodeOptions extends AbstractNodeOptions {
     trackers: TrackerInfo[],
@@ -55,7 +55,7 @@ export const createNetworkNode = ({
         webRtcSignaller,
         metricsContext,
         negotiatedProtocolVersions,
-        NodeWebRtcConnectionFactory,
+        webRtcConnectionFactory,
         newWebrtcConnectionTimeout,
         peerPingInterval,
         webrtcDatachannelBufferThresholdLow,

--- a/packages/network/src/simulator/AbstractClientWsEndpoint_simulator.ts
+++ b/packages/network/src/simulator/AbstractClientWsEndpoint_simulator.ts
@@ -12,7 +12,6 @@ export type HandshakeValues = { uuid: string, peerId: PeerId }
 /*
 export interface WebSocketConnectionFactory<C extends AbstractWsConnection> {
     createConnection(peerInfo: PeerInfo): C
-    cleanUp(): void
 }
 */
 

--- a/packages/network/src/simulator/NodeClientWsConnection_simulator.ts
+++ b/packages/network/src/simulator/NodeClientWsConnection_simulator.ts
@@ -12,9 +12,6 @@ import { Simulator } from './Simulator'
 export const NodeWebSocketConnectionFactory: WebSocketConnectionFactory<NodeClientWsConnection> = Object.freeze({
     createConnection(peerInfo: PeerInfo): NodeClientWsConnection {
         return new NodeClientWsConnection(peerInfo)
-    },
-    cleanUp(): void {
-
     }
 })
 */

--- a/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
+++ b/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
@@ -6,13 +6,15 @@ import { WebRtcConnectionFactory } from "../connection/webrtc/WebRtcEndpoint"
 import { Simulator } from "./Simulator"
 import { DescriptionType } from 'node-datachannel'
 
-const NodeWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
+export const webRtcConnectionFactory = new class implements WebRtcConnectionFactory {
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new NodeWebRtcConnection(opts)
     }
-})
-
-export default NodeWebRtcConnectionFactory
+    registerWebRtcEndpoint(): void {
+    }
+    unregisterWebRtcEndpoint(): void {
+    }
+}
 
 export class NodeWebRtcConnection extends WebRtcConnection {
     private readonly logger: Logger

--- a/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
+++ b/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
@@ -9,9 +9,6 @@ import { DescriptionType } from 'node-datachannel'
 const NodeWebRtcConnectionFactory: WebRtcConnectionFactory = Object.freeze({
     createConnection(opts: ConstructorOptions): WebRtcConnection {
         return new NodeWebRtcConnection(opts)
-    },
-    cleanUp(): void {
-        //nodeDataChannel.cleanup()
     }
 })
 

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -55,7 +55,6 @@ describe('BrowserWebRtcConnection', () => {
     afterAll(() => {
         conn1.close()
         conn2.close()
-        BrowserWebRtcConnectionFactory.cleanUp()
     })
 
     it('can connect', async () => {

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -1,4 +1,4 @@
-import BrowserWebRtcConnectionFactory from "../../src/connection/webrtc/BrowserWebRtcConnection"
+import { webRtcConnectionFactory } from "../../src/connection/webrtc/BrowserWebRtcConnection"
 import { runAndWaitForEvents } from "streamr-test-utils"
 import { MessageQueue} from "../../src/connection/MessageQueue"
 import { ConstructorOptions } from "../../src/connection/webrtc/WebRtcConnection"
@@ -24,8 +24,8 @@ const connectionOpts2: ConstructorOptions = {
 
 describe('BrowserWebRtcConnection', () => {
 
-    const conn1 = BrowserWebRtcConnectionFactory.createConnection(connectionOpts1)
-    const conn2 = BrowserWebRtcConnectionFactory.createConnection(connectionOpts2)
+    const conn1 = webRtcConnectionFactory.createConnection(connectionOpts1)
+    const conn2 = webRtcConnectionFactory.createConnection(connectionOpts2)
 
     conn1.on('localCandidate', (candidate, mid) => {
         conn2.addRemoteCandidate(candidate, mid)

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -14,7 +14,7 @@ import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { NegotiatedProtocolVersions } from '../../src/connection/NegotiatedProtocolVersions'
 import { MetricsContext } from '../../src/helpers/Metric'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 import { startServerWsEndpoint } from '../utils'
 const { StreamMessage, MessageID, MessageRef } = MessageLayer
@@ -54,7 +54,7 @@ describe('delivery of messages in protocol layer', () => {
             new RtcSignaller(peerInfo1, nodeToTracker),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
         const wrtcEndpoint2 =  new WebRtcEndpoint(
             peerInfo2,
@@ -62,7 +62,7 @@ describe('delivery of messages in protocol layer', () => {
             new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
 
         // @ts-expect-error: private field

--- a/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
+++ b/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
@@ -10,7 +10,7 @@ import { MessageID, StreamMessage, toStreamID } from "streamr-client-protocol"
 import { runAndWaitForEvents } from "streamr-test-utils"
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 
 describe('Node-to-Node protocol version negotiation', () => {
     let tracker: Tracker
@@ -54,7 +54,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             new RtcSignaller(peerInfo1, nodeToTracker1),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
-            NodeWebRtcConnectionFactory,
+            webRtcConnectionFactory,
             5000
         )
         ep2 = new WebRtcEndpoint(
@@ -63,7 +63,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
-            NodeWebRtcConnectionFactory,
+            webRtcConnectionFactory,
             5000
         )
         ep3 = new WebRtcEndpoint(
@@ -72,7 +72,7 @@ describe('Node-to-Node protocol version negotiation', () => {
             new RtcSignaller(peerInfo3, nodeToTracker3),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo3),
-            NodeWebRtcConnectionFactory,
+            webRtcConnectionFactory,
             5000
         )
         nodeToNode1 = new NodeToNode(ep1)

--- a/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -8,7 +8,7 @@ import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { wait } from 'streamr-test-utils'
 import { NegotiatedProtocolVersions } from '../../src/connection/NegotiatedProtocolVersions'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 
 describe('WebRtcEndpoint: back pressure handling', () => {
     let tracker: Tracker
@@ -43,7 +43,7 @@ describe('WebRtcEndpoint: back pressure handling', () => {
             new RtcSignaller(peerInfo1, nodeToTracker1),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
         ep2 = new WebRtcEndpoint(
             peerInfo2,
@@ -51,7 +51,7 @@ describe('WebRtcEndpoint: back pressure handling', () => {
             new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
         await Promise.all([
             ep1.connect('ep2', tracker.getTrackerId()),

--- a/packages/network/test/integration/webrtc-multi-signaller.test.ts
+++ b/packages/network/test/integration/webrtc-multi-signaller.test.ts
@@ -7,7 +7,7 @@ import { Event as EndpointEvent } from '../../src/connection/webrtc/IWebRtcEndpo
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { NegotiatedProtocolVersions } from '../../src/connection/NegotiatedProtocolVersions'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 
 describe('WebRTC multisignaller test', () => {
@@ -66,7 +66,7 @@ describe('WebRTC multisignaller test', () => {
             new RtcSignaller(peerInfo1, nodeToTracker1),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo1),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
         endpoint2 = new WebRtcEndpoint(
             peerInfo2,
@@ -74,7 +74,7 @@ describe('WebRTC multisignaller test', () => {
             new RtcSignaller(peerInfo2, nodeToTracker2),
             new MetricsContext(),
             new NegotiatedProtocolVersions(peerInfo2),
-            NodeWebRtcConnectionFactory
+            webRtcConnectionFactory
         )
     })
 

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -46,7 +46,6 @@ describe('NodeWebRtcConnection', () => {
     afterAll(() => {
         conn1.close()
         conn2.close()
-        NodeWebRtcConnectionFactory.cleanUp()
     })
 
     it('can connect', async () => {

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -1,4 +1,4 @@
-import NodeWebRtcConnectionFactory from "../../src/connection/webrtc/NodeWebRtcConnection"
+import { webRtcConnectionFactory } from "../../src/connection/webrtc/NodeWebRtcConnection"
 import { MessageQueue} from "../../src/connection/MessageQueue"
 import { ConstructorOptions } from "../../src/connection/webrtc/WebRtcConnection"
 import { DeferredConnectionAttempt } from "../../src/connection/webrtc/DeferredConnectionAttempt"
@@ -23,8 +23,8 @@ const connectionOpts2: ConstructorOptions = {
 
 describe('NodeWebRtcConnection', () => {
 
-    const conn1 = NodeWebRtcConnectionFactory.createConnection(connectionOpts1)
-    const conn2 = NodeWebRtcConnectionFactory.createConnection(connectionOpts2)
+    const conn1 = webRtcConnectionFactory.createConnection(connectionOpts1)
+    const conn2 = webRtcConnectionFactory.createConnection(connectionOpts2)
 
     conn1.on('localCandidate', (candidate, mid) => {
         conn2.addRemoteCandidate(candidate, mid)

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -1,4 +1,4 @@
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 import { runAndWaitForEvents } from 'streamr-test-utils'
 import { MessageQueue} from '../../src/connection/MessageQueue'
 import { ConstructorOptions } from '../../src/connection/webrtc/WebRtcConnection'
@@ -24,19 +24,19 @@ const connectionOpts2: ConstructorOptions = {
 
 describe('NodeWebRtcConnection', () => {
 
-    const conn1 = NodeWebRtcConnectionFactory.createConnection(connectionOpts1)
-    const conn2 = NodeWebRtcConnectionFactory.createConnection(connectionOpts2)
+    const conn1 = webRtcConnectionFactory.createConnection(connectionOpts1)
+    const conn2 = webRtcConnectionFactory.createConnection(connectionOpts2)
 
-    conn1.on('localCandidate', (candidate, mid) => {
+    conn1.on('localCandidate', (candidate: any, mid: any) => {
         conn2.addRemoteCandidate(candidate, mid)
     })
-    conn2.on('localCandidate', (candidate, mid) => {
+    conn2.on('localCandidate', (candidate: any, mid: any) => {
         conn1.addRemoteCandidate(candidate, mid)
     })
-    conn1.on('localDescription', (type, description) => {
+    conn1.on('localDescription', (type: any, description: any) => {
         conn2.setRemoteDescription(description, type)
     })
-    conn2.on('localDescription', (type, description) => {
+    conn2.on('localDescription', (type: any, description: any) => {
         conn1.setRemoteDescription(description, type)
     })
     beforeAll(async () => {

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -55,7 +55,6 @@ describe('NodeWebRtcConnection', () => {
     afterAll(() => {
         conn1.close()
         conn2.close()
-        NodeWebRtcConnectionFactory.cleanUp()
     })
 
     it('can connect', async () => {

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -7,7 +7,7 @@ import { Event as EndpointEvent } from '../../src/connection/webrtc/IWebRtcEndpo
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { NegotiatedProtocolVersions } from '../../src/connection/NegotiatedProtocolVersions'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
-import NodeWebRtcConnectionFactory from '../../src/connection/webrtc/NodeWebRtcConnection'
+import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'
 
 describe('WebRtcEndpoint', () => {
@@ -18,7 +18,7 @@ describe('WebRtcEndpoint', () => {
     let endpoint2: WebRtcEndpoint
 
     describe.each([
-        NodeWebRtcConnectionFactory // TODO: add web-version when done
+        webRtcConnectionFactory // TODO: add web-version when done
     ])('when configured with %s', (factory) => {
 
         beforeEach(async () => {
@@ -455,7 +455,7 @@ describe('WebRtcEndpoint', () => {
                 new RtcSignaller(peerInfo, nodeToTracker),
                 new MetricsContext(),
                 new NegotiatedProtocolVersions(peerInfo),
-                NodeWebRtcConnectionFactory,
+                webRtcConnectionFactory,
                 15000,    // newConnectionTimeout
                 5 * 1000, // pingInternval
                 2 ** 15,  // webrtcDatachannelBufferThresholdLow


### PR DESCRIPTION
Update `network` to use `node-datachannel` v0.3.2.

Also fix cleanup logic when using node-datachannel: when all `NodeWebRtcEndpoints` stop, we clean up the global `nodeDataChannel` library object.