### PR TITLE
client: getStorageNodeMetadata()

### DIFF
--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -172,7 +172,7 @@ export class Resends implements Context {
         }
 
         const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]
-        const nodeUrl = await this.storageNodeRegistry.getStorageNodeUrl(nodeAddress)
+        const nodeUrl = await (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).http
         const url = createUrl(nodeUrl, endpointSuffix, streamPartId, query)
         const messageStream = SubscribePipeline<T>(
             new MessageStream<T>(this),

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -1,7 +1,7 @@
 import { Wallet } from 'ethers'
 import { ConfigTest, Stream } from '../../src'
 import { StreamrClient } from '../../src/StreamrClient'
-import { createTestStream, fetchPrivateKeyWithGas } from '../test-utils/utils'
+import { createEthereumAddress, createTestStream, fetchPrivateKeyWithGas } from '../test-utils/utils'
 
 import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { EthereumAddress } from 'streamr-client-protocol'
@@ -48,8 +48,8 @@ describe('StorageNodeRegistry2', () => {
         await storageNodeClient.setStorageNodeMetadata({
             http: url
         })
-        const createdNodeUrl = await storageNodeClient.getStorageNodeUrl(storageNodeAddress)
-        expect(createdNodeUrl).toEqual(url)
+        const metadata = await storageNodeClient.getStorageNodeMetadata(storageNodeAddress)
+        expect(metadata.http).toEqual(url)
     })
 
     it('add stream to storage node', async () => {
@@ -89,6 +89,12 @@ describe('StorageNodeRegistry2', () => {
 
     it('delete a node', async () => {
         await storageNodeClient.setStorageNodeMetadata(undefined)
-        return expect(storageNodeClient.getStorageNodeUrl(storageNodeAddress)).rejects.toThrow()
+        return expect(storageNodeClient.getStorageNodeMetadata(storageNodeAddress)).rejects.toThrow()
+    })
+
+    it('metadata from non-existing node', async () => {
+        return expect(async () => {
+            await storageNodeClient.getStorageNodeMetadata(createEthereumAddress(Date.now()))
+        }).rejects.toThrow('Node not found')
     })
 })

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -81,13 +81,6 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async getStorageNodeUrl(_nodeAddress: EthereumAddress): Promise<string> {
-        // return some dummy value: the receiving component passes the info to FakeRest,
-        // and it is ignored there
-        return ''
-    }
-
-    // eslint-disable-next-line class-methods-use-this
     async stop(): Promise<void> {
         // no-op
     }
@@ -95,6 +88,15 @@ export class FakeStorageNodeRegistry implements Omit<StorageNodeRegistry,
     // eslint-disable-next-line class-methods-use-this
     async setStorageNodeMetadata(_metadata: StorageNodeMetadata | undefined): Promise<void> {
         throw new Error('not implemented')
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async getStorageNodeMetadata(_nodeAddress: string): Promise<StorageNodeMetadata> {
+        // return some dummy value: the receiving component passes the info to FakeRest,
+        // and it is ignored there
+        return {
+            http: ''
+        }
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -19,6 +19,7 @@ import { Signal } from '../../src/utils/Signal'
 import { PublishMetadata } from '../../src/publish/Publisher'
 import { Pipeline } from '../../src/utils/Pipeline'
 import { StreamPermission } from '../../src/permission'
+import { padEnd } from 'lodash'
 
 const testDebugRoot = Debug('test')
 const testDebug = testDebugRoot.extend.bind(testDebugRoot)
@@ -587,6 +588,10 @@ export async function until(condition: MaybeAsync<() => boolean>, timeOutMs = 10
     } finally {
         clearTimeout(t)
     }
+}
+
+export const createEthereumAddress = (id: number): string => {
+    return '0x' + padEnd(String(id), 40, '0')
 }
 
 export const createEthereumAddressCache = (): { getAddress: (privateKey: string) => EthereumAddress } => {


### PR DESCRIPTION
New public client method `getStorageNodeMetadata(address: EthereumAddress)` to get storage node metadata. 

Removed internal `getStorageNodeUrl(address: EthereumAddress)` method as we can now use the new public method to query the URL. 

### Functional differences

- The data source has changed: `getStorageNodeUrl()`  used The Graph, and `getStorageNodeMetadata()` uses the contract directly

### Checklist

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog
