### PR TITLE
broker [NET-839]:  Publisher plugins set msgChainId

### DIFF
--- a/packages/broker/src/plugins/http/publishEndpoint.ts
+++ b/packages/broker/src/plugins/http/publishEndpoint.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express'
 import { StreamrClient } from 'streamr-client'
 import { Logger } from 'streamr-network'
+import { v4 as uuid } from 'uuid'
 import { parseQueryParameter, parsePositiveInteger, parseTimestamp } from '../../helpers/parser'
 import { PlainPayloadFormat } from '../../helpers/PayloadFormat'
 
@@ -8,6 +9,7 @@ const logger = new Logger(module)
 const PAYLOAD_FORMAT = new PlainPayloadFormat()
 
 export const createEndpoint = (streamrClient: StreamrClient): express.Router => {
+    const msgChainId = uuid()
     const router = express.Router()
     router.use(express.raw({
         limit: '1024kb',
@@ -43,7 +45,8 @@ export const createEndpoint = (streamrClient: StreamrClient): express.Router => 
         try {
             await streamrClient.publish(streamPartDefinition, content, {
                 timestamp,
-                partitionKey
+                partitionKey,
+                msgChainId
             })
             return res.sendStatus(200)
         } catch (e) {

--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -36,7 +36,7 @@ export class Bridge implements MqttServerListener {
         this.streamIdDomain = streamIdDomain
     }
 
-    async onMessageReceived(topic: string, payload: string): Promise<void> {
+    async onMessageReceived(topic: string, payload: string, clientId: string): Promise<void> {
         let message
         try {
             message = this.payloadFormat.createMessage(payload)
@@ -46,7 +46,8 @@ export class Bridge implements MqttServerListener {
         }
         const { content, metadata } = message
         const publishedMessage = await this.streamrClient.publish(this.getStreamId(topic), content, {
-            timestamp: metadata.timestamp
+            timestamp: metadata.timestamp,
+            msgChainId: clientId
         })
         this.publishMessageChains.add(createMessageChainKey(publishedMessage))
     }

--- a/packages/broker/src/plugins/mqtt/MqttServer.ts
+++ b/packages/broker/src/plugins/mqtt/MqttServer.ts
@@ -8,7 +8,7 @@ import { ApiAuthenticator } from '../../apiAuthenticator'
 const logger = new Logger(module)
 
 export interface MqttServerListener {
-    onMessageReceived(topic: string, payload: string): void
+    onMessageReceived(topic: string, payload: string, clientId: string): void
     onSubscribed(topics: string, clientId: string): void
     onUnsubscribed(topics: string, clientId: string): void
 }
@@ -31,7 +31,7 @@ export class MqttServer {
         })
         this.aedes.on('publish', (packet: IPublishPacket, client: aedes.Client) => {
             if (client !== null) {  // is null if the this server sent the message
-                this.listener?.onMessageReceived(packet.topic, packet.payload.toString())
+                this.listener?.onMessageReceived(packet.topic, packet.payload.toString(), client.id)
             }
         })
         this.aedes.on('subscribe', (subscriptions: ISubscription[], client: aedes.Client) => {

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -2,6 +2,7 @@ import WebSocket from 'ws'
 import { StreamrClient } from 'streamr-client'
 import { Logger } from 'streamr-network'
 import { ParsedQs } from 'qs'
+import { v4 as uuid } from 'uuid'
 import { parsePositiveInteger, parseQueryParameter } from '../../helpers/parser'
 import { Connection } from './Connection'
 import { closeWithError } from './closeWebsocket'
@@ -28,6 +29,7 @@ export class PublishConnection implements Connection {
     }
 
     init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
+        const msgChainId = uuid()
         ws.on('message', (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)
@@ -37,7 +39,8 @@ export class PublishConnection implements Connection {
                     partition: this.partition
                 }, content, {
                     timestamp: metadata.timestamp,
-                    partitionKey
+                    partitionKey,
+                    msgChainId
                 })
             } catch (err: any) {
                 closeWithError(err, 'Unable to publish', ws, logger)

--- a/packages/broker/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/broker/test/integration/multiple-publisher-plugins.test.ts
@@ -5,7 +5,7 @@ import { StreamPermission } from 'streamr-client'
 import { Tracker } from '@streamr/network-tracker'
 import { Broker } from '../../src/broker'
 import { startBroker, createClient, createTestStream, fetchPrivateKeyWithGas, startTestTracker, Queue } from '../utils'
-import { fastPrivateKey, wait, waitForCondition, waitForEvent } from 'streamr-test-utils'
+import { fastPrivateKey, waitForCondition, waitForEvent } from 'streamr-test-utils'
 import { range, sample } from 'lodash'
 
 const MESSAGE_COUNT = 120
@@ -102,7 +102,7 @@ describe('multiple publisher plugins', () => {
         const client = await createClient(tracker, privateKey)
         const stream = await createTestStream(client, module)
         streamId = stream.id
-        stream.grantPermissions({
+        await stream.grantPermissions({
             permissions: [StreamPermission.SUBSCRIBE],
             public: true
         })
@@ -110,7 +110,7 @@ describe('multiple publisher plugins', () => {
     })
 
     afterAll(async () => {
-        await tracker.stop()
+        await tracker?.stop()
     })
 
     beforeEach(async () => {
@@ -141,8 +141,6 @@ describe('multiple publisher plugins', () => {
         await subscriber.subscribe(streamId, (message: object) => {
             receivedMessages.push(message)
         })
-        // TODO: better waiting
-        await wait(3000)
 
         const messages = await publishMessages(streamId)
 

--- a/packages/broker/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/broker/test/integration/multiple-publisher-plugins.test.ts
@@ -1,0 +1,189 @@
+import mqtt, { AsyncMqttClient } from 'async-mqtt'
+import WebSocket from 'ws'
+import fetch from 'node-fetch'
+import { StreamPermission } from 'streamr-client'
+import { Tracker } from '@streamr/network-tracker'
+import { Broker } from '../../src/broker'
+import { startBroker, createClient, createTestStream, fetchPrivateKeyWithGas, startTestTracker, Queue } from '../utils'
+import { fastPrivateKey, wait, waitForCondition, waitForEvent } from 'streamr-test-utils'
+import { range, sample } from 'lodash'
+
+const MESSAGE_COUNT = 120
+const trackerPort = 13610
+const mqttPort = 13611
+const wsPort = 13612
+const httpPort = 13613
+
+const sendPostRequest = (url: string, content: object): Promise<unknown> => {
+    return fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(content),
+        headers: { 'Content-Type': 'application/json' }
+    })
+}
+
+interface PluginPublisher {
+    connect: (streamId: string) => Promise<void>
+    publish: (msg: object, streamId: string) => Promise<unknown>
+    close: () => Promise<void>
+}
+
+class MqttPluginPublisher implements PluginPublisher {
+    client: AsyncMqttClient | undefined
+    async connect(): Promise<void> {
+        this.client = await mqtt.connectAsync(`mqtt://localhost:${mqttPort}`)
+    }
+    publish(msg: object, streamId: string): Promise<unknown> {
+        return this.client!.publish(streamId, JSON.stringify(msg))
+    }
+    close(): Promise<void> {
+        return this.client!.end(false)
+    }
+}
+
+class WebsocketPluginPublisher implements PluginPublisher {
+    client: WebSocket | undefined
+    async connect(streamId: string): Promise<void> {
+        this.client = new WebSocket(`ws://localhost:${wsPort}/streams/${encodeURIComponent(streamId)}/publish`)
+        await waitForEvent(this.client, 'open')
+    }
+    async publish(msg: object): Promise<unknown> {
+        return this.client!.send(JSON.stringify(msg))
+    }
+    async close(): Promise<void> {
+        return this.client!.close()
+    }
+}
+
+class HttpPluginPublisher implements PluginPublisher {
+    async connect(): Promise<void> {
+    }
+    async publish(msg: object, streamId: string): Promise<unknown> {
+        return sendPostRequest(`http://localhost:${httpPort}/streams/${encodeURIComponent(streamId)}`, msg)
+    }
+    async close(): Promise<void> {
+    }
+}
+
+const publishMessages = async (streamId: string): Promise<any[]> => {
+    const publishers: Record<string,PluginPublisher> = {
+        mqtt1: new MqttPluginPublisher(),
+        mqtt2: new MqttPluginPublisher(),
+        websocket1: new WebsocketPluginPublisher(),
+        websocket2: new WebsocketPluginPublisher(),
+        http1: new HttpPluginPublisher(),
+        http2: new HttpPluginPublisher(),
+    }
+    await Promise.all(Object.values(publishers).map((publisher) => publisher.connect(streamId)))
+    const messages: { index: number, publisher: string }[] = []
+    for (const index of range(MESSAGE_COUNT)) {
+        messages.push({
+            index,
+            publisher: sample(Object.keys(publishers)) as any
+        })
+    }
+    for await (const msg of messages) {
+        await publishers[msg.publisher].publish(msg, streamId)
+    }
+    await Promise.all(Object.values(publishers).map((publisher) => publisher.close()))
+    return messages
+}
+
+describe('multiple publisher plugins', () => {
+
+    let tracker: Tracker
+    let broker: Broker
+    let privateKey: string
+    let streamId: string
+
+    beforeAll(async () => {
+        privateKey = await fetchPrivateKeyWithGas()
+        tracker = await startTestTracker(trackerPort)
+        const client = await createClient(tracker, privateKey)
+        const stream = await createTestStream(client, module)
+        streamId = stream.id
+        stream.grantPermissions({
+            permissions: [StreamPermission.SUBSCRIBE],
+            public: true
+        })
+        await client.destroy()
+    })
+
+    afterAll(async () => {
+        await tracker.stop()
+    })
+
+    beforeEach(async () => {
+        broker = await startBroker({
+            privateKey,
+            trackerPort,
+            httpPort,
+            extraPlugins: {
+                mqtt: {
+                    port: mqttPort
+                },
+                websocket: {
+                    port: wsPort
+                },
+                http: {}
+            }
+        })
+    })
+
+    afterEach(async () => {
+        await broker.stop()
+    })
+
+    it('subscribe by StreamrClient', async () => {
+
+        const receivedMessages: Queue<object> = new Queue()
+        const subscriber = await createClient(tracker, fastPrivateKey())
+        await subscriber.subscribe(streamId, (message: object) => {
+            receivedMessages.push(message)
+        })
+        // TODO: better waiting
+        await wait(3000)
+
+        const messages = await publishMessages(streamId)
+
+        await waitForCondition(() => receivedMessages.size() >= messages.length)
+        expect(receivedMessages.items).toIncludeSameMembers(messages)
+        await subscriber.destroy()
+
+    }, 10 * 1000)
+
+    it('subscribe by websocket plugin', async () => {
+
+        const receivedMessages: Queue<object> = new Queue()
+        const subscriber = new WebSocket(`ws://localhost:${wsPort}/streams/${encodeURIComponent(streamId)}/subscribe`)
+        subscriber.on('message', (message: string) => {
+            receivedMessages.push(JSON.parse(message))
+        })
+
+        const messages = await publishMessages(streamId)
+
+        await waitForCondition(() => receivedMessages.size() >= messages.length)
+        expect(receivedMessages.items).toIncludeSameMembers(messages)
+        await subscriber.close()
+
+    })
+
+    it('subscribe by mqtt plugin', async () => {
+
+        const receivedMessages: Queue<object> = new Queue()
+        const subscriber = await mqtt.connectAsync(`mqtt://localhost:${mqttPort}`)
+        subscriber.on('message', (topic: string, message: Buffer) => {
+            if (topic === streamId) {
+                receivedMessages.push(JSON.parse(message.toString()))
+            }
+        })
+        await subscriber.subscribe(streamId)
+
+        const messages = await publishMessages(streamId)
+
+        await waitForCondition(() => receivedMessages.size() >= messages.length)
+        expect(receivedMessages.items).toIncludeSameMembers(messages)
+        await subscriber.end(true)
+
+    })
+})

--- a/packages/broker/test/unit/plugins/http/publishEndpoint.test.ts
+++ b/packages/broker/test/unit/plugins/http/publishEndpoint.test.ts
@@ -48,7 +48,8 @@ describe('PublishEndpoint', () => {
             foo: 'bar'
         }, {
             timestamp: expectedTimestamp,
-            partitionKey: expectedPartitionKey
+            partitionKey: expectedPartitionKey,
+            msgChainId: expect.any(String)
         })
     }
 
@@ -88,6 +89,20 @@ describe('PublishEndpoint', () => {
             queryParams: { partitionKey: 'mock-key' },
             expectedPartitionKey: 'mock-key'
         })
+    })
+
+    it('msgChainId constant between publish calls', async () => {
+        await postMessage({
+            foo: 1
+        }, {})
+        await postMessage({
+            foo: 2
+        }, {})
+        expect(streamrClient.publish).toBeCalledTimes(2)
+        const firstMessageMsgChainId = (streamrClient.publish as any).mock.calls[0][2].msgChainId
+        const secondMessageMsgChainId = (streamrClient.publish as any).mock.calls[1][2].msgChainId
+        expect(firstMessageMsgChainId).toBeDefined()
+        expect(firstMessageMsgChainId).toBe(secondMessageMsgChainId)
     })
 
     it('empty', async () => {

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -18,33 +18,37 @@ const MOCK_MESSAGE_ID = {
 
 describe('MQTT Bridge', () => {
 
+    let streamrClient: Partial<StreamrClient>
+    let subscription: Pick<Subscription, 'streamPartId'|'unsubscribe'>
+
+    beforeEach(() => {
+        subscription = {
+            streamPartId: toStreamPartID(toStreamID(MOCK_STREAM_ID), 0),
+            unsubscribe: jest.fn().mockResolvedValue(undefined)
+        }
+        streamrClient = {
+            publish: jest.fn().mockResolvedValue({
+                messageId: MOCK_MESSAGE_ID
+            }),
+            subscribe: jest.fn().mockResolvedValue(subscription),
+            unsubscribe: jest.fn().mockResolvedValue(undefined)
+        }
+    })
+
     describe.each([
         [MOCK_STREAM_ID_DOMAIN, MOCK_TOPIC],
         [undefined, MOCK_STREAM_ID]
     ])('streamIdDomain: %p', (streamIdDomain: string|undefined, topic: string) => {
 
         let bridge: Bridge
-        let streamrClient: Partial<StreamrClient>
-        let subscription: Pick<Subscription, 'streamPartId'|'unsubscribe'>
 
         beforeEach(() => {
-            subscription = {
-                streamPartId: toStreamPartID(toStreamID(MOCK_STREAM_ID), 0),
-                unsubscribe: jest.fn().mockResolvedValue(undefined)
-            }
-            streamrClient = {
-                publish: jest.fn().mockResolvedValue({
-                    messageId: MOCK_MESSAGE_ID
-                }),
-                subscribe: jest.fn().mockResolvedValue(subscription),
-                unsubscribe: jest.fn().mockResolvedValue(undefined)
-            }
             bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), streamIdDomain)
         })
 
         it('onMessageReceived', async () => {
-            await bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT))
-            expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, {})
+            await bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, { msgChainId: expect.any(String) })
         })
 
         it('onSubscribed', async () => {
@@ -58,5 +62,31 @@ describe('MQTT Bridge', () => {
             expect(subscription.unsubscribe).toBeCalled()
         })
     
+    })
+
+    describe('msgChain', () => {
+
+        let bridge: Bridge
+
+        beforeEach(() => {
+            bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), undefined)
+        })
+
+        it('constant between publish calls', async () => {
+            await bridge.onMessageReceived(MOCK_TOPIC, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            await bridge.onMessageReceived(MOCK_TOPIC, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            const firstMessageMsgChainId = (streamrClient.publish as any).mock.calls[0][2].msgChainId
+            const secondMessageMsgChainId = (streamrClient.publish as any).mock.calls[1][2].msgChainId
+            expect(firstMessageMsgChainId).toBe(secondMessageMsgChainId)
+        })
+    
+        it('different for each connection', async () => {
+            await bridge.onMessageReceived(MOCK_TOPIC, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            await bridge.onMessageReceived(MOCK_TOPIC, JSON.stringify(MOCK_CONTENT), 'other-client-id')
+            const firstMessageMsgChainId = (streamrClient.publish as any).mock.calls[0][2].msgChainId
+            const secondMessageMsgChainId = (streamrClient.publish as any).mock.calls[1][2].msgChainId
+            expect(firstMessageMsgChainId).not.toBe(secondMessageMsgChainId)
+        })
+
     })
 })

--- a/packages/broker/test/unit/plugins/websocket/PublishConnection.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/PublishConnection.test.ts
@@ -1,0 +1,55 @@
+import StreamrClient from 'streamr-client'
+import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
+import { PublishConnection } from '../../../../src/plugins/websocket/PublishConnection'
+
+const MOCK_STREAM_ID = 'streamId'
+const MOCK_CONTENT1 = {
+    foo: 1
+}
+const MOCK_CONTENT2 = {
+    foo: 2
+}
+
+const createConnection = (streamrClient: Pick<StreamrClient, 'publish'>): (payload: string) => void => {
+    let onWebsocketMessage: (payload: string) => void | undefined
+    const connection = new PublishConnection(MOCK_STREAM_ID, {})
+    const mockWebSocket = {
+        on: (_event: 'message', listener: (payload: string) => void) => {
+            onWebsocketMessage = listener
+        }
+    }
+    connection.init(mockWebSocket as any, streamrClient as any, new PlainPayloadFormat())
+    return onWebsocketMessage!
+}
+
+describe('PublishConnection', () => {
+
+    let mockStreamrClient: Pick<StreamrClient, 'publish'>
+    
+    beforeEach(() => {
+        mockStreamrClient = {
+            publish: jest.fn()
+        }
+    })
+
+    it('msgChainId constant between publish calls', () => {
+        const onWebsocketMessage = createConnection(mockStreamrClient)
+        onWebsocketMessage(JSON.stringify(MOCK_CONTENT1))
+        onWebsocketMessage(JSON.stringify(MOCK_CONTENT2))
+        expect(mockStreamrClient.publish).toHaveBeenNthCalledWith(1, { id: MOCK_STREAM_ID }, MOCK_CONTENT1, { msgChainId: expect.any(String) })
+        const firstMessageMsgChainId = (mockStreamrClient.publish as any).mock.calls[0][2].msgChainId
+        expect(mockStreamrClient.publish).toHaveBeenNthCalledWith(2, { id: MOCK_STREAM_ID }, MOCK_CONTENT2, { msgChainId: firstMessageMsgChainId })
+    })
+
+    it('msgChainId different for each connection', () => {
+        const onWebsocketMessage1 = createConnection(mockStreamrClient)
+        const onWebsocketMessage2 = createConnection(mockStreamrClient)
+        onWebsocketMessage1(JSON.stringify(MOCK_CONTENT1))
+        onWebsocketMessage2(JSON.stringify(MOCK_CONTENT2))
+        expect(mockStreamrClient.publish).toHaveBeenNthCalledWith(1, { id: MOCK_STREAM_ID }, MOCK_CONTENT1, { msgChainId: expect.any(String) })
+        expect(mockStreamrClient.publish).toHaveBeenNthCalledWith(2, { id: MOCK_STREAM_ID }, MOCK_CONTENT2, { msgChainId: expect.any(String) })
+        const firstMessageMsgChainId = (mockStreamrClient.publish as any).mock.calls[0][2].msgChainId
+        const secondMessageMsgChainId = (mockStreamrClient.publish as any).mock.calls[1][2].msgChainId
+        expect(firstMessageMsgChainId).not.toBe(secondMessageMsgChainId)
+    })
+})

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -77,7 +77,9 @@ describe('WebsocketServer', () => {
                     partition: undefined
                 }, 
                 MOCK_MESSAGE,
-                {}
+                {
+                    msgChainId: expect.any(String)
+                }
             )
         })
 
@@ -89,7 +91,9 @@ describe('WebsocketServer', () => {
                     partition: 123
                 }, 
                 MOCK_MESSAGE,
-                {}
+                {
+                    msgChainId: expect.any(String)
+                }
             )
         })
 
@@ -102,7 +106,8 @@ describe('WebsocketServer', () => {
                 }, 
                 MOCK_MESSAGE,
                 {
-                    partitionKey: 'mock-key'
+                    partitionKey: 'mock-key',
+                    msgChainId: expect.any(String)
                 }
             )
         })
@@ -116,7 +121,8 @@ describe('WebsocketServer', () => {
                 }, 
                 MOCK_MESSAGE,
                 {
-                    partitionKey: 'bar'
+                    partitionKey: 'bar',
+                    msgChainId: expect.any(String)
                 }
             )
         })

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -180,6 +180,10 @@ export class Queue<T> {
         await waitForCondition(() => this.items.length > 0, timeout)
         return this.items.shift()!
     }
+
+    size(): number {
+        return this.items.length
+    }
 }
 
 export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {


### PR DESCRIPTION
Each publisher plugin sets `msgChainId` when it publishes messages via `StreamrClient`. For stateful plugins (`mqtt`, `websocket`), the `msgChainId` is connection-specific. For `http` plugin the `msgChain` is generated at the startup of the plugin.

### Implementation

`mqtt` plugin uses Aedes's `client.id` field as `msgChainId`. The value to that field is read from an incoming connection  packet. The spec required that there can't be two clients connected with same clientId simultanously. Users of MQTT client libraries can possibly set a custom value to that field, and in that situation the `client.id` wouldn't be globally unique. If a custom value is not used, the value is typically very unique:
- spec: "3.1.3.1 Client Identifier" spec in http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html 
- implementation is Aedes: https://github.com/moscajs/aedes/blob/e3e50ded602e7d69bdf8ba15ee07ce3527e004f1/lib/handlers/connect.js#L78
- e.g. `clientId` option settable in https://github.com/mqttjs/MQTT.js client library, but defaults to a unique identifier

### Future improvements

- `http` plugin could use cookies to emulate "connections", and assign connection-specific `msgChainId` values that way (if needed in the future)

### Checklist

- [x] Has passing tests that demonstrate this change works