### PR TITLE
refactor: SigningUtil remove async, normalize inputs

### DIFF
--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -11,7 +11,7 @@ import {
     EthereumAddress
 } from 'streamr-client-protocol'
 
-import { pOrderedResolve, CacheAsyncFn, instanceId } from './utils'
+import { pOrderedResolve, instanceId, CacheFn } from './utils'
 import { Stoppable } from './utils/Stoppable'
 import { Context } from './utils/Context'
 import { StreamRegistryCached } from './StreamRegistryCached'
@@ -60,14 +60,13 @@ export class Validator extends StreamMessageValidator implements Stoppable, Cont
         this.doValidation = super.validate.bind(this)
     }
 
-    private cachedVerify = CacheAsyncFn(async (address: EthereumAddress, payload: string, signature: string) => {
+    private cachedVerify = CacheFn( (address: EthereumAddress, payload: string, signature: string) => {
         if (this.isStopped) { return true }
         return SigningUtil.verify(address, payload, signature)
     }, {
         // forcibly use small cache otherwise keeps n serialized messages in memory
         ...this.cacheOptions,
         maxSize: 100,
-        cachePromiseRejection: true,
         cacheKey: (args) => args.join('|'),
     })
 

--- a/packages/protocol/test/unit/utils/SigningUtil.test.ts
+++ b/packages/protocol/test/unit/utils/SigningUtil.test.ts
@@ -9,7 +9,7 @@ describe('SigningUtil', () => {
     describe('sign', () => {
         it('produces correct signature', async () => {
             const payload = 'data-to-sign'
-            const signature = await SigningUtil.sign(payload, privateKey)
+            const signature = SigningUtil.sign(payload, privateKey)
             assert.strictEqual(signature, '0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
         })
     })
@@ -19,7 +19,7 @@ describe('SigningUtil', () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = await SigningUtil.recover(signature, payload)
+            const recoveredAddress = SigningUtil.recover(signature, payload)
             assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
         })
 
@@ -27,21 +27,21 @@ describe('SigningUtil', () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = 'c97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = await SigningUtil.recover(signature, payload)
+            const recoveredAddress = SigningUtil.recover(signature, payload)
             assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
         })
 
         it('throws if the address can not be recovered (invalid signature)', async () => {
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            await assert.rejects(SigningUtil.recover(signature, payload))
+            expect(() => SigningUtil.recover(signature, payload)).toThrowError()
         })
 
         it('returns a different address if the content is tampered', async () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = await SigningUtil.recover(signature, payload)
+            const recoveredAddress = SigningUtil.recover(signature, payload)
             assert.notStrictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
         })
     })
@@ -51,7 +51,7 @@ describe('SigningUtil', () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const isValid = await SigningUtil.verify(address, payload, signature)
+            const isValid = SigningUtil.verify(address, payload, signature)
             assert(isValid)
         })
 
@@ -59,7 +59,7 @@ describe('SigningUtil', () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const isValid = await SigningUtil.verify(address, payload, signature)
+            const isValid = SigningUtil.verify(address, payload, signature)
             assert(!isValid)
         })
 
@@ -67,7 +67,7 @@ describe('SigningUtil', () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
             const payload = 'foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const isValid = await SigningUtil.verify(address, payload, signature)
+            const isValid = SigningUtil.verify(address, payload, signature)
             assert(!isValid)
         })
     })

--- a/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
@@ -17,7 +17,7 @@ describe('StreamMessageValidator', () => {
     let getStream: (streamId: string) => Promise<StreamMetadata>
     let isPublisher: (address: EthereumAddress, streamId: string) => Promise<boolean>
     let isSubscriber: (address: EthereumAddress, streamId: string) => Promise<boolean>
-    let verify: ((address: EthereumAddress, payload: string, signature: string) => Promise<boolean>) | undefined
+    let verify: ((address: EthereumAddress, payload: string, signature: string) => boolean) | undefined
     let msg: StreamMessage
     let msgWithNewGroupKey: StreamMessage
 
@@ -46,8 +46,8 @@ describe('StreamMessageValidator', () => {
     }
 
     /* eslint-disable */
-    const sign = async (msgToSign: StreamMessage, privateKey: string) => {
-        msgToSign.signature = await SigningUtil.sign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
+    const sign = (msgToSign: StreamMessage, privateKey: string) => {
+        msgToSign.signature = SigningUtil.sign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
     }
     /* eslint-enable */
 
@@ -67,14 +67,14 @@ describe('StreamMessageValidator', () => {
             content: '{}',
         })
 
-        await sign(msg, publisherPrivateKey)
+        sign(msg, publisherPrivateKey)
 
         msgWithNewGroupKey = new StreamMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'),
             content: '{}',
             newGroupKey: new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex')
         })
-        await sign(msgWithNewGroupKey, publisherPrivateKey)
+        sign(msgWithNewGroupKey, publisherPrivateKey)
         assert.notStrictEqual(msg.signature, msgWithNewGroupKey.signature)
 
         groupKeyRequest = new GroupKeyRequest({
@@ -85,7 +85,7 @@ describe('StreamMessageValidator', () => {
         }).toStreamMessage(
             new MessageID(toStreamID(`SYSTEM/keyexchange/${publisher.toLowerCase()}`), 0, 0, 0, subscriber, 'msgChainId'), null,
         )
-        await sign(groupKeyRequest, subscriberPrivateKey)
+        sign(groupKeyRequest, subscriberPrivateKey)
 
         groupKeyResponse = new GroupKeyResponse({
             requestId: 'requestId',
@@ -97,7 +97,7 @@ describe('StreamMessageValidator', () => {
         }).toStreamMessage(
             new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null,
         )
-        await sign(groupKeyResponse, publisherPrivateKey)
+        sign(groupKeyResponse, publisherPrivateKey)
 
         groupKeyAnnounce = new GroupKeyAnnounce({
             streamId: toStreamID('streamId'),
@@ -108,7 +108,7 @@ describe('StreamMessageValidator', () => {
         }).toStreamMessage(
             new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null,
         )
-        await sign(groupKeyAnnounce, publisherPrivateKey)
+        sign(groupKeyAnnounce, publisherPrivateKey)
 
         groupKeyErrorResponse = new GroupKeyErrorResponse({
             requestId: 'requestId',
@@ -119,7 +119,7 @@ describe('StreamMessageValidator', () => {
         }).toStreamMessage(
             new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null,
         )
-        await sign(groupKeyErrorResponse, publisherPrivateKey)
+        sign(groupKeyErrorResponse, publisherPrivateKey)
     })
 
     describe('validate(unknown message type)', () => {


### PR DESCRIPTION
- Remove unneeded `async` modifiers from utility methods in `SigningUtil`
- Normalize all addresses and private keys passed to `SigningUtil` to avoid problems resulting form leading `0x` substrings.
