### PR TITLE
NET-845: Drop support for ETH_LEGACY signature type

### DIFF
--- a/packages/client/src/publish/Signer.ts
+++ b/packages/client/src/publish/Signer.ts
@@ -61,7 +61,7 @@ export class Signer {
             throw new Error('Timestamp is required as part of the data to sign.')
         }
 
-        if (signatureType !== SignatureType.ETH_LEGACY && signatureType !== SignatureType.ETH) {
+        if (signatureType !== SignatureType.ETH) {
             throw new Error(`Unrecognized signature type: ${signatureType}`)
         }
 

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -29,7 +29,6 @@ export enum ContentType {
 
 export enum SignatureType {
     NONE = 0,
-    ETH_LEGACY = 1,
     ETH = 2
 }
 
@@ -87,7 +86,7 @@ export type StreamMessageUnsigned<T> = StreamMessage<T> & {
  * Signed StreamMessage.
  */
 export type StreamMessageSigned<T> = StreamMessage<T> & {
-    signatureType: SignatureType.ETH | SignatureType.ETH_LEGACY
+    signatureType: SignatureType.ETH
     signature: string
 }
 
@@ -330,12 +329,7 @@ export default class StreamMessage<T = unknown> {
             return `${this.getStreamId()}${this.getStreamPartition()}${this.getTimestamp()}${this.messageId.sequenceNumber}`
                 + `${this.getPublisherId().toLowerCase()}${this.messageId.msgChainId}${prev}${this.getSerializedContent()}${newGroupKey}`
         }
-
-        if (signatureType === StreamMessage.SIGNATURE_TYPES.ETH_LEGACY) {
-            // verification of messages signed by old clients
-            return `${this.getStreamId()}${this.getTimestamp()}${this.getPublisherId().toLowerCase()}${this.getSerializedContent()}`
-        }
-
+        
         throw new ValidationError(`Unrecognized signature type: ${signatureType}`)
     }
 

--- a/packages/protocol/src/utils/StreamMessageValidator.ts
+++ b/packages/protocol/src/utils/StreamMessageValidator.ts
@@ -116,8 +116,7 @@ export default class StreamMessageValidator {
     ): Promise<void> {
         const payload = streamMessage.getPayloadToSign()
 
-        if (streamMessage.signatureType === StreamMessage.SIGNATURE_TYPES.ETH_LEGACY
-            || streamMessage.signatureType === StreamMessage.SIGNATURE_TYPES.ETH) {
+        if (streamMessage.signatureType === StreamMessage.SIGNATURE_TYPES.ETH) {
             let success
             try {
                 success = verifyFn(streamMessage.getPublisherId(), payload, streamMessage.signature!)


### PR DESCRIPTION
It was used in Message Layer v29: https://github.com/streamr-dev/network-monorepo/commit/9905fafdcc3b29ec7661ec27a26d360b68654115
