### PR TITLE
refactor(client): RsaKeyPair

### DIFF
--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -1,21 +1,7 @@
 import crypto from 'crypto'
-import { O } from 'ts-toolbelt'
-import { promisify } from 'util'
 import { arrayify, hexlify } from '@ethersproject/bytes'
 import { StreamMessage, EncryptedGroupKey, StreamMessageError } from 'streamr-client-protocol'
 import { GroupKey } from './GroupKey'
-
-const { webcrypto } = crypto
-
-function getSubtle(): any {
-    // @ts-expect-error webcrypto.subtle does not currently exist in node types
-    const subtle = typeof window !== 'undefined' ? window?.crypto?.subtle : webcrypto.subtle
-    if (!subtle) {
-        const url = 'https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto'
-        throw new Error(`SubtleCrypto not supported. This feature is available only in secure contexts (HTTPS) & Node 16+. ${url}`)
-    }
-    return subtle
-}
 
 export class StreamMessageProcessingError extends StreamMessageError {
     constructor(message = '', streamMessage: StreamMessage) {
@@ -27,34 +13,6 @@ export class UnableToDecryptError extends StreamMessageProcessingError {
     constructor(message = '', streamMessage: StreamMessage) {
         super(`Unable to decrypt. ${message}`, streamMessage)
     }
-}
-
-function ab2str(...args: any[]): string {
-    // @ts-expect-error Uint8Array parameters
-    return String.fromCharCode.apply(null, new Uint8Array(...args) as unknown as number[])
-}
-
-// shim browser btoa for node
-function btoa(str: string | Uint8Array): string {
-    if (global.btoa) { return global.btoa(str as string) }
-    let buffer
-
-    if (Buffer.isBuffer(str)) {
-        buffer = str
-    } else {
-        buffer = Buffer.from(str.toString(), 'binary')
-    }
-
-    return buffer.toString('base64')
-}
-
-async function exportCryptoKey(key: CryptoKey, { isPrivate = false } = {}): Promise<string> {
-    const keyType = isPrivate ? 'pkcs8' : 'spki'
-    const exported = await getSubtle().exportKey(keyType, key)
-    const exportedAsString = ab2str(exported)
-    const exportedAsBase64 = btoa(exportedAsString)
-    const TYPE = isPrivate ? 'PRIVATE' : 'PUBLIC'
-    return `-----BEGIN ${TYPE} KEY-----\n${exportedAsBase64}\n-----END ${TYPE} KEY-----\n`
 }
 
 export class EncryptionUtil {
@@ -174,100 +132,3 @@ export class EncryptionUtil {
     }
 }
 
-// after RsaKeyPair is ready
-type InitializedRsaKeyPair = O.Overwrite<RsaKeyPair, {
-    privateKey: string,
-    publicKey: string,
-}>
-
-export class RsaKeyPair {
-    /**
-     * Creates a new instance + waits for ready.
-     * Convenience.
-     */
-    static async create(): Promise<RsaKeyPair> {
-        const pair = new RsaKeyPair()
-        await pair.onReady()
-        return pair
-    }
-
-    public privateKey: string | undefined
-    public publicKey: string | undefined
-    private _generateKeyPairPromise: Promise<void> | undefined
-
-    async onReady(): Promise<void> {
-        if (this.isReady()) { return undefined }
-        return this._generateKeyPair()
-    }
-
-    isReady(this: RsaKeyPair): this is InitializedRsaKeyPair {
-        return (this.privateKey !== undefined && this.publicKey !== undefined)
-    }
-
-    // Returns a String (base64 encoding)
-    getPublicKey(): string {
-        if (!this.isReady()) { throw new Error('RsaKeyPair not ready.') }
-        return this.publicKey
-    }
-
-    // Returns a String (base64 encoding)
-    getPrivateKey(): string {
-        if (!this.isReady()) { throw new Error('RsaKeyPair not ready.') }
-        return this.privateKey
-    }
-
-    private async _generateKeyPair(): Promise<void> {
-        if (!this._generateKeyPairPromise) {
-            this._generateKeyPairPromise = this.__generateKeyPair()
-        }
-        return this._generateKeyPairPromise
-    }
-
-    private async __generateKeyPair(): Promise<void> {
-        if (typeof window !== 'undefined') { return this._keyPairBrowser() }
-        return this._keyPairServer()
-    }
-
-    private async _keyPairServer(): Promise<void> {
-        // promisify here to work around browser/server packaging
-        const generateKeyPair = promisify(crypto.generateKeyPair)
-        const { publicKey, privateKey } = await generateKeyPair('rsa', {
-            modulusLength: 4096,
-            publicKeyEncoding: {
-                type: 'spki',
-                format: 'pem',
-            },
-            privateKeyEncoding: {
-                type: 'pkcs8',
-                format: 'pem',
-            },
-        })
-
-        this.privateKey = privateKey
-        this.publicKey = publicKey
-    }
-
-    private async _keyPairBrowser(): Promise<void> {
-        const { publicKey, privateKey } = await getSubtle().generateKey({
-            name: 'RSA-OAEP',
-            modulusLength: 4096,
-            publicExponent: new Uint8Array([1, 0, 1]), // 65537
-            hash: 'SHA-256'
-        }, true, ['encrypt', 'decrypt'])
-        if (!(publicKey && privateKey)) {
-            // TS says this is possible.
-            throw new Error('could not generate keys')
-        }
-
-        const [exportedPrivate, exportedPublic] = await Promise.all([
-            exportCryptoKey(privateKey, {
-                isPrivate: true,
-            }),
-            exportCryptoKey(publicKey, {
-                isPrivate: false,
-            })
-        ])
-        this.privateKey = exportedPrivate
-        this.publicKey = exportedPublic
-    }
-}

--- a/packages/client/src/encryption/RsaKeyPair.ts
+++ b/packages/client/src/encryption/RsaKeyPair.ts
@@ -1,0 +1,141 @@
+import crypto from 'crypto'
+import { O } from 'ts-toolbelt'
+import { promisify } from 'util'
+
+const { webcrypto } = crypto
+
+function getSubtle(): any {
+    // @ts-expect-error webcrypto.subtle does not currently exist in node types
+    const subtle = typeof window !== 'undefined' ? window?.crypto?.subtle : webcrypto.subtle
+    if (!subtle) {
+        const url = 'https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto'
+        throw new Error(`SubtleCrypto not supported. This feature is available only in secure contexts (HTTPS) & Node 16+. ${url}`)
+    }
+    return subtle
+}
+
+function ab2str(...args: any[]): string {
+    // @ts-expect-error Uint8Array parameters
+    return String.fromCharCode.apply(null, new Uint8Array(...args) as unknown as number[])
+}
+
+// shim browser btoa for node
+function btoa(str: string | Uint8Array): string {
+    if (global.btoa) { return global.btoa(str as string) }
+    let buffer
+
+    if (Buffer.isBuffer(str)) {
+        buffer = str
+    } else {
+        buffer = Buffer.from(str.toString(), 'binary')
+    }
+
+    return buffer.toString('base64')
+}
+
+async function exportCryptoKey(key: CryptoKey, { isPrivate = false } = {}): Promise<string> {
+    const keyType = isPrivate ? 'pkcs8' : 'spki'
+    const exported = await getSubtle().exportKey(keyType, key)
+    const exportedAsString = ab2str(exported)
+    const exportedAsBase64 = btoa(exportedAsString)
+    const TYPE = isPrivate ? 'PRIVATE' : 'PUBLIC'
+    return `-----BEGIN ${TYPE} KEY-----\n${exportedAsBase64}\n-----END ${TYPE} KEY-----\n`
+}
+
+// after RsaKeyPair is ready
+type InitializedRsaKeyPair = O.Overwrite<RsaKeyPair, {
+    privateKey: string,
+    publicKey: string,
+}>
+
+export class RsaKeyPair {
+    /**
+     * Creates a new instance + waits for ready.
+     * Convenience.
+     */
+    static async create(): Promise<RsaKeyPair> {
+        const pair = new RsaKeyPair()
+        await pair.onReady()
+        return pair
+    }
+
+    public privateKey: string | undefined
+    public publicKey: string | undefined
+    private _generateKeyPairPromise: Promise<void> | undefined
+
+    async onReady(): Promise<void> {
+        if (this.isReady()) { return undefined }
+        return this._generateKeyPair()
+    }
+
+    isReady(this: RsaKeyPair): this is InitializedRsaKeyPair {
+        return (this.privateKey !== undefined && this.publicKey !== undefined)
+    }
+
+    // Returns a String (base64 encoding)
+    getPublicKey(): string {
+        if (!this.isReady()) { throw new Error('RsaKeyPair not ready.') }
+        return this.publicKey
+    }
+
+    // Returns a String (base64 encoding)
+    getPrivateKey(): string {
+        if (!this.isReady()) { throw new Error('RsaKeyPair not ready.') }
+        return this.privateKey
+    }
+
+    private async _generateKeyPair(): Promise<void> {
+        if (!this._generateKeyPairPromise) {
+            this._generateKeyPairPromise = this.__generateKeyPair()
+        }
+        return this._generateKeyPairPromise
+    }
+
+    private async __generateKeyPair(): Promise<void> {
+        if (typeof window !== 'undefined') { return this._keyPairBrowser() }
+        return this._keyPairServer()
+    }
+
+    private async _keyPairServer(): Promise<void> {
+        // promisify here to work around browser/server packaging
+        const generateKeyPair = promisify(crypto.generateKeyPair)
+        const { publicKey, privateKey } = await generateKeyPair('rsa', {
+            modulusLength: 4096,
+            publicKeyEncoding: {
+                type: 'spki',
+                format: 'pem',
+            },
+            privateKeyEncoding: {
+                type: 'pkcs8',
+                format: 'pem',
+            },
+        })
+
+        this.privateKey = privateKey
+        this.publicKey = publicKey
+    }
+
+    private async _keyPairBrowser(): Promise<void> {
+        const { publicKey, privateKey } = await getSubtle().generateKey({
+            name: 'RSA-OAEP',
+            modulusLength: 4096,
+            publicExponent: new Uint8Array([1, 0, 1]), // 65537
+            hash: 'SHA-256'
+        }, true, ['encrypt', 'decrypt'])
+        if (!(publicKey && privateKey)) {
+            // TS says this is possible.
+            throw new Error('could not generate keys')
+        }
+
+        const [exportedPrivate, exportedPublic] = await Promise.all([
+            exportCryptoKey(privateKey, {
+                isPrivate: true,
+            }),
+            exportCryptoKey(publicKey, {
+                isPrivate: false,
+            })
+        ])
+        this.privateKey = exportedPrivate
+        this.publicKey = exportedPublic
+    }
+}

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -12,7 +12,8 @@ import {
 } from './KeyExchangeStream'
 
 import { GroupKey } from './GroupKey'
-import { EncryptionUtil, RsaKeyPair } from './EncryptionUtil'
+import { EncryptionUtil } from './EncryptionUtil'
+import { RsaKeyPair } from './RsaKeyPair'
 import { GroupKeyStoreFactory } from './GroupKeyStoreFactory'
 import { Lifecycle, scoped } from 'tsyringe'
 import { GroupKeyStore } from './GroupKeyStore'

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -12,12 +12,12 @@ import {
 } from './KeyExchangeStream'
 
 import { GroupKey } from './GroupKey'
-import { EncryptionUtil } from './EncryptionUtil'
+import { EncryptionUtil, RsaKeyPair } from './EncryptionUtil'
 import { GroupKeyStoreFactory } from './GroupKeyStoreFactory'
 import { Lifecycle, scoped } from 'tsyringe'
 import { GroupKeyStore } from './GroupKeyStore'
 
-async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, encryptionUtil: EncryptionUtil): Promise<GroupKey[]> {
+async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, rsaPrivateKey: string): Promise<GroupKey[]> {
     let encryptedGroupKeys: EncryptedGroupKey[] = []
     if (GroupKeyResponse.is(streamMessage)) {
         encryptedGroupKeys = GroupKeyResponse.fromArray(streamMessage.getParsedContent() || []).encryptedGroupKeys || []
@@ -29,7 +29,7 @@ async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, encry
     const tasks = encryptedGroupKeys.map(async (encryptedGroupKey) => (
         new GroupKey(
             encryptedGroupKey.groupKeyId,
-            await encryptionUtil.decryptWithPrivateKey(encryptedGroupKey.encryptedGroupKeyHex, true)
+            await EncryptionUtil.decryptWithPrivateKey(encryptedGroupKey.encryptedGroupKeyHex, rsaPrivateKey, true)
         )
     ))
     await Promise.allSettled(tasks)
@@ -40,7 +40,7 @@ async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, encry
 export class SubscriberKeyExchange implements Context {
     readonly id
     readonly debug
-    encryptionUtil
+    private rsaKeyPair: RsaKeyPair
 
     constructor(
         private subscriber: Subscriber,
@@ -49,7 +49,7 @@ export class SubscriberKeyExchange implements Context {
     ) {
         this.id = instanceId(this)
         this.debug = this.subscriber.debug.extend(this.id)
-        this.encryptionUtil = new EncryptionUtil()
+        this.rsaKeyPair = new RsaKeyPair()
     }
 
     async requestKeys({ streamId, publisherId, groupKeyIds }: {
@@ -58,7 +58,7 @@ export class SubscriberKeyExchange implements Context {
         groupKeyIds: GroupKeyId[]
     }): Promise<GroupKey[]> {
         const requestId = uuid('GroupKeyRequest')
-        const rsaPublicKey = this.encryptionUtil.getPublicKey()
+        const rsaPublicKey = this.rsaKeyPair.getPublicKey()
         const msg = new GroupKeyRequest({
             streamId,
             requestId,
@@ -66,7 +66,7 @@ export class SubscriberKeyExchange implements Context {
             groupKeyIds,
         })
         const response = await this.keyExchangeStream.request(publisherId, msg)
-        return response ? getGroupKeysFromStreamMessage(response, this.encryptionUtil) : []
+        return response ? getGroupKeysFromStreamMessage(response, this.rsaKeyPair.getPrivateKey()) : []
     }
 
     async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
@@ -104,7 +104,7 @@ export class SubscriberKeyExchange implements Context {
 
     async getGroupKey(streamMessage: StreamMessage): Promise<GroupKey | undefined> {
         if (!streamMessage.groupKeyId) { return undefined }
-        await this.encryptionUtil.onReady()
+        await this.rsaKeyPair.onReady()
         return this.getKey(streamMessage)
     }
 

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -3,7 +3,7 @@
  */
 export * from './StreamrClient'
 export * from './Stream'
-export {} from './encryption/EncryptionUtil'
+export { StreamMessageProcessingError, UnableToDecryptError } from './encryption/EncryptionUtil'
 export { StreamrClientEvents } from './events'
 export { MessageMetadata } from './publish/PublishPipeline'
 export { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -3,7 +3,7 @@
  */
 export * from './StreamrClient'
 export * from './Stream'
-export * from './encryption/EncryptionUtil'
+export {} from './encryption/EncryptionUtil'
 export { StreamrClientEvents } from './events'
 export { MessageMetadata } from './publish/PublishPipeline'
 export { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'

--- a/packages/client/test/unit/Encryption.test.ts
+++ b/packages/client/test/unit/Encryption.test.ts
@@ -9,132 +9,111 @@ import { RsaKeyPair } from '../../src/encryption/RsaKeyPair'
 
 const { StreamMessage, MessageID } = MessageLayer
 
-// wrap these tests so can run same tests as if in browser
-function runTests({ isBrowser = false } = {}) {
-    const streamId = toStreamID('streamId')
-    describe(`Environment: ${isBrowser ? 'Browser' : 'Server'}`, () => {
-        beforeAll(() => {
-            // this is the toggle used in EncryptionUtil/RsaKeyPair to
-            // use the webcrypto apis
-            // @ts-expect-error unknown property
-            process.browser = !!isBrowser
-        })
+const STREAM_ID = toStreamID('streamId')
 
-        afterAll(() => {
-            // @ts-expect-error unknown property
-            process.browser = !isBrowser
-        })
+describe('EncryptionUtil and RsaKeyPair', () => {
+    describe('RsaKeyPair instance', () => {
+        let rsaKeyPair: RsaKeyPair
 
-        describe('RsaKeyPair instance', () => {
-            let rsaKeyPair: RsaKeyPair
+        beforeEach(async () => {
+            rsaKeyPair = await RsaKeyPair.create()
+        }, 10000)
 
-            beforeEach(async () => {
-                rsaKeyPair = await RsaKeyPair.create()
-            }, 10000)
-
-            it('rsa decryption after encryption equals the initial plaintext', () => {
-                const plaintext = 'some random text'
-                const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey())
-                expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey()).toString('utf8')).toStrictEqual(plaintext)
-            })
-
-            it('rsa decryption after encryption equals the initial plaintext (hex strings)', () => {
-                const plaintext = 'some random text'
-                const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey(), true)
-                expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey(), true).toString('utf8')).toStrictEqual(plaintext)
-            })
-        })
-
-        it('aes decryption after encryption equals the initial plaintext', () => {
-            const key = GroupKey.generate()
+        it('rsa decryption after encryption equals the initial plaintext', () => {
             const plaintext = 'some random text'
-            // @ts-expect-error private
-            const ciphertext = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-            // @ts-expect-error private
-            expect(EncryptionUtil.decrypt(ciphertext, key).toString('utf8')).toStrictEqual(plaintext)
+            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey())
+            expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey()).toString('utf8')).toStrictEqual(plaintext)
         })
 
-        it('aes encryption preserves size (plus iv)', () => {
-            const key = GroupKey.generate()
+        it('rsa decryption after encryption equals the initial plaintext (hex strings)', () => {
             const plaintext = 'some random text'
-            const plaintextBuffer = Buffer.from(plaintext, 'utf8')
-            // @ts-expect-error private
-            const ciphertext = EncryptionUtil.encrypt(plaintextBuffer, key)
-            const ciphertextBuffer = ethers.utils.arrayify(`0x${ciphertext}`)
-            expect(ciphertextBuffer.length).toStrictEqual(plaintextBuffer.length + 16)
-        })
-
-        it('multiple same encrypt() calls use different ivs and produce different ciphertexts', () => {
-            const key = GroupKey.generate()
-            const plaintext = 'some random text'
-            // @ts-expect-error private
-            const ciphertext1 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-            // @ts-expect-error private
-            const ciphertext2 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
-            expect(ciphertext1.slice(0, 32)).not.toStrictEqual(ciphertext2.slice(0, 32))
-            expect(ciphertext1.slice(32)).not.toStrictEqual(ciphertext2.slice(32))
-        })
-
-        it('StreamMessage gets encrypted', () => {
-            const key = GroupKey.generate()
-            const streamMessage = new StreamMessage({
-                messageId: new MessageID(streamId, 0, 1, 0, 'publisherId', 'msgChainId'),
-                content: {
-                    foo: 'bar',
-                },
-                contentType: StreamMessage.CONTENT_TYPES.JSON,
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
-                signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
-                signature: null,
-            })
-            EncryptionUtil.encryptStreamMessage(streamMessage, key)
-            expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
-            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.AES)
-        })
-
-        it('StreamMessage decryption after encryption equals the initial StreamMessage', () => {
-            const key = GroupKey.generate()
-            const streamMessage = new StreamMessage({
-                messageId: new MessageID(streamId, 0, 1, 0, 'publisherId', 'msgChainId'),
-                content: {
-                    foo: 'bar',
-                },
-                contentType: StreamMessage.CONTENT_TYPES.JSON,
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
-                signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
-                signature: null,
-            })
-            EncryptionUtil.encryptStreamMessage(streamMessage, key)
-            EncryptionUtil.decryptStreamMessage(streamMessage, key)
-            expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
-            expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
-        })
-
-        describe('GroupKey.validate', () => {
-            it('throws if key is the wrong size', () => {
-                expect(() => {
-                    GroupKey.validate(GroupKey.from(['test', crypto.randomBytes(16)]))
-                }).toThrow('size')
-            })
-
-            it('throws if key is not a buffer', () => {
-                expect(() => {
-                    // @ts-expect-error expected error below is desirable, show typecheks working as intended
-                    GroupKey.validate(GroupKey.from(['test', Array.from(crypto.randomBytes(32))]))
-                }).toThrow('Buffer')
-            })
-
-            it('does not throw with valid values', () => {
-                GroupKey.validate(GroupKey.generate())
-            })
+            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey(), true)
+            expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey(), true).toString('utf8')).toStrictEqual(plaintext)
         })
     })
-}
 
-runTests({
-    isBrowser: false,
+    it('aes decryption after encryption equals the initial plaintext', () => {
+        const key = GroupKey.generate()
+        const plaintext = 'some random text'
+        // @ts-expect-error private
+        const ciphertext = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+        // @ts-expect-error private
+        expect(EncryptionUtil.decrypt(ciphertext, key).toString('utf8')).toStrictEqual(plaintext)
+    })
+
+    it('aes encryption preserves size (plus iv)', () => {
+        const key = GroupKey.generate()
+        const plaintext = 'some random text'
+        const plaintextBuffer = Buffer.from(plaintext, 'utf8')
+        // @ts-expect-error private
+        const ciphertext = EncryptionUtil.encrypt(plaintextBuffer, key)
+        const ciphertextBuffer = ethers.utils.arrayify(`0x${ciphertext}`)
+        expect(ciphertextBuffer.length).toStrictEqual(plaintextBuffer.length + 16)
+    })
+
+    it('multiple same encrypt() calls use different ivs and produce different ciphertexts', () => {
+        const key = GroupKey.generate()
+        const plaintext = 'some random text'
+        // @ts-expect-error private
+        const ciphertext1 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+        // @ts-expect-error private
+        const ciphertext2 = EncryptionUtil.encrypt(Buffer.from(plaintext, 'utf8'), key)
+        expect(ciphertext1.slice(0, 32)).not.toStrictEqual(ciphertext2.slice(0, 32))
+        expect(ciphertext1.slice(32)).not.toStrictEqual(ciphertext2.slice(32))
+    })
+
+    it('StreamMessage gets encrypted', () => {
+        const key = GroupKey.generate()
+        const streamMessage = new StreamMessage({
+            messageId: new MessageID(STREAM_ID, 0, 1, 0, 'publisherId', 'msgChainId'),
+            content: {
+                foo: 'bar',
+            },
+            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+            signature: null,
+        })
+        EncryptionUtil.encryptStreamMessage(streamMessage, key)
+        expect(streamMessage.getSerializedContent()).not.toStrictEqual('{"foo":"bar"}')
+        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.AES)
+    })
+
+    it('StreamMessage decryption after encryption equals the initial StreamMessage', () => {
+        const key = GroupKey.generate()
+        const streamMessage = new StreamMessage({
+            messageId: new MessageID(STREAM_ID, 0, 1, 0, 'publisherId', 'msgChainId'),
+            content: {
+                foo: 'bar',
+            },
+            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+            signature: null,
+        })
+        EncryptionUtil.encryptStreamMessage(streamMessage, key)
+        EncryptionUtil.decryptStreamMessage(streamMessage, key)
+        expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
+        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
+    })
+
+    describe('GroupKey.validate', () => {
+        it('throws if key is the wrong size', () => {
+            expect(() => {
+                GroupKey.validate(GroupKey.from(['test', crypto.randomBytes(16)]))
+            }).toThrow('size')
+        })
+
+        it('throws if key is not a buffer', () => {
+            expect(() => {
+                // @ts-expect-error expected error below is desirable, show typecheks working as intended
+                GroupKey.validate(GroupKey.from(['test', Array.from(crypto.randomBytes(32))]))
+            }).toThrow('Buffer')
+        })
+
+        it('does not throw with valid values', () => {
+            GroupKey.validate(GroupKey.generate())
+        })
+    })
 })
 
-runTests({
-    isBrowser: true,
-})

--- a/packages/client/test/unit/Encryption.test.ts
+++ b/packages/client/test/unit/Encryption.test.ts
@@ -4,16 +4,17 @@ import { ethers } from 'ethers'
 import { MessageLayer, toStreamID } from 'streamr-client-protocol'
 
 import { GroupKey } from '../../src/encryption/GroupKey'
-import { EncryptionUtil, RsaKeyPair } from '../../src/encryption/EncryptionUtil'
+import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
+import { RsaKeyPair } from '../../src/encryption/RsaKeyPair'
 
 const { StreamMessage, MessageID } = MessageLayer
 
 // wrap these tests so can run same tests as if in browser
-function TestEncryptionUtil({ isBrowser = false } = {}) {
+function runTests({ isBrowser = false } = {}) {
     const streamId = toStreamID('streamId')
-    describe(`EncryptionUtil ${isBrowser ? 'Browser' : 'Server'}`, () => {
+    describe(`Environment: ${isBrowser ? 'Browser' : 'Server'}`, () => {
         beforeAll(() => {
-            // this is the toggle used in EncryptionUtil to
+            // this is the toggle used in EncryptionUtil/RsaKeyPair to
             // use the webcrypto apis
             // @ts-expect-error unknown property
             process.browser = !!isBrowser
@@ -24,7 +25,7 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
             process.browser = !isBrowser
         })
 
-        describe('EncryptionUtil instance', () => {
+        describe('RsaKeyPair instance', () => {
             let rsaKeyPair: RsaKeyPair
 
             beforeEach(async () => {
@@ -130,10 +131,10 @@ function TestEncryptionUtil({ isBrowser = false } = {}) {
     })
 }
 
-TestEncryptionUtil({
+runTests({
     isBrowser: false,
 })
 
-TestEncryptionUtil({
+runTests({
     isBrowser: true,
 })

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -1,37 +1,13 @@
-import crypto from 'crypto'
-
 import { ethers } from 'ethers'
 import { MessageLayer, toStreamID } from 'streamr-client-protocol'
-
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
-import { RsaKeyPair } from '../../src/encryption/RsaKeyPair'
 
 const { StreamMessage, MessageID } = MessageLayer
 
 const STREAM_ID = toStreamID('streamId')
 
-describe('EncryptionUtil and RsaKeyPair', () => {
-    describe('RsaKeyPair instance', () => {
-        let rsaKeyPair: RsaKeyPair
-
-        beforeEach(async () => {
-            rsaKeyPair = await RsaKeyPair.create()
-        }, 10000)
-
-        it('rsa decryption after encryption equals the initial plaintext', () => {
-            const plaintext = 'some random text'
-            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey())
-            expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey()).toString('utf8')).toStrictEqual(plaintext)
-        })
-
-        it('rsa decryption after encryption equals the initial plaintext (hex strings)', () => {
-            const plaintext = 'some random text'
-            const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey(), true)
-            expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey(), true).toString('utf8')).toStrictEqual(plaintext)
-        })
-    })
-
+describe('EncryptionUtil', () => {
     it('aes decryption after encryption equals the initial plaintext', () => {
         const key = GroupKey.generate()
         const plaintext = 'some random text'
@@ -96,24 +72,4 @@ describe('EncryptionUtil and RsaKeyPair', () => {
         expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
         expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
     })
-
-    describe('GroupKey.validate', () => {
-        it('throws if key is the wrong size', () => {
-            expect(() => {
-                GroupKey.validate(GroupKey.from(['test', crypto.randomBytes(16)]))
-            }).toThrow('size')
-        })
-
-        it('throws if key is not a buffer', () => {
-            expect(() => {
-                // @ts-expect-error expected error below is desirable, show typecheks working as intended
-                GroupKey.validate(GroupKey.from(['test', Array.from(crypto.randomBytes(32))]))
-            }).toThrow('Buffer')
-        })
-
-        it('does not throw with valid values', () => {
-            GroupKey.validate(GroupKey.generate())
-        })
-    })
 })
-

--- a/packages/client/test/unit/GroupKey.test.ts
+++ b/packages/client/test/unit/GroupKey.test.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto'
+import { GroupKey } from '../../src/encryption/GroupKey'
+
+describe('GroupKey.validate', () => {
+
+    describe('validate', () => {
+        it('throws if key is the wrong size', () => {
+            expect(() => {
+                GroupKey.validate(GroupKey.from(['test', crypto.randomBytes(16)]))
+            }).toThrow('size')
+        })
+    
+        it('throws if key is not a buffer', () => {
+            expect(() => {
+                // @ts-expect-error expected error below is desirable, show typecheks working as intended
+                GroupKey.validate(GroupKey.from(['test', Array.from(crypto.randomBytes(32))]))
+            }).toThrow('Buffer')
+        })
+    
+        it('does not throw with valid values', () => {
+            GroupKey.validate(GroupKey.generate())
+        })
+    
+    })
+})

--- a/packages/client/test/unit/GroupKey.test.ts
+++ b/packages/client/test/unit/GroupKey.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto'
 import { GroupKey } from '../../src/encryption/GroupKey'
 
-describe('GroupKey.validate', () => {
+describe('GroupKey', () => {
 
     describe('validate', () => {
         it('throws if key is the wrong size', () => {

--- a/packages/client/test/unit/RsaKeyPair.test.ts
+++ b/packages/client/test/unit/RsaKeyPair.test.ts
@@ -1,0 +1,22 @@
+import { RsaKeyPair } from '../../src/encryption/RsaKeyPair'
+import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
+
+describe('RsaKeyPair', () => {
+    let rsaKeyPair: RsaKeyPair
+
+    beforeEach(async () => {
+        rsaKeyPair = await RsaKeyPair.create()
+    }, 10000)
+
+    it('rsa decryption after encryption equals the initial plaintext', () => {
+        const plaintext = 'some random text'
+        const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey())
+        expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey()).toString('utf8')).toStrictEqual(plaintext)
+    })
+
+    it('rsa decryption after encryption equals the initial plaintext (hex strings)', () => {
+        const plaintext = 'some random text'
+        const ciphertext = EncryptionUtil.encryptWithPublicKey(Buffer.from(plaintext, 'utf8'), rsaKeyPair.getPublicKey(), true)
+        expect(EncryptionUtil.decryptWithPrivateKey(ciphertext, rsaKeyPair.getPrivateKey(), true).toString('utf8')).toStrictEqual(plaintext)
+    })
+})


### PR DESCRIPTION
**TODO broswer test fails, maybe needs longer key (and must by dividable by 8 bits, i.e. min 592)**

Extracted `RsaKeyPair` class from `EncryptionUtil`:
- `EncryptionUtil` contains static utility methods for `RSA` and `AES` encryption/decryption
- `RsaKeyPair` is a data class for a RSA key pair (a public key and a private key)

Modified `index-exports.ts` to export only the custom `Error` classes.  The `EncryptionUtil` is no longer exported as it should not be used by end-users.

Divided `Encryption.test.ts` to three tests:
- `EncryptionUtil.test.ts`
- `RsaKeyPair.test.ts`
- `GroupKey.test.ts`

Earlier `Encryption.test.ts` run the tests also in an emulated browser environment. It is not clear whether that emulation worked correctly. Now we run all tests only in the normal Node environment. The browser tests (`npm run test-browser-realtime` and `npm run test-browser-resend`) give us basic test coverage for the encryption functionality as encrypted streams are used in some browser tests. If we need more coverage, we could maybe run encryption-related unit tests in a real browser environment instead of a simulated one.