### PR TITLE
NET-828: no longer bind IConnectionSource events in manager

### DIFF
--- a/packages/dht/src/connection/IConnectionSource.ts
+++ b/packages/dht/src/connection/IConnectionSource.ts
@@ -1,4 +1,5 @@
 import { IConnection } from './IConnection'
+import { PeerDescriptor } from '../proto/DhtRpc'
 
 export enum Event {
     CONNECTED = 'streamr:dht:connectionsource:connected'
@@ -7,4 +8,5 @@ export enum Event {
 export interface IConnectionSource {
     on(event: Event.CONNECTED, listener: (connection: IConnection) => void): this
     once(event: Event.CONNECTED, listener: (connection: IConnection) => void): this
+    setOwnPeerDescriptor(peerDescriptor: PeerDescriptor): void
 }


### PR DESCRIPTION
<!--- Provide a general summary of the changes -->

## Checklist

<!--- Feel free to remove any that are not relevant -->

- [ ] Has passing tests that demonstrate this change works
- [ ] Updated Changelog
- [ ] Updated Documentation
