### PR TITLE
test(broker): Config wizard and migration

### DIFF
--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer'
+import inquirer, { Answers } from 'inquirer'
 import { Wallet } from 'ethers'
 import path from 'path'
 import { writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs'
@@ -11,6 +11,23 @@ import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
 import * as BrokerConfigSchema from './config.schema.json'
 import { getDefaultFile } from './config'
 import { CURRENT_CONFIGURATION_VERSION, formSchemaUrl } from '../config/migration'
+
+export interface PrivateKeyAnswers extends Answers {
+    generateOrImportPrivateKey: 'Import' | 'Generate',
+    importPrivateKey?: string
+}
+
+export interface PluginAnswers extends Answers  {
+    enabledApiPlugins: string[],
+    websocketPort?: string
+    mqttPort?: string
+    publishHttpPort?: string
+    enableMinerPlugin: boolean
+}
+
+export interface StorageAnswers extends Answers  {
+    storagePath: string
+}
 
 const createLogger = () => {
     return {
@@ -157,7 +174,7 @@ export const storagePathPrompts = [{
     when: (answers: inquirer.Answers): boolean => existsSync(answers.storagePath)
 }]
 
-export const getConfig = (privateKey: string, pluginsAnswers: inquirer.Answers): any => {
+export const getConfig = (privateKey: string, pluginsAnswers: PluginAnswers): any => {
     const config = { ... CONFIG_TEMPLATE, plugins: { ... CONFIG_TEMPLATE.plugins } }
     config.client.auth.privateKey = privateKey
 
@@ -189,16 +206,16 @@ export const getConfig = (privateKey: string, pluginsAnswers: inquirer.Answers):
     return config
 }
 
-const selectStoragePath = async (): Promise<inquirer.Answers> => {
+const selectStoragePath = async (): Promise<StorageAnswers> => {
     let answers
     do {
         answers = await inquirer.prompt(storagePathPrompts)
     } while (answers.overwrite === false)
-    return answers
+    return answers as any
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const createStorageFile = async (config: any, answers: inquirer.Answers): Promise<string> => {
+export const createStorageFile = async (config: any, answers: StorageAnswers): Promise<string> => {
     const dirPath = path.dirname(answers.storagePath)
     const dirExists = existsSync(dirPath)
     if (!dirExists) {
@@ -211,8 +228,8 @@ export const createStorageFile = async (config: any, answers: inquirer.Answers):
     return answers.storagePath
 }
 
-export const getPrivateKey = (answers: inquirer.Answers): string => {
-    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT) ? answers.importPrivateKey : Wallet.createRandom().privateKey
+export const getPrivateKey = (answers: PrivateKeyAnswers): string => {
+    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT) ? answers.importPrivateKey! : Wallet.createRandom().privateKey
 }
 
 export const getNodeIdentity = (privateKey: string): {
@@ -229,8 +246,8 @@ export const getNodeIdentity = (privateKey: string): {
 }
 
 export const start = async (
-    getPrivateKeyAnswers = () => inquirer.prompt(PRIVATE_KEY_PROMPTS),
-    getPluginAnswers = () => inquirer.prompt(createPluginPrompts()),
+    getPrivateKeyAnswers = (): Promise<PrivateKeyAnswers> => inquirer.prompt(PRIVATE_KEY_PROMPTS) as any,
+    getPluginAnswers = (): Promise<PluginAnswers> => inquirer.prompt(createPluginPrompts()) as any,
     getStorageAnswers = selectStoragePath,
     logger = createLogger()
 ): Promise<void> => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../src/config/ConfigWizard'
 import { readFileSync } from 'fs'
 import { createBroker } from '../../src/broker'
+import { needsMigration } from '../../src/config/migration'
 
 const MOCK_PRIVATE_KEY = '0x1234567890123456789012345678901234567890123456789012345678901234'
 
@@ -236,6 +237,7 @@ describe('ConfigWizard', () => {
             expect(config.apiAuthentication.keys).toBeDefined()
             expect(config.apiAuthentication.keys.length).toBe(1)
             assertPluginConfig(config)
+            expect(needsMigration(config)).toBe(false)
             return expect(createBroker(config)).resolves.toBeDefined()
         }
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -260,15 +260,17 @@ describe('ConfigWizard', () => {
                 publishHttpPort: '3172',
                 enableMinerPlugin: true
             }
-            await assertValidFlow(pluginAnswers,
-            (config: any) => {
-                expect(Object.keys(config.plugins)).toIncludeSameMembers(['brubeckMiner', 'websocket', 'mqtt', 'publishHttp'])
-                expect(config.plugins.websocket.port).toBe(parseInt(pluginAnswers.websocketPort!))
-                expect(config.plugins.mqtt.port).toBe(parseInt(pluginAnswers.mqttPort!))
-                expect(config.plugins.brubeckMiner).toEqual({})
-                expect(config.plugins.publishHttp).toMatchObject({})
-                expect(config.httpServer.port).toBe(parseInt(pluginAnswers.publishHttpPort!))
-            })
+            await assertValidFlow(
+                pluginAnswers,
+                (config: any) => {
+                    expect(Object.keys(config.plugins)).toIncludeSameMembers(['brubeckMiner', 'websocket', 'mqtt', 'publishHttp'])
+                    expect(config.plugins.websocket.port).toBe(parseInt(pluginAnswers.websocketPort!))
+                    expect(config.plugins.mqtt.port).toBe(parseInt(pluginAnswers.mqttPort!))
+                    expect(config.plugins.brubeckMiner).toEqual({})
+                    expect(config.plugins.publishHttp).toMatchObject({})
+                    expect(config.httpServer.port).toBe(parseInt(pluginAnswers.publishHttpPort!))
+                }
+            )
         })
     })
 })

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -2,10 +2,8 @@ import { cloneDeep, merge } from 'lodash'
 import { validateConfig as validateClientConfig } from 'streamr-client'
 import { createMigratedConfig, CURRENT_CONFIGURATION_VERSION, formSchemaUrl, needsMigration } from '../../src/config/migration'
 import BROKER_CONFIG_SCHEMA from '../../src/config/config.schema.json'
-import WEBSOCKER_PLUGIN_CONFIG_SCHEMA from '../../src/plugins/websocket/config.schema.json'
-import MQTT_PLUGIN_CONFIG_SCHEMA from '../../src/plugins/mqtt/config.schema.json'
-import BRUBECK_MINER_PLUGIN_CONFIG_SCHEMA from '../../src/plugins/brubeckMiner/config.schema.json'
 import { validateConfig } from '../../src/config/validateConfig'
+import { createPlugin } from '../../src/pluginRegistry'
 
 const MOCK_PRIVATE_KEY = '0x1111111111111111111111111111111111111111111111111111111111111111'
 const MOCK_API_KEY = 'mock-api-key'
@@ -130,35 +128,36 @@ const configWizardFull = {
     }
 }
 
-const pluginSchemas: Record<string,any> = {
-    websocket: WEBSOCKER_PLUGIN_CONFIG_SCHEMA,
-    mqtt: MQTT_PLUGIN_CONFIG_SCHEMA,
-    brubeckMiner: BRUBECK_MINER_PLUGIN_CONFIG_SCHEMA,
-}
-
-const validateTargetConfig = (config: any): void | never => {
+const validateTargetConfig = async (config: any): Promise<void> | never => {
     validateConfig(config, BROKER_CONFIG_SCHEMA)
     validateClientConfig(config.client)
-    Object.keys(config.plugins).forEach((name) => {
-        const pluginConfig = config.plugins[name]
-        const schema = pluginSchemas[name]
+    for (const pluginName of Object.keys(config.plugins)) {
+        const pluginConfig = config.plugins[pluginName]
+        const plugin = await createPlugin(pluginName, {
+            ...pluginConfig,
+            name: pluginName,
+            streamrClient: undefined,
+            apiAuthenticator: undefined,
+            brokerConfig: config
+        })
+        const schema = plugin.getConfigSchema()
         if (schema !== undefined) {
-            validateConfig(pluginConfig, schema, name)
+            validateConfig(pluginConfig, schema, pluginName)
         }
-    })
+    }
 }
 
-const testMigration = (source: any, assertTarget: (target: any) => void | never) => {
+const testMigration = async (source: any, assertTarget: (target: any) => void | never) => {
     expect(needsMigration(source)).toBe(true)
     const target = createMigratedConfig(source)
     assertTarget(target)
-    validateTargetConfig(target)
+    await validateTargetConfig(target)
 }
 
 describe('Config migration', () => {
-    it('config wizard minimal', () => {
+    it('config wizard minimal', async () => {
         const source = configWizardMinimal
-        testMigration(source, (target) => {
+        await testMigration(source, (target) => {
             expect(target).toStrictEqual({
                 $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
                 client: {
@@ -176,9 +175,9 @@ describe('Config migration', () => {
         })
     })
 
-    it('config wizard full', () => {
+    it('config wizard full', async () => {
         const source = configWizardFull
-        testMigration(source, (target) => {
+        await testMigration(source, (target) => {
             expect(target).toStrictEqual({
                 $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
                 client: {
@@ -206,25 +205,25 @@ describe('Config migration', () => {
         })
     })
 
-    it('optional fields removed', () => {
+    it('optional fields removed', async () => {
         const source = cloneDeep(configWizardMinimal) as any
         delete source.apiAuthentication
         delete source.httpServer
-        testMigration(source, (target: any) => {
+        await testMigration(source, (target: any) => {
             expect(target.apiAuthentication).toBeUndefined()
             expect(target.httpServer).toBeUndefined()
         })    
     })
 
-    it('plugin port not defined', () => {
+    it('plugin port not defined', async () => {
         const source = cloneDeep(configWizardFull) as any
         delete source.plugins.websocket.port
-        testMigration(source, (target: any) => {
+        await testMigration(source, (target: any) => {
             expect(target.plugins.websocket.port).toBeUndefined()
         })  
     })
 
-    it('manually configured values', () => {
+    it('manually configured values', async () => {
         const source = cloneDeep(configWizardMinimal) as any
         source.network.name = 'mock-name'
         source.network.location = {
@@ -234,7 +233,7 @@ describe('Config migration', () => {
             city: null
         }
         source.plugins.metrics.consoleAndPM2IntervalInSeconds = 123
-        testMigration(source, (target: any) => {
+        await testMigration(source, (target: any) => {
             expect(target.client.network.name).toBeUndefined()
             expect(target.client.network.location).toStrictEqual({
                 latitude: 12.34,
@@ -245,18 +244,18 @@ describe('Config migration', () => {
         })
     })
 
-    it('legacy plugin', () => {
+    it('legacy plugin', async () => {
         const source = cloneDeep(configWizardMinimal) as any
         source.plugins.legacyMqtt = {}
-        testMigration(source, (target: any) => {
+        await testMigration(source, (target: any) => {
             expect(target.plugins.legacyMqtt).toBeUndefined()
         })  
     })
 
-    it('storage plugin', () => {
+    it('storage plugin', async () => {
         const source = cloneDeep(configWizardMinimal) as any
         source.plugins.storage = {}
-        expect(() => testMigration(source, () => {})).toThrow('Migration not supported for plugin: storage')
+        return expect(async () => testMigration(source, () => {})).rejects.toThrow('Migration not supported for plugin: storage')
     })
 
     it('no migration', () => {
@@ -359,6 +358,26 @@ describe('Config migration', () => {
                 }
             })
             expect(createMigratedConfig(v1)).toEqual(v2)
+        })
+
+        it('unknown plugin', async () => {
+            const v1 = createConfig(1, {
+                plugins: {
+                    foobar: {}
+                }
+            })
+            return expect(async () => testMigration(v1, () => {})).rejects.toThrow('Unknown plugin: foobar')
+        })
+
+        it('invalid plugin config', async () => {
+            const v1 = createConfig(1, {
+                plugins: {
+                    websocket: {
+                        foobar: true
+                    }
+                }
+            })
+            return expect(async () => testMigration(v1, () => {})).rejects.toThrow('websocket plugin: must NOT have additional properties (foobar)')
         })
     })
 })

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -133,17 +133,14 @@ const validateTargetConfig = async (config: any): Promise<void> | never => {
     validateClientConfig(config.client)
     for (const pluginName of Object.keys(config.plugins)) {
         const pluginConfig = config.plugins[pluginName]
-        const plugin = await createPlugin(pluginName, {
+        // validates the config against the schema
+        await createPlugin(pluginName, {
             ...pluginConfig,
             name: pluginName,
             streamrClient: undefined,
             apiAuthenticator: undefined,
             brokerConfig: config
         })
-        const schema = plugin.getConfigSchema()
-        if (schema !== undefined) {
-            validateConfig(pluginConfig, schema, pluginName)
-        }
     }
 }
 


### PR DESCRIPTION
Enhanced config-related tests.

`ConfigWizard.test.ts`:
- checks that a generated config file can be used to create a Broker instance
- checks that a generated config file doesn't need migration
- added test for "no plugins" user flow

`configMigration.test.ts`:
- uses `pluginRegistry` to check validity of plugins and plugin configs
- checks that migrated config can't have unknown plugins
- checks that migrated config can't have invalid plugin configs

Added also type annotations for `ConfigWizard` answers.