### PR TITLE
refactor(client): Annotate field visibility

### DIFF
--- a/packages/client/src/DestroySignal.ts
+++ b/packages/client/src/DestroySignal.ts
@@ -14,8 +14,8 @@ import { Signal } from './utils/Signal'
  */
 @scoped(Lifecycle.ContainerScoped)
 export class DestroySignal implements Context {
-    onDestroy = Signal.once()
-    trigger = this.destroy
+    public onDestroy = Signal.once()
+    public trigger = this.destroy
     readonly id = instanceId(this)
     readonly debug
 

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -19,10 +19,10 @@ export const DEFAULT_HEADERS = {
 }
 
 export class AuthFetchError extends Error {
-    response?: Response
-    body?: any
-    code: ErrorCode
-    errorCode: ErrorCode
+    public response?: Response
+    public body?: any
+    public code: ErrorCode
+    public errorCode: ErrorCode
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(message: string, response?: Response, body?: any, errorCode?: ErrorCode) {

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -29,10 +29,11 @@ export class SignatureRequiredError extends StreamMessageError {
  */
 @scoped(Lifecycle.ContainerScoped)
 export class Validator extends StreamMessageValidator implements Context {
-    id
-    debug
-    isStopped = false
+    readonly id
+    readonly debug
+    private isStopped = false
     private doValidation: StreamMessageValidator['validate']
+
     constructor(
         context: Context,
         @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached,

--- a/packages/client/src/encryption/BrowserPersistentStore.ts
+++ b/packages/client/src/encryption/BrowserPersistentStore.ts
@@ -1,11 +1,11 @@
-import { get, set, del, clear, keys, createStore } from 'idb-keyval'
+import { get, set, del, clear, keys, createStore, UseStore } from 'idb-keyval'
 import { PersistentStore } from './PersistentStore'
 import { StreamID } from 'streamr-client-protocol'
 
 export default class BrowserPersistentStore implements PersistentStore<string, string> {
-    readonly clientId: string
-    readonly streamId: string
-    private store
+    private readonly clientId: string
+    private readonly streamId: string
+    private store: UseStore
     private dbName: string
 
     constructor({ clientId, streamId }: { clientId: string, streamId: StreamID }) {

--- a/packages/client/src/encryption/BrowserPersistentStore.ts
+++ b/packages/client/src/encryption/BrowserPersistentStore.ts
@@ -3,14 +3,10 @@ import { PersistentStore } from './PersistentStore'
 import { StreamID } from 'streamr-client-protocol'
 
 export default class BrowserPersistentStore implements PersistentStore<string, string> {
-    private readonly clientId: string
-    private readonly streamId: string
     private store: UseStore
     private dbName: string
 
     constructor({ clientId, streamId }: { clientId: string, streamId: StreamID }) {
-        this.streamId = encodeURIComponent(streamId)
-        this.clientId = encodeURIComponent(clientId)
         this.dbName = `streamr-client::${clientId}::${streamId}`
         this.store = createStore(this.dbName, 'GroupKeys')
     }

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -75,8 +75,11 @@ export class GroupKey {
 
     }
 
+    /** @internal */
     id: string
+    /** @internal */
     hex: string
+    /** @internal */
     data: Uint8Array
 
     constructor(groupKeyId: string, groupKeyBufferOrHexString: Uint8Array | string) {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -16,7 +16,8 @@ type GroupKeyStoreOptions = {
 }
 
 export class GroupKeyPersistence implements PersistentStore<string, GroupKey> {
-    store: PersistentStore<string, string>
+    private store: PersistentStore<string, string>
+
     constructor(options: ServerPersistentStoreOptions) {
         this.store = new ServerPersistentStore(options)
     }
@@ -72,9 +73,9 @@ export class GroupKeyPersistence implements PersistentStore<string, GroupKey> {
 export class GroupKeyStore implements Context {
     readonly id
     readonly debug
-    store
-    currentGroupKeyId: GroupKeyId | undefined // current key id if any
-    nextGroupKeys: GroupKey[] = [] // the keys to use next, disappears if not actually used. Max queue size 2
+    private store: GroupKeyPersistence
+    private currentGroupKeyId: GroupKeyId | undefined // current key id if any
+    private nextGroupKeys: GroupKey[] = [] // the keys to use next, disappears if not actually used. Max queue size 2
 
     constructor({ context, clientId, streamId, groupKeys }: GroupKeyStoreOptions) {
         this.id = instanceId(this)

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -6,7 +6,7 @@ import { Context, ContextError } from '../utils/Context'
 import { ConfigInjectionToken, CacheConfig } from '../Config'
 import { Ethereum } from '../Ethereum'
 
-import { EncryptionConfig, parseGroupKeys } from './KeyExchangeStream'
+import { EncryptionConfig, GroupKeysSerialized, parseGroupKeys } from './KeyExchangeStream'
 import { GroupKeyStore } from './GroupKeyStore'
 import { GroupKey } from './GroupKey'
 import { StreamID } from 'streamr-client-protocol'
@@ -26,8 +26,9 @@ export class GroupKeyStoreFactory implements Context {
     readonly id
     readonly debug
     private cleanupFns: ((...args: any[]) => any)[] = []
-    initialGroupKeys
-    getStore: ((streamId: StreamID) => Promise<GroupKeyStore>) & { clear(): void }
+    private initialGroupKeys: Record<string, GroupKeysSerialized>
+    public getStore: ((streamId: StreamID) => Promise<GroupKeyStore>) & { clear(): void }
+
     constructor(
         context: Context,
         private ethereum: Ethereum,

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -63,7 +63,8 @@ const { GROUP_KEY_RESPONSE, GROUP_KEY_ERROR_RESPONSE } = StreamMessage.MESSAGE_T
 export class KeyExchangeStream implements Context {
     readonly id
     readonly debug
-    subscribe: (() => Promise<Subscription<unknown>>) & { reset(): void }
+    public subscribe: (() => Promise<Subscription<unknown>>) & { reset(): void }
+    
     constructor(
         context: Context,
         private ethereum: Ethereum,

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -30,10 +30,10 @@ class InvalidGroupKeyRequestError extends ValidationError {
 
 @scoped(Lifecycle.ContainerScoped)
 export class PublisherKeyExchange implements Context {
-    enabled = true
+    private enabled = true
     readonly id
     readonly debug
-    getSubscription
+    private getSubscription: (() => Promise<Subscription<unknown> | undefined>) & { reset(): void, isStarted(): boolean }
 
     constructor(
         @inject(delay(() => Publisher)) private publisher: Publisher,

--- a/packages/client/src/encryption/ServerPersistentStore.ts
+++ b/packages/client/src/encryption/ServerPersistentStore.ts
@@ -24,14 +24,14 @@ export type ServerPersistentStoreOptions = {
 
 export default class ServerPersistentStore implements PersistentStore<string, string>, Context {
     readonly id: string
-    readonly clientId: string
-    readonly streamId: string
-    readonly dbFilePath: string
+    private readonly clientId: string
+    private readonly streamId: string
+    private readonly dbFilePath: string
     private store?: Database
     private error?: Error
     private readonly initialData
     private initCalled = false
-    readonly migrationsPath: string
+    private readonly migrationsPath: string
     readonly debug
 
     constructor({

--- a/packages/client/src/encryption/ServerPersistentStore.ts
+++ b/packages/client/src/encryption/ServerPersistentStore.ts
@@ -24,7 +24,6 @@ export type ServerPersistentStoreOptions = {
 
 export default class ServerPersistentStore implements PersistentStore<string, string>, Context {
     readonly id: string
-    private readonly clientId: string
     private readonly streamId: string
     private readonly dbFilePath: string
     private store?: Database
@@ -45,7 +44,6 @@ export default class ServerPersistentStore implements PersistentStore<string, st
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
         this.streamId = encodeURIComponent(streamId)
-        this.clientId = encodeURIComponent(clientId)
         this.initialData = initialData
         const paths = envPaths('streamr-client')
         const dbFilePath = resolve(paths.data, join(rootPath, clientId, 'GroupKeys.db'))

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -40,7 +40,7 @@ async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, encry
 export class SubscriberKeyExchange implements Context {
     readonly id
     readonly debug
-    encryptionUtil
+    private encryptionUtil: EncryptionUtil
 
     constructor(
         private subscriber: Subscriber,

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -10,7 +10,7 @@ import { Ethereum } from '../Ethereum'
 
 @scoped(Lifecycle.ContainerScoped)
 export class Encrypt {
-    isStopped = false
+    private isStopped = false
 
     constructor(
         private streamRegistryCached: StreamRegistryCached,

--- a/packages/client/src/publish/MessageChain.ts
+++ b/packages/client/src/publish/MessageChain.ts
@@ -39,9 +39,9 @@ export function getCachedMessageChain(cacheConfig: CacheConfig):
 export class MessageChain {
     private readonly streamId: StreamID
     private readonly streamPartition: number
-    readonly publisherId
-    readonly msgChainId
-    prevMsgRef?: MessageRef
+    private readonly publisherId: string
+    private readonly msgChainId: string
+    private prevMsgRef?: MessageRef
 
     constructor(streamPartId: StreamPartID, { publisherId, msgChainId = randomString(20) }: MessageChainOptions) {
         [this.streamId, this.streamPartition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -45,8 +45,8 @@ export class MessageCreatorAnonymous implements IMessageCreator {
 @scoped(Lifecycle.ContainerScoped)
 export class MessageCreator implements IMessageCreator {
     // encrypt
-    queue: ReturnType<typeof LimitAsyncFnByKey>
-    getMsgChain
+    private queue: ReturnType<typeof LimitAsyncFnByKey>
+    private getMsgChain
 
     /*
      * Get function for creating stream messages.

--- a/packages/client/src/publish/PublishPipeline.ts
+++ b/packages/client/src/publish/PublishPipeline.ts
@@ -21,8 +21,8 @@ import { StreamDefinition } from '../types'
 import { InspectOptions } from 'util'
 
 export class FailedToPublishError extends Error {
-    publishMetadata
-    reason
+    public publishMetadata
+    public reason
     constructor(publishMetadata: PublishMetadataStrict, reason?: Error) {
         // eslint-disable-next-line max-len
         super(`Failed to publish to stream ${formStreamDefinitionDescription(publishMetadata.streamDefinition)} due to: ${reason && reason.stack ? reason.stack : reason}.`)
@@ -68,12 +68,12 @@ export class PublishPipeline implements Context {
     readonly id
     readonly debug
     /** takes metadata & creates stream messages. unsigned, unencrypted */
-    streamMessageQueue!: PushPipeline<PublishQueueIn, PublishQueueOut>
+    private streamMessageQueue!: PushPipeline<PublishQueueIn, PublishQueueOut>
     /** signs, encrypts then publishes messages */
-    publishQueue!: Pipeline<PublishQueueOut, PublishQueueOut>
-    isStarted = false
-    isStopped = false
-    inProgress = new Set<Deferred<StreamMessage>>()
+    private publishQueue!: Pipeline<PublishQueueOut, PublishQueueOut>
+    private isStarted = false
+    private isStopped = false
+    private inProgress = new Set<Deferred<StreamMessage>>()
 
     constructor(
         context: Context,

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -2,14 +2,13 @@
  * Public Publishing API
  */
 import { StreamMessage } from 'streamr-client-protocol'
-import { scoped, Lifecycle, inject, delay } from 'tsyringe'
+import { scoped, Lifecycle } from 'tsyringe'
 
 import { instanceId } from '../utils'
 import { Context } from '../utils/Context'
 import { CancelableGenerator, ICancelable } from '../utils/iterators'
 
 import { MessageMetadata, PublishMetadata, PublishPipeline } from './PublishPipeline'
-import { PublisherKeyExchange } from '../encryption/PublisherKeyExchange'
 import { StreamDefinition } from '../types'
 
 export type { PublishMetadata }
@@ -26,19 +25,19 @@ const parseTimestamp = (metadata?: MessageMetadata): number => {
 export class Publisher implements Context {
     readonly id
     readonly debug
-    streamMessageQueue
-    publishQueue
-
+    private streamMessageQueue
+    private publishQueue
     private inProgress = new Set<ICancelable>()
 
     constructor(
         context: Context,
-        private pipeline: PublishPipeline,
-        @inject(delay(() => PublisherKeyExchange)) private keyExchange: PublisherKeyExchange
+        private pipeline: PublishPipeline
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
+        // @ts-expect-error private
         this.streamMessageQueue = pipeline.streamMessageQueue
+        // @ts-expect-error private
         this.publishQueue = pipeline.publishQueue
     }
 

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -25,8 +25,6 @@ const parseTimestamp = (metadata?: MessageMetadata): number => {
 export class Publisher implements Context {
     readonly id
     readonly debug
-    private streamMessageQueue
-    private publishQueue
     private inProgress = new Set<ICancelable>()
 
     constructor(
@@ -35,10 +33,6 @@ export class Publisher implements Context {
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
-        // @ts-expect-error private
-        this.streamMessageQueue = pipeline.streamMessageQueue
-        // @ts-expect-error private
-        this.publishQueue = pipeline.publishQueue
     }
 
     async publish<T>(streamDefinition: StreamDefinition, content: T, metadata?: MessageMetadata): Promise<StreamMessage<T>> {

--- a/packages/client/src/publish/Signer.ts
+++ b/packages/client/src/publish/Signer.ts
@@ -12,12 +12,13 @@ import { ConfigInjectionToken } from '../Config'
 
 @scoped(Lifecycle.ContainerScoped)
 export class Signer {
-    signData
+    private signData: (d: string) => Promise<string>
+
     constructor(@inject(ConfigInjectionToken.Auth) authOptions: AuthenticatedConfig) {
         this.signData = Signer.getSigningFunction(authOptions)
     }
 
-    static getSigningFunction(options: AuthenticatedConfig): (d: string) => Promise<string> {
+    private static getSigningFunction(options: AuthenticatedConfig): (d: string) => Promise<string> {
         if ('privateKey' in options && options.privateKey) {
             const { privateKey } = options
             const key = (typeof privateKey === 'string' && privateKey.startsWith('0x'))

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -15,9 +15,9 @@ type IDecrypt<T> = {
 }
 
 export class Decrypt<T> implements IDecrypt<T>, Context {
-    id
-    debug
-    isStopped = false
+    readonly id
+    readonly debug
+    private isStopped = false
 
     constructor(
         context: Context,

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -21,14 +21,14 @@ import { SubscribeConfig } from '../Config'
 export class OrderMessages<T> implements Context {
     readonly id
     readonly debug
-    stopSignal = Signal.once()
-    done = false
-    resendStreams = new Set<MessageStream<T>>() // holds outstanding resends for cleanup
-    outBuffer = new PushBuffer<StreamMessage<T>>()
-    inputClosed = false
-    orderMessages: boolean
-    enabled = true
-    orderingUtil
+    private stopSignal = Signal.once()
+    private done = false
+    private resendStreams = new Set<MessageStream<T>>() // holds outstanding resends for cleanup
+    private outBuffer = new PushBuffer<StreamMessage<T>>()
+    private inputClosed = false
+    private orderMessages: boolean
+    private enabled = true
+    private orderingUtil
 
     constructor(
         private options: SubscribeConfig,

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -15,6 +15,7 @@ export interface ResendSubscriptionEvents {
 export class ResendSubscription<T> extends Subscription<T> {
     private orderMessages
     private eventEmitter: EventEmitter<ResendSubscriptionEvents>
+
     /** @internal */
     constructor(
         subSession: SubscriptionSession<T>,

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -19,7 +19,7 @@ import { range } from 'lodash'
 export class Subscriber implements Context {
     readonly id
     readonly debug
-    readonly subSessions: Map<StreamPartID, SubscriptionSession<unknown>> = new Map()
+    private readonly subSessions: Map<StreamPartID, SubscriptionSession<unknown>> = new Map()
 
     constructor(
         context: Context,
@@ -156,6 +156,7 @@ export class Subscriber implements Context {
      */
     private getAllSubscriptions(): Subscription<unknown>[] {
         return [...this.subSessions.values()].reduce((o: Subscription<unknown>[], s: SubscriptionSession<unknown>) => {
+            // @ts-expect-error private
             o.push(...s.subscriptions)
             return o
         }, [])
@@ -191,6 +192,7 @@ export class Subscriber implements Context {
         }))
 
         return results.flatMap((subSession) => ([
+            // @ts-expect-error private
             ...subSession.subscriptions
         ]))
     }

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -13,7 +13,7 @@ export { MessageStreamOnMessage as SubscriptionOnMessage }
  */
 export class Subscription<T = unknown> extends MessageStream<T> {
     /** @internal */
-    context: SubscriptionSession<T>
+    private context: SubscriptionSession<T>
     readonly streamPartId: StreamPartID
 
     /** @internal */

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -22,13 +22,13 @@ export class SubscriptionSession<T> implements Context {
     readonly debug
     public readonly streamPartId: StreamPartID
     /** active subs */
-    subscriptions: Set<Subscription<T>> = new Set()
-    pendingRemoval: WeakSet<Subscription<T>> = new WeakSet()
-    isRetired: boolean = false
-    isStopped = false
-    pipeline
-    node
-    onRetired = Signal.once()
+    private subscriptions: Set<Subscription<T>> = new Set()
+    private pendingRemoval: WeakSet<Subscription<T>> = new WeakSet()
+    private isRetired: boolean = false
+    private isStopped = false
+    private pipeline
+    private node
+    public readonly onRetired = Signal.once()
 
     constructor(
         context: Context,

--- a/packages/client/src/utils/AggregatedError.ts
+++ b/packages/client/src/utils/AggregatedError.ts
@@ -27,9 +27,10 @@ function joinStackTraces(errs: Error[]): string {
 }
 
 export class AggregatedError extends Error {
-    errors: Set<Error>
-    ownMessage: string
-    ownStack?: string
+    public errors: Set<Error>
+    public ownMessage: string
+    public ownStack?: string
+    
     constructor(errors: Error[] = [], errorMessage = '') {
         const message = joinMessages([
             errorMessage,

--- a/packages/client/src/utils/Context.ts
+++ b/packages/client/src/utils/Context.ts
@@ -10,8 +10,9 @@ export abstract class Context {
 }
 
 export class ContextError extends Error {
-    context: Context
-    code?: string
+    public context: Context
+    public code?: string
+    
     constructor(context: Context, message: string = '', ...args: any[]) {
         // @ts-expect-error inspectOpts not in debug types
         super(`${context?.id}: ${formatWithOptions({ ...(context?.debug?.inspectOpts || {}), colors: false }, message, ...args)}`)

--- a/packages/client/src/utils/Gate.ts
+++ b/packages/client/src/utils/Gate.ts
@@ -36,7 +36,7 @@ import { Debug } from './log'
 export class Gate implements Context {
     readonly id
     readonly debug
-    isLocked = false
+    public isLocked = false
     private pending?: Deferred<void>
 
     constructor(name?: string) {

--- a/packages/client/src/utils/Pipeline.ts
+++ b/packages/client/src/utils/Pipeline.ts
@@ -92,7 +92,7 @@ export class Pipeline<InType, OutType = InType> implements IPipeline<InType, Out
     protected iterator: AsyncGenerator<OutType>
     private isIterating = false
     /** @internal */
-    isCleaningUp = false
+    public isCleaningUp = false
     private definition: PipelineDefinition<InType, OutType>
 
     /** @internal */

--- a/packages/client/src/utils/PullBuffer.ts
+++ b/packages/client/src/utils/PullBuffer.ts
@@ -5,7 +5,8 @@ import { pull, PushBuffer } from './PushBuffer'
  * Pull from a source into self.
  */
 export class PullBuffer<InType> extends PushBuffer<InType> {
-    source: AsyncGenerator<InType>
+    private source: AsyncGenerator<InType>
+    
     constructor(source: AsyncGenerator<InType>, ...args: ConstructorParameters<typeof PushBuffer>) {
         super(...args)
         this.source = source

--- a/packages/client/src/utils/PushBuffer.ts
+++ b/packages/client/src/utils/PushBuffer.ts
@@ -44,8 +44,9 @@ export type IPushBuffer<InType, OutType = InType> = {
  */
 export class PushBuffer<T> implements IPushBuffer<T>, Context {
     static Error = PushBufferError
-    id
-    debug
+
+    readonly id
+    readonly debug
 
     protected readonly buffer: (T | Error)[] = []
     readonly bufferSize: number

--- a/packages/client/src/utils/Signal.ts
+++ b/packages/client/src/utils/Signal.ts
@@ -78,9 +78,9 @@ export class Signal<ArgsType extends any[] = []> {
         return this.create<ArgsType>(TRIGGER_TYPE.PARALLEL)
     }
 
-    listeners: (SignalListener<ArgsType> | SignalListenerWrap<ArgsType>)[] = []
-    isEnded = false
-    triggerCountValue = 0
+    protected listeners: (SignalListener<ArgsType> | SignalListenerWrap<ArgsType>)[] = []
+    protected isEnded = false
+    protected triggerCountValue = 0
 
     constructor(
         protected triggerType: TRIGGER_TYPE = TRIGGER_TYPE.PARALLEL

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -534,7 +534,8 @@ export function pOnce<ArgsType extends unknown[], ReturnType>(
 }
 
 export class TimeoutError extends Error {
-    timeout: number
+    public timeout: number
+    
     constructor(msg = '', timeout = 0) {
         super(`The operation timed out. ${timeout}ms. ${msg}`)
         this.timeout = timeout

--- a/packages/client/test/end-to-end/StreamrClient.test.ts
+++ b/packages/client/test/end-to-end/StreamrClient.test.ts
@@ -18,6 +18,7 @@ import {
 import { StreamrClient } from '../../src/StreamrClient'
 import { Defer } from '../../src/utils'
 import * as G from '../../src/utils/GeneratorUtils'
+import { PublishPipeline } from '../../src/publish/PublishPipeline'
 
 jest.setTimeout(60000)
 
@@ -247,7 +248,9 @@ describeRepeats('StreamrClient', () => {
             const gotMessages = Defer()
             const published: any[] = []
             // @ts-expect-error private
-            client.publisher.publishQueue.onMessage.listen(async ([streamMessage]) => {
+            const publishPipeline = client.container.resolve(PublishPipeline)
+            // @ts-expect-error private
+            publishPipeline.publishQueue.onMessage.listen(async ([streamMessage]) => {
                 const requiredStreamPartID = toStreamPartID(toStreamID(streamDefinition.id), streamDefinition.partition)
                 if (requiredStreamPartID !== streamMessage.getStreamPartID()) { return }
                 onMessage()

--- a/packages/client/test/end-to-end/Validation.test.ts
+++ b/packages/client/test/end-to-end/Validation.test.ts
@@ -67,6 +67,7 @@ describe('Validation', () => {
             sub.onError.listen(onSubError)
 
             const BAD_INDEX = 2
+            // @ts-expect-error private 
             sub.context.pipeline.forEachBefore((streamMessage: StreamMessage, index: number) => {
                 if (index === BAD_INDEX) {
                     // eslint-disable-next-line no-param-reassign
@@ -135,6 +136,7 @@ describe('Validation', () => {
             sub.onError.listen(onSubError)
 
             const BAD_INDEX = 2
+            // @ts-expect-error private 
             sub.context.pipeline.mapBefore(async (streamMessage: StreamMessage, index: number) => {
                 if (index === BAD_INDEX) {
                     const msg = streamMessage.clone()

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -536,6 +536,7 @@ describe('decryption', () => {
                     // @ts-expect-error private
                     const subSession = subscriber.subscriber.getSubscriptionSession(sub.streamPartId)
                     if (!subSession) { throw new Error('no subsession?') }
+                    // @ts-expect-error private
                     subSession.pipeline.forEachBefore((streamMessage: StreamMessage, index: number) => {
                         if (index === BAD_INDEX) {
                             // eslint-disable-next-line no-param-reassign

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -15,12 +15,18 @@ import { StreamPermission } from '../../src/permission'
 import { Subscription } from '../../src/subscribe/Subscription'
 import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { ClientFactory, createClientFactory } from '../test-utils/fake/fakeEnvironment'
+import { PublishPipeline } from '../../src/publish/PublishPipeline'
 
 const debug = Debug('StreamrClient::test')
 const TIMEOUT = 15 * 1000
 const NUM_MESSAGES = 5
 
 jest.setTimeout(30000)
+
+const getPublishPipeline = (client: StreamrClient): PublishPipeline => {
+    // @ts-expect-error private
+    return client.container.resolve(PublishPipeline)
+}
 
 describe('decryption', () => {
     let publishTestMessages: ReturnType<typeof getPublishTestStreamMessages>
@@ -37,7 +43,7 @@ describe('decryption', () => {
     function checkEncryptionMessages(testClient: StreamrClient) {
         const onSendTest = Defer()
         // @ts-expect-error private
-        testClient.publisher.publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
+        getPublishPipeline(testClient).publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
             // check encryption is as expected
             if (streamMessage.messageType === StreamMessage.MESSAGE_TYPES.MESSAGE) {
                 expect(streamMessage.encryptionType).toEqual(StreamMessage.ENCRYPTION_TYPES.AES)
@@ -246,7 +252,7 @@ describe('decryption', () => {
                 function checkEncryptionMessagesPerStream(testClient: StreamrClient) {
                     const onSendTest = Defer()
                     // @ts-expect-error private
-                    testClient.publisher.publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
+                    getPublishPipeline(testClient).publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
                         // check encryption is as expected
                         if (streamMessage.getStreamId() === stream2.id) {
                             didFindStream2 = true
@@ -284,7 +290,7 @@ describe('decryption', () => {
 
                     const published: any[] = []
                     // @ts-expect-error private
-                    publisher.publisher.streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
+                    getPublishPipeline(publisher).streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
                         if (streamMessage.getStreamId() !== testStream.id) { return }
                         published.push(streamMessage.getParsedContent())
                     })
@@ -325,7 +331,7 @@ describe('decryption', () => {
 
                 const published: any[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     published.push(streamMessage.getParsedContent())
                 })
@@ -355,7 +361,7 @@ describe('decryption', () => {
                 })
                 const publishedStreamMessages: any[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     publishedStreamMessages.push(streamMessage.clone())
                     await publisher.updateEncryptionKey({
@@ -402,12 +408,12 @@ describe('decryption', () => {
                 const contentClear: any[] = []
                 const streamMessagesPublished: StreamMessage<any>[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.forEach(([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.forEach(([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     contentClear.push(streamMessage.getParsedContent())
                 })
                 // @ts-expect-error private
-                publisher.publisher.publishQueue.forEach(([streamMessage]) => {
+                getPublishPipeline(publisher).publishQueue.forEach(([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     streamMessagesPublished.push(streamMessage)
                 })
@@ -439,7 +445,7 @@ describe('decryption', () => {
                     distributionMethod: 'rotate'
                 })
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.forEach(async () => {
+                getPublishPipeline(publisher).streamMessageQueue.forEach(async () => {
                     await publisher.updateEncryptionKey({
                         streamId: stream.id,
                         distributionMethod: 'rotate'
@@ -447,7 +453,7 @@ describe('decryption', () => {
                 })
                 const published: any[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.forEach(([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.forEach(([streamMessage]) => {
                     if (streamMessage.getStreamId() !== stream.id) { return }
                     published.push(streamMessage.getParsedContent())
                 })
@@ -476,7 +482,7 @@ describe('decryption', () => {
                     distributionMethod: 'rotate'
                 })
                 // @ts-expect-error private
-                publisher.publisher.publishQueue.forEach(async () => {
+                getPublishPipeline(publisher).publishQueue.forEach(async () => {
                     await publisher.updateEncryptionKey({
                         streamId: stream.id,
                         distributionMethod: 'rotate'
@@ -517,13 +523,13 @@ describe('decryption', () => {
                     contentClear = []
 
                     // @ts-expect-error private
-                    publisher.publisher.streamMessageQueue.forEach(([streamMessage]) => {
+                    getPublishPipeline(publisher).streamMessageQueue.forEach(([streamMessage]) => {
                         if (streamMessage.getStreamId() !== stream.id) { return }
                         contentClear.push(streamMessage.getParsedContent())
                     })
 
                     // @ts-expect-error private
-                    publisher.publisher.publishQueue.forEach(async () => {
+                    getPublishPipeline(publisher).publishQueue.forEach(async () => {
                         await publisher.updateEncryptionKey({
                             streamId: stream.id,
                             distributionMethod: 'rotate'
@@ -641,7 +647,7 @@ describe('decryption', () => {
             function checkEncryptionMessagesPerStream(testClient: StreamrClient) {
                 const onSendTest = Defer()
                 // @ts-expect-error private
-                testClient.publisher.publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
+                getPublishPipeline(testClient).publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() === stream2.id) {
                         didFindStream2 = true
                         testClient.debug('streamMessage.encryptionType', streamMessage.encryptionType, StreamMessage.ENCRYPTION_TYPES.AES)
@@ -673,7 +679,7 @@ describe('decryption', () => {
                 })
                 const published: any[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.onMessage.listen(async ([streamMessage]) => {
                     if (streamMessage.getStreamId() !== testStream.id) { return }
                     published.push(streamMessage.getParsedContent())
                     await publisher.updateEncryptionKey({
@@ -711,7 +717,7 @@ describe('decryption', () => {
             function checkEncryptionMessagesPerStream(testClient: StreamrClient) {
                 const onSendTest = Defer()
                 // @ts-expect-error private
-                testClient.publisher.publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
+                getPublishPipeline(testClient).publishQueue.forEach(onSendTest.wrapError(async ([streamMessage]) => {
                     testClient.debug({ streamMessage })
 
                     if (streamMessage.getStreamId() === stream2.id) {
@@ -751,7 +757,7 @@ describe('decryption', () => {
 
                 const contentClear: any[] = []
                 // @ts-expect-error private
-                publisher.publisher.streamMessageQueue.onMessage.listen(([streamMessage]) => {
+                getPublishPipeline(publisher).streamMessageQueue.onMessage.listen(([streamMessage]) => {
                     if (streamMessage.getStreamId() !== testStream.id) { return }
                     contentClear.push(streamMessage.getParsedContent())
                 })

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -18,6 +18,7 @@ jest.setTimeout(50000)
 function monkeypatchMessageHandler<T = any>(sub: Subscription<T>, fn: ((msg: StreamMessage<T>, count: number) => void | null)) {
     let count = 0
     // eslint-disable-next-line no-param-reassign
+    // @ts-expect-error private
     sub.context.pipeline.pipeBefore(async function* DropMessages(src: AsyncGenerator<any>) {
         for await (const msg of src) {
             const result = fn(msg, count)

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -139,7 +139,8 @@ describe('Group Key Persistence', () => {
 
             // this will be called if group key request is sent
             // @ts-expect-error private
-            const onKeyExchangeMessage = jest.spyOn(publisher.publisher.keyExchange, 'onKeyExchangeMessage')
+            const publisherKeyExchange = publisher.container.resolve(PublisherKeyExchange)
+            const onKeyExchangeMessage = jest.spyOn(publisherKeyExchange, 'onKeyExchangeMessage' as any)
 
             // this should set up group key
             const published = await publishTestMessages(1)

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -22,6 +22,7 @@ import { StreamPermission } from '../../src/permission'
 import { padEnd } from 'lodash'
 import { Context } from '../../src/utils/Context'
 import { StreamrClientConfig } from '../../src/Config'
+import { PublishPipeline } from '../../src/publish/PublishPipeline'
 
 const testDebugRoot = Debug('test')
 const testDebug = testDebugRoot.extend.bind(testDebugRoot)
@@ -490,7 +491,9 @@ export function getPublishTestStreamMessages(
 
         const contents = new WeakMap()
         // @ts-expect-error private
-        client.publisher.streamMessageQueue.onMessage.listen(([streamMessage]) => {
+        const publishPipeline = client.container.resolve(PublishPipeline)
+        // @ts-expect-error private
+        publishPipeline.streamMessageQueue.onMessage.listen(([streamMessage]) => {
             contents.set(streamMessage, streamMessage.serializedContent)
         })
         const publishStream = publishTestMessagesGenerator(client, streamDefinition, maxMessages, options)

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -221,12 +221,12 @@ export function snapshot(): string {
 }
 
 export class LeaksDetector {
-    leakDetectors: Map<string, LeakDetector> = new Map()
-    ignoredValues = new WeakSet()
-    id = instanceId(this)
-    debug = testDebug(this.id)
-    seen = new WeakSet()
-    didGC = false
+    private leakDetectors: Map<string, LeakDetector> = new Map()
+    private ignoredValues = new WeakSet()
+    private id = instanceId(this)
+    private debug = testDebug(this.id)
+    private seen = new WeakSet()
+    private didGC = false
 
     // temporary whitelist leaks in network code
     ignoredKeys = new Set([

--- a/packages/client/test/unit/Encryption.test.ts
+++ b/packages/client/test/unit/Encryption.test.ts
@@ -47,7 +47,9 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
         it('aes decryption after encryption equals the initial plaintext', () => {
             const key = GroupKey.generate()
             const plaintext = 'some random text'
+            // @ts-expect-error private
             const ciphertext = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+            // @ts-expect-error private
             expect(EncryptionUtil.decrypt(ciphertext, key).toString('utf8')).toStrictEqual(plaintext)
         })
 
@@ -55,6 +57,7 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
             const key = GroupKey.generate()
             const plaintext = 'some random text'
             const plaintextBuffer = Buffer.from(plaintext, 'utf8')
+            // @ts-expect-error private
             const ciphertext = EncryptionUtil.encrypt(plaintextBuffer, key)
             const ciphertextBuffer = ethers.utils.arrayify(`0x${ciphertext}`)
             expect(ciphertextBuffer.length).toStrictEqual(plaintextBuffer.length + 16)
@@ -63,7 +66,9 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
         it('multiple same encrypt() calls use different ivs and produce different ciphertexts', () => {
             const key = GroupKey.generate()
             const plaintext = 'some random text'
+            // @ts-expect-error private
             const ciphertext1 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+            // @ts-expect-error private
             const ciphertext2 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
             expect(ciphertext1.slice(0, 32)).not.toStrictEqual(ciphertext2.slice(0, 32))
             expect(ciphertext1.slice(32)).not.toStrictEqual(ciphertext2.slice(32))

--- a/packages/client/test/unit/Signer.test.ts
+++ b/packages/client/test/unit/Signer.test.ts
@@ -36,6 +36,7 @@ describe('Signer', () => {
 
         it('should return correct signature', async () => {
             const payload = 'data-to-sign'
+            // @ts-expect-error private
             const signature = await signer.signData(payload)
             expect(signature).toEqual('0x084b3ac0f2ad17d387ca5bbf5d72d8f1dfd1b372e399ce6b0bfc60793e'
                 + 'b717d2431e498294f202d8dfd9f56158391d453c018470aea92ed6a80a23c20ab6f7ac1b')
@@ -55,6 +56,7 @@ describe('Signer', () => {
                 + streamMessage.messageId.sequenceNumber + address.toLowerCase() + streamMessage.messageId.msgChainId
                 + streamMessage.getSerializedContent()
 
+            // @ts-expect-error private
             const expectedSignature = await signer.signData(payload)
             await signer.sign(streamMessage)
             expect(streamMessage.signature).toBe(expectedSignature)
@@ -77,8 +79,10 @@ describe('Signer', () => {
                 streamMessage.messageId.sequenceNumber, address.toLowerCase(), streamMessage.messageId.msgChainId,
                 streamMessage.prevMsgRef!.timestamp, streamMessage.prevMsgRef!.sequenceNumber, streamMessage.getSerializedContent()
             ]
+            // @ts-expect-error private
             const expectedSignature = await signer.signData(payload.join(''))
             expect(payload.join('')).toEqual(streamMessage.getPayloadToSign())
+            // @ts-expect-error private
             expect(expectedSignature).toEqual(await signer.signData(streamMessage.getPayloadToSign()))
             await signer.sign(streamMessage)
             expect(streamMessage.signature).toBe(expectedSignature)
@@ -103,6 +107,7 @@ describe('Signer', () => {
             ]
 
             await expect(async () => {
+                // @ts-expect-error private
                 await signer.signData(payload.join(''))
             }).rejects.toThrow('privateKey')
             await expect(async () => {


### PR DESCRIPTION
Annotate fields visibilities: many fields are now `private`, and some field explicitly marked as `public`/`protected`.

Also removed some obsolete fields in `BrowserPersistenceStore`, `ServerPersistenceStore` and `Publisher`.