### PR TITLE
Improve broker readmes

### DIFF
--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -6,20 +6,13 @@
 
 # streamr-broker
 
-Main executable for running a broker node in Streamr Network.
-
-The broker node extends the minimal network node provided by the
-[streamr-network](https://github.com/streamr-dev/network) library with
-- client-facing support for foreign protocols (e.g. HTTP, MQTT) via plugins
-- support for long-term persistence of data using Apache Cassandra.
+The Broker node is your application's access point to data streams in the Streamr Network. The Broker node is also used for mining and staking.
 
 ## Table of Contents
 - [Install](#install)
-- [Configure](#configure)
+- [Plugins](#plugins)
 - [Run](#run)
 - [Develop](#develop)
-- [Release](#release)
-- [Misc](#misc)
 
 ## Install
 | NodeJS version `16.13.x` and NPM version `8.x` is required |
@@ -30,21 +23,17 @@ To install streamr-broker:
 npm install -g streamr-broker
 ```
 
-## Configure
+## Plugins
 
-To enable the features you want, configure some [plugins](plugins.md).
+The Broker node ships with a number of plugins for configuring your Broker node to match your specific needs. For easy data integration from any environment, plugins for HTTP, Websocket, and MQTT are provided. Read more about available [plugins](plugins.md).
 
 ## Run
-When developing the Broker, it is convenient to run it as part of the full Streamr development stack. Check out
-the [streamr-docker-dev](https://github.com/streamr-dev/streamr-docker-dev) tool that can be used to run the full stack.
-
-If instead you want to run a broker node by itself without Docker, follow the steps below.
 
 First install the package
 ```
 npm install -g streamr-broker
 ```
-Optionally, create a configuration file with interactive tool:
+Create a configuration file with interactive tool:
 ```
 broker-init 
 ```
@@ -52,74 +41,7 @@ Then run the command broker with the desired configuration file
 ```
 broker <configFile>
 ```
-See folder "configs" for example configurations. To run a simple local broker
-```
-broker configs/development-1.env.json
-```
-Then run the command tracker with default values
-```
-tracker
-```
-
-### Deleting expired data from Storage node
-To delete expired data from storage node run
-
-```
-broker <configFile> --deleteExpired
-```
-
-or
-
-```
-node app.js <configFile> --deleteExpired
-```
 
 ## Develop
 
-Install dependencies:
-
-    npm ci
-
-Run the tests:
-
-    npm run test
-
-We use [eslint](https://github.com/eslint/eslint) for code formatting:
-
-    npm run eslint
-
-Code coverage:
-
-    npm run coverage
-
-### Debug
-
-To get all debug messages:
-
-    LOG_LEVEL=debug
-
-... or adjust debugging to desired level:
-
-    LOG_LEVEL=[debug|info|warn|error]
-
-To disable all logs
-
-    NOLOG=true
-
-### Regenerate self-signed certificate fixture
-To regenerate self-signed certificate in `./test/fixtures` run:
-
-```bash
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 36500 -nodes -subj "/CN=localhost"
-```
-
-## Release
-
-Publishing to NPM is automated via GitHub Actions. Follow the steps below to publish.
-
-1. `git checkout master && git pull`
-2. Update version with either `npm version patch`, `npm version minor`, or `npm version major`. Use semantic versioning
-https://semver.org/. Files package.json and package-lock.json will be automatically updated, and an appropriate git commit and tag created.
-3. `git push --follow-tags`
-4. Wait for GitHub Actions to run tests
-5. If tests passed, GitHub Actions will publish the new version to NPM
+Check the [Broker dev notes](develop.md) if you're intending to contribute to the codebase.

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -5,8 +5,11 @@
 </p>
 
 # streamr-broker
+Broker nodes are Streamr nodes that run externally to your application. You start up a node on a server, and interface with it remotely using one of the supported protocols.
 
-The Broker node is your application's access point to data streams in the Streamr Network. The Broker node is also used for mining and staking.
+The Broker node ships with plugins for HTTP, Websocket, and MQTT protocols. Libraries for these protocols exist in practically every programming language, meaning that you can conveniently publish and subscribe to data from the Streamr Network using any programming language.
+
+Broker nodes have a plugin architecture that allows them to perform other tasks in addition to (or instead of) serving applications, such as mining.
 
 ## Table of Contents
 - [Install](#install)
@@ -23,9 +26,13 @@ To install streamr-broker:
 npm install -g streamr-broker
 ```
 
+For more information on the different ways to install a Broker node, see [setting up a Broker node](https://streamr.network/docs/streamr-network/installing-broker-node).
+
 ## Plugins
 
-The Broker node ships with a number of plugins for configuring your Broker node to match your specific needs. For easy data integration from any environment, plugins for HTTP, Websocket, and MQTT are provided. Read more about available [plugins](plugins.md).
+The Broker node ships with a number of plugins for configuring your Broker node to match your specific needs. For easy data integration from any environment, plugins for HTTP, Websocket, and MQTT are provided. 
+
+Read more about available [plugins](plugins.md).
 
 ## Run
 

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -35,11 +35,11 @@ npm install -g streamr-broker
 ```
 Create a configuration file with interactive tool:
 ```
-broker-init 
+streamr-broker-init 
 ```
 Then run the command broker with the desired configuration file
 ```
-broker <configFile>
+streamr-broker <configFile>
 ```
 
 ## Develop

--- a/packages/broker/develop.md
+++ b/packages/broker/develop.md
@@ -1,0 +1,82 @@
+
+## Develop
+
+The information here is mostly for the Streamr team and others intending to contribute to the codebase.
+
+When developing the Broker, it is convenient to run it as part of the full Streamr development stack. Check out
+the [streamr-docker-dev](https://github.com/streamr-dev/streamr-docker-dev) tool that can be used to run the full stack.
+
+If instead you want to run a broker node by itself without Docker, follow the steps in the [Run](#run) section.
+
+See folder "configs" for example configurations. To run a broker connected to the local dev environment:
+```
+broker configs/development-1.env.json
+```
+Then run the command tracker with default values
+```
+tracker
+```
+
+To run tests, first install dependencies:
+
+    npm ci
+
+Run the tests:
+
+    npm run test
+
+We use [eslint](https://github.com/eslint/eslint) for code formatting:
+
+    npm run eslint
+
+Code coverage:
+
+    npm run coverage
+
+### Debug
+
+To get all debug messages:
+
+    LOG_LEVEL=debug
+
+... or adjust debugging to desired level:
+
+    LOG_LEVEL=[debug|info|warn|error]
+
+To disable all logs
+
+    NOLOG=true
+
+
+## Release
+
+Publishing to NPM is automated via GitHub Actions. Follow the steps below to publish.
+
+1. `git checkout master && git pull`
+2. Update version with either `npm version patch`, `npm version minor`, or `npm version major`. Use semantic versioning
+https://semver.org/. Files package.json and package-lock.json will be automatically updated, and an appropriate git commit and tag created.
+3. `git push --follow-tags`
+4. Wait for GitHub Actions to run tests
+5. If tests passed, GitHub Actions will publish the new version to NPM
+
+## Misc dev notes
+
+### Regenerate self-signed certificate fixture
+To regenerate self-signed certificate in `./test/fixtures` run:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 36500 -nodes -subj "/CN=localhost"
+```
+
+### Deleting expired data from Storage node
+To delete expired data from storage node run
+
+```
+broker <configFile> --deleteExpired
+```
+
+or
+
+```
+node app.js <configFile> --deleteExpired
+```

--- a/packages/broker/develop.md
+++ b/packages/broker/develop.md
@@ -10,7 +10,7 @@ If instead you want to run a broker node by itself without Docker, follow the st
 
 See folder "configs" for example configurations. To run a broker connected to the local dev environment:
 ```
-broker configs/development-1.env.json
+streamr-broker configs/development-1.env.json
 ```
 Then run the command tracker with default values
 ```
@@ -29,10 +29,6 @@ We use [eslint](https://github.com/eslint/eslint) for code formatting:
 
     npm run eslint
 
-Code coverage:
-
-    npm run coverage
-
 ### Debug
 
 To get all debug messages:
@@ -50,14 +46,7 @@ To disable all logs
 
 ## Release
 
-Publishing to NPM is automated via GitHub Actions. Follow the steps below to publish.
-
-1. `git checkout master && git pull`
-2. Update version with either `npm version patch`, `npm version minor`, or `npm version major`. Use semantic versioning
-https://semver.org/. Files package.json and package-lock.json will be automatically updated, and an appropriate git commit and tag created.
-3. `git push --follow-tags`
-4. Wait for GitHub Actions to run tests
-5. If tests passed, GitHub Actions will publish the new version to NPM
+For release instructions, see the [monorepo root readme](https://github.com/streamr-dev/network-monorepo/).
 
 ## Misc dev notes
 
@@ -72,11 +61,5 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 36500 -no
 To delete expired data from storage node run
 
 ```
-broker <configFile> --deleteExpired
-```
-
-or
-
-```
-node app.js <configFile> --deleteExpired
+npm run delete-expired-data
 ```

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -6,7 +6,7 @@ The Broker ships with a number of plugins that add functionality or APIs.
 - [Authentication](#authentication)
 - [Websocket](#websocket)
 - [MQTT](#mqtt)
-- [PublishHttp](#publishhttp)
+- [HTTP](#http)
 
 ## Authentication
 
@@ -115,7 +115,7 @@ If you want to publish or subscribe to a specific partition of a stream, you can
 - `/streams/:streamId/publish?partitionKey=foo`: use the given key to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams))
 - `/streams/:streamId/publish?partitionKeyField=customerId`: use the given field in a JSON to choose the `paritionKey` (e.g. `{ "customerId": "foo", ...  }` -> `paritionKey` is `foo`)
 
-**TODO**: define which partition is used if partition is not specified for publish/subscribe.
+By default, a random partition is selected.
 
 #### Secure connections
 
@@ -181,14 +181,15 @@ Some MQTT clients expect the username and password to be passed in the connectio
 mqtt://any-username:my-secret-api-key@localhost:1883
 ```
 
-
 ### Advanced usage
+
+#### Port
 
 The default port is `1883`. You can change it with `port` config option. 
 
-Explicit metadata can be provided the same way it is provided to the `websocket` plugin ([see above](#explicit-metadata)).
+#### Explicit metadata
 
-**TODO**: define partition support for publish/subscribe.
+Explicit metadata can be provided the same way it is provided to the `websocket` plugin ([see above](#explicit-metadata)).
 
 #### Topic domains
 
@@ -209,32 +210,15 @@ This way you can publish and subscribe to a stream by using only the path part o
 await client.publish('path-part', ...)  // publishes to a stream "0x1234567890123456789012345678901234567890/path-part"
 ```
 
-## PublishHttp
+## HTTP
 
-If you want to publish stream data with HTTP POST calls, use the `publishHttp` plugin:
+At the moment, only publishing is supported over HTTP. To subscribe, use one of the other protocol plugins as they allow a continuous streaming connection.
+
+To publish over HTTP, enable the `publishHttp` plugin:
 
 ```
 plugins: {
     "publishHttp": {}
-}
-```
-
-The default HTTP server port is `7171`. You can change it by specifying a `port` value for the root level `httpServer` option:
-
-```
-"network": ...
-"plugins": ...
-"httpServer": {
-    "port": 1234
-}
-```
-
-If you provide a SSL certificate it will support use SSL/TLS connections:
-```
-"httpServer": {
-    ...
-    "certFileName": "path/cert.pem",
-    "privateKeyFileName": "path/key.pem"
 }
 ```
 
@@ -252,6 +236,7 @@ http://localhost:7171/streams/foo.eth%2fbar
 ```
 
 The endpoint returns HTTP 200 status if the message was published successfully. 
+
 
 ### Passing the API key
 
@@ -273,7 +258,32 @@ http://localhost:7171/streams/foo.eth%2fbar
 
 ### Advanced usage
 
+#### Explicit metadata
+
 The endpoint supports the following optional query parameters:
 
 - `timestamp` can be used to set the message timestamp explicitly. The timestamp should be passed in ISO-8601 string (e.g. `2001-02-03T04:05:06Z`), or as milliseconds since epoch, e.g. `1234567890000`
 - `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams)). The default (in case neither is provided) is to select a random partition for each message.
+
+#### Port
+
+The default HTTP server port is `7171`. You can change it by specifying a `port` value for the root level `httpServer` option:
+
+```
+"network": ...
+"plugins": ...
+"httpServer": {
+    "port": 1234
+}
+```
+
+#### Secure connections
+
+If you provide a SSL certificate it will support use SSL/TLS connections:
+```
+"httpServer": {
+    ...
+    "certFileName": "path/cert.pem",
+    "privateKeyFileName": "path/key.pem"
+}
+```

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -1,17 +1,34 @@
 # Plugins
 
+The Broker ships with a number of plugins that add functionality or APIs.
+
 ## Table of Contents
-- [Dependencies](#dependencies)
+- [Authentication](#authentication)
 - [Websocket](#websocket)
 - [MQTT](#mqtt)
 - [PublishHttp](#publishhttp)
+
+## Authentication
+
+The integration APIs exposed by plugins can be secured via API keys. In your Broker config file, define some API keys under the root level `apiAuthentication` object:
+
+```
+{
+    "network": ...
+    "plugins": ...
+    "apiAuthentication": {
+        "keys": ["my-secret-api-key"]
+    }
+}
+```
+
+How to pass the API key depends on the protocol in question and is described in the sections below.
 
 ## Websocket
 
 The `websocket` plugin provides a websocket interface for publishing and subscribing. 
 
-To enable the plugin, add the plugin definition to the Broker configuration JSON:
-
+To enable the Websocket plugin, define a `websocket` object in the `plugins` section of the Broker configuration file:
 
 ```
 plugins: {
@@ -35,6 +52,14 @@ const socket = new WebSocket(`ws://localhost:${port}/streams/${encodeURIComponen
 socket.addEventListener('open', () => {
     socket.send(JSON.stringify(message))
 })
+```
+
+### Passing the API key
+
+Pass the [API key](#authentication) by adding an `apiKey` query parameter to the connection URL:
+
+```
+const socket = new WebSocket(`...?apiKey=my-secret-api-key`)
 ```
 
 ### Advanced usage
@@ -81,28 +106,6 @@ socket.send(JSON.stringify(payload))
 
 The configuration option affects also the incoming messages. Those messages will be derived in the same restructured format.
 
-#### Authenticated connections
-
-You can restrict that clients can create connections only if they know a secret API key.
-
-To enable the restriction, define some API keys in the Broker's root level `apiAuthentication` config:
-
-```
-{
-    "network": ...
-    "plugins": ...
-    "apiAuthentication": {
-        "keys": ["foobar"]
-    }
-}
-```
-
-And add the `apiKey` parameter to the connection URL:
-
-```
-const socket = new WebSocket(`...?apiKey=foobar`)
-```
-
 #### Partitions
 
 If you want to publish or subscribe to a specific partition of a stream, you can add query parameters to the URL:
@@ -135,7 +138,7 @@ const socket = new WebSocket(`wss://...`)
 
 ## MQTT
 
-As an alternative to Websockets, it is possible to publish and subscribe to a stream using a [MQTT](https://mqtt.org) connection:
+You can publish and subscribe to a stream using [MQTT](https://mqtt.org), making the Broker appear like a traditional MQTT broker towards connected applications and devices. To enable the MQTT plugin, define an `mqtt` object in the `plugins` section of the Broker configuration file:
 
 ```
 plugins: {
@@ -143,7 +146,7 @@ plugins: {
 }
 ```
 
-You can use any MQTT client to connect to the Broker. E.g subscribe with  [async-mqtt](https://www.npmjs.com/package/async-mqtt) library:
+You can use any MQTT client to connect to the Broker. Here's an example of subscribing to a stream with the [async-mqtt](https://www.npmjs.com/package/async-mqtt) library:
 
 ```
 import mqtt from 'async-mqtt'
@@ -154,7 +157,7 @@ client.on('message', (topic, message) => {
 await client.subscribe(streamId)
 ```
 
-And publish data with the same library:
+Publishing data with the same library:
 
 ```
 import mqtt from 'async-mqtt'
@@ -162,19 +165,28 @@ const client = await mqtt.connectAsync(`mqtt://localhost:${port}`)
 await client.publish(streamId, JSON.stringify(msg))
 ```
 
+### Passing the API key
+
+The authentication scheme of the MQTT protocol uses a username and password. When connecting to the MQTT plugin of Streamr Broker, you can provide anything you want as the username and the [API key](#authentication) as the password:
+```
+mqtt.connectAsync(`mqtt://localhost:${port}`, {
+    username: 'any-username',
+    password: apiKey,
+})
+```
+
+Some MQTT clients expect the username and password to be passed in the connection URL:
+
+```
+mqtt://any-username:my-secret-api-key@localhost:1883
+```
+
+
 ### Advanced usage
 
 The default port is `1883`. You can change it with `port` config option. 
 
 Explicit metadata can be provided the same way it is provided to the `websocket` plugin ([see above](#explicit-metadata)).
-
-API authentication is also supported. Define the keys in the Broker config ([see above](#authenticated-connections)) and provide the API key as a password when you create a connection:
-```
-mqtt.connectAsync(`mqtt://localhost:${port}`, {
-    username: '',
-    password: apiKey,
-})
-```
 
 **TODO**: define partition support for publish/subscribe.
 
@@ -194,7 +206,7 @@ plugins: {
 This way you can publish and subscribe to a stream by using only the path part of a `streamId`
 
 ```
-await client.publish('foobar', ...)  // publishes to a stream "0x1234567890123456789012345678901234567890/foobar"
+await client.publish('path-part', ...)  // publishes to a stream "0x1234567890123456789012345678901234567890/path-part"
 ```
 
 ## PublishHttp
@@ -226,10 +238,9 @@ If you provide a SSL certificate it will support use SSL/TLS connections:
 }
 ```
 
-The plugin provides a single endpoint: `/streams/:streamId` with the following optional query parameters:
+The plugin provides a single endpoint: `/streams/:streamId`.
 
-- `timestamp` in ISO-8601 format e.g. 2001-02-03T04:05:06Z, or as a number 1234567890000
-- `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams)) **TODO**: define which partition is used when neither parameter is given
+Note that the `streamId` is part of the URL and may contain slashes which need to be URL-encoded (`/` becomes `%2f`).
 
 To publish a message to a stream, send the data as a POST payload:
 
@@ -241,3 +252,28 @@ http://localhost:7171/streams/foo.eth%2fbar
 ```
 
 The endpoint returns HTTP 200 status if the message was published successfully. 
+
+### Passing the API key
+
+Pass the API key in the `Authorization` header, with content `bearer <key>`, for example
+
+```
+Authorization: bearer my-secret-api-key
+```
+
+A curl example:
+
+```
+curl \
+--header 'Content-Type: application/json' \
+--header 'Authorization: bearer my-secret-api-key' \
+--data '{"foo":"bar"}' \
+http://localhost:7171/streams/foo.eth%2fbar
+```
+
+### Advanced usage
+
+The endpoint supports the following optional query parameters:
+
+- `timestamp` can be used to set the message timestamp explicitly. The timestamp should be passed in ISO-8601 string (e.g. `2001-02-03T04:05:06Z`), or as milliseconds since epoch, e.g. `1234567890000`
+- `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams)). The default (in case neither is provided) is to select a random partition for each message.


### PR DESCRIPTION
Quick contribution to broker readmes (md changes only):

- Clean up `README.md` by making it more user-oriented and splitting dev-related information to a new `develop.md` file
- Clean up `plugins.md`, with focus on consistency and describing how to pass the API key to each plugin