### PR TITLE
build(protocol): move types/debug to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26003,7 +26003,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
-                "@types/debug": "^4.1.7",
                 "debug": "^4.3.2",
                 "heap": "^0.2.6",
                 "secp256k1": "^4.0.2",
@@ -26012,6 +26011,7 @@
             },
             "devDependencies": {
                 "@streamr/dev-config": "^1.0.0",
+                "@types/debug": "^4.1.7",
                 "@types/heap": "^0.2.28",
                 "@types/jest": "^27.0.2",
                 "@types/secp256k1": "^4.0.3",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@streamr/dev-config": "^1.0.0",
+    "@types/debug": "^4.1.7",
     "@types/heap": "^0.2.28",
     "@types/jest": "^27.0.2",
     "@types/secp256k1": "^4.0.3",
@@ -40,7 +41,6 @@
   },
   "dependencies": {
     "@ethersproject/hdnode": "^5.4.0",
-    "@types/debug": "^4.1.7",
     "debug": "^4.3.2",
     "heap": "^0.2.6",
     "secp256k1": "^4.0.2",


### PR DESCRIPTION
Move @types/debug to dev dependencies.

## Checklist

<!--- Feel free to remove any that are not relevant -->

- [ ] Has passing tests that demonstrate this change works
- [ ] Updated Changelog
- [ ] Updated Documentation
