### PR TITLE
refactor(client): remove obsolete isUnsubscribed property

### DIFF
--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -15,10 +15,6 @@ export class Subscription<T = unknown> extends MessageStream<T> {
     /** @internal */
     context: SubscriptionSession<T>
     readonly streamPartId: StreamPartID
-    /**
-     * prevent buffered data from yielding
-     * @internal */
-    isUnsubscribed = false
 
     /** @internal */
     constructor(subSession: SubscriptionSession<T>, options?: MessageStreamOptions) {

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -184,7 +184,7 @@ export class SubscriptionSession<T> implements Context, Stoppable {
         this.subscriptions.delete(sub)
 
         try {
-            if (!sub.isUnsubscribed && !sub.isDone()) {
+            if (!sub.isDone()) {
                 await sub.unsubscribe()
             }
         } finally {


### PR DESCRIPTION
The `Subscription.isUnsubscribed` property is always `false`.