### PR TITLE
refactor(client): Explicit method delegation

### DIFF
--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -90,7 +90,6 @@ export const createMessagingPluginTest = <T>(
             if (pluginClient !== undefined) {
                 await api.closeClient(pluginClient)
             }
-            streamrClient?.debug('destroy after test')
             await streamrClient?.destroy()
         })
 

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -56,7 +56,6 @@ describe('MQTT Bridge', () => {
     })
 
     afterEach(async () => {
-        streamrClient?.debug('destroy after test')
         await streamrClient?.destroy()
     })
 

--- a/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageNode.test.ts
@@ -6,14 +6,12 @@ import {
     startTestTracker
 } from '../../../utils'
 import { Broker } from "../../../../src/broker"
-import StreamrClient from 'streamr-client'
 
 const trackerPort = 12503
 
 describe('StorageNode', () => {
     let tracker: Tracker
     let storageNode: Broker
-    let storageNodeClient: StreamrClient
     let storageNodeAccount: Wallet
 
     beforeAll(async () => {
@@ -28,7 +26,6 @@ describe('StorageNode', () => {
     afterAll(async () => {
         await tracker?.stop()
         await storageNode?.stop()
-        await storageNodeClient?.destroy()
     })
 
     it('has node id same as address', async () => {

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -181,9 +181,6 @@ export class BrubeckNode implements Context {
     /** @internal */
     startNode: () => Promise<unknown> = this.startNodeTask
 
-    /**
-     * Get started network node.
-     */
     getNode: () => Promise<NetworkNodeStub> = this.startNodeTask
 
     /** @internal */

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -44,9 +44,7 @@ export const getEthereumAddressFromNodeId = (nodeId: string): string => {
 export class BrubeckNode implements Context {
     private cachedNode?: NetworkNode
     private options
-    /** @internal */
     readonly id
-    /** @internal */
     readonly debug
     private startNodeCalled = false
     private startNodeComplete = false
@@ -178,12 +176,10 @@ export class BrubeckNode implements Context {
         }
     })
 
-    /** @internal */
     startNode: () => Promise<unknown> = this.startNodeTask
 
     getNode: () => Promise<NetworkNodeStub> = this.startNodeTask
 
-    /** @internal */
     async getNodeId() {
         const node = await this.getNode()
         return node.getNodeId()
@@ -194,7 +190,6 @@ export class BrubeckNode implements Context {
      * Basically a wrapper around: (await getNode()).publish(…)
      * but will be sync in case that node is already started.
      * Zalgo intentional. See below.
-     * @internal
      */
     publishToNode(streamMessage: StreamMessage): void | Promise<void> {
         // NOTE: function is intentionally not async for performance reasons.
@@ -218,7 +213,6 @@ export class BrubeckNode implements Context {
         }
     }
 
-    /** @internal */
     async openProxyConnection(streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection): Promise<void> {
         try {
             if (this.isStarting()) {
@@ -230,7 +224,6 @@ export class BrubeckNode implements Context {
         }
     }
 
-    /** @internal */
     async closeProxyConnection(streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection): Promise<void> {
         try {
             if (this.isStarting()) {

--- a/packages/client/src/DestroySignal.ts
+++ b/packages/client/src/DestroySignal.ts
@@ -16,9 +16,7 @@ import { Signal } from './utils/Signal'
 export class DestroySignal implements Context {
     onDestroy = Signal.once()
     trigger = this.destroy
-    /** @internal */
     readonly id = instanceId(this)
-    /** @internal */
     readonly debug
 
     constructor(context: Context) {

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -129,12 +129,10 @@ export class Ethereum {
         }
     }
 
-    /** @internal */
     isAuthenticated() {
         return (this._getAddress !== undefined)
     }
 
-    /** @internal */
     canEncrypt() {
         return !!(this._getAddress && this._getSigner)
     }
@@ -148,7 +146,6 @@ export class Ethereum {
         return (await this._getAddress()).toLowerCase()
     }
 
-    /** @internal */
     getSigner(): Signer {
         if (!this._getSigner) {
             // _getSigner is assigned in constructor
@@ -158,7 +155,6 @@ export class Ethereum {
         return this._getSigner()
     }
 
-    /** @internal */
     async getStreamRegistryChainSigner(): Promise<Signer> {
         if (!this._getStreamRegistryChainSigner) {
             throw new Error("StreamrClient not authenticated! Can't send transactions or sign messages.")
@@ -168,7 +164,6 @@ export class Ethereum {
 
     /**
      * @returns Ethers.js Provider, a connection to the Ethereum network (mainnet)
-     * @internal
      */
     getMainnetProvider(): Provider {
         return this.getAllMainnetProviders()[0]
@@ -176,7 +171,6 @@ export class Ethereum {
 
     /**
      * @returns Array of Ethers.js Providers, connections to the Ethereum network (mainnet)
-     * @internal
      */
     getAllMainnetProviders(): Provider[] {
         if (!this.ethereumConfig.mainChainRPCs || !this.ethereumConfig.mainChainRPCs.rpcs.length) {
@@ -190,7 +184,6 @@ export class Ethereum {
 
     /**
      * @returns Ethers.js Provider, a connection to the Stream Registry Chain
-     * @internal
      */
     getStreamRegistryChainProvider(): Provider {
         return this.getAllStreamRegistryChainProviders()[0]
@@ -198,7 +191,6 @@ export class Ethereum {
 
     /**
      * @returns Array of Ethers.js Providers, connections to the Stream Registry Chain
-     * @internal
      */
     getAllStreamRegistryChainProviders(): Provider[] {
         if (!this.ethereumConfig.streamRegistryChainRPCs || !this.ethereumConfig.streamRegistryChainRPCs.rpcs.length) {
@@ -210,12 +202,10 @@ export class Ethereum {
         })
     }
 
-    /** @internal */
     getMainnetOverrides(): Overrides {
         return this.getOverrides('ethereum', this.getMainnetProvider())
     }
 
-    /** @internal */
     getStreamRegistryOverrides(): Overrides {
         return this.getOverrides(this.ethereumConfig?.streamRegistryChainRPCs?.name ?? 'polygon', this.getStreamRegistryChainProvider())
     }

--- a/packages/client/src/StorageNodeRegistry.ts
+++ b/packages/client/src/StorageNodeRegistry.ts
@@ -92,7 +92,7 @@ export class StorageNodeRegistry {
         this.initStreamAssignmentEventListener('removeFromStorageNode', 'Removed', eventEmitter)
     }
 
-    initStreamAssignmentEventListener(clientEvent: keyof StreamrClientEvents, contractEvent: string, eventEmitter: StreamrClientEventEmitter) {
+    private initStreamAssignmentEventListener(clientEvent: keyof StreamrClientEvents, contractEvent: string, eventEmitter: StreamrClientEventEmitter) {
         type Listener = (streamId: string, nodeAddress: string, extra: any) => void
         initEventGateway(
             clientEvent,

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -11,7 +11,6 @@ import { StreamRegistry } from './StreamRegistry'
 import { Ethereum } from './Ethereum'
 import { StorageNodeRegistry } from './StorageNodeRegistry'
 import { BrubeckContainer } from './Container'
-import { StreamEndpoints } from './StreamEndpoints'
 import { StreamEndpointsCached } from './StreamEndpointsCached'
 import {
     EthereumAddress,
@@ -85,7 +84,6 @@ class StreamrStream implements StreamMetadata {
     protected _resends: Resends
     protected _publisher: Publisher
     protected _subscriber: Subscriber
-    protected _streamEndpoints: StreamEndpoints
     protected _streamEndpointsCached: StreamEndpointsCached
     protected _streamRegistry: StreamRegistry
     protected _nodeRegistry: StorageNodeRegistry
@@ -104,7 +102,6 @@ class StreamrStream implements StreamMetadata {
         this._resends = _container.resolve<Resends>(Resends)
         this._publisher = _container.resolve<Publisher>(Publisher)
         this._subscriber = _container.resolve<Subscriber>(Subscriber)
-        this._streamEndpoints = _container.resolve<StreamEndpoints>(StreamEndpoints)
         this._streamEndpointsCached = _container.resolve<StreamEndpointsCached>(StreamEndpointsCached)
         this._streamRegistry = _container.resolve<StreamRegistry>(StreamRegistry)
         this._nodeRegistry = _container.resolve<StorageNodeRegistry>(StorageNodeRegistry)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -11,7 +11,7 @@ import { StreamRegistry } from './StreamRegistry'
 import { Ethereum } from './Ethereum'
 import { StorageNodeRegistry } from './StorageNodeRegistry'
 import { BrubeckContainer } from './Container'
-import { StreamEndpointsCached } from './StreamEndpointsCached'
+import { StreamRegistryCached } from './StreamRegistryCached'
 import {
     EthereumAddress,
     StreamID,
@@ -84,8 +84,8 @@ class StreamrStream implements StreamMetadata {
     protected _resends: Resends
     protected _publisher: Publisher
     protected _subscriber: Subscriber
-    protected _streamEndpointsCached: StreamEndpointsCached
     protected _streamRegistry: StreamRegistry
+    protected _streamRegistryCached: StreamRegistryCached
     protected _nodeRegistry: StorageNodeRegistry
     protected _ethereuem: Ethereum
     private readonly _httpFetcher: HttpFetcher
@@ -102,7 +102,7 @@ class StreamrStream implements StreamMetadata {
         this._resends = _container.resolve<Resends>(Resends)
         this._publisher = _container.resolve<Publisher>(Publisher)
         this._subscriber = _container.resolve<Subscriber>(Subscriber)
-        this._streamEndpointsCached = _container.resolve<StreamEndpointsCached>(StreamEndpointsCached)
+        this._streamRegistryCached = _container.resolve<StreamRegistryCached>(StreamRegistryCached)
         this._streamRegistry = _container.resolve<StreamRegistry>(StreamRegistry)
         this._nodeRegistry = _container.resolve<StorageNodeRegistry>(StorageNodeRegistry)
         this._ethereuem = _container.resolve<Ethereum>(Ethereum)
@@ -121,7 +121,7 @@ class StreamrStream implements StreamMetadata {
                 id: this.id
             })
         } finally {
-            this._streamEndpointsCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
         for (const key of Object.keys(props)) {
             // @ts-expect-error
@@ -147,7 +147,7 @@ class StreamrStream implements StreamMetadata {
         try {
             await this._streamRegistry.deleteStream(this.id)
         } finally {
-            this._streamEndpointsCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
     }
 
@@ -198,7 +198,7 @@ class StreamrStream implements StreamMetadata {
                 'timed out waiting for storage nodes to respond'
             )
         } finally {
-            this._streamEndpointsCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
             await assignmentSubscription?.unsubscribe() // should never reject...
         }
     }
@@ -210,7 +210,7 @@ class StreamrStream implements StreamMetadata {
         try {
             return this._nodeRegistry.removeStreamFromStorageNode(this.id, nodeAddress)
         } finally {
-            this._streamEndpointsCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
     }
 

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -18,12 +18,9 @@ export interface StreamValidationInfo {
 
 @scoped(Lifecycle.ContainerScoped)
 export class StreamEndpoints implements Context {
-    /** @internal */
     readonly id
-    /** @internal */
     readonly debug
 
-    /** @internal */
     constructor(
         context: Context,
         @inject(delay(() => StreamRegistry)) private readonly streamRegistry: StreamRegistry,

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -32,9 +32,6 @@ export class StreamEndpoints implements Context {
         this.debug = context.debug.extend(this.id)
     }
 
-    /**
-     * @category Important
-     */
     async getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
         this.debug('getOrCreateStream %o', {
             props,

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -1,5 +1,0 @@
-export interface StreamValidationInfo {
-    id: string
-    partitions: number
-    storageDays: number
-}

--- a/packages/client/src/StreamEndpoints.ts
+++ b/packages/client/src/StreamEndpoints.ts
@@ -1,48 +1,5 @@
-/**
- * Public Stream meta APIs.
- */
-import { scoped, Lifecycle, inject, delay } from 'tsyringe'
-
-import { instanceId } from './utils'
-import { Context } from './utils/Context'
-
-import { Stream } from './Stream'
-import { ErrorCode } from './authFetch'
-import { StreamRegistry } from './StreamRegistry'
-
 export interface StreamValidationInfo {
     id: string
     partitions: number
     storageDays: number
-}
-
-@scoped(Lifecycle.ContainerScoped)
-export class StreamEndpoints implements Context {
-    readonly id
-    readonly debug
-
-    constructor(
-        context: Context,
-        @inject(delay(() => StreamRegistry)) private readonly streamRegistry: StreamRegistry,
-    ) {
-        this.id = instanceId(this)
-        this.debug = context.debug.extend(this.id)
-    }
-
-    async getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
-        this.debug('getOrCreateStream %o', {
-            props,
-        })
-        try {
-            return await this.streamRegistry.getStream(props.id)
-        } catch (err: any) {
-            // If stream does not exist, attempt to create it
-            if (err.errorCode === ErrorCode.NOT_FOUND) {
-                const stream = await this.streamRegistry.createStream(props)
-                this.debug('created stream: %s %o', props.id, stream.toObject())
-                return stream
-            }
-            throw err
-        }
-    }
 }

--- a/packages/client/src/StreamEndpointsCached.ts
+++ b/packages/client/src/StreamEndpointsCached.ts
@@ -1,6 +1,3 @@
-/**
- * Cached Subset of StreamEndpoints.
- */
 import { EthereumAddress, StreamID } from 'streamr-client-protocol'
 import { Lifecycle, scoped, inject, delay } from 'tsyringe'
 import { CacheAsyncFn, instanceId } from './utils'

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -10,7 +10,7 @@ import { instanceId, until } from './utils'
 import { Context } from './utils/Context'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from './Config'
 import { Stream, StreamProperties } from './Stream'
-import { NotFoundError } from './authFetch'
+import { ErrorCode, NotFoundError } from './authFetch'
 import {
     StreamID,
     EthereumAddress,
@@ -110,6 +110,23 @@ export class StreamRegistry implements Context {
                 'streamRegistry',
                 this.graphQLClient
             )
+        }
+    }
+
+    async getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
+        this.debug('getOrCreateStream %o', {
+            props,
+        })
+        try {
+            return await this.getStream(props.id)
+        } catch (err: any) {
+            // If stream does not exist, attempt to create it
+            if (err.errorCode === ErrorCode.NOT_FOUND) {
+                const stream = await this.createStream(props)
+                this.debug('created stream: %s %o', props.id, stream.toObject())
+                return stream
+            }
+            throw err
         }
     }
 

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -113,9 +113,6 @@ export class StreamRegistry implements Context {
         }
     }
 
-    /**
-     * @category Important
-     */
     async createStream(propsOrStreamIdOrPath: StreamProperties | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
@@ -205,9 +202,6 @@ export class StreamRegistry implements Context {
         ])
     }
 
-    /**
-     * @category Important
-     */
     async getStream(streamIdOrPath: string): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Getting stream %s', streamId)

--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -36,7 +36,7 @@ import {
     streamPermissionToSolidityType,
     ChainPermissions
 } from './permission'
-import { StreamEndpointsCached } from './StreamEndpointsCached'
+import { StreamRegistryCached } from './StreamRegistryCached'
 
 /** @internal */
 export type StreamQueryResult = {
@@ -77,7 +77,7 @@ export class StreamRegistry implements Context {
         @inject(BrubeckContainer) private container: DependencyContainer,
         @inject(ConfigInjectionToken.Root) private config: StrictStreamrClientConfig,
         @inject(SynchronizedGraphQLClient) private graphQLClient: SynchronizedGraphQLClient,
-        @inject(delay(() => StreamEndpointsCached)) private streamEndpointsCached: StreamEndpointsCached
+        @inject(delay(() => StreamRegistryCached)) private streamRegistryCached: StreamRegistryCached
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -410,7 +410,7 @@ export class StreamRegistry implements Context {
         ...assignments: PermissionAssignment[]
     ): Promise<void> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        this.streamEndpointsCached.clearStream(streamId)
+        this.streamRegistryCached.clearStream(streamId)
         await this.connectToStreamRegistryContract()
         for (const assignment of assignments) {
             for (const permission of assignment.permissions) {
@@ -433,7 +433,7 @@ export class StreamRegistry implements Context {
         for (const item of items) {
             // eslint-disable-next-line no-await-in-loop
             const streamId = await this.streamIdBuilder.toStreamID(item.streamId)
-            this.streamEndpointsCached.clearStream(streamId)
+            this.streamRegistryCached.clearStream(streamId)
             streamIds.push(streamId)
             targets.push(item.assignments.map((assignment) => {
                 return isPublicPermissionAssignment(assignment) ? PUBLIC_PERMISSION_ADDRESS : assignment.user

--- a/packages/client/src/StreamRegistryCached.ts
+++ b/packages/client/src/StreamRegistryCached.ts
@@ -9,7 +9,7 @@ import { StreamPermission } from './permission'
 const SEPARATOR = '|' // always use SEPARATOR for cache key
 
 @scoped(Lifecycle.ContainerScoped)
-export class StreamEndpointsCached implements Context {
+export class StreamRegistryCached implements Context {
     readonly id = instanceId(this)
     readonly debug
 

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -49,8 +49,6 @@ export class StreamrClient implements Context {
     readonly debug
     /** @internal */
     onDestroy
-    /** @internal */
-    isDestroyed
 
     private container: DependencyContainer
     private node: BrubeckNode
@@ -90,7 +88,6 @@ export class StreamrClient implements Context {
         this.debug = context.debug
 
         this.onDestroy = this.destroySignal.onDestroy.bind(this.destroySignal)
-        this.isDestroyed = this.destroySignal.isDestroyed.bind(this.destroySignal)
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -17,17 +17,19 @@ import { ResendSubscription } from './subscribe/ResendSubscription'
 import { BrubeckNode } from './BrubeckNode'
 import { DestroySignal } from './DestroySignal'
 import { StreamEndpoints } from './StreamEndpoints'
-import { StreamEndpointsCached } from './StreamEndpointsCached'
 import { GroupKeyStoreFactory, UpdateEncryptionKeyOptions } from './encryption/GroupKeyStoreFactory'
-import { StorageNodeRegistry } from './StorageNodeRegistry'
+import { StorageNodeMetadata, StorageNodeRegistry } from './StorageNodeRegistry'
 import { StreamRegistry } from './StreamRegistry'
-import { Methods, Plugin } from './utils/Plugin'
 import { StreamDefinition } from './types'
 import { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
+import { EthereumAddress, ProxyDirection, StreamID, StreamMessage } from 'streamr-client-protocol'
+import { MessageStream, MessageStreamOnMessage } from './subscribe/MessageStream'
+import { Stream, StreamProperties } from './Stream'
+import { SearchStreamsPermissionFilter } from './searchStreams'
+import { PermissionAssignment, PermissionQuery } from './permission'
 import { MetricsPublisher } from './MetricsPublisher'
-import { StreamMessage } from 'streamr-client-protocol'
 
 let uid: string = process.pid != null
     // Use process id in node uid.
@@ -36,22 +38,10 @@ let uid: string = process.pid != null
     // that utilize server-side rendering (no `window` while build's target is `web`).
     : ''
 
-// these are mixed in via Plugin function above
-// use MethodNames to only grab methods
-export interface StreamrClient extends Ethereum,
-    Methods<StreamEndpoints>,
-    Methods<Omit<Subscriber, 'subscribe'>>,
-    Methods<StreamRegistry>,
-    // connect/pOnce in BrubeckNode are pOnce, we override them anyway
-    Methods<Omit<BrubeckNode, 'destroy' | 'connect'>>,
-    Methods<Publisher>,
-    Methods<StorageNodeRegistry>,
-    Methods<GroupKeyStoreFactory>,
-    Methods<Resends>,
-    Methods<ProxyPublishSubscribe>{
-}
-
-class StreamrClientBase implements Context {
+/**
+ * @category Important
+ */
+export class StreamrClient implements Context {
     static generateEthereumAccount = Ethereum.generateEthereumAccount.bind(Ethereum)
 
     /** @internal */
@@ -63,40 +53,52 @@ class StreamrClientBase implements Context {
     /** @internal */
     isDestroyed
 
-    constructor(
-        private container: DependencyContainer,
-        context: Context,
-        private node: BrubeckNode,
-        private ethereum: Ethereum,
-        private streamEndpoints: StreamEndpoints,
-        private resends: Resends,
-        private publisher: Publisher,
-        private subscriber: Subscriber,
-        private proxyPublishSubscribe: ProxyPublishSubscribe,
-        private groupKeyStore: GroupKeyStoreFactory,
-        private destroySignal: DestroySignal,
-        private streamRegistry: StreamRegistry,
-        private storageNodeRegistry: StorageNodeRegistry,
-        private streamIdBuilder: StreamIDBuilder,
-        private eventEmitter: StreamrClientEventEmitter,
-        _metricsPublisher: MetricsPublisher // side effect: activates metrics publisher
-    ) { // eslint-disable-line function-paren-newline
+    private container: DependencyContainer
+    private node: BrubeckNode
+    private ethereum: Ethereum
+    private streamEndpoints: StreamEndpoints
+    private resends: Resends
+    private publisher: Publisher
+    private subscriber: Subscriber
+    private proxyPublishSubscribe: ProxyPublishSubscribe
+    private groupKeyStore: GroupKeyStoreFactory
+    private destroySignal: DestroySignal
+    private streamRegistry: StreamRegistry
+    private storageNodeRegistry: StorageNodeRegistry
+    private streamIdBuilder: StreamIDBuilder
+    private eventEmitter: StreamrClientEventEmitter
+
+    constructor(options: StreamrClientConfig = {}, parentContainer = rootContainer) {
+        const config = createStrictConfig(options)
+        const { childContainer: container } = initContainer(config, parentContainer)
+
+        this.container = container
+        this.node = container.resolve<BrubeckNode>(BrubeckNode)
+        this.ethereum = container.resolve<Ethereum>(Ethereum)
+        this.streamEndpoints = container.resolve<StreamEndpoints>(StreamEndpoints)
+        this.resends = container.resolve<Resends>(Resends)
+        this.publisher = container.resolve<Publisher>(Publisher)
+        this.subscriber = container.resolve<Subscriber>(Subscriber)
+        this.proxyPublishSubscribe = container.resolve<ProxyPublishSubscribe>(ProxyPublishSubscribe)
+        this.groupKeyStore = container.resolve<GroupKeyStoreFactory>(GroupKeyStoreFactory)
+        this.destroySignal = container.resolve<DestroySignal>(DestroySignal)
+        this.streamRegistry = container.resolve<StreamRegistry>(StreamRegistry)
+        this.storageNodeRegistry = container.resolve<StorageNodeRegistry>(StorageNodeRegistry)
+        this.streamIdBuilder = container.resolve<StreamIDBuilder>(StreamIDBuilder)
+        this.eventEmitter = container.resolve<StreamrClientEventEmitter>(StreamrClientEventEmitter)
+        container.resolve<MetricsPublisher>(MetricsPublisher) // side effect: activates metrics publisher
+
+        const context = container.resolve<Context>(Context as any)
         this.id = context.id
         this.debug = context.debug
-        Plugin(this, this.streamEndpoints)
-        Plugin(this, this.ethereum)
-        Plugin(this, this.publisher)
-        Plugin(this, this.subscriber)
-        Plugin(this, this.proxyPublishSubscribe)
-        Plugin(this, this.resends)
-        Plugin(this, this.node)
-        Plugin(this, this.groupKeyStore)
-        Plugin(this, this.streamRegistry)
-        Plugin(this, this.storageNodeRegistry)
 
         this.onDestroy = this.destroySignal.onDestroy.bind(this.destroySignal)
         this.isDestroyed = this.destroySignal.isDestroyed.bind(this.destroySignal)
     }
+
+    // --------------------------------------------------------------------------------------------
+    // Publish
+    // --------------------------------------------------------------------------------------------
 
     /**
      * @category Important
@@ -111,6 +113,28 @@ class StreamrClientBase implements Context {
         this.eventEmitter.emit('publish', undefined)
         return result
     }
+
+    async updateEncryptionKey(opts: UpdateEncryptionKeyOptions): Promise<void> {
+        if (opts.streamId === undefined) {
+            throw new Error('streamId required')
+        }
+        const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
+        if (opts.distributionMethod === 'rotate') {
+            if (opts.key === undefined) {
+                return this.groupKeyStore.rotateGroupKey(streamId)
+            } else { // eslint-disable-line no-else-return
+                return this.groupKeyStore.setNextGroupKey(streamId, opts.key)
+            }
+        } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
+            return this.groupKeyStore.rekey(streamId, opts.key)
+        } else {
+            throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Subscribe
+    // --------------------------------------------------------------------------------------------
 
     /**
      * @category Important
@@ -152,23 +176,202 @@ class StreamrClientBase implements Context {
         return sub
     }
 
-    async updateEncryptionKey(opts: UpdateEncryptionKeyOptions): Promise<void> {
-        if (opts.streamId === undefined) {
-            throw new Error('streamId required')
-        }
-        const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
-        if (opts.distributionMethod === 'rotate') {
-            if (opts.key === undefined) {
-                return this.groupKeyStore.rotateGroupKey(streamId)
-            } else { // eslint-disable-line no-else-return
-                return this.groupKeyStore.setNextGroupKey(streamId, opts.key)
-            }
-        } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
-            return this.groupKeyStore.rekey(streamId, opts.key)
-        } else {
-            throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
-        }
+    /**
+     * Subscribe to all partitions for stream.
+     */
+    subscribeAll<T>(streamId: StreamID, onMessage?: SubscriptionOnMessage<T>): Promise<MessageStream<T>> {
+        return this.subscriber.subscribeAll(streamId, onMessage)
     }
+
+    /**
+     * @category Important
+     */
+    unsubscribe(streamDefinitionOrSubscription?: StreamDefinition | Subscription): Promise<unknown> {
+        return this.subscriber.unsubscribe(streamDefinitionOrSubscription)
+    }
+
+    /**
+     * Get subscriptions matching streamId or streamId + streamPartition
+     * @category Important
+     */
+    getSubscriptions(streamDefinition?: StreamDefinition): Promise<Subscription<unknown>[]> {
+        return this.subscriber.getSubscriptions(streamDefinition)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Resend
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Call last/from/range as appropriate based on arguments
+     * @category Important
+     */
+    resend<T>(
+        streamDefinition: StreamDefinition,
+        options: ResendOptions,
+        onMessage?: MessageStreamOnMessage<T>
+    ): Promise<MessageStream<T>> {
+        return this.resends.resend(streamDefinition, options, onMessage)
+    }
+
+    /**
+     * Resend for all partitions of a stream.
+     */
+    resendAll<T>(streamId: StreamID, options: ResendOptions, onMessage?: MessageStreamOnMessage<T>): Promise<MessageStream<T>> {
+        return this.resends.resendAll(streamId, options, onMessage)
+    }
+
+    waitForStorage(streamMessage: StreamMessage, options?: {
+        interval?: number
+        timeout?: number
+        count?: number
+        messageMatchFn?: (msgTarget: StreamMessage, msgGot: StreamMessage) => boolean
+    }) {
+        return this.resends.waitForStorage(streamMessage, options)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Stream management
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * @category Important
+     */
+    getStream(streamIdOrPath: string): Promise<Stream> {
+        return this.streamRegistry.getStream(streamIdOrPath)
+    }
+
+    /**
+     * @category Important
+     */
+    createStream(propsOrStreamIdOrPath: StreamProperties | string): Promise<Stream> {
+        return this.streamRegistry.createStream(propsOrStreamIdOrPath)
+    }
+
+    /**
+     * @category Important
+     */
+    getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
+        return this.streamEndpoints.getOrCreateStream(props)
+    }
+
+    updateStream(props: StreamProperties): Promise<Stream> {
+        return this.streamRegistry.updateStream(props)
+    }
+
+    deleteStream(streamIdOrPath: string) {
+        return this.streamRegistry.deleteStream(streamIdOrPath)
+    }
+
+    searchStreams(term: string | undefined, permissionFilter: SearchStreamsPermissionFilter | undefined): AsyncGenerator<Stream> {
+        return this.streamRegistry.searchStreams(term, permissionFilter)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Permissions
+    // --------------------------------------------------------------------------------------------
+
+    getStreamPublishers(streamIdOrPath: string): AsyncGenerator<EthereumAddress> {
+        return this.streamRegistry.getStreamPublishers(streamIdOrPath)
+    }
+
+    getStreamSubscribers(streamIdOrPath: string): AsyncGenerator<EthereumAddress> {
+        return this.streamRegistry.getStreamSubscribers(streamIdOrPath)
+    }
+
+    hasPermission(query: PermissionQuery): Promise<boolean> {
+        return this.streamRegistry.hasPermission(query)
+    }
+
+    getPermissions(streamIdOrPath: string): Promise<PermissionAssignment[]> {
+        return this.streamRegistry.getPermissions(streamIdOrPath)
+    }
+
+    grantPermissions(streamIdOrPath: string, ...assignments: PermissionAssignment[]): Promise<void> {
+        return this.streamRegistry.grantPermissions(streamIdOrPath, ...assignments)
+    }
+
+    revokePermissions(streamIdOrPath: string, ...assignments: PermissionAssignment[]): Promise<void> {
+        return this.streamRegistry.revokePermissions(streamIdOrPath, ...assignments)
+    }
+
+    setPermissions(...items: {
+        streamId: string,
+        assignments: PermissionAssignment[]
+    }[]): Promise<void> {
+        return this.streamRegistry.setPermissions(...items)
+    }
+
+    isStreamPublisher(streamIdOrPath: string, userAddress: EthereumAddress): Promise<boolean> {
+        return this.streamRegistry.isStreamPublisher(streamIdOrPath, userAddress)
+    }
+    
+    isStreamSubscriber(streamIdOrPath: string, userAddress: EthereumAddress): Promise<boolean> {
+        return this.streamRegistry.isStreamSubscriber(streamIdOrPath, userAddress)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Storage
+    // --------------------------------------------------------------------------------------------
+
+    setStorageNodeMetadata(metadata: StorageNodeMetadata | undefined): Promise<void> {
+        return this.storageNodeRegistry.setStorageNodeMetadata(metadata)
+    }
+
+    getStorageNodeMetadata(nodeAddress: EthereumAddress): Promise<StorageNodeMetadata> {
+        return this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)
+    }
+    
+    addStreamToStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
+        return this.storageNodeRegistry.addStreamToStorageNode(streamIdOrPath, nodeAddress)
+    }
+    
+    removeStreamFromStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
+        return this.storageNodeRegistry.removeStreamFromStorageNode(streamIdOrPath, nodeAddress)
+    }
+    
+    isStoredStream(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
+        return this.storageNodeRegistry.isStoredStream(streamIdOrPath, nodeAddress)
+    }
+    
+    getStoredStreams(nodeAddress: EthereumAddress): Promise<{ streams: Stream[], blockNumber: number }> {
+        return this.storageNodeRegistry.getStoredStreams(nodeAddress)
+    }
+    
+    getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
+        return this.storageNodeRegistry.getStorageNodes(streamIdOrPath)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Authentication
+    // --------------------------------------------------------------------------------------------
+
+    getAddress(): Promise<EthereumAddress> {
+        return this.ethereum.getAddress()
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Network node
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Get started network node
+     */
+    getNode() {
+        return this.node.getNode()
+    }
+
+    openProxyConnections(streamDefinition: StreamDefinition, nodeIds: string[], direction: ProxyDirection): Promise<void> {
+        return this.proxyPublishSubscribe.openProxyConnections(streamDefinition, nodeIds, direction)
+    }
+
+    closeProxyConnections(streamDefinition: StreamDefinition, nodeIds: string[], direction: ProxyDirection): Promise<void> {
+        return this.proxyPublishSubscribe.closeProxyConnections(streamDefinition, nodeIds, direction)
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Lifecycle
+    // --------------------------------------------------------------------------------------------
 
     connect = pOnce(async () => {
         await this.node.startNode()
@@ -193,6 +396,10 @@ class StreamrClientBase implements Context {
         await Promise.all(tasks)
     })
 
+    // --------------------------------------------------------------------------------------------
+    // Logging
+    // --------------------------------------------------------------------------------------------
+
     /** @internal */
     enableDebugLogging(prefix = 'Streamr*') { // eslint-disable-line class-methods-use-this
         Debug.enable(prefix)
@@ -202,6 +409,10 @@ class StreamrClientBase implements Context {
     disableDebugLogging() { // eslint-disable-line class-methods-use-this
         Debug.disable()
     }
+
+    // --------------------------------------------------------------------------------------------
+    // Events
+    // --------------------------------------------------------------------------------------------
 
     on<T extends keyof StreamrClientEvents>(eventName: T, listener: StreamrClientEvents[T]) {
         this.eventEmitter.on(eventName, listener as any)
@@ -271,47 +482,4 @@ export function initContainer(config: StrictStreamrClientConfig, parentContainer
         childContainer: c,
         rootContext
     }
-}
-
-/**
- * @category Important
- */
-export class StreamrClient extends StreamrClientBase {
-    constructor(options: StreamrClientConfig = {}, parentContainer = rootContainer) {
-        const config = createStrictConfig(options)
-        const { childContainer: c } = initContainer(config, parentContainer)
-        super(
-            c,
-            c.resolve<Context>(Context as any),
-            c.resolve<BrubeckNode>(BrubeckNode),
-            c.resolve<Ethereum>(Ethereum),
-            c.resolve<StreamEndpoints>(StreamEndpoints),
-            c.resolve<Resends>(Resends),
-            c.resolve<Publisher>(Publisher),
-            c.resolve<Subscriber>(Subscriber),
-            c.resolve<ProxyPublishSubscribe>(ProxyPublishSubscribe),
-            c.resolve<GroupKeyStoreFactory>(GroupKeyStoreFactory),
-            c.resolve<DestroySignal>(DestroySignal),
-            c.resolve<StreamRegistry>(StreamRegistry),
-            c.resolve<StorageNodeRegistry>(StorageNodeRegistry),
-            c.resolve<StreamIDBuilder>(StreamIDBuilder),
-            c.resolve<StreamrClientEventEmitter>(StreamrClientEventEmitter),
-            c.resolve<MetricsPublisher>(MetricsPublisher)
-        )
-    }
-}
-
-/** @internal */
-export const Dependencies = {
-    Context,
-    BrubeckNode,
-    StorageNodeRegistry,
-    StreamEndpoints,
-    StreamEndpointsCached,
-    Resends,
-    Publisher,
-    Subscriber,
-    ProxyPublishSubscribe,
-    GroupKeyStoreFactory,
-    DestroySignal,
 }

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -16,7 +16,6 @@ import { ResendOptions, Resends } from './subscribe/Resends'
 import { ResendSubscription } from './subscribe/ResendSubscription'
 import { BrubeckNode } from './BrubeckNode'
 import { DestroySignal } from './DestroySignal'
-import { StreamEndpoints } from './StreamEndpoints'
 import { GroupKeyStoreFactory, UpdateEncryptionKeyOptions } from './encryption/GroupKeyStoreFactory'
 import { StorageNodeMetadata, StorageNodeRegistry } from './StorageNodeRegistry'
 import { StreamRegistry } from './StreamRegistry'
@@ -56,7 +55,6 @@ export class StreamrClient implements Context {
     private container: DependencyContainer
     private node: BrubeckNode
     private ethereum: Ethereum
-    private streamEndpoints: StreamEndpoints
     private resends: Resends
     private publisher: Publisher
     private subscriber: Subscriber
@@ -75,7 +73,6 @@ export class StreamrClient implements Context {
         this.container = container
         this.node = container.resolve<BrubeckNode>(BrubeckNode)
         this.ethereum = container.resolve<Ethereum>(Ethereum)
-        this.streamEndpoints = container.resolve<StreamEndpoints>(StreamEndpoints)
         this.resends = container.resolve<Resends>(Resends)
         this.publisher = container.resolve<Publisher>(Publisher)
         this.subscriber = container.resolve<Subscriber>(Subscriber)
@@ -252,7 +249,7 @@ export class StreamrClient implements Context {
      * @category Important
      */
     getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
-        return this.streamEndpoints.getOrCreateStream(props)
+        return this.streamRegistry.getOrCreateStream(props)
     }
 
     updateStream(props: StreamProperties): Promise<Stream> {

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -14,7 +14,7 @@ import {
 import { pOrderedResolve, CacheAsyncFn, instanceId } from './utils'
 import { Stoppable } from './utils/Stoppable'
 import { Context } from './utils/Context'
-import { StreamEndpointsCached } from './StreamEndpointsCached'
+import { StreamRegistryCached } from './StreamRegistryCached'
 import { ConfigInjectionToken, SubscribeConfig, CacheConfig } from './Config'
 
 export class SignatureRequiredError extends StreamMessageError {
@@ -36,19 +36,19 @@ export class Validator extends StreamMessageValidator implements Stoppable, Cont
     private doValidation: StreamMessageValidator['validate']
     constructor(
         context: Context,
-        @inject(delay(() => StreamEndpointsCached)) streamEndpoints: StreamEndpointsCached,
+        @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached,
         @inject(ConfigInjectionToken.Subscribe) private options: SubscribeConfig,
         @inject(ConfigInjectionToken.Cache) private cacheOptions: CacheConfig,
     ) {
         super({
             getStream: (streamId: StreamID) => {
-                return streamEndpoints.getStream(streamId)
+                return streamRegistryCached.getStream(streamId)
             },
             isPublisher: (publisherId: EthereumAddress, streamId: StreamID) => {
-                return streamEndpoints.isStreamPublisher(streamId, publisherId)
+                return streamRegistryCached.isStreamPublisher(streamId, publisherId)
             },
             isSubscriber: (ethAddress: EthereumAddress, streamId: StreamID) => {
-                return streamEndpoints.isStreamSubscriber(streamId, ethAddress)
+                return streamRegistryCached.isStreamSubscriber(streamId, ethAddress)
             },
             verify: (address: EthereumAddress, payload: string, signature: string) => {
                 return this.cachedVerify(address, payload, signature)

--- a/packages/client/src/authFetch.ts
+++ b/packages/client/src/authFetch.ts
@@ -110,7 +110,6 @@ export async function authRequest(
     throw new ErrorClass(`Request ${debug.namespace} to ${url} returned with error code ${response.status}.`, response, body, errorCode)
 }
 
-/** @internal */
 export async function authFetch<T extends object>(
     url: string,
     opts?: any,

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -23,13 +23,10 @@ export interface UpdateEncryptionKeyOptions {
 
 @scoped(Lifecycle.ContainerScoped)
 export class GroupKeyStoreFactory implements Context {
-    /** @internal */
     readonly id
-    /** @internal */
     readonly debug
     private cleanupFns: ((...args: any[]) => any)[] = []
     initialGroupKeys
-    /** @internal */
     getStore: ((streamId: StreamID) => Promise<GroupKeyStore>) & { clear(): void }
     constructor(
         context: Context,
@@ -72,25 +69,21 @@ export class GroupKeyStoreFactory implements Context {
         return store
     }
 
-    /** @internal */
     async useGroupKey(streamId: StreamID) {
         const store = await this.getStore(streamId)
         return store.useGroupKey()
     }
 
-    /** @internal */
     async rotateGroupKey(streamId: StreamID) {
         const store = await this.getStore(streamId)
         return store.rotateGroupKey()
     }
 
-    /** @internal */
     async setNextGroupKey(streamId: StreamID, newKey: GroupKey) {
         const store = await this.getStore(streamId)
         return store.setNextGroupKey(newKey)
     }
 
-    /** @internal */
     async rekey(streamId: StreamID, newKey?: GroupKey) {
         const store = await this.getStore(streamId)
         return store.rekey(newKey)

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -19,7 +19,6 @@ export {
     UserPermissionAssignment,
     PublicPermissionAssignment
 } from './permission'
-export { StreamValidationInfo } from './StreamEndpoints'
 export { StorageNodeAssignmentEvent, StorageNodeMetadata } from './StorageNodeRegistry'
 export { SearchStreamsPermissionFilter } from './searchStreams'
 export {

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -3,7 +3,7 @@
  */
 import { StreamMessage } from 'streamr-client-protocol'
 import { PublisherKeyExchange } from '../encryption/PublisherKeyExchange'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { EncryptionUtil } from '../encryption/EncryptionUtil'
 import { Ethereum } from '../Ethereum'
@@ -14,7 +14,7 @@ export class Encrypt implements Stoppable {
     isStopped = false
 
     constructor(
-        private streamEndpoints: StreamEndpointsCached,
+        private streamRegistryCached: StreamRegistryCached,
         @inject(delay(() => PublisherKeyExchange)) private keyExchange: PublisherKeyExchange,
         private ethereum: Ethereum,
     ) {
@@ -48,12 +48,12 @@ export class Encrypt implements Stoppable {
 
         const streamId = streamMessage.getStreamId()
 
-        const isPublic = await this.streamEndpoints.isPublic(streamId)
+        const isPublic = await this.streamRegistryCached.isPublic(streamId)
         if (isPublic || this.isStopped) {
             return
         }
 
-        const stream = await this.streamEndpoints.getStream(streamId)
+        const stream = await this.streamRegistryCached.getStream(streamId)
 
         const [groupKey, nextGroupKey] = await this.keyExchange.useGroupKey(stream.id)
         if (this.isStopped) { return }

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -36,7 +36,6 @@ export class Publisher implements Context, Stoppable {
         this.publishQueue = pipeline.publishQueue
     }
 
-    /** @internal */
     async publish<T>(
         streamDefinition: StreamDefinition,
         content: T,
@@ -64,7 +63,6 @@ export class Publisher implements Context, Stoppable {
         })
     }
 
-    /** @internal */
     async collect<T>(target: AsyncIterable<StreamMessage<T>>, n?: number) { // eslint-disable-line class-methods-use-this
         const msgs = []
         for await (const msg of target) {
@@ -81,7 +79,6 @@ export class Publisher implements Context, Stoppable {
         return msgs
     }
 
-    /** @internal */
     async collectMessages<T>(target: AsyncIterable<T>, n?: number) { // eslint-disable-line class-methods-use-this
         const msgs = []
         for await (const msg of target) {
@@ -98,7 +95,6 @@ export class Publisher implements Context, Stoppable {
         return msgs
     }
 
-    /** @internal */
     async* publishFrom<T>(streamDefinition: StreamDefinition, seq: AsyncIterable<T>) {
         const items = CancelableGenerator(seq)
         this.inProgress.add(items)
@@ -111,7 +107,6 @@ export class Publisher implements Context, Stoppable {
         }
     }
 
-    /** @internal */
     async* publishFromMetadata<T>(streamDefinition: StreamDefinition, seq: AsyncIterable<PublishMetadata<T>>) {
         const items = CancelableGenerator(seq)
         this.inProgress.add(items)
@@ -124,23 +119,19 @@ export class Publisher implements Context, Stoppable {
         }
     }
 
-    /** @internal */
     startKeyExchange() {
         return this.keyExchange.start()
     }
 
-    /** @internal */
     stopKeyExchange() {
         return this.keyExchange.stop()
     }
 
-    /** @internal */
     async start() {
         this.isStopped = false
         this.pipeline.start()
     }
 
-    /** @internal */
     async stop() {
         this.isStopped = true
         await Promise.allSettled([

--- a/packages/client/src/publish/StreamPartitioner.ts
+++ b/packages/client/src/publish/StreamPartitioner.ts
@@ -5,14 +5,14 @@ import { StreamID, Utils } from 'streamr-client-protocol'
 import { CacheFn } from '../utils'
 import { ConfigInjectionToken, CacheConfig } from '../Config'
 import { inject, Lifecycle, scoped } from 'tsyringe'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 
 export type PartitionKey = string | number | undefined
 
 @scoped(Lifecycle.ContainerScoped)
 export class StreamPartitioner {
     constructor(
-        private streamEndpoints: StreamEndpointsCached,
+        private streamRegistryCached: StreamRegistryCached,
         @inject(ConfigInjectionToken.Cache) private cacheOptions: CacheConfig,
     ) {
         // NOTE: ensure cache partitions by streamId + partitionCount.
@@ -28,7 +28,7 @@ export class StreamPartitioner {
             return 0
         }
 
-        const stream = await this.streamEndpoints.getStream(streamId)
+        const stream = await this.streamRegistryCached.getStream(streamId)
         return this.computeStreamPartition(stream.id, stream.partitions, partitionKey)
     }
 

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -5,7 +5,7 @@ import { StreamMessage } from 'streamr-client-protocol'
 
 import { EncryptionUtil, UnableToDecryptError } from '../encryption/EncryptionUtil'
 import { SubscriberKeyExchange } from '../encryption/SubscriberKeyExchange'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 import { Context } from '../utils/Context'
 import { DestroySignal } from '../DestroySignal'
 import { Stoppable } from '../utils/Stoppable'
@@ -22,7 +22,7 @@ export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
 
     constructor(
         context: Context,
-        private streamEndpoints: StreamEndpointsCached,
+        private streamRegistryCached: StreamRegistryCached,
         private keyExchange: SubscriberKeyExchange,
         private destroySignal: DestroySignal,
     ) {
@@ -74,7 +74,7 @@ export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
             }
             this.debug('Decrypt Error', err)
             // clear cached permissions if cannot decrypt, likely permissions need updating
-            this.streamEndpoints.clearStream(streamMessage.getStreamId())
+            this.streamRegistryCached.clearStream(streamMessage.getStreamId())
             throw err
         }
     }

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -87,10 +87,6 @@ export class Resends implements Context {
         this.debug = context.debug.extend(this.id)
     }
 
-    /**
-     * Call last/from/range as appropriate based on arguments
-     * @category Important
-     */
     async resend<T>(
         streamDefinition: StreamDefinition,
         options: ResendOptions,
@@ -107,9 +103,6 @@ export class Resends implements Context {
         return sub
     }
 
-    /**
-     * Resend for all partitions of a stream.
-     */
     async resendAll<T>(streamId: StreamID, options: ResendOptions, onMessage?: MessageStreamOnMessage<T>): Promise<MessageStream<T>> {
         const { partitions } = await this.streamEndpoints.getStream(streamId)
         if (partitions === 1) {

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -16,7 +16,7 @@ import { BrubeckContainer } from '../Container'
 import { createQueryString, Rest } from '../Rest'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 import { random, range } from 'lodash'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 
@@ -78,7 +78,7 @@ export class Resends implements Context {
         context: Context,
         @inject(delay(() => StorageNodeRegistry)) private storageNodeRegistry: StorageNodeRegistry,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
-        @inject(delay(() => StreamEndpointsCached)) private streamEndpoints: StreamEndpointsCached,
+        @inject(delay(() => StreamRegistryCached)) private streamRegistryCached: StreamRegistryCached,
         @inject(Rest) private rest: Rest,
         @inject(BrubeckContainer) private container: DependencyContainer,
         @inject(ConfigInjectionToken.Root) private config: StrictStreamrClientConfig
@@ -104,7 +104,7 @@ export class Resends implements Context {
     }
 
     async resendAll<T>(streamId: StreamID, options: ResendOptions, onMessage?: MessageStreamOnMessage<T>): Promise<MessageStream<T>> {
-        const { partitions } = await this.streamEndpoints.getStream(streamId)
+        const { partitions } = await this.streamRegistryCached.getStream(streamId)
         if (partitions === 1) {
             // nothing interesting to do, treat as regular subscription
             return this.resend<T>(streamId, options, onMessage)

--- a/packages/client/src/subscribe/SubscribePipeline.ts
+++ b/packages/client/src/subscribe/SubscribePipeline.ts
@@ -15,7 +15,7 @@ import { ConfigInjectionToken } from '../Config'
 import { Resends } from './Resends'
 import { DestroySignal } from '../DestroySignal'
 import { DependencyContainer } from 'tsyringe'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 
 export function SubscribePipeline<T = unknown>(
     messageStream: MessageStream<T>,
@@ -25,7 +25,7 @@ export function SubscribePipeline<T = unknown>(
 ): MessageStream<T> {
     const validate = new Validator(
         context,
-        container.resolve(StreamEndpointsCached),
+        container.resolve(StreamRegistryCached),
         container.resolve(ConfigInjectionToken.Subscribe),
         container.resolve(ConfigInjectionToken.Cache)
     )
@@ -63,7 +63,7 @@ export function SubscribePipeline<T = unknown>(
 
     const decrypt = new Decrypt<T>(
         context,
-        container.resolve(StreamEndpointsCached),
+        container.resolve(StreamRegistryCached),
         container.resolve(SubscriberKeyExchange),
         container.resolve(DestroySignal),
     )

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -6,7 +6,7 @@ import { Subscription, SubscriptionOnMessage } from './Subscription'
 import { StreamID, StreamPartID } from 'streamr-client-protocol'
 import { BrubeckContainer } from '../Container'
 import { StreamIDBuilder } from '../StreamIDBuilder'
-import { StreamEndpointsCached } from '../StreamEndpointsCached'
+import { StreamRegistryCached } from '../StreamRegistryCached'
 import { StreamDefinition } from '../types'
 import { MessageStream, pullManyToOne } from './MessageStream'
 import { range } from 'lodash'
@@ -25,7 +25,7 @@ export class Subscriber implements Context {
         context: Context,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(BrubeckContainer) private container: DependencyContainer,
-        @inject(delay(() => StreamEndpointsCached))private streamEndpoints: StreamEndpointsCached,
+        @inject(delay(() => StreamRegistryCached)) private streamRegistryCached: StreamRegistryCached,
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -40,7 +40,7 @@ export class Subscriber implements Context {
     }
 
     async subscribeAll<T>(streamId: StreamID, onMessage?: SubscriptionOnMessage<T>): Promise<MessageStream<T>> {
-        const { partitions } = await this.streamEndpoints.getStream(streamId)
+        const { partitions } = await this.streamRegistryCached.getStream(streamId)
         if (partitions === 1) {
             // nothing interesting to do, treat as regular subscription
             return this.subscribe<T>(streamId, onMessage)

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -39,9 +39,6 @@ export class Subscriber implements Context {
         return this.subscribeTo(streamPartId, onMessage)
     }
 
-    /**
-     * Subscribe to all partitions for stream.
-     */
     async subscribeAll<T>(streamId: StreamID, onMessage?: SubscriptionOnMessage<T>): Promise<MessageStream<T>> {
         const { partitions } = await this.streamEndpoints.getStream(streamId)
         if (partitions === 1) {
@@ -117,9 +114,6 @@ export class Subscriber implements Context {
         await subSession.remove(sub)
     }
 
-    /**
-     * @category Important
-     */
     async unsubscribe(streamDefinitionOrSubscription?: StreamDefinition | Subscription): Promise<unknown> {
         if (streamDefinitionOrSubscription instanceof Subscription) {
             return this.remove(streamDefinitionOrSubscription)
@@ -189,10 +183,6 @@ export class Subscriber implements Context {
         return this.subSessions.size
     }
 
-    /**
-     * Get subscriptions matching streamId or streamId + streamPartition
-     * @category Important
-     */
     async getSubscriptions(streamDefinition?: StreamDefinition): Promise<Subscription<unknown>[]> {
         if (!streamDefinition) {
             return this.getAllSubscriptions()

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -11,7 +11,6 @@ import { ethers } from 'ethers'
 import { Context } from '../../src/utils/Context'
 import { BrubeckNode } from '../../src/BrubeckNode'
 import { StorageNodeRegistry } from '../../src/StorageNodeRegistry'
-import { StreamEndpoints } from '../../src/StreamEndpoints'
 import { StreamEndpointsCached } from '../../src/StreamEndpointsCached'
 import { Resends } from '../../src/subscribe/Resends'
 import { Publisher } from '../../src/publish/Publisher'
@@ -23,7 +22,6 @@ const Dependencies = {
     Context,
     BrubeckNode,
     StorageNodeRegistry,
-    StreamEndpoints,
     StreamEndpointsCached,
     Resends,
     Publisher,

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -11,7 +11,7 @@ import { ethers } from 'ethers'
 import { Context } from '../../src/utils/Context'
 import { BrubeckNode } from '../../src/BrubeckNode'
 import { StorageNodeRegistry } from '../../src/StorageNodeRegistry'
-import { StreamEndpointsCached } from '../../src/StreamEndpointsCached'
+import { StreamRegistryCached } from '../../src/StreamRegistryCached'
 import { Resends } from '../../src/subscribe/Resends'
 import { Publisher } from '../../src/publish/Publisher'
 import { Subscriber } from '../../src/subscribe/Subscriber'
@@ -22,7 +22,7 @@ const Dependencies = {
     Context,
     BrubeckNode,
     StorageNodeRegistry,
-    StreamEndpointsCached,
+    StreamRegistryCached,
     Resends,
     Publisher,
     Subscriber,

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -1,6 +1,6 @@
 import { wait } from 'streamr-test-utils'
 import { getPublishTestMessages, fetchPrivateKeyWithGas, snapshot, LeaksDetector } from '../test-utils/utils'
-import { StreamrClient, initContainer, Dependencies } from '../../src/StreamrClient'
+import { StreamrClient, initContainer } from '../../src/StreamrClient'
 import { container, DependencyContainer } from 'tsyringe'
 import { Subscription } from '../../src/subscribe/Subscription'
 import { counterId, Defer } from '../../src/utils'
@@ -8,6 +8,29 @@ import { counterId, Defer } from '../../src/utils'
 import { ConfigTest } from '../../src/ConfigTest'
 import { createStrictConfig, StrictStreamrClientConfig } from '../../src/Config'
 import { ethers } from 'ethers'
+import { Context } from '../../src/utils/Context'
+import { BrubeckNode } from '../../src/BrubeckNode'
+import { StorageNodeRegistry } from '../../src/StorageNodeRegistry'
+import { StreamEndpoints } from '../../src/StreamEndpoints'
+import { StreamEndpointsCached } from '../../src/StreamEndpointsCached'
+import { Resends } from '../../src/subscribe/Resends'
+import { Publisher } from '../../src/publish/Publisher'
+import { Subscriber } from '../../src/subscribe/Subscriber'
+import { GroupKeyStoreFactory } from '../../src/encryption/GroupKeyStoreFactory'
+import { DestroySignal } from '../../src/DestroySignal'
+
+const Dependencies = {
+    Context,
+    BrubeckNode,
+    StorageNodeRegistry,
+    StreamEndpoints,
+    StreamEndpointsCached,
+    Resends,
+    Publisher,
+    Subscriber,
+    GroupKeyStoreFactory,
+    DestroySignal
+}
 
 const MAX_MESSAGES = 5
 const TIMEOUT = 30000

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -40,7 +40,7 @@ describe('NodeMetrics', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            generatorClient?.stop(),
+            generatorClient?.destroy(),
             subscriberClient?.destroy()
         ])
     })

--- a/packages/client/test/end-to-end/Resends.test.ts
+++ b/packages/client/test/end-to-end/Resends.test.ts
@@ -164,7 +164,7 @@ describe('resends', () => {
                 expect(receivedMsgs).toHaveLength(publishedStream2.length)
                 expect(receivedMsgs).toEqual(publishedStream2)
                 expect(onResent).toHaveBeenCalledTimes(1)
-                expect(await client.count(stream2.id)).toBe(0)
+                expect(await client.getSubscriptions(stream2.id)).toHaveLength(0)
             })
 
             it('can ignore errors in resend', async () => {
@@ -195,7 +195,7 @@ describe('resends', () => {
                 await publishTestMessagesStream2(3)
                 await sub.collect(3)
 
-                expect(await client.count(stream2.id)).toBe(0)
+                expect(await client.getSubscriptions(stream2.id)).toHaveLength(0)
                 expect(onResent).toHaveBeenCalledTimes(1)
             })
 
@@ -226,7 +226,7 @@ describe('resends', () => {
                 const receivedMsgs = await sub.collect(3)
 
                 expect(receivedMsgs).toEqual(published)
-                expect(await client.count(stream2.id)).toBe(0)
+                expect(await client.getSubscriptions(stream2.id)).toHaveLength(0)
                 expect(onResent).toHaveBeenCalledTimes(1)
                 expect(onSubError).toHaveBeenCalledTimes(1)
             })
@@ -269,7 +269,7 @@ describe('resends', () => {
                 expect(receivedMsgs).toHaveLength(publishedStream2.length)
                 expect(receivedMsgs).toEqual(publishedStream2)
                 expect(onResent).toHaveBeenCalledTimes(1)
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
         })
     })
@@ -423,7 +423,7 @@ describe('resends', () => {
                         last: published.length
                     }
                 })
-                expect(await client.count(stream.id)).toBe(1)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(1)
 
                 const onResent = jest.fn()
                 sub.once('resendComplete', onResent)
@@ -436,12 +436,12 @@ describe('resends', () => {
                 expect(receivedMsgs).toHaveLength(published.length)
                 expect(onResent).toHaveBeenCalledTimes(1)
                 expect(receivedMsgs).toEqual(published)
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('client.subscribe works as regular subscribe when just passing streamId as string', async () => {
                 const sub = await client.subscribe(stream.id)
-                expect(await client.count(stream.id)).toBe(1)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(1)
 
                 published.push(...await publishTestMessages(2))
 
@@ -475,7 +475,7 @@ describe('resends', () => {
 
                 expect(receivedMsgs).toHaveLength(published.length)
                 expect(receivedMsgs).toEqual(published)
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('ends resend if unsubscribed', async () => {
@@ -498,7 +498,7 @@ describe('resends', () => {
                 const msgs = receivedMsgs
                 expect(msgs).toHaveLength(END_AFTER)
                 expect(msgs).toEqual(published.slice(0, END_AFTER))
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('can return before start', async () => {
@@ -509,13 +509,13 @@ describe('resends', () => {
                     }
                 })
 
-                expect(await client.count(stream.id)).toBe(1)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(1)
 
                 await sub.return()
                 published.push(...await publishTestMessages(2))
                 const received = await sub.collect(published.length)
                 expect(received).toHaveLength(0)
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('can end asynchronously', async () => {
@@ -546,7 +546,7 @@ describe('resends', () => {
                 const msgs = received
                 expect(msgs).toHaveLength(published.length)
                 expect(msgs).toEqual(published)
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('can end inside resend', async () => {
@@ -570,7 +570,7 @@ describe('resends', () => {
                 const msgs = receivedMsgs
                 expect(msgs).toHaveLength(END_AFTER)
                 expect(msgs).toEqual(published.slice(0, END_AFTER))
-                expect(await client.count(stream.id)).toBe(0)
+                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
             it('does not error if no storage assigned', async () => {
@@ -581,7 +581,7 @@ describe('resends', () => {
                         last: 5
                     }
                 })
-                expect(await client.count(nonStoredStream.id)).toBe(1)
+                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(1)
 
                 const onResent = jest.fn()
                 sub.once('resendComplete', onResent)
@@ -592,7 +592,7 @@ describe('resends', () => {
                 expect(receivedMsgs).toHaveLength(publishedMessages.length)
                 expect(onResent).toHaveBeenCalledTimes(1)
                 expect(receivedMsgs).toEqual(publishedMessages)
-                expect(await client.count(nonStoredStream.id)).toBe(0)
+                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
             })
         })
     })

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -47,7 +47,7 @@ describe('StreamRegistry', () => {
         })
 
         it('valid id', async () => {
-            const newId = `${wallet.address.toLowerCase()}/StreamEndpoints-createStream-newId-${Date.now()}`
+            const newId = `${wallet.address.toLowerCase()}/StreamRegistry-createStream-newId-${Date.now()}`
             const newStream = await client.createStream({
                 id: newId,
             })
@@ -56,7 +56,7 @@ describe('StreamRegistry', () => {
         })
 
         it('valid path', async () => {
-            const newPath = `/StreamEndpoints-createStream-newPath-${Date.now()}`
+            const newPath = `/StreamRegistry-createStream-newPath-${Date.now()}`
             const expectedId = `${wallet.address.toLowerCase()}${newPath}`
             const newStream = await client.createStream({
                 id: newPath,
@@ -115,7 +115,7 @@ describe('StreamRegistry', () => {
         })
 
         it('get a non-existing Stream', async () => {
-            const streamId = `${wallet.address.toLowerCase()}/StreamEndpoints-nonexisting-${Date.now()}`
+            const streamId = `${wallet.address.toLowerCase()}/StreamRegistry-nonexisting-${Date.now()}`
             return expect(() => client.getStream(streamId)).rejects.toThrow(NotFoundError)
         })
     })
@@ -129,7 +129,7 @@ describe('StreamRegistry', () => {
         })
 
         it('new Stream by id', async () => {
-            const newId = `${wallet.address.toLowerCase()}/StreamEndpoints-getOrCreate-newId-${Date.now()}`
+            const newId = `${wallet.address.toLowerCase()}/StreamRegistry-getOrCreate-newId-${Date.now()}`
             const newStream = await client.getOrCreateStream({
                 id: newId,
             })
@@ -137,7 +137,7 @@ describe('StreamRegistry', () => {
         })
 
         it('new Stream by path', async () => {
-            const newPath = `/StreamEndpoints-getOrCreate-newPath-${Date.now()}`
+            const newPath = `/StreamRegistry-getOrCreate-newPath-${Date.now()}`
             const newStream = await client.getOrCreateStream({
                 id: newPath,
             })
@@ -153,7 +153,7 @@ describe('StreamRegistry', () => {
         it('fails if stream prefixed with other users address', async () => {
             // can't create streams for other users
             const otherAddress = randomEthereumAddress()
-            const newPath = `/StreamEndpoints-getOrCreate-newPath-${Date.now()}`
+            const newPath = `/StreamRegistry-getOrCreate-newPath-${Date.now()}`
             // backend should error
             await expect(async () => {
                 await client.getOrCreateStream({

--- a/packages/client/test/end-to-end/SubscribeAll.test.ts
+++ b/packages/client/test/end-to-end/SubscribeAll.test.ts
@@ -66,7 +66,7 @@ describe('SubscribeAll', () => {
             expect(subMsgs).toContainEqual(msg)
         }
         await client.unsubscribe()
-        expect(client.countAll()).toBe(0)
+        expect(await client.getSubscriptions()).toHaveLength(0)
     })
 
     it('works with single partition', async () => {
@@ -90,7 +90,7 @@ describe('SubscribeAll', () => {
             expect(subMsgs).toContainEqual(msg)
         }
         await client.unsubscribe()
-        expect(client.countAll()).toBe(0)
+        expect(await client.getSubscriptions()).toHaveLength(0)
     })
 
     it('can stop prematurely', async () => {
@@ -111,7 +111,7 @@ describe('SubscribeAll', () => {
         // got the messages
         expect(subMsgs).toHaveLength(MAX_MESSAGES)
         // unsubscribed from everything
-        expect(await client.count(stream.id)).toBe(0)
+        expect((await client.getSubscriptions(stream.id)).length).toBe(0)
     })
 
     it('stops with unsubscribeAll', async () => {
@@ -131,7 +131,7 @@ describe('SubscribeAll', () => {
         // got the messages
         expect(subMsgs).toHaveLength(MAX_MESSAGES)
         // unsubscribed from everything
-        expect(client.countAll()).toBe(0)
+        expect(await client.getSubscriptions()).toHaveLength(0)
     })
 
     it('stops only when all subs are unsubbed', async () => {
@@ -166,6 +166,6 @@ describe('SubscribeAll', () => {
         // got the messages
         expect(subMsgs.length).toBe(PARTITIONS * NUM_MESSAGES)
         // unsubscribed from everything
-        expect(await client.count(stream.id)).toBe(0)
+        expect((await client.getSubscriptions(stream.id)).length).toBe(0)
     })
 })

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -574,9 +574,10 @@ describe('decryption', () => {
                         // @ts-expect-error
                         groupKeys: keys,
                     })
-                    const subSession = subscriber.getSubscriptionSession(sub.streamPartId)
+                    // @ts-expect-error private
+                    const subSession = subscriber.subscriber.getSubscriptionSession(sub.streamPartId)
                     if (!subSession) { throw new Error('no subsession?') }
-                    subSession.pipeline.forEachBefore((streamMessage, index) => {
+                    subSession.pipeline.forEachBefore((streamMessage: StreamMessage, index: number) => {
                         if (index === BAD_INDEX) {
                             // eslint-disable-next-line no-param-reassign
                             streamMessage.groupKeyId = 'badgroupkey'

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -15,7 +15,7 @@ import { NotFoundError } from '../../../src/authFetch'
 import { StreamRegistry } from '../../../src/StreamRegistry'
 import { SearchStreamsPermissionFilter } from '../../../src'
 import { Multimap } from '../utils'
-import { StreamEndpointsCached } from '../../../src/StreamEndpointsCached'
+import { StreamRegistryCached } from '../../../src/StreamRegistryCached'
 import { DOCKER_DEV_STORAGE_NODE } from '../../../src/ConfigTest'
 import { formStorageNodeAssignmentStreamId } from '../../../src/utils'
 
@@ -37,18 +37,18 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     private readonly streamIdBuilder: StreamIDBuilder
     private readonly ethereum: Ethereum
     private readonly container: DependencyContainer
-    private readonly streamEndpointsCached: StreamEndpointsCached
+    private readonly streamRegistryCached: StreamRegistryCached
 
     constructor(
         @inject(StreamIDBuilder) streamIdBuilder: StreamIDBuilder,
         @inject(Ethereum) ethereum: Ethereum,
         @inject(BrubeckContainer) container: DependencyContainer,
-        @inject(StreamEndpointsCached) streamEndpointsCached: StreamEndpointsCached
+        @inject(StreamRegistryCached) streamRegistryCached: StreamRegistryCached
     ) {
         this.streamIdBuilder = streamIdBuilder
         this.ethereum = ethereum
         this.container = container
-        this.streamEndpointsCached = streamEndpointsCached
+        this.streamRegistryCached = streamRegistryCached
         const storageNodeAssignmentStreamPermissions = new Multimap<string,StreamPermission>()
         storageNodeAssignmentStreamPermissions.add(DOCKER_DEV_STORAGE_NODE.toLowerCase(), StreamPermission.PUBLISH)
         this.registryItems.set(formStorageNodeAssignmentStreamId(DOCKER_DEV_STORAGE_NODE), {
@@ -162,7 +162,7 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
         modifyRegistryItem: (registryItem: RegistryItem, target: string, permissions: StreamPermission[]) => void
     ): Promise<void> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        this.streamEndpointsCached.clearStream(streamId)
+        this.streamRegistryCached.clearStream(streamId)
         const registryItem = this.registryItems.get(streamId)
         if (registryItem === undefined) {
             throw new Error('Stream not found')

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -193,6 +193,11 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     // eslint-disable-next-line class-methods-use-this
+    getOrCreateStream(_props: { id: string, partitions?: number }): Promise<Stream> {
+        throw new Error('not implemented')
+    }
+
+    // eslint-disable-next-line class-methods-use-this
     deleteStream(_streamIdOrPath: string): Promise<void> {
         throw new Error('not implemented')
     }


### PR DESCRIPTION
Use explicit method delegation in `StreamrClient` to delegate method calls to helper classes (`Publisher`, `Subscriber` etc.)

Compared to the previous implementation using `Plugin` delegation:
- improves readability as we can easily see what are the public methods of `StreamrClient`
- IDE autocompletion and navigation to methods works better
- no need to annotate methods with @internal

Before this PR all methods of helper classes were injected to `StreamrClient` instances. Now internal methods are no longer included. This is not a breaking change as internal methods aren't supposed to be used by end-users.

### Small refactoring

- Moved `getOrCreateStream` from `StreamEndpoints` to `StreamRegistry`, and deleted the `StreamEndpoints` class. Renamed `StreamEndpointsCached` to `StreamRegistryCached`. Removed obsolete `StreamValidationInfo` interface.

- removed `isDestroyed()` internal methods.

- Updated some tests to use public methods instead of internal methods.

### Future improvements

- We could remove the `Plugin` class if `Signal.ts` implementation doesn't need it