### PR TITLE
test(client): Anonymous publisher

### DIFF
--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -28,26 +28,11 @@ export type MessageCreateOptions<T = unknown> = {
     encryptionType?: EncryptionType
 }
 
-export interface IMessageCreator {
-    create: <T>(streamId: StreamID, options: MessageCreateOptions<T>) => Promise<StreamMessage<T>>
-    stop: () => Promise<void> | void
-}
-
-export class MessageCreatorAnonymous implements IMessageCreator {
-    // eslint-disable-next-line class-methods-use-this
-    async create<T>(_streamId: string, _options: MessageCreateOptions<T>): Promise<StreamMessage<T>> {
-        throw new Error('Anonymous user can not publish.')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    stop(): void {}
-}
-
 /**
  * Create StreamMessages from metadata.
  */
 @scoped(Lifecycle.ContainerScoped)
-export class MessageCreator implements IMessageCreator {
+export class MessageCreator {
     // encrypt
     private queue: ReturnType<typeof LimitAsyncFnByKey>
     private getMsgChain

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -33,13 +33,8 @@ export type MessageCreateOptions<T = unknown> = {
  */
 @scoped(Lifecycle.ContainerScoped)
 export class MessageCreator {
-    // encrypt
     private queue: ReturnType<typeof LimitAsyncFnByKey>
     private getMsgChain
-
-    /*
-     * Get function for creating stream messages.
-     */
 
     constructor(
         private streamPartitioner: StreamPartitioner,

--- a/packages/client/test/integration/anonymous-client.test.ts
+++ b/packages/client/test/integration/anonymous-client.test.ts
@@ -1,0 +1,21 @@
+import { fastPrivateKey } from 'streamr-test-utils'
+import { StreamrClient } from '../../src/StreamrClient'
+import { createFakeContainer, DEFAULT_CLIENT_OPTIONS } from '../test-utils/fake/fakeEnvironment'
+import { createTestStream } from '../test-utils/utils'
+
+describe('anonymous client', () => {
+
+    it('fails to publish', async () => {
+        const dependencyContainer = createFakeContainer(undefined)
+        const owner = new StreamrClient({
+            auth: {
+                privateKey: fastPrivateKey()
+            },
+            ...DEFAULT_CLIENT_OPTIONS
+        }, dependencyContainer)
+        const stream = await createTestStream(owner, module)
+
+        const publisher = new StreamrClient(DEFAULT_CLIENT_OPTIONS, dependencyContainer)
+        expect(() => publisher.publish(stream, { foo: 'bar' })).rejects.toThrow('not authenticated with private key')
+    })
+})

--- a/packages/client/test/test-utils/fake/fakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/fakeEnvironment.ts
@@ -16,6 +16,10 @@ import { FakeHttpUtil } from './FakeHttpUtil'
 import { HttpUtil } from '../../../src/HttpUtil'
 import { EthereumAddress } from 'streamr-client-protocol'
 
+export const DEFAULT_CLIENT_OPTIONS = {
+    metrics: false
+}
+
 export interface ClientFactory {
     createClient: (opts?: StreamrClientConfig) => StreamrClient
 }
@@ -44,7 +48,7 @@ export const createFakeContainer = (config: StreamrClientConfig | undefined): De
          */
         const { privateKey } = c.resolve(ConfigInjectionToken.Auth) as AuthConfig
         const activeNodes = c.resolve(ActiveNodes)
-        const address = ethereumAddressCache.getAddress(privateKey!)
+        const address = ethereumAddressCache.getAddress(privateKey ?? fastPrivateKey())
         let node = activeNodes.getNode(address)
         if (node === undefined) {
             const { id } = c.resolve(ConfigInjectionToken.Root) as StrictStreamrClientConfig
@@ -70,7 +74,7 @@ export const createClientFactory = (): ClientFactory => {
                 }
             }
             const config = {
-                metrics: false,
+                ...DEFAULT_CLIENT_OPTIONS,
                 ...authOpts,
                 ...opts
             }


### PR DESCRIPTION
Added a test case for anonymous publishing. 

Removed obsolete `MessageCreatorAnonymous` class and  `IMessageCreator` interface.
