### PR TITLE
client: config migration sequence

### DIFF
--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -143,15 +143,19 @@ const convertV1ToV2 = (source: any): Config => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createMigratedConfig = (source: any): Config | never => {
-    const version = getVersion(source)
-    const isTestnetConfig = (version === undefined) && (isValidConfig(source, TEST_CONFIG_SCHEMA))
-    if (isTestnetConfig) {
-        return convertTestnet3ToV1(source)
-    } else if (version === 1) {
-        return convertV1ToV2(source)
-    } else {
-        throw new Error('Unable to migrate the config')
-    }
+    let config = source
+    do {
+        const version = getVersion(config)
+        const isTestnetConfig = (version === undefined) && (isValidConfig(config, TEST_CONFIG_SCHEMA))
+        if (isTestnetConfig) {
+            config = convertTestnet3ToV1(config)
+        } else if (version === 1) {
+            config = convertV1ToV2(config)
+        } else {
+            throw new Error(`Unable to migrate the config: version=${version}`)
+        }
+    } while (needsMigration(config))
+    return config
 }
 
 /* 

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -152,10 +152,7 @@ const validateTargetConfig = (config: any): void | never => {
 
 const testMigration = (source: any, assertTarget: (target: any) => void | never) => {
     expect(needsMigration(source)).toBe(true)
-    let target = source
-    do {
-        target = createMigratedConfig(target)
-    } while (needsMigration(target))
+    const target = createMigratedConfig(source)
     assertTarget(target)
     validateTargetConfig(target)
 }


### PR DESCRIPTION
Support client config migrations that require multiple migration steps, e.g. `testnet3` -> `v1` -> `v2`.