### PR TITLE
test(client): Group key delivery

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -56,7 +56,7 @@ export class StreamrClient implements Context {
     private publisher: Publisher
     private subscriber: Subscriber
     private proxyPublishSubscribe: ProxyPublishSubscribe
-    private groupKeyStore: GroupKeyStoreFactory
+    private groupKeyStoreFactory: GroupKeyStoreFactory
     private destroySignal: DestroySignal
     private streamRegistry: StreamRegistry
     private storageNodeRegistry: StorageNodeRegistry
@@ -75,7 +75,7 @@ export class StreamrClient implements Context {
         this.publisher = container.resolve<Publisher>(Publisher)
         this.subscriber = container.resolve<Subscriber>(Subscriber)
         this.proxyPublishSubscribe = container.resolve<ProxyPublishSubscribe>(ProxyPublishSubscribe)
-        this.groupKeyStore = container.resolve<GroupKeyStoreFactory>(GroupKeyStoreFactory)
+        this.groupKeyStoreFactory = container.resolve<GroupKeyStoreFactory>(GroupKeyStoreFactory)
         this.destroySignal = container.resolve<DestroySignal>(DestroySignal)
         this.streamRegistry = container.resolve<StreamRegistry>(StreamRegistry)
         this.storageNodeRegistry = container.resolve<StorageNodeRegistry>(StorageNodeRegistry)
@@ -110,14 +110,15 @@ export class StreamrClient implements Context {
             throw new Error('streamId required')
         }
         const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
+        const store = await this.groupKeyStoreFactory.getStore(streamId)
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {
-                return this.groupKeyStore.rotateGroupKey(streamId)
+                return store.rotateGroupKey()
             } else { // eslint-disable-line no-else-return
-                return this.groupKeyStore.setNextGroupKey(streamId, opts.key)
+                return store.setNextGroupKey(opts.key)
             }
         } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
-            return this.groupKeyStore.rekey(streamId, opts.key)
+            return store.rekey(opts.key)
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
         }
@@ -381,7 +382,7 @@ export class StreamrClient implements Context {
             this.destroySignal.destroy().then(() => undefined),
             this.publisher.stop(),
             this.subscriber.stop(),
-            this.groupKeyStore.stop()
+            this.groupKeyStoreFactory.stop()
         ]
 
         await Promise.allSettled(tasks)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -65,7 +65,8 @@ export class StreamrClient implements Context {
 
     constructor(options: StreamrClientConfig = {}, parentContainer = rootContainer) {
         const config = createStrictConfig(options)
-        const { childContainer: container } = initContainer(config, parentContainer)
+        const container = parentContainer.createChildContainer()
+        initContainer(config, container)
 
         this.container = container
         this.node = container.resolve<BrubeckNode>(BrubeckNode)
@@ -423,9 +424,8 @@ export class StreamrClient implements Context {
  */
 export function initContainer(
     config: StrictStreamrClientConfig, 
-    parentContainer = rootContainer
-): { childContainer: DependencyContainer; rootContext: Context } {
-    const c = parentContainer.createChildContainer()
+    c: DependencyContainer
+): Context {
     uid = uid || `${uuid().slice(-4)}${uuid().slice(0, 4)}`
     const id = counterId(`StreamrClient:${uid}${config.id ? `:${config.id}` : ''}`)
     const debug = Debug(id)
@@ -472,8 +472,5 @@ export function initContainer(
         c.register(token, { useValue })
     })
 
-    return {
-        childContainer: c,
-        rootContext
-    }
+    return rootContext
 }

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -70,26 +70,6 @@ export class GroupKeyStoreFactory implements Context {
         return store
     }
 
-    async useGroupKey(streamId: StreamID): Promise<[GroupKey | undefined, GroupKey | undefined]> {
-        const store = await this.getStore(streamId)
-        return store.useGroupKey()
-    }
-
-    async rotateGroupKey(streamId: StreamID): Promise<void> {
-        const store = await this.getStore(streamId)
-        return store.rotateGroupKey()
-    }
-
-    async setNextGroupKey(streamId: StreamID, newKey: GroupKey): Promise<void> {
-        const store = await this.getStore(streamId)
-        return store.setNextGroupKey(newKey)
-    }
-
-    async rekey(streamId: StreamID, newKey?: GroupKey): Promise<void> {
-        const store = await this.getStore(streamId)
-        return store.rekey(newKey)
-    }
-
     async stop(): Promise<void> {
         this.getStore.clear()
         const { cleanupFns } = this

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -86,7 +86,7 @@ export class PublisherKeyExchange implements Context {
         this.onKeyExchangeMessage = this.onKeyExchangeMessage.bind(this)
     }
 
-    getWrapError(
+    private getWrapError(
         streamMessage: StreamMessage
     ): (error: ValidationError) => Promise<StreamMessage<GroupKeyResponse | GroupKeyErrorResponse> | undefined> {
         return async (error: ValidationError) => {
@@ -171,7 +171,7 @@ export class PublisherKeyExchange implements Context {
         return sub
     }
 
-    async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
+    private async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
         return this.groupKeyStoreFactory.getStore(streamId)
     }
 

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -175,52 +175,11 @@ export class PublisherKeyExchange implements Context {
         return this.groupKeyStoreFactory.getStore(streamId)
     }
 
-    async rotateGroupKey(streamId: StreamID): Promise<void> {
-        if (!this.enabled) { return }
-        try {
-            const groupKeyStore = await this.getGroupKeyStore(streamId)
-            await groupKeyStore.rotateGroupKey()
-        } finally {
-            this.streamRegistryCached.clearStream(streamId)
-        }
-    }
-
-    async setNextGroupKey(streamId: StreamID, groupKey: GroupKey): Promise<void> {
-        if (!this.enabled) { return }
-        try {
-            const groupKeyStore = await this.getGroupKeyStore(streamId)
-            if (!this.enabled) { return }
-
-            await groupKeyStore.setNextGroupKey(groupKey)
-        } finally {
-            this.streamRegistryCached.clearStream(streamId)
-        }
-    }
-
     async useGroupKey(streamId: StreamID): Promise<never[] | [GroupKey | undefined, GroupKey | undefined]> {
         await this.getSubscription()
         if (!this.enabled) { return [] }
         const groupKeyStore = await this.getGroupKeyStore(streamId)
         if (!this.enabled) { return [] }
         return groupKeyStore.useGroupKey()
-    }
-
-    async hasAnyGroupKey(streamId: StreamID): Promise<boolean> {
-        const groupKeyStore = await this.getGroupKeyStore(streamId)
-        if (!this.enabled) { return false }
-        return !(await groupKeyStore.isEmpty())
-    }
-
-    async rekey(streamId: StreamID): Promise<void> {
-        try {
-            if (!this.enabled) { return }
-            const groupKeyStore = await this.getGroupKeyStore(streamId)
-            if (!this.enabled) { return }
-            await groupKeyStore.rekey()
-            if (!this.enabled) { return }
-            await this.getSubscription()
-        } finally {
-            this.streamRegistryCached.clearStream(streamId)
-        }
     }
 }

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -51,7 +51,7 @@ export const createGroupKeyResponse = async (
         }
         const key = EncryptionUtil.encryptWithPublicKey(groupKey.data, rsaPublicKey, true)
         return new EncryptedGroupKey(id, key)
-    }))).filter(Boolean) as EncryptedGroupKey[]
+    }))).filter((item) => item !== null) as EncryptedGroupKey[]
 
     debug?.('Subscriber requested groupKeys: %d. Got: %d. %o', groupKeyIds.length, encryptedGroupKeys.length, {
         subscriberId,

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -30,7 +30,7 @@ export async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage
     const tasks = encryptedGroupKeys.map(async (encryptedGroupKey) => (
         new GroupKey(
             encryptedGroupKey.groupKeyId,
-            await EncryptionUtil.decryptWithPrivateKey(encryptedGroupKey.encryptedGroupKeyHex, rsaPrivateKey, true)
+            EncryptionUtil.decryptWithPrivateKey(encryptedGroupKey.encryptedGroupKeyHex, rsaPrivateKey, true)
         )
     ))
     await Promise.allSettled(tasks)

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -53,7 +53,7 @@ export class SubscriberKeyExchange implements Context {
         this.rsaKeyPair = new RsaKeyPair()
     }
 
-    async requestKeys({ streamId, publisherId, groupKeyIds }: {
+    private async requestKeys({ streamId, publisherId, groupKeyIds }: {
         streamId: StreamID,
         publisherId: string,
         groupKeyIds: GroupKeyId[]
@@ -70,11 +70,11 @@ export class SubscriberKeyExchange implements Context {
         return response ? getGroupKeysFromStreamMessage(response, this.rsaKeyPair.getPrivateKey()) : []
     }
 
-    async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
+    private async getGroupKeyStore(streamId: StreamID): Promise<GroupKeyStore> {
         return this.groupKeyStoreFactory.getStore(streamId)
     }
 
-    async getKey(streamMessage: StreamMessage): Promise<GroupKey | undefined> {
+    private async getKey(streamMessage: StreamMessage): Promise<GroupKey | undefined> {
         const streamId = streamMessage.getStreamId()
         const publisherId = streamMessage.getPublisherId()
         const { groupKeyId } = streamMessage

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -18,7 +18,7 @@ import { GroupKeyStoreFactory } from './GroupKeyStoreFactory'
 import { Lifecycle, scoped } from 'tsyringe'
 import { GroupKeyStore } from './GroupKeyStore'
 
-async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, rsaPrivateKey: string): Promise<GroupKey[]> {
+export async function getGroupKeysFromStreamMessage(streamMessage: StreamMessage, rsaPrivateKey: string): Promise<GroupKey[]> {
     let encryptedGroupKeys: EncryptedGroupKey[] = []
     if (GroupKeyResponse.is(streamMessage)) {
         encryptedGroupKeys = GroupKeyResponse.fromArray(streamMessage.getParsedContent() || []).encryptedGroupKeys || []

--- a/packages/client/src/utils/waitForMessage.ts
+++ b/packages/client/src/utils/waitForMessage.ts
@@ -1,0 +1,68 @@
+import { StreamMessage } from 'streamr-client-protocol'
+
+import { Defer, Deferred } from '../utils'
+import { DestroySignal } from '../DestroySignal'
+
+import { Subscription } from '../subscribe/Subscription'
+
+export type MessageMatch = (streamMessage: StreamMessage) => boolean
+
+const waitForSubMessage = (
+    sub: Subscription<unknown>,
+    matchFn: MessageMatch
+): Deferred<StreamMessage> => {
+    const task = Defer<StreamMessage>()
+    const onMessage = (streamMessage: StreamMessage) => {
+        try {
+            if (matchFn(streamMessage)) {
+                task.resolve(streamMessage)
+            }
+        } catch (err) {
+            task.reject(err)
+        }
+    }
+    task.finally(async () => {
+        await sub.unsubscribe()
+    }).catch(() => {}) // important: prevent unchained finally cleanup causing unhandled rejection
+    sub.consume(onMessage).catch((err) => task.reject(err))
+    sub.onError.listen(task.reject)
+    return task
+}
+
+export const publishAndWaitForResponseMessage = async (
+    publish: () => Promise<unknown>,
+    matchFn: MessageMatch,
+    createSubscription: () => Promise<Subscription<unknown>>,
+    onBeforeUnsubscribe: () => void,
+    destroySignal: DestroySignal
+): Promise<StreamMessage<unknown> | undefined> => {
+    let responseTask: Deferred<StreamMessage<unknown>> | undefined
+    const onDestroy = () => {
+        if (responseTask) {
+            responseTask.resolve(undefined)
+        }
+    }
+
+    destroySignal.onDestroy.listen(onDestroy)
+    let sub: Subscription<unknown> | undefined
+    try {
+        sub = await createSubscription()
+        responseTask = waitForSubMessage(sub, matchFn)
+
+        await publish()
+
+        return await responseTask
+    } catch (err) {
+        if (responseTask) {
+            responseTask.reject(err)
+        }
+        throw err
+    } finally {
+        destroySignal.onDestroy.unlisten(onDestroy)
+        if (sub) {
+            onBeforeUnsubscribe()
+            await sub.unsubscribe()
+        }
+        await responseTask
+    }
+}

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -1,7 +1,7 @@
 import { wait } from 'streamr-test-utils'
 import { getPublishTestMessages, fetchPrivateKeyWithGas, snapshot, LeaksDetector } from '../test-utils/utils'
 import { StreamrClient, initContainer } from '../../src/StreamrClient'
-import { container, DependencyContainer } from 'tsyringe'
+import { container as rootContainer, DependencyContainer } from 'tsyringe'
 import { Subscription } from '../../src/subscribe/Subscription'
 import { counterId, Defer } from '../../src/utils'
 
@@ -37,7 +37,7 @@ describe('MemoryLeaks', () => {
 
     beforeEach(() => {
         leaksDetector = new LeaksDetector()
-        leaksDetector.ignoreAll(container)
+        leaksDetector.ignoreAll(rootContainer)
         leaksDetector.ignoreAll(ethers)
         snapshot()
     })
@@ -66,7 +66,8 @@ describe('MemoryLeaks', () => {
                     },
                     ...opts,
                 })
-                const { childContainer, rootContext } = initContainer(config)
+                const childContainer = rootContainer.createChildContainer()
+                const rootContext = initContainer(config, childContainer)
                 return { config, childContainer, rootContext }
             }
         })

--- a/packages/client/test/test-utils/fake/FakeBrubeckNode.ts
+++ b/packages/client/test/test-utils/fake/FakeBrubeckNode.ts
@@ -139,6 +139,15 @@ export class FakeBrubeckNode implements Omit<BrubeckNode, 'startNodeCalled' | 's
         this.debug(`Created${name ? ' ' + name : ''}: ${id}`)
     }
 
+    addSubscriber(streamPartId: StreamPartID, onMessage: (msg: StreamMessage<unknown>) => unknown): void {
+        this.networkNodeStub.addMessageListener((msg: StreamMessage) => {
+            if (msg.getStreamPartID() === streamPartId) {
+                onMessage(msg)
+            }
+        })
+        this.networkNodeStub.subscribe(streamPartId)
+    }
+
     async getNodeId(): Promise<EthereumAddress> {
         return this.id
     }

--- a/packages/client/test/test-utils/fake/fakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/fakeEnvironment.ts
@@ -1,11 +1,11 @@
 import { fastPrivateKey } from 'streamr-test-utils'
 import { container, DependencyContainer } from 'tsyringe'
 import { BrubeckNode } from '../../../src/BrubeckNode'
-import { ConfigInjectionToken, StreamrClientConfig, StrictStreamrClientConfig } from '../../../src/Config'
+import { ConfigInjectionToken, createStrictConfig, StreamrClientConfig, StrictStreamrClientConfig } from '../../../src/Config'
 import { DestroySignal } from '../../../src/DestroySignal'
 import { AuthConfig } from '../../../src/Ethereum'
 import { StorageNodeRegistry } from '../../../src/StorageNodeRegistry'
-import { StreamrClient } from '../../../src/StreamrClient'
+import { initContainer, StreamrClient } from '../../../src/StreamrClient'
 import { StreamRegistry } from '../../../src/StreamRegistry'
 import { FakeBrubeckNode } from './FakeBrubeckNode'
 import { ActiveNodes } from './ActiveNodes'
@@ -19,8 +19,11 @@ export interface ClientFactory {
     createClient: (opts?: StreamrClientConfig) => StreamrClient
 }
 
-export const createClientFactory = (): ClientFactory => {
+export const createFakeContainer = (config: StreamrClientConfig | undefined): DependencyContainer => {
     const mockContainer = container.createChildContainer()
+    if (config !== undefined) {
+        initContainer(createStrictConfig(config), mockContainer)
+    }
     mockContainer.registerSingleton(StreamRegistry, FakeStreamRegistry as any)
     mockContainer.registerSingleton(StorageNodeRegistry, FakeStorageNodeRegistry as any)
     mockContainer.registerSingleton(HttpUtil, FakeHttpUtil)
@@ -50,7 +53,11 @@ export const createClientFactory = (): ClientFactory => {
         }
         return node as any
     } })
+    return mockContainer
+}
 
+export const createClientFactory = (): ClientFactory => {
+    const mockContainer = createFakeContainer(undefined) // config is initialized in StreamrClient constructor (no need to call initContainer here)
     return {
         createClient: (opts?: StreamrClientConfig) => {
             let authOpts

--- a/packages/client/test/test-utils/fake/fakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/fakeEnvironment.ts
@@ -14,6 +14,7 @@ import { FakeStorageNodeRegistry } from './FakeStorageNodeRegistry'
 import { FakeStreamRegistry } from './FakeStreamRegistry'
 import { FakeHttpUtil } from './FakeHttpUtil'
 import { HttpUtil } from '../../../src/HttpUtil'
+import { EthereumAddress } from 'streamr-client-protocol'
 
 export interface ClientFactory {
     createClient: (opts?: StreamrClientConfig) => StreamrClient
@@ -76,4 +77,15 @@ export const createClientFactory = (): ClientFactory => {
             return new StreamrClient(config, mockContainer)
         }
     }
+}
+
+export const addFakeNode = (
+    nodeId: EthereumAddress,
+    mockContainer: DependencyContainer
+): FakeBrubeckNode => {
+    const activeNodes = mockContainer.resolve(ActiveNodes)
+    const destroySignal = mockContainer.resolve(DestroySignal)
+    const node = new FakeBrubeckNode(nodeId, activeNodes, destroySignal)
+    activeNodes.addNode(node)
+    return node
 }

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { container } from 'tsyringe'
+import { container as rootContainer } from 'tsyringe'
 import { StreamMessage, toStreamID } from 'streamr-client-protocol'
 import { BrubeckNode, NetworkNodeStub } from '../../src/BrubeckNode'
 import { Publisher } from '../../src/publish/Publisher'
@@ -31,7 +31,8 @@ const createMockContainer = async (
             }
         }
     }
-    const { childContainer } = initContainer(config, container)
+    const childContainer = rootContainer.createChildContainer()
+    initContainer(config, childContainer)
     return childContainer
         .registerSingleton(StreamRegistry, FakeStreamRegistry as any)
         .register(BrubeckNode, { useValue: brubeckNode as any })

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -39,12 +39,12 @@ const createMockStream = async (
     return stream
 }
 
-const createMockGroupKeyRequest = (
+const createGroupKeyRequest = (
     streamId: StreamID,
     rsaPublicKey: string,
     subscriberWallet: Wallet,
     publisherAddress: EthereumAddress
-) => {
+): StreamMessage => {
     const publisherKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(publisherAddress)
     const msg = new StreamMessage({
         messageId: new MessageID(publisherKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, subscriberWallet.address, 'msgChainId'),
@@ -85,11 +85,15 @@ describe('PublisherKeyExchange', () => {
         publisherRsaKeyPair = await RsaKeyPair.create()
     })
 
-    it('responses to a group key request', async () => {
+    /*
+     * A publisher node starts a subscription to receive group key requests
+     * - tests that a correct kind of response message is sent to a subscriber node
+     */
+    it('responds to a group key request', async () => {
         const publisherKeyExchange = fakeContainer.resolve(PublisherKeyExchange)
         await publisherKeyExchange.useGroupKey(mockStream.id) // subscribes to the key exchange stream
 
-        const groupKeyRequest = createMockGroupKeyRequest(
+        const groupKeyRequest = createGroupKeyRequest(
             mockStream.id,
             publisherRsaKeyPair.getPublicKey(),
             subscriberWallet,

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -1,0 +1,124 @@
+import 'reflect-metadata'
+import { DependencyContainer } from 'tsyringe'
+import { v4 as uuid } from 'uuid'
+import { 
+    EthereumAddress,
+    MessageID,
+    SigningUtil,
+    StreamID,
+    StreamIDUtils,
+    StreamMessage,
+    StreamPartIDUtils,
+    toStreamPartID
+} from 'streamr-client-protocol'
+import { StreamRegistry } from '../../src/StreamRegistry'
+import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
+import { GroupKeyStoreFactory } from '../../src/encryption/GroupKeyStoreFactory'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { PublisherKeyExchange } from '../../src/encryption/PublisherKeyExchange'
+import { waitForCondition } from 'streamr-test-utils'
+import { Wallet } from 'ethers'
+import { RsaKeyPair } from '../../src/encryption/RsaKeyPair'
+import { Stream } from '../../src/Stream'
+import { StreamPermission } from '../../src/permission'
+import { getGroupKeysFromStreamMessage } from '../../src/encryption/SubscriberKeyExchange'
+import { addFakeNode, createFakeContainer } from '../test-utils/fake/fakeEnvironment'
+
+const MOCK_GROUP_KEY = new GroupKey('mock-group-key-id', Buffer.from('mock-group-key-256-bits---------'))
+
+const createMockStream = async (
+    subscriberAddress: EthereumAddress,
+    fakeContainer: DependencyContainer
+) => {
+    const streamRegistry = fakeContainer.resolve(StreamRegistry)
+    const stream = await streamRegistry.createStream(StreamPartIDUtils.parse('stream#0'))
+    streamRegistry.grantPermissions(stream.id, {
+        permissions: [StreamPermission.SUBSCRIBE],
+        user: subscriberAddress
+    })
+    return stream
+}
+
+const createMockGroupKeyRequest = (
+    streamId: StreamID,
+    rsaPublicKey: string,
+    subscriberWallet: Wallet,
+    publisherAddress: EthereumAddress
+) => {
+    const publisherKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(publisherAddress)
+    const msg = new StreamMessage({
+        messageId: new MessageID(publisherKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, subscriberWallet.address, 'msgChainId'),
+        content: JSON.stringify([
+            uuid(), 
+            streamId,
+            rsaPublicKey,
+            [MOCK_GROUP_KEY.id]
+        ]),
+        messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
+        encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        contentType: StreamMessage.CONTENT_TYPES.JSON
+    })
+    msg.signature = SigningUtil.sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), subscriberWallet.privateKey)
+    return msg
+}
+
+describe('PublisherKeyExchange', () => {
+
+    let publisherWallet: Wallet
+    let subscriberWallet: Wallet
+    let mockStream: Stream
+    let publisherRsaKeyPair: RsaKeyPair
+    let fakeContainer: DependencyContainer
+
+    beforeAll(async () => {
+        publisherWallet = Wallet.createRandom()
+        subscriberWallet = Wallet.createRandom()
+        fakeContainer = createFakeContainer({
+            auth: {
+                privateKey: publisherWallet.privateKey
+            }
+        })
+        mockStream = await createMockStream(subscriberWallet.address, fakeContainer)
+        const groupKeyStoreFactory = fakeContainer.resolve(GroupKeyStoreFactory)
+        const groupKeyStore = await groupKeyStoreFactory.getStore(mockStream.id)
+        groupKeyStore.add(MOCK_GROUP_KEY)
+        publisherRsaKeyPair = await RsaKeyPair.create()
+    })
+
+    it('responses to a group key request', async () => {
+        const publisherKeyExchange = fakeContainer.resolve(PublisherKeyExchange)
+        await publisherKeyExchange.useGroupKey(mockStream.id) // subscribes to the key exchange stream
+
+        const groupKeyRequest = createMockGroupKeyRequest(
+            mockStream.id,
+            publisherRsaKeyPair.getPublicKey(),
+            subscriberWallet,
+            publisherWallet.address
+        )
+        const groupKeyResponses: StreamMessage[] = []
+        const subscriberNode = addFakeNode(subscriberWallet.address, fakeContainer)
+        const subscriberKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(subscriberWallet.address)
+        subscriberNode.addSubscriber(toStreamPartID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
+            groupKeyResponses.push(msg)
+        })
+        subscriberNode.publishToNode(groupKeyRequest)
+
+        await waitForCondition(() => groupKeyResponses.length > 0)
+        const groupKeyResponse = groupKeyResponses[0]
+        expect(groupKeyResponse).toMatchObject({
+            messageId: {
+                streamId: subscriberKeyExchangeStreamId,
+                streamPartition: DEFAULT_PARTITION,
+                publisherId: publisherWallet.address.toLowerCase(),
+            },
+            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE,
+            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+            signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
+            signature: expect.any(String)
+        })
+        const groupKeys = await getGroupKeysFromStreamMessage(groupKeyResponse, publisherRsaKeyPair.getPrivateKey())
+        expect(groupKeys).toHaveLength(1)
+        expect(groupKeys[0].hex).toBe(MOCK_GROUP_KEY.hex)
+    })
+})

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -67,7 +67,7 @@ describe('PublisherKeyExchange', () => {
     let publisherWallet: Wallet
     let subscriberWallet: Wallet
     let mockStream: Stream
-    let publisherRsaKeyPair: RsaKeyPair
+    let subscriberRsaKeyPair: RsaKeyPair
     let fakeContainer: DependencyContainer
 
     beforeAll(async () => {
@@ -82,7 +82,7 @@ describe('PublisherKeyExchange', () => {
         const groupKeyStoreFactory = fakeContainer.resolve(GroupKeyStoreFactory)
         const groupKeyStore = await groupKeyStoreFactory.getStore(mockStream.id)
         groupKeyStore.add(MOCK_GROUP_KEY)
-        publisherRsaKeyPair = await RsaKeyPair.create()
+        subscriberRsaKeyPair = await RsaKeyPair.create()
     })
 
     /*
@@ -95,7 +95,7 @@ describe('PublisherKeyExchange', () => {
 
         const groupKeyRequest = createGroupKeyRequest(
             mockStream.id,
-            publisherRsaKeyPair.getPublicKey(),
+            subscriberRsaKeyPair.getPublicKey(),
             subscriberWallet,
             publisherWallet.address
         )
@@ -121,8 +121,8 @@ describe('PublisherKeyExchange', () => {
             signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
             signature: expect.any(String)
         })
-        const groupKeys = await getGroupKeysFromStreamMessage(groupKeyResponse, publisherRsaKeyPair.getPrivateKey())
+        const groupKeys = await getGroupKeysFromStreamMessage(groupKeyResponse, subscriberRsaKeyPair.getPrivateKey())
         expect(groupKeys).toHaveLength(1)
-        expect(groupKeys[0].hex).toBe(MOCK_GROUP_KEY.hex)
+        expect(groupKeys[0]).toEqual(MOCK_GROUP_KEY)
     })
 })

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { container } from 'tsyringe'
+import { container as rootContainer } from 'tsyringe'
 import { toStreamID } from 'streamr-client-protocol'
 import { initContainer } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
@@ -10,7 +10,8 @@ describe('Stream', () => {
     describe('update', () => {
         it('fields not updated if transaction fails', async () => {
             const config = createStrictConfig({})
-            const { childContainer: mockContainer } = initContainer(config, container)
+            const mockContainer = rootContainer.createChildContainer()
+            initContainer(config, mockContainer)
             mockContainer.registerInstance(StreamRegistry, {
                 updateStream: jest.fn().mockRejectedValue(new Error('mock-error'))
             } as any)

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -1,0 +1,112 @@
+import 'reflect-metadata'
+import { DependencyContainer } from 'tsyringe'
+import { 
+    EthereumAddress,
+    GroupKeyRequestSerialized,
+    MessageID,
+    SigningUtil,
+    StreamIDUtils,
+    StreamMessage,
+    StreamPartIDUtils,
+    toStreamPartID
+} from 'streamr-client-protocol'
+import { StreamRegistry } from '../../src/StreamRegistry'
+import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { createGroupKeyResponse } from '../../src/encryption/PublisherKeyExchange'
+import { waitForCondition } from 'streamr-test-utils'
+import { Wallet } from 'ethers'
+import { Stream } from '../../src/Stream'
+import { StreamPermission } from '../../src/permission'
+import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { addFakeNode, createFakeContainer } from '../test-utils/fake/fakeEnvironment'
+
+const MOCK_GROUP_KEY = new GroupKey('mock-group-key-id', Buffer.from('mock-group-key-256-bits---------'))
+
+const createMockStream = async (
+    publisherAddress: EthereumAddress,
+    fakeContainer: DependencyContainer
+) => {
+    const streamRegistry = fakeContainer.resolve(StreamRegistry)
+    const stream = await streamRegistry.createStream(StreamPartIDUtils.parse('stream#0'))
+    streamRegistry.grantPermissions(stream.id, {
+        permissions: [StreamPermission.PUBLISH],
+        user: publisherAddress
+    })
+    return stream
+}
+
+const createMockGroupKeyResponse = async (
+    groupKeyRequest: StreamMessage<GroupKeyRequestSerialized>,
+    publisherWallet: Wallet
+): Promise<StreamMessage> => {
+    const subscriberAddress = groupKeyRequest.getPublisherId()
+    const subscriberKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(subscriberAddress)
+    const msg = new StreamMessage({
+        messageId: new MessageID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, publisherWallet.address, 'msgChainId'),
+        content: (await createGroupKeyResponse(
+            groupKeyRequest,
+            async () => MOCK_GROUP_KEY,
+            async () => true
+        )).serialize(),
+        messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE,
+        encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA
+    })
+    msg.signature = SigningUtil.sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), publisherWallet.privateKey)
+    return msg
+}
+
+describe('SubscriberKeyExchange', () => {
+
+    let publisherWallet: Wallet
+    let subscriberWallet: Wallet
+    let mockStream: Stream
+    let fakeContainer: DependencyContainer
+
+    beforeAll(async () => {
+        publisherWallet = Wallet.createRandom()
+        subscriberWallet = Wallet.createRandom()
+        fakeContainer = createFakeContainer({
+            auth: {
+                privateKey: subscriberWallet.privateKey
+            }
+        })
+        mockStream = await createMockStream(publisherWallet.address, fakeContainer)
+    })
+
+    it('requests a group key', async () => {
+        const groupKeyRequests: StreamMessage<GroupKeyRequestSerialized>[] = []
+        const publisherNode = addFakeNode(publisherWallet.address, fakeContainer)
+        const publisherKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(publisherWallet.address)
+        publisherNode.addSubscriber(toStreamPartID(publisherKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
+            groupKeyRequests.push(msg as any)
+        })
+    
+        const subscriberKeyExchange = fakeContainer.resolve(SubscriberKeyExchange)
+        const receivedGroupKey = subscriberKeyExchange.getGroupKey({
+            getStreamId: () => mockStream.id,
+            getPublisherId: () => publisherWallet.address,
+            groupKeyId: MOCK_GROUP_KEY.id
+        } as any)
+        
+        await waitForCondition(() => groupKeyRequests.length > 0)
+        const groupKeyRequest = groupKeyRequests[0]
+        expect(groupKeyRequest).toMatchObject({
+            messageId: {
+                streamId: publisherKeyExchangeStreamId,
+                streamPartition: DEFAULT_PARTITION,
+                publisherId: subscriberWallet.address.toLowerCase()
+            },
+            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
+            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
+            signature: expect.any(String)
+        })
+        
+        const groupKeyResponse = await createMockGroupKeyResponse(groupKeyRequest, publisherWallet) 
+        publisherNode.publishToNode(groupKeyResponse)
+        
+        expect((await receivedGroupKey)!.hex).toBe(MOCK_GROUP_KEY.hex)
+    })
+})

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -74,6 +74,11 @@ describe('SubscriberKeyExchange', () => {
         mockStream = await createMockStream(publisherWallet.address, fakeContainer)
     })
 
+    /*
+     * A subscriber node requests a group key by calling subscriberKeyExchange.getGroupKey()
+     * - tests that a correct kind of request message is sent to a publisher node
+     * - tests that we can parse the group key from the response sent by the publisher
+     */
     it('requests a group key', async () => {
         const groupKeyRequests: StreamMessage<GroupKeyRequestSerialized>[] = []
         const publisherNode = addFakeNode(publisherWallet.address, fakeContainer)

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -108,10 +108,16 @@ describe('SubscriberKeyExchange', () => {
             signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
             signature: expect.any(String)
         })
+        expect(groupKeyRequest.getParsedContent()).toEqual([
+            expect.any(String),
+            mockStream.id,
+            expect.any(String),
+            [ MOCK_GROUP_KEY.id ]
+        ])
         
         const groupKeyResponse = await createMockGroupKeyResponse(groupKeyRequest, publisherWallet) 
         publisherNode.publishToNode(groupKeyResponse)
         
-        expect((await receivedGroupKey)!.hex).toBe(MOCK_GROUP_KEY.hex)
+        expect((await receivedGroupKey)!).toEqual(MOCK_GROUP_KEY)
     })
 })

--- a/packages/protocol/src/protocol/message_layer/index.ts
+++ b/packages/protocol/src/protocol/message_layer/index.ts
@@ -3,7 +3,7 @@ import MessageRef from "./MessageRef"
 import StreamMessage from "./StreamMessage"
 import { StreamMessageType } from "./StreamMessage"
 import GroupKeyMessage from "./GroupKeyMessage"
-import GroupKeyRequest from "./GroupKeyRequest"
+import GroupKeyRequest, { GroupKeyRequestSerialized } from "./GroupKeyRequest"
 import GroupKeyResponse from "./GroupKeyResponse"
 import GroupKeyAnnounce from "./GroupKeyAnnounce"
 import GroupKeyErrorResponse from "./GroupKeyErrorResponse"
@@ -21,6 +21,7 @@ export {
     StreamMessageType,
     GroupKeyMessage,
     GroupKeyRequest,
+    GroupKeyRequestSerialized,
     GroupKeyResponse,
     GroupKeyAnnounce,
     GroupKeyErrorResponse,


### PR DESCRIPTION
Added tests for `GroupKey` delivery between a subscriber and a publisher:
- `PublisherKeyExchange.test.ts`
  - tests that a correct kind of response message is sent to a subscriber node
- `SubscriberKeyExchange.test.ts`
  - tests that a correct kind of request message is sent to a publisher node
  - tests that we can parse the group key from the response sent by the publisher
 
 Also added `MessageCreator.test.ts` to test low level message construction functionality.
 
### Refactoring

Removed method delegation in `GroupKeyStoreFactory`: client now calls `GroupKeyStore` methods directly.

Created some `GroupKey`-related helper methods by extracting part of the logic to separate methods:
- `createGroupKeyResponse`(used by `PublisherKeyExchange`)
- `publishAndWaitForResponseMessage` (used by `KeyExchangeStream`)

Refactored `initContainer` function: now it modifies the container given as an argument instead of creating a child container. 

### Test utilities

Added utilities to run tests in a fake environment:
- `createFakeContainer`: creates a dependency injection container, which contains fake instances of `BrubeckNode`, `StreamRegistry` etc. (implemented already in a previous PR, but now is a separate function)
- `addFakeNode`: adds a fake `BrubeckNode` to the fake environment (e.g. a fake publisher node)
- `FakeBrubeckNode#addSubscriber` to implement a simple subscriber node: subscribes to a stream and calls a callback for each incoming message