### PR TITLE
build(client): update sqlite3 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22933,9 +22933,10 @@
             "license": "MIT"
         },
         "node_modules/sqlite3": {
-            "version": "5.0.3",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
+            "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
             "hasInstallScript": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "node-addon-api": "^4.2.0",
@@ -25744,7 +25745,7 @@
                 "reflect-metadata": "^0.1.13",
                 "split2": "^3.2.2",
                 "sqlite": "^4.0.23",
-                "sqlite3": "^5.0.3",
+                "sqlite3": "^5.0.8",
                 "streamr-client-protocol": "^12.0.0",
                 "streamr-network": "^35.0.0",
                 "ts-toolbelt": "^9.6.0",
@@ -41455,7 +41456,9 @@
             "version": "4.0.23"
         },
         "sqlite3": {
-            "version": "5.0.3",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.8.tgz",
+            "integrity": "sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==",
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "node-addon-api": "^4.2.0",
@@ -41843,7 +41846,7 @@
                 "reflect-metadata": "^0.1.13",
                 "split2": "^3.2.2",
                 "sqlite": "^4.0.23",
-                "sqlite3": "^5.0.3",
+                "sqlite3": "^5.0.8",
                 "streamr-client-protocol": "^12.0.0",
                 "streamr-network": "^35.0.0",
                 "streamr-test-utils": "^2.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -158,7 +158,7 @@
         "reflect-metadata": "^0.1.13",
         "split2": "^3.2.2",
         "sqlite": "^4.0.23",
-        "sqlite3": "^5.0.3",
+        "sqlite3": "^5.0.8",
         "streamr-client-protocol": "^12.0.0",
         "streamr-network": "^35.0.0",
         "ts-toolbelt": "^9.6.0",


### PR DESCRIPTION
Debugging build issue with Node >= 16.14.x

* [sqlite3 GitHub](https://github.com/TryGhost/node-sqlite3)
* [sqlite3 npm](https://www.npmjs.com/package/sqlite3)
* sqlite3 v5.0.8 fails to build Docker image

## Checklist

<!--- Feel free to remove any that are not relevant -->

- [ ] Has passing tests that demonstrate this change works
- [ ] Updated Changelog
- [ ] Updated Documentation
