### PR TITLE
refactor(protocol): KeyExchangeStream partition 

### DIFF
--- a/packages/client/src/StreamRegistry.ts
+++ b/packages/client/src/StreamRegistry.ts
@@ -14,7 +14,9 @@ import { ErrorCode, NotFoundError } from './HttpUtil'
 import {
     StreamID,
     EthereumAddress,
-    StreamIDUtils, toStreamID,
+    StreamIDUtils, 
+    toStreamID,
+    KeyExchangeStreamIDUtils
 } from 'streamr-client-protocol'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { omit } from 'lodash'
@@ -219,7 +221,7 @@ export class StreamRegistry implements Context {
     async getStream(streamIdOrPath: string): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Getting stream %s', streamId)
-        if (StreamIDUtils.isKeyExchangeStream(streamId)) {
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
             return new Stream({ id: streamId, partitions: 1 }, this.container)
         }
         let metadata
@@ -236,7 +238,7 @@ export class StreamRegistry implements Context {
     private async getStreamFromGraph(streamIdOrPath: string): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Getting stream %s from theGraph', streamId)
-        if (StreamIDUtils.isKeyExchangeStream(streamId)) {
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
             return new Stream({ id: streamId, partitions: 1 }, this.container)
         }
         const response = await this.graphQLClient.sendQuery(

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -57,8 +57,8 @@ export class KeyExchangeStream implements Context {
     private async createSubscription(): Promise<Subscription<unknown>> {
         // subscribing to own keyexchange stream
         const publisherId = await this.ethereum.getAddress()
-        const streamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherId)
-        const sub = await this.subscriber.subscribe(streamId)
+        const streamPartId = KeyExchangeStreamIDUtils.formStreamPartID(publisherId)
+        const sub = await this.subscriber.subscribe(streamPartId)
         const onDestroy = () => {
             return sub.unsubscribe()
         }
@@ -71,7 +71,7 @@ export class KeyExchangeStream implements Context {
     }
 
     async request(publisherId: EthereumAddress, request: GroupKeyRequest): Promise<StreamMessage<unknown> | undefined> {
-        const streamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherId)
+        const streamPartId = KeyExchangeStreamIDUtils.formStreamPartID(publisherId)
 
         const matchFn = (streamMessage: StreamMessage) => {
             const { messageType } = streamMessage
@@ -83,7 +83,7 @@ export class KeyExchangeStream implements Context {
         }
 
         return publishAndWaitForResponseMessage(
-            () => this.publisher.publish(streamId, request),
+            () => this.publisher.publish(streamPartId, request),
             matchFn,
             () => this.createSubscription(),
             () => this.subscribe.reset(),
@@ -103,6 +103,6 @@ export class KeyExchangeStream implements Context {
             return msg
         }
 
-        return this.publisher.publish(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberId), response)
+        return this.publisher.publish(KeyExchangeStreamIDUtils.formStreamPartID(subscriberId), response)
     }
 }

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -3,8 +3,8 @@ import {
     GroupKeyRequest,
     GroupKeyResponse,
     GroupKeyErrorResponse,
-    StreamIDUtils,
-    EthereumAddress
+    EthereumAddress,
+    KeyExchangeStreamIDUtils
 } from 'streamr-client-protocol'
 import { Lifecycle, scoped, delay, inject } from 'tsyringe'
 
@@ -57,7 +57,7 @@ export class KeyExchangeStream implements Context {
     private async createSubscription(): Promise<Subscription<unknown>> {
         // subscribing to own keyexchange stream
         const publisherId = await this.ethereum.getAddress()
-        const streamId = StreamIDUtils.formKeyExchangeStreamID(publisherId)
+        const streamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherId)
         const sub = await this.subscriber.subscribe(streamId)
         const onDestroy = () => {
             return sub.unsubscribe()
@@ -71,7 +71,7 @@ export class KeyExchangeStream implements Context {
     }
 
     async request(publisherId: EthereumAddress, request: GroupKeyRequest): Promise<StreamMessage<unknown> | undefined> {
-        const streamId = StreamIDUtils.formKeyExchangeStreamID(publisherId)
+        const streamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherId)
 
         const matchFn = (streamMessage: StreamMessage) => {
             const { messageType } = streamMessage
@@ -103,6 +103,6 @@ export class KeyExchangeStream implements Context {
             return msg
         }
 
-        return this.publisher.publish(StreamIDUtils.formKeyExchangeStreamID(subscriberId), response)
+        return this.publisher.publish(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberId), response)
     }
 }

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -1,5 +1,5 @@
 import { inject, DependencyContainer, scoped, Lifecycle } from 'tsyringe'
-import { EthereumAddress, StreamID, StreamIDUtils } from 'streamr-client-protocol'
+import { EthereumAddress, KeyExchangeStreamIDUtils, StreamID } from 'streamr-client-protocol'
 import { Stream, StreamProperties } from '../../../src/Stream'
 import {
     StreamPermission,
@@ -86,7 +86,7 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     async getStream(id: StreamID): Promise<Stream> {
-        if (StreamIDUtils.isKeyExchangeStream(id)) {
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(id)) {
             return new Stream({ id, partitions: 1 }, this.container)
         }
         const registryItem = this.registryItems.get(id)

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -3,10 +3,10 @@ import { DependencyContainer } from 'tsyringe'
 import { v4 as uuid } from 'uuid'
 import { 
     EthereumAddress,
+    KeyExchangeStreamIDUtils,
     MessageID,
     SigningUtil,
     StreamID,
-    StreamIDUtils,
     StreamMessage,
     StreamPartIDUtils,
     toStreamPartID
@@ -45,7 +45,7 @@ const createGroupKeyRequest = (
     subscriberWallet: Wallet,
     publisherAddress: EthereumAddress
 ): StreamMessage => {
-    const publisherKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(publisherAddress)
+    const publisherKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherAddress)
     const msg = new StreamMessage({
         messageId: new MessageID(publisherKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, subscriberWallet.address, 'msgChainId'),
         content: JSON.stringify([
@@ -101,7 +101,7 @@ describe('PublisherKeyExchange', () => {
         )
         const groupKeyResponses: StreamMessage[] = []
         const subscriberNode = addFakeNode(subscriberWallet.address, fakeContainer)
-        const subscriberKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(subscriberWallet.address)
+        const subscriberKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberWallet.address)
         subscriberNode.addSubscriber(toStreamPartID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
             groupKeyResponses.push(msg)
         })

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -9,10 +9,8 @@ import {
     StreamID,
     StreamMessage,
     StreamPartIDUtils,
-    toStreamPartID
 } from 'streamr-client-protocol'
 import { StreamRegistry } from '../../src/StreamRegistry'
-import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
 import { GroupKeyStoreFactory } from '../../src/encryption/GroupKeyStoreFactory'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { PublisherKeyExchange } from '../../src/encryption/PublisherKeyExchange'
@@ -45,9 +43,16 @@ const createGroupKeyRequest = (
     subscriberWallet: Wallet,
     publisherAddress: EthereumAddress
 ): StreamMessage => {
-    const publisherKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherAddress)
+    const publisherKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(publisherAddress)
     const msg = new StreamMessage({
-        messageId: new MessageID(publisherKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, subscriberWallet.address, 'msgChainId'),
+        messageId: new MessageID(
+            StreamPartIDUtils.getStreamID(publisherKeyExchangeStreamPartId),
+            StreamPartIDUtils.getStreamPartition(publisherKeyExchangeStreamPartId),
+            0,
+            0,
+            subscriberWallet.address,
+            'msgChainId'
+        ),
         content: JSON.stringify([
             uuid(), 
             streamId,
@@ -101,8 +106,8 @@ describe('PublisherKeyExchange', () => {
         )
         const groupKeyResponses: StreamMessage[] = []
         const subscriberNode = addFakeNode(subscriberWallet.address, fakeContainer)
-        const subscriberKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberWallet.address)
-        subscriberNode.addSubscriber(toStreamPartID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
+        const subscriberKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address)
+        subscriberNode.addSubscriber(subscriberKeyExchangeStreamPartId, (msg: StreamMessage) => {
             groupKeyResponses.push(msg)
         })
         subscriberNode.publishToNode(groupKeyRequest)
@@ -111,8 +116,8 @@ describe('PublisherKeyExchange', () => {
         const groupKeyResponse = groupKeyResponses[0]
         expect(groupKeyResponse).toMatchObject({
             messageId: {
-                streamId: subscriberKeyExchangeStreamId,
-                streamPartition: DEFAULT_PARTITION,
+                streamId: StreamPartIDUtils.getStreamID(subscriberKeyExchangeStreamPartId),
+                streamPartition: StreamPartIDUtils.getStreamPartition(subscriberKeyExchangeStreamPartId),
                 publisherId: publisherWallet.address.toLowerCase(),
             },
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE,

--- a/packages/client/test/unit/StreamIDBuilder.test.ts
+++ b/packages/client/test/unit/StreamIDBuilder.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import { StreamIDBuilder } from '../../src/StreamIDBuilder'
 import { Ethereum } from '../../src/Ethereum'
-import { StreamIDUtils, StreamPartIDUtils } from 'streamr-client-protocol'
+import { KeyExchangeStreamIDUtils, StreamPartIDUtils } from 'streamr-client-protocol'
 import { StreamDefinition } from '../../src'
 
 const address = '0xf5B45CC4cc510C31Cd6B64B8F4f341C283894086'
@@ -29,7 +29,7 @@ describe('StreamIDBuilder', () => {
         })
 
         it('key-exchange stream id', () => {
-            return expect(streamIdBuilder.toStreamID(StreamIDUtils.KEY_EXCHANGE_STREAM_PREFIX + '0xABCdef12345'))
+            return expect(streamIdBuilder.toStreamID(KeyExchangeStreamIDUtils.STREAM_ID_PREFIX + '0xABCdef12345'))
                 .resolves
                 .toEqual('SYSTEM/keyexchange/0xABCdef12345')
         })

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -3,9 +3,9 @@ import { DependencyContainer } from 'tsyringe'
 import { 
     EthereumAddress,
     GroupKeyRequestSerialized,
+    KeyExchangeStreamIDUtils,
     MessageID,
     SigningUtil,
-    StreamIDUtils,
     StreamMessage,
     StreamPartIDUtils,
     toStreamPartID
@@ -41,7 +41,7 @@ const createMockGroupKeyResponse = async (
     publisherWallet: Wallet
 ): Promise<StreamMessage> => {
     const subscriberAddress = groupKeyRequest.getPublisherId()
-    const subscriberKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(subscriberAddress)
+    const subscriberKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberAddress)
     const msg = new StreamMessage({
         messageId: new MessageID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, publisherWallet.address, 'msgChainId'),
         content: (await createGroupKeyResponse(
@@ -82,7 +82,7 @@ describe('SubscriberKeyExchange', () => {
     it('requests a group key', async () => {
         const groupKeyRequests: StreamMessage<GroupKeyRequestSerialized>[] = []
         const publisherNode = addFakeNode(publisherWallet.address, fakeContainer)
-        const publisherKeyExchangeStreamId = StreamIDUtils.formKeyExchangeStreamID(publisherWallet.address)
+        const publisherKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherWallet.address)
         publisherNode.addSubscriber(toStreamPartID(publisherKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
             groupKeyRequests.push(msg as any)
         })

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -8,10 +8,8 @@ import {
     SigningUtil,
     StreamMessage,
     StreamPartIDUtils,
-    toStreamPartID
 } from 'streamr-client-protocol'
 import { StreamRegistry } from '../../src/StreamRegistry'
-import { DEFAULT_PARTITION } from '../../src/StreamIDBuilder'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { createGroupKeyResponse } from '../../src/encryption/PublisherKeyExchange'
 import { waitForCondition } from 'streamr-test-utils'
@@ -41,9 +39,16 @@ const createMockGroupKeyResponse = async (
     publisherWallet: Wallet
 ): Promise<StreamMessage> => {
     const subscriberAddress = groupKeyRequest.getPublisherId()
-    const subscriberKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(subscriberAddress)
+    const subscriberKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(subscriberAddress)
     const msg = new StreamMessage({
-        messageId: new MessageID(subscriberKeyExchangeStreamId, DEFAULT_PARTITION, 0, 0, publisherWallet.address, 'msgChainId'),
+        messageId: new MessageID(
+            StreamPartIDUtils.getStreamID(subscriberKeyExchangeStreamPartId),
+            StreamPartIDUtils.getStreamPartition(subscriberKeyExchangeStreamPartId),
+            0,
+            0,
+            publisherWallet.address,
+            'msgChainId'
+        ),
         content: (await createGroupKeyResponse(
             groupKeyRequest,
             async () => MOCK_GROUP_KEY,
@@ -82,8 +87,8 @@ describe('SubscriberKeyExchange', () => {
     it('requests a group key', async () => {
         const groupKeyRequests: StreamMessage<GroupKeyRequestSerialized>[] = []
         const publisherNode = addFakeNode(publisherWallet.address, fakeContainer)
-        const publisherKeyExchangeStreamId = KeyExchangeStreamIDUtils.formKeyExchangeStreamID(publisherWallet.address)
-        publisherNode.addSubscriber(toStreamPartID(publisherKeyExchangeStreamId, DEFAULT_PARTITION), (msg: StreamMessage) => {
+        const publisherKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address)
+        publisherNode.addSubscriber(publisherKeyExchangeStreamPartId, (msg: StreamMessage) => {
             groupKeyRequests.push(msg as any)
         })
     
@@ -98,8 +103,8 @@ describe('SubscriberKeyExchange', () => {
         const groupKeyRequest = groupKeyRequests[0]
         expect(groupKeyRequest).toMatchObject({
             messageId: {
-                streamId: publisherKeyExchangeStreamId,
-                streamPartition: DEFAULT_PARTITION,
+                streamId: StreamPartIDUtils.getStreamID(publisherKeyExchangeStreamPartId),
+                streamPartition:  StreamPartIDUtils.getStreamPartition(publisherKeyExchangeStreamPartId),
                 publisherId: subscriberWallet.address.toLowerCase()
             },
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,

--- a/packages/protocol/src/utils/KeyExchangeStreamID.ts
+++ b/packages/protocol/src/utils/KeyExchangeStreamID.ts
@@ -4,8 +4,8 @@ import { EthereumAddress } from './types'
 
 export class KeyExchangeStreamIDUtils {
 
-    static STREAM_ID_PREFIX = 'SYSTEM/keyexchange/'
-    static PARTITION = 0
+    static readonly STREAM_ID_PREFIX = 'SYSTEM/keyexchange/'
+    static readonly PARTITION = 0
 
     static formStreamPartID(recipient: EthereumAddress): StreamPartID {
         const streamId = (KeyExchangeStreamIDUtils.STREAM_ID_PREFIX + recipient.toLowerCase()) as StreamID

--- a/packages/protocol/src/utils/KeyExchangeStreamID.ts
+++ b/packages/protocol/src/utils/KeyExchangeStreamID.ts
@@ -1,12 +1,15 @@
 import { StreamID } from './StreamID'
+import { StreamPartID, toStreamPartID } from './StreamPartID'
 import { EthereumAddress } from './types'
 
 export class KeyExchangeStreamIDUtils {
 
     static STREAM_ID_PREFIX = 'SYSTEM/keyexchange/'
+    static PARTITION = 0
 
-    static formKeyExchangeStreamID(recipient: EthereumAddress): StreamID {
-        return (KeyExchangeStreamIDUtils.STREAM_ID_PREFIX + recipient.toLowerCase()) as StreamID
+    static formStreamPartID(recipient: EthereumAddress): StreamPartID {
+        const streamId = (KeyExchangeStreamIDUtils.STREAM_ID_PREFIX + recipient.toLowerCase()) as StreamID
+        return toStreamPartID(streamId, KeyExchangeStreamIDUtils.PARTITION)
     }
     
     static isKeyExchangeStream(streamId: StreamID | string): boolean {

--- a/packages/protocol/src/utils/KeyExchangeStreamID.ts
+++ b/packages/protocol/src/utils/KeyExchangeStreamID.ts
@@ -1,0 +1,22 @@
+import { StreamID } from './StreamID'
+import { EthereumAddress } from './types'
+
+export class KeyExchangeStreamIDUtils {
+
+    static STREAM_ID_PREFIX = 'SYSTEM/keyexchange/'
+
+    static formKeyExchangeStreamID(recipient: EthereumAddress): StreamID {
+        return (KeyExchangeStreamIDUtils.STREAM_ID_PREFIX + recipient.toLowerCase()) as StreamID
+    }
+    
+    static isKeyExchangeStream(streamId: StreamID | string): boolean {
+        return streamId.startsWith(KeyExchangeStreamIDUtils.STREAM_ID_PREFIX)
+    }
+    
+    static getRecipient(streamId: StreamID): EthereumAddress | undefined {
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
+            return streamId.substring(KeyExchangeStreamIDUtils.STREAM_ID_PREFIX.length)
+        }
+        return undefined
+    }
+}

--- a/packages/protocol/src/utils/StreamID.ts
+++ b/packages/protocol/src/utils/StreamID.ts
@@ -1,3 +1,4 @@
+import { KeyExchangeStreamIDUtils } from './KeyExchangeStreamID'
 import { EthereumAddress, ENSName } from './types'
 
 export type StreamID = string & { readonly __brand: 'streamID' } // Nominal typing
@@ -20,7 +21,7 @@ export function toStreamID(streamIdOrPath: string, domain?: EthereumAddress | EN
     const firstSlashIdx = streamIdOrPath.indexOf('/')
     if (firstSlashIdx === -1) { // legacy format
         return streamIdOrPath as StreamID
-    } else if (StreamIDUtils.isKeyExchangeStream(streamIdOrPath)) { // key-exchange format
+    } else if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamIdOrPath)) { // key-exchange format
         return streamIdOrPath as StreamID
     } else if (firstSlashIdx === 0) { // path-only format
         if (domain === undefined) {
@@ -36,20 +37,10 @@ export function toStreamID(streamIdOrPath: string, domain?: EthereumAddress | EN
 
 export class StreamIDUtils {
 
-    static readonly KEY_EXCHANGE_STREAM_PREFIX = 'SYSTEM/keyexchange/'
-
-    static formKeyExchangeStreamID(recipient: EthereumAddress): StreamID {
-        return (StreamIDUtils.KEY_EXCHANGE_STREAM_PREFIX + recipient.toLowerCase()) as StreamID
-    }
-    
     static isPathOnlyFormat(streamIdOrPath: string): boolean {
         return streamIdOrPath.startsWith('/')
     }
-    
-    static isKeyExchangeStream(streamId: StreamID | string): boolean {
-        return streamId.startsWith(StreamIDUtils.KEY_EXCHANGE_STREAM_PREFIX)
-    }
-    
+
     static getDomain(streamId: StreamID): EthereumAddress | ENSName | undefined {
         const domainAndPath = StreamIDUtils.getDomainAndPath(streamId)
         return domainAndPath?.[0]
@@ -70,18 +61,11 @@ export class StreamIDUtils {
     
     static getDomainAndPath(streamId: StreamID): [EthereumAddress | ENSName, string] | undefined {
         const firstSlashIdx = streamId.indexOf('/')
-        if (firstSlashIdx !== -1 && !StreamIDUtils.isKeyExchangeStream(streamId)) {
+        if (firstSlashIdx !== -1 && !KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
             return [streamId.substring(0, firstSlashIdx), streamId.substring(firstSlashIdx)]
         } else {
             return undefined
         }
     }
-    
-    static getRecipient(streamId: StreamID): EthereumAddress | undefined {
-        if (StreamIDUtils.isKeyExchangeStream(streamId)) {
-            return streamId.substring(StreamIDUtils.KEY_EXCHANGE_STREAM_PREFIX.length)
-        }
-        return undefined
-    }
-    
+
 }

--- a/packages/protocol/src/utils/index.ts
+++ b/packages/protocol/src/utils/index.ts
@@ -6,6 +6,7 @@ import { generateMnemonicFromAddress, parseAddressFromNodeId } from './NodeUtil'
 import { keyToArrayIndex } from "./HashUtil"
 import { StreamID, toStreamID, StreamIDUtils } from "./StreamID"
 import { StreamPartID, toStreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } from "./StreamPartID"
+import { KeyExchangeStreamIDUtils } from "./KeyExchangeStreamID"
 import { EthereumAddress, ENSName, ProxyDirection } from "./types"
 
 export {
@@ -26,6 +27,7 @@ export {
     StreamPartID,
     StreamPartIDUtils,
     MAX_PARTITION_COUNT,
+    KeyExchangeStreamIDUtils,
     EthereumAddress,
     ENSName,
     ProxyDirection

--- a/packages/protocol/test/unit/utils/KeyExchangeStream.test.ts
+++ b/packages/protocol/test/unit/utils/KeyExchangeStream.test.ts
@@ -2,9 +2,9 @@ import assert from 'assert'
 import { KeyExchangeStreamIDUtils } from '../../../src/utils/KeyExchangeStreamID'
 import { toStreamID } from '../../../src/utils/StreamID'
 
-describe('formKeyExchangeStreamID', () => {
-    it('forms key-exchange stream ids', () => {
-        expect(KeyExchangeStreamIDUtils.formKeyExchangeStreamID('0xFaFa1234')).toEqual('SYSTEM/keyexchange/0xfafa1234')
+describe('formStreamPartID', () => {
+    it('forms key-exchange stream part id', () => {
+        expect(KeyExchangeStreamIDUtils.formStreamPartID('0xFaFa1234')).toEqual('SYSTEM/keyexchange/0xfafa1234#0')
     })
 })
 

--- a/packages/protocol/test/unit/utils/KeyExchangeStream.test.ts
+++ b/packages/protocol/test/unit/utils/KeyExchangeStream.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert'
+import { KeyExchangeStreamIDUtils } from '../../../src/utils/KeyExchangeStreamID'
+import { toStreamID } from '../../../src/utils/StreamID'
+
+describe('formKeyExchangeStreamID', () => {
+    it('forms key-exchange stream ids', () => {
+        expect(KeyExchangeStreamIDUtils.formKeyExchangeStreamID('0xFaFa1234')).toEqual('SYSTEM/keyexchange/0xfafa1234')
+    })
+})
+
+describe('isKeyExchangeStream', () => {
+    it('returns true for streams that start with the correct prefix', () => {
+        assert(KeyExchangeStreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchange/0x1234'))
+        assert(KeyExchangeStreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchange/foo'))
+    })
+    it('returns false for other streams', () => {
+        assert(!KeyExchangeStreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchangefoo'))
+    })
+})
+
+describe('getRecipient', () => {
+    it('returns recipient in the case of a key-exchange stream', () => {
+        const streamId = toStreamID('SYSTEM/keyexchange/0x1234')
+        expect(KeyExchangeStreamIDUtils.getRecipient(streamId)).toEqual('0x1234')
+    })
+
+    it('returns undefined in the case of a non-key-exchange stream', () => {
+        const address = '0xaAAAaaaaAA123456789012345678901234567890'
+        const streamId = toStreamID('/foo/BAR', address)
+        expect(KeyExchangeStreamIDUtils.getRecipient(streamId)).toBeUndefined()
+    })
+})

--- a/packages/protocol/test/unit/utils/StreamID.test.ts
+++ b/packages/protocol/test/unit/utils/StreamID.test.ts
@@ -1,16 +1,10 @@
-import assert from 'assert'
 import {
     StreamIDUtils,
     toStreamID
 } from '../../../src'
+import { KeyExchangeStreamIDUtils } from '../../../src/utils/KeyExchangeStreamID'
 
 const address = '0xaAAAaaaaAA123456789012345678901234567890'
-
-describe('formKeyExchangeStreamID', () => {
-    it('forms key-exchange stream ids', () => {
-        expect(StreamIDUtils.formKeyExchangeStreamID('0xFaFa1234')).toEqual(StreamIDUtils.KEY_EXCHANGE_STREAM_PREFIX + '0xfafa1234')
-    })
-})
 
 describe('toStreamID', () => {
     it('path-only format', () => {
@@ -65,7 +59,7 @@ describe('isPathOnlyFormat', () => {
     })
 
     it('returns false on key-exchange format', () => {
-        expect(StreamIDUtils.isPathOnlyFormat(StreamIDUtils.formKeyExchangeStreamID(address))).toEqual(false)
+        expect(StreamIDUtils.isPathOnlyFormat(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toEqual(false)
     })
 
     it('returns false on legacy format', () => {
@@ -81,23 +75,13 @@ describe('isPathOnlyFormat', () => {
     })
 })
 
-describe('isKeyExchangeStream', () => {
-    it('returns true for streams that start with the correct prefix', () => {
-        assert(StreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchange/0x1234'))
-        assert(StreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchange/foo'))
-    })
-    it('returns false for other streams', () => {
-        assert(!StreamIDUtils.isKeyExchangeStream('SYSTEM/keyexchangefoo'))
-    })
-})
-
 describe('getDomainAndPath', () => {
     it('returns undefined for legacy stream id', () => {
         expect(StreamIDUtils.getDomainAndPath(toStreamID('7wa7APtlTq6EC5iTCBy6dw'))).toBeUndefined()
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getDomainAndPath(StreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getDomainAndPath(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
     })
 
     it('returns domain and path for full stream id', () => {
@@ -112,7 +96,7 @@ describe('getDomain', () => {
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getDomain(StreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getDomain(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
     })
 
     it('returns address for full stream id', () => {
@@ -151,7 +135,7 @@ describe('getPath', () => {
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getPath(StreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getPath(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
     })
 
     it('returns path for full stream id', () => {
@@ -159,14 +143,3 @@ describe('getPath', () => {
     })
 })
 
-describe('getRecipient', () => {
-    it('returns recipient in the case of a key-exchange stream', () => {
-        const streamId = toStreamID('SYSTEM/keyexchange/0x1234')
-        expect(StreamIDUtils.getRecipient(streamId)).toEqual('0x1234')
-    })
-
-    it('returns undefined in the case of a non-key-exchange stream', () => {
-        const streamId = toStreamID('/foo/BAR', address)
-        expect(StreamIDUtils.getRecipient(streamId)).toBeUndefined()
-    })
-})

--- a/packages/protocol/test/unit/utils/StreamID.test.ts
+++ b/packages/protocol/test/unit/utils/StreamID.test.ts
@@ -59,7 +59,7 @@ describe('isPathOnlyFormat', () => {
     })
 
     it('returns false on key-exchange format', () => {
-        expect(StreamIDUtils.isPathOnlyFormat(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toEqual(false)
+        expect(StreamIDUtils.isPathOnlyFormat(toStreamID(KeyExchangeStreamIDUtils.formStreamPartID(address)))).toEqual(false)
     })
 
     it('returns false on legacy format', () => {
@@ -81,7 +81,7 @@ describe('getDomainAndPath', () => {
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getDomainAndPath(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getDomainAndPath(toStreamID(KeyExchangeStreamIDUtils.formStreamPartID(address)))).toBeUndefined()
     })
 
     it('returns domain and path for full stream id', () => {
@@ -96,7 +96,7 @@ describe('getDomain', () => {
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getDomain(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getDomain(toStreamID(KeyExchangeStreamIDUtils.formStreamPartID(address)))).toBeUndefined()
     })
 
     it('returns address for full stream id', () => {
@@ -135,7 +135,7 @@ describe('getPath', () => {
     })
 
     it('returns undefined for key-exchange stream id', () => {
-        expect(StreamIDUtils.getPath(KeyExchangeStreamIDUtils.formKeyExchangeStreamID(address))).toBeUndefined()
+        expect(StreamIDUtils.getPath(toStreamID(KeyExchangeStreamIDUtils.formStreamPartID(address)))).toBeUndefined()
     })
 
     it('returns path for full stream id', () => {


### PR DESCRIPTION
Changed `StreamIDUtils.formKeyExchangeStreamID` to return `StreamPartID` instead of `StreamPart`. 

The method is used by `StreamrClient`. Therefore when the client publishes/subscribes to a key exchange stream, it uses `0` partition explicitly . The functionality doesn't change as publish and subscribe currently use `0` partition by default if no partition is specified. But after this PR, key exchange operations don't need to rely on that default behavior.

Also extracted key exchange stream id utility methods to a separate `KeyExchangeStreamIDUtils` utils. As one of the methods doesn't operate on `StreamID` but `StreamPartID`, it wouldn't be optimal to leave key exchange methods to 
 be part `StreamIDUtils`. This change also simplifies the basic usage of `StreamIDUtils`.