### PR TITLE
broker [NET-842]: Publish to non-existent stream

### DIFF
--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -52,7 +52,7 @@ export class Bridge implements MqttServerListener {
             })
             this.publishMessageChains.add(createMessageChainKey(publishedMessage))
         } catch (err: any) {
-            logger.warn('Unable to publish')
+            logger.warn('Unable to publish, reason: %s', err)
         }
     }
 

--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -45,11 +45,15 @@ export class Bridge implements MqttServerListener {
             return
         }
         const { content, metadata } = message
-        const publishedMessage = await this.streamrClient.publish(this.getStreamId(topic), content, {
-            timestamp: metadata.timestamp,
-            msgChainId: clientId
-        })
-        this.publishMessageChains.add(createMessageChainKey(publishedMessage))
+        try {
+            const publishedMessage = await this.streamrClient.publish(this.getStreamId(topic), content, {
+                timestamp: metadata.timestamp,
+                msgChainId: clientId
+            })
+            this.publishMessageChains.add(createMessageChainKey(publishedMessage))
+        } catch (err: any) {
+            logger.warn('Unable to publish')
+        }
     }
 
     async onSubscribed(topic: string, clientId: string): Promise<void> {

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -30,11 +30,11 @@ export class PublishConnection implements Connection {
 
     init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
         const msgChainId = uuid()
-        ws.on('message', (payload: string) => {
+        ws.on('message', async (payload: string) => {
             try {
                 const { content, metadata } = payloadFormat.createMessage(payload)
                 const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
-                streamrClient.publish({
+                await streamrClient.publish({
                     id: this.streamId,
                     partition: this.partition
                 }, content, {

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -4,6 +4,7 @@ import { Tracker } from '@streamr/network-tracker'
 import { Broker } from '../../src/broker'
 import { Message } from '../../src/helpers/PayloadFormat'
 import { createClient, startBroker, createTestStream, Queue, fetchPrivateKeyWithGas, startTestTracker } from '../utils'
+import { wait } from 'streamr-test-utils'
 
 interface MessagingPluginApi<T> {
     createClient: (action: 'publish'|'subscribe', streamId: string, apiKey: string) => Promise<T>
@@ -93,24 +94,39 @@ export const createMessagingPluginTest = <T>(
             await streamrClient?.destroy()
         })
 
-        test('publish', async () => {
-            await streamrClient.subscribe(stream.id, (content: any, metadata: any) => {
-                messageQueue.push({ content, metadata: metadata.messageId })
+        describe('happy path', () => {
+            test('publish', async () => {
+                await streamrClient.subscribe(stream.id, (content: any, metadata: any) => {
+                    messageQueue.push({ content, metadata: metadata.messageId })
+                })
+                pluginClient = await api.createClient('publish', stream.id, MOCK_API_KEY)
+                await api.publish(MOCK_MESSAGE, stream.id, pluginClient)
+                const message = await messageQueue.pop()
+                assertReceivedMessage(message)
             })
-            pluginClient = await api.createClient('publish', stream.id, MOCK_API_KEY)
-            await api.publish(MOCK_MESSAGE, stream.id, pluginClient)
-            const message = await messageQueue.pop()
-            assertReceivedMessage(message)
+    
+            test('subscribe', async () => {
+                pluginClient = await api.createClient('subscribe', stream.id, MOCK_API_KEY)
+                await api.subscribe(messageQueue, stream.id, pluginClient)
+                await streamrClient.publish(stream.id, MOCK_MESSAGE.content, {
+                    timestamp: MOCK_MESSAGE.metadata.timestamp
+                })
+                const message = await messageQueue.pop()
+                assertReceivedMessage(message)
+            })
         })
 
-        test('subscribe', async () => {
-            pluginClient = await api.createClient('subscribe', stream.id, MOCK_API_KEY)
-            await api.subscribe(messageQueue, stream.id, pluginClient)
-            await streamrClient.publish(stream.id, MOCK_MESSAGE.content, {
-                timestamp: MOCK_MESSAGE.metadata.timestamp
-            })
-            const message = await messageQueue.pop()
-            assertReceivedMessage(message)
+        it('publish to non-existent stream', async () => {
+            const streamId = 'non-existent-stream'
+            pluginClient = await api.createClient('publish', streamId, MOCK_API_KEY)
+            await api.publish(MOCK_MESSAGE, streamId, pluginClient)
+            // Wait for some time so that the plugin can handle the publish request (api.publish() 
+            // resolves immediately e.g. in websocket plugin test as websocket.send() doesn't 
+            // return a promise). 
+            // If the api.publish call causes the plugin to throw an unhandled error, jest catches 
+            // the error and this test fails. There should be "Unable to publish" warning in the 
+            // Broker log, but this test can't verify it. 
+            await wait(1000)
         })
     })
 }


### PR DESCRIPTION
Improved error handling in `websocket` and `mqtt` plugins. Publishing to a non-existent stream caused Broker to throw an unhandled error. 

We close the `websocket` connection if an error occurs. For `mqtt` we only log a warning to Broker's console.

### Open questions

- Should we close the connection when a publish error occurs? Should `websocket` and `mqtt` plugin behave similarly?

- [x] Has passing tests that demonstrate this change works
