### PR TITLE
client [NET-332]: MessageMetadata.msgChainId field

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Method signatures of `client.publish` and `stream.publish` have changed: optional `metadata` is given an object instead of positional arguments
+  - new metadata fields: `sequenceNumber` and `msgChainId`
 - Method `getStorageNodesOf()` renamed to `getStorageNodes()`
 - Method `getStoredStreamsOf()` renamed to `getStoredStreams()`
 - Method `isStreamStoredInStorageNode()` renamed to `isStoredStream()`

--- a/packages/client/src/publish/PublishPipeline.ts
+++ b/packages/client/src/publish/PublishPipeline.ts
@@ -46,7 +46,8 @@ export class FailedToPublishError extends Error {
 export interface MessageMetadata {
     timestamp?: string | number | Date
     sequenceNumber?: number
-    partitionKey?: string | number
+    partitionKey?: string | number,
+    msgChainId?: string
 }
 
 // TODO better name? 
@@ -195,7 +196,8 @@ export class PublishPipeline implements Context, Stoppable {
         this.debug('publish >> %o', {
             streamDefinition: formStreamDefinitionDescription(publishMetadata.streamDefinition),
             timestamp: publishMetadata.timestamp,
-            partitionKey: publishMetadata.partitionKey
+            partitionKey: publishMetadata.partitionKey,
+            msgChainId: publishMetadata.msgChainId
         })
         this.startQueue()
 

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -50,6 +50,7 @@ export class Publisher implements Context, Stoppable {
             content,
             timestamp: parseTimestamp(metadata),
             partitionKey: metadata?.partitionKey,
+            msgChainId: metadata?.msgChainId
         })
     }
 

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -60,6 +60,7 @@ describe('Publisher', () => {
     })
 
     it('happy path', async () => {
+        const testStartTime = Date.now()
         await publisher.publish(STREAM_ID, {
             foo: 'bar'
         })
@@ -76,7 +77,7 @@ describe('Publisher', () => {
                 sequenceNumber: 0,
                 streamId: STREAM_ID,
                 streamPartition: DEFAULT_PARTITION,
-                timestamp: expect.any(Number)
+                timestamp: expect.toBeWithin(testStartTime, Date.now() + 1)
             },
             messageType: 27,
             newGroupKey: null,


### PR DESCRIPTION
New `msgChainId` field in `MessageMetadata`. This allows `client.publish` and `stream.publish` methods to get an explicit `msgChainId` as a parameter.

- [x] Has passing tests that demonstrate this change works
- [x] Updated Changelog
