### PR TITLE
refactor(client): Remove `stop()` methods

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -380,6 +380,7 @@ export class StreamrClient implements Context {
             this.destroySignal.destroy().then(() => undefined),
             this.publisher.stop(),
             this.subscriber.stop(),
+            this.groupKeyStore.stop()
         ]
 
         await Promise.allSettled(tasks)

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -12,7 +12,6 @@ import {
 } from 'streamr-client-protocol'
 
 import { pOrderedResolve, instanceId, CacheFn } from './utils'
-import { Stoppable } from './utils/Stoppable'
 import { Context } from './utils/Context'
 import { StreamRegistryCached } from './StreamRegistryCached'
 import { ConfigInjectionToken, SubscribeConfig, CacheConfig } from './Config'
@@ -29,7 +28,7 @@ export class SignatureRequiredError extends StreamMessageError {
  * Handles caching remote calls
  */
 @scoped(Lifecycle.ContainerScoped)
-export class Validator extends StreamMessageValidator implements Stoppable, Context {
+export class Validator extends StreamMessageValidator implements Context {
     id
     debug
     isStopped = false

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -88,11 +88,4 @@ export class GroupKeyStoreFactory implements Context {
         const store = await this.getStore(streamId)
         return store.rekey(newKey)
     }
-
-    async stop(): Promise<void> {
-        this.getStore.clear()
-        const { cleanupFns } = this
-        this.cleanupFns = []
-        await Promise.allSettled(cleanupFns)
-    }
 }

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -88,4 +88,11 @@ export class GroupKeyStoreFactory implements Context {
         const store = await this.getStore(streamId)
         return store.rekey(newKey)
     }
+
+    async stop(): Promise<void> {
+        this.getStore.clear()
+        const { cleanupFns } = this
+        this.cleanupFns = []
+        await Promise.allSettled(cleanupFns)
+    }
 }

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -16,7 +16,6 @@ import { Subscriber } from '../subscribe/Subscriber'
 import { Publisher } from '../publish/Publisher'
 import { Subscription } from '../subscribe/Subscription'
 import { Ethereum } from '../Ethereum'
-import { Stoppable } from '../utils/Stoppable'
 
 import { GroupKey, GroupKeyish } from './GroupKey'
 
@@ -61,7 +60,7 @@ function waitForSubMessage(
 const { GROUP_KEY_RESPONSE, GROUP_KEY_ERROR_RESPONSE } = StreamMessage.MESSAGE_TYPES
 
 @scoped(Lifecycle.ContainerScoped)
-export class KeyExchangeStream implements Context, Stoppable {
+export class KeyExchangeStream implements Context {
     readonly id
     readonly debug
     subscribe: (() => Promise<Subscription<unknown>>) & { reset(): void }

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -64,7 +64,6 @@ export class KeyExchangeStream implements Context {
     readonly id
     readonly debug
     subscribe: (() => Promise<Subscription<unknown>>) & { reset(): void }
-    isStopped = false
     constructor(
         context: Context,
         private ethereum: Ethereum,
@@ -93,13 +92,7 @@ export class KeyExchangeStream implements Context {
         return sub
     }
 
-    stop(): void {
-        this.isStopped = true
-    }
-
     async request(publisherId: EthereumAddress, request: GroupKeyRequest): Promise<StreamMessage<unknown> | undefined> {
-        if (this.isStopped) { return undefined }
-
         const streamId = StreamIDUtils.formKeyExchangeStreamID(publisherId)
 
         let responseTask: Deferred<StreamMessage<unknown>> | undefined
@@ -113,7 +106,6 @@ export class KeyExchangeStream implements Context {
         let sub: Subscription<unknown> | undefined
         try {
             sub = await this.createSubscription()
-            if (this.isStopped || !sub) { return undefined }
             responseTask = waitForSubMessage(sub, (content, streamMessage) => {
                 const { messageType } = streamMessage
                 if (messageType !== GROUP_KEY_RESPONSE && messageType !== GROUP_KEY_ERROR_RESPONSE) {
@@ -123,14 +115,7 @@ export class KeyExchangeStream implements Context {
                 return GroupKeyResponse.fromArray(content).requestId === request.requestId
             })
 
-            if (this.isStopped) { return undefined }
-
             await this.publisher.publish(streamId, request)
-
-            if (this.isStopped) {
-                responseTask.resolve(undefined)
-                return undefined
-            }
 
             return await responseTask
         } catch (err) {
@@ -152,8 +137,6 @@ export class KeyExchangeStream implements Context {
         subscriberId: EthereumAddress, 
         response: GroupKeyResponse | GroupKeyErrorResponse
     ): Promise<StreamMessage<GroupKeyResponse | GroupKeyErrorResponse> | undefined> {
-        if (this.isStopped) { return undefined }
-
         // hack overriding toStreamMessage method to set correct encryption type
         const toStreamMessage = response.toStreamMessage.bind(response)
         response.toStreamMessage = (...args) => {

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -202,15 +202,4 @@ export class PublisherKeyExchange implements Context {
             this.streamRegistryCached.clearStream(streamId)
         }
     }
-
-    async start(): Promise<void> {
-        this.enabled = true
-        await this.subscribe()
-    }
-
-    async stop(): Promise<void> {
-        this.enabled = false
-        this.getSubscription.reset()
-        await this.subscribe()
-    }
 }

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -57,7 +57,6 @@ export class SubscriberKeyExchange implements Context {
         publisherId: string,
         groupKeyIds: GroupKeyId[]
     }): Promise<GroupKey[]> {
-        if (this.isStopped) { return [] }
         const requestId = uuid('GroupKeyRequest')
         const rsaPublicKey = this.encryptionUtil.getPublicKey()
         const msg = new GroupKeyRequest({

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -41,7 +41,6 @@ export class SubscriberKeyExchange implements Context {
     readonly id
     readonly debug
     encryptionUtil
-    isStopped = false
 
     constructor(
         private subscriber: Subscriber,
@@ -71,16 +70,11 @@ export class SubscriberKeyExchange implements Context {
         return response ? getGroupKeysFromStreamMessage(response, this.encryptionUtil) : []
     }
 
-    stop(): void {
-        this.isStopped = true
-    }
-
     async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
         return this.groupKeyStoreFactory.getStore(streamId)
     }
 
     async getKey(streamMessage: StreamMessage): Promise<GroupKey | undefined> {
-        if (this.isStopped) { return undefined }
         const streamId = streamMessage.getStreamId()
         const publisherId = streamMessage.getPublisherId()
         const { groupKeyId } = streamMessage
@@ -90,9 +84,7 @@ export class SubscriberKeyExchange implements Context {
 
         const groupKeyStore = await this.getGroupKeyStore(streamId)
 
-        if (this.isStopped) { return undefined }
         const existingGroupKey = await groupKeyStore.get(groupKeyId)
-        if (this.isStopped) { return undefined }
 
         if (existingGroupKey) {
             return existingGroupKey
@@ -104,32 +96,23 @@ export class SubscriberKeyExchange implements Context {
             groupKeyIds: [groupKeyId],
         })
 
-        if (this.isStopped) { return undefined }
         await Promise.all(receivedGroupKeys.map(async (groupKey: GroupKey) => (
             groupKeyStore.add(groupKey)
         )))
 
-        if (this.isStopped) { return undefined }
         return receivedGroupKeys.find((groupKey) => groupKey.id === groupKeyId)
     }
 
     async getGroupKey(streamMessage: StreamMessage): Promise<GroupKey | undefined> {
-        if (this.isStopped) { return undefined }
-
         if (!streamMessage.groupKeyId) { return undefined }
         await this.encryptionUtil.onReady()
-
-        if (this.isStopped) { return undefined }
         return this.getKey(streamMessage)
     }
 
     async addNewKey(streamMessage: StreamMessage): Promise<void> {
-        if (this.isStopped) { return }
-
         if (!streamMessage.newGroupKey) { return }
         const streamId = streamMessage.getStreamId()
         const groupKeyStore = await this.getGroupKeyStore(streamId)
-        if (this.isStopped) { return }
         // newGroupKey has been converted into GroupKey
         const groupKey: unknown = streamMessage.newGroupKey
         await groupKeyStore.add(groupKey as GroupKey)

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -7,10 +7,9 @@ import { StreamRegistryCached } from '../StreamRegistryCached'
 import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { EncryptionUtil } from '../encryption/EncryptionUtil'
 import { Ethereum } from '../Ethereum'
-import { Stoppable } from '../utils/Stoppable'
 
 @scoped(Lifecycle.ContainerScoped)
-export class Encrypt implements Stoppable {
+export class Encrypt {
     isStopped = false
 
     constructor(

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -11,7 +11,6 @@ import {
 } from 'streamr-client-protocol'
 
 import { LimitAsyncFnByKey } from '../utils'
-import { Stoppable } from '../utils/Stoppable'
 
 import { getCachedMessageChain } from './MessageChain'
 import { ConfigInjectionToken, CacheConfig } from '../Config'
@@ -44,7 +43,7 @@ export class MessageCreatorAnonymous implements IMessageCreator {
  * Create StreamMessages from metadata.
  */
 @scoped(Lifecycle.ContainerScoped)
-export class MessageCreator implements IMessageCreator, Stoppable {
+export class MessageCreator implements IMessageCreator {
     isStopped = false
     // encrypt
     queue: ReturnType<typeof LimitAsyncFnByKey>

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -44,7 +44,6 @@ export class MessageCreatorAnonymous implements IMessageCreator {
  */
 @scoped(Lifecycle.ContainerScoped)
 export class MessageCreator implements IMessageCreator {
-    isStopped = false
     // encrypt
     queue: ReturnType<typeof LimitAsyncFnByKey>
     getMsgChain
@@ -104,12 +103,7 @@ export class MessageCreator implements IMessageCreator {
         })
     }
 
-    async start(): Promise<void> {
-        this.isStopped = false
-    }
-
     async stop(): Promise<void> {
-        this.isStopped = true
         this.streamPartitioner.clear()
         this.queue.clear()
         this.getMsgChain.clear()

--- a/packages/client/src/publish/PublishPipeline.ts
+++ b/packages/client/src/publish/PublishPipeline.ts
@@ -9,7 +9,6 @@ import { instanceId, Defer, Deferred } from '../utils'
 import { Context, ContextError } from '../utils/Context'
 import { Pipeline } from '../utils/Pipeline'
 import { PushPipeline } from '../utils/PushPipeline'
-import { Stoppable } from '../utils/Stoppable'
 
 import { MessageCreator } from './MessageCreator'
 import { BrubeckNode } from '../BrubeckNode'
@@ -65,7 +64,7 @@ export type PublishQueueIn<T = unknown> = [PublishMetadataStrict<T>, Deferred<St
 export type PublishQueueOut<T = unknown> = [StreamMessage<T>, Deferred<StreamMessage<T>>]
 
 @scoped(Lifecycle.ContainerScoped)
-export class PublishPipeline implements Context, Stoppable {
+export class PublishPipeline implements Context {
     readonly id
     readonly debug
     /** takes metadata & creates stream messages. unsigned, unencrypted */

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -114,14 +114,6 @@ export class Publisher implements Context {
         }
     }
 
-    startKeyExchange(): Promise<void> {
-        return this.keyExchange.start()
-    }
-
-    stopKeyExchange(): Promise<void> {
-        return this.keyExchange.stop()
-    }
-
     async start(): Promise<void> {
         this.pipeline.start()
     }

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -9,7 +9,6 @@ import { Context } from '../utils/Context'
 import { CancelableGenerator, ICancelable } from '../utils/iterators'
 
 import { MessageMetadata, PublishMetadata, PublishPipeline } from './PublishPipeline'
-import { Stoppable } from '../utils/Stoppable'
 import { PublisherKeyExchange } from '../encryption/PublisherKeyExchange'
 import { StreamDefinition } from '../types'
 
@@ -24,7 +23,7 @@ const parseTimestamp = (metadata?: MessageMetadata): number => {
 }
 
 @scoped(Lifecycle.ContainerScoped)
-export class Publisher implements Context, Stoppable {
+export class Publisher implements Context {
     readonly id
     readonly debug
     streamMessageQueue

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -28,7 +28,6 @@ export class Publisher implements Context {
     readonly debug
     streamMessageQueue
     publishQueue
-    isStopped = false
 
     private inProgress = new Set<ICancelable>()
 
@@ -124,12 +123,10 @@ export class Publisher implements Context {
     }
 
     async start(): Promise<void> {
-        this.isStopped = false
         this.pipeline.start()
     }
 
     async stop(): Promise<void> {
-        this.isStopped = true
         await Promise.allSettled([
             this.pipeline.stop(),
             ...[...this.inProgress].map((item) => item.cancel().catch(() => {}))

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -8,14 +8,13 @@ import { SubscriberKeyExchange } from '../encryption/SubscriberKeyExchange'
 import { StreamRegistryCached } from '../StreamRegistryCached'
 import { Context } from '../utils/Context'
 import { DestroySignal } from '../DestroySignal'
-import { Stoppable } from '../utils/Stoppable'
 import { instanceId } from '../utils'
 
 type IDecrypt<T> = {
     decrypt: (streamMessage: StreamMessage<T>) => Promise<StreamMessage<T>>
 }
 
-export class Decrypt<T> implements IDecrypt<T>, Context, Stoppable {
+export class Decrypt<T> implements IDecrypt<T>, Context {
     id
     debug
     isStopped = false

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -3,7 +3,6 @@ import { DependencyContainer, inject } from 'tsyringe'
 import { StreamMessage, StreamPartID } from 'streamr-client-protocol'
 
 import { Scaffold, instanceId, until } from '../utils'
-import { Stoppable } from '../utils/Stoppable'
 import { Context } from '../utils/Context'
 import { Signal } from '../utils/Signal'
 import { MessageStream } from './MessageStream'
@@ -18,7 +17,7 @@ import { BrubeckNode, NetworkNodeStub } from '../BrubeckNode'
  * A session contains one or more subscriptions to a single streamId + streamPartition pair.
  */
 
-export class SubscriptionSession<T> implements Context, Stoppable {
+export class SubscriptionSession<T> implements Context {
     readonly id
     readonly debug
     public readonly streamPartId: StreamPartID

--- a/packages/client/src/utils/Stoppable.ts
+++ b/packages/client/src/utils/Stoppable.ts
@@ -1,4 +1,0 @@
-export type Stoppable = {
-    isStopped: boolean
-    stop(): void | Promise<void>
-}

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -7,6 +7,7 @@ import { GroupKey } from '../../src/encryption/GroupKey'
 import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { ClientFactory, createClientFactory } from '../test-utils/fake/fakeEnvironment'
 import { fastPrivateKey } from 'streamr-test-utils'
+import { PublisherKeyExchange } from '../../src/encryption/PublisherKeyExchange'
 
 const TIMEOUT = 30 * 1000
 jest.setTimeout(60000)
@@ -99,7 +100,7 @@ describe('Group Key Persistence', () => {
 
             it('works', async () => {
                 // @ts-expect-error private
-                const publisherKeyExchange: PublisherKeyExchange = publisher2.container.resolve(PublisherKeyExchange)
+                const publisherKeyExchange = publisher2.container.resolve(PublisherKeyExchange)
                 // subscribes to the key exchange stream
                 // TODO: this should probably happen automatically if there are keys
                 // also probably needs to create a connection handle

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -98,10 +98,12 @@ describe('Group Key Persistence', () => {
             }, 2 * TIMEOUT)
 
             it('works', async () => {
+                // @ts-expect-error private
+                const publisherKeyExchange: PublisherKeyExchange = publisher2.container.resolve(PublisherKeyExchange)
+                // subscribes to the key exchange stream
                 // TODO: this should probably happen automatically if there are keys
                 // also probably needs to create a connection handle
-                // @ts-expect-error private
-                await publisher2.publisher.startKeyExchange()
+                await publisherKeyExchange.useGroupKey(stream.id)
 
                 const received = []
                 const sub = await subscriber.resend(


### PR DESCRIPTION
- remove `stop()` methods which were not called by any component:
  - `KeyExchangeStream`
  - `GroupKeyStoreFactory`
  - `SubscriberKeyExchange`
  - `PublisherKeyExchange`
- remove obsolete `isStopped` field from classes (the value was never read):
  - `MessageCreator`
  - `Publisher`
- remove obsolete `Stoppable` interface
- remove methods from `Publisher` which started/stopped `PublisherKeyExchange`:
  - these methods were not part of public API and not called by other components
  - if we want to add public API methods to start/stop `PublisherKeyExchange`, we could use `PublisherKeyExchange#start` and `PublisherKeyExchange#stop` directly
  
 ### Future improvements
 
 - Do we want to start `PublisherKeyExchange` automatically if there are GroupKeys to be served to potential subscribers? Or do we want to have a public API method to start the the service? (NET-855)
 - If we need, we could add a new helper class (e.g. `TaskManager`), which could stop all pending promises when `client.destroy()` is called. (NET-856)