### PR TITLE
refactor(client): Remove obsolete classes

### DIFF
--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -18,7 +18,7 @@ export const DEFAULT_HEADERS = {
     'Streamr-Client': `streamr-client-javascript/${getVersionString()}`,
 }
 
-export class AuthFetchError extends Error {
+export class HttpError extends Error {
     public response?: Response
     public body?: any
     public code: ErrorCode
@@ -41,24 +41,24 @@ export class AuthFetchError extends Error {
     }
 }
 
-export class ValidationError extends AuthFetchError {
+export class ValidationError extends HttpError {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(message: string, response?: Response, body?: any) {
         super(message, response, body, ErrorCode.VALIDATION_ERROR)
     }
 }
 
-export class NotFoundError extends AuthFetchError {
+export class NotFoundError extends HttpError {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(message: string, response?: Response, body?: any) {
         super(message, response, body, ErrorCode.NOT_FOUND)
     }
 }
 
-const ERROR_TYPES = new Map<ErrorCode, typeof AuthFetchError>()
+const ERROR_TYPES = new Map<ErrorCode, typeof HttpError>()
 ERROR_TYPES.set(ErrorCode.VALIDATION_ERROR, ValidationError)
 ERROR_TYPES.set(ErrorCode.NOT_FOUND, NotFoundError)
-ERROR_TYPES.set(ErrorCode.UNKNOWN, AuthFetchError)
+ERROR_TYPES.set(ErrorCode.UNKNOWN, HttpError)
 
 const parseErrorCode = (body: string) => {
     let json
@@ -80,7 +80,7 @@ export class HttpUtil {
         abortController = new AbortController()
     ): Promise<Readable> {
         const startTime = Date.now()
-        const response = await authRequest(url, {
+        const response = await fetchResponse(url, {
             signal: abortController.signal,
             ...opts,
         })
@@ -115,14 +115,14 @@ export class HttpUtil {
     }
 }
 
-async function authRequest(
+async function fetchResponse(
     url: string,
     opts?: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     debug?: Debugger,
     fetchFn: typeof fetch = fetch
 ): Promise<Response> {
     if (!debug) {
-        const id = counterId('authResponse')
+        const id = counterId('httpResponse')
         debug = Debug('utils').extend(id) // eslint-disable-line no-param-reassign
     }
 

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -3,13 +3,7 @@ import { arrayify, hexlify } from '@ethersproject/bytes'
 import { StreamMessage, EncryptedGroupKey, StreamMessageError } from 'streamr-client-protocol'
 import { GroupKey } from './GroupKey'
 
-export class StreamMessageProcessingError extends StreamMessageError {
-    constructor(message = '', streamMessage: StreamMessage) {
-        super(`Could not process. ${message}`, streamMessage)
-    }
-}
-
-export class UnableToDecryptError extends StreamMessageProcessingError {
+export class UnableToDecryptError extends StreamMessageError {
     constructor(message = '', streamMessage: StreamMessage) {
         super(`Unable to decrypt. ${message}`, streamMessage)
     }

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -19,7 +19,7 @@ import { Publisher } from '../publish/Publisher'
 import { GroupKeyStoreFactory } from './GroupKeyStoreFactory'
 
 import { GroupKey } from './GroupKey'
-import { EncryptionUtil, StreamMessageProcessingError } from './EncryptionUtil'
+import { EncryptionUtil, UnableToDecryptError } from './EncryptionUtil'
 import { KeyExchangeStream } from './KeyExchangeStream'
 
 import { StreamRegistryCached } from '../StreamRegistryCached'
@@ -157,7 +157,7 @@ export class PublisherKeyExchange implements Context {
         }
 
         sub.consume(this.onKeyExchangeMessage).catch(() => {})
-        sub.onError.listen(async (err: Error | StreamMessageProcessingError) => {
+        sub.onError.listen(async (err: Error | UnableToDecryptError) => {
             if (!('streamMessage' in err)) {
                 this.debug('unexpected', err)
                 return // do nothing, supress.

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -3,7 +3,7 @@
  */
 export * from './StreamrClient'
 export * from './Stream'
-export { StreamMessageProcessingError, UnableToDecryptError } from './encryption/EncryptionUtil'
+export { UnableToDecryptError } from './encryption/EncryptionUtil'
 export { StreamrClientEvents } from './events'
 export { MessageMetadata } from './publish/PublishPipeline'
 export { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -10,11 +10,7 @@ import { Context } from '../utils/Context'
 import { DestroySignal } from '../DestroySignal'
 import { instanceId } from '../utils'
 
-type IDecrypt<T> = {
-    decrypt: (streamMessage: StreamMessage<T>) => Promise<StreamMessage<T>>
-}
-
-export class Decrypt<T> implements IDecrypt<T>, Context {
+export class Decrypt<T> implements Context {
     readonly id
     readonly debug
     private isStopped = false

--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -12,20 +12,15 @@ import * as G from '../utils/GeneratorUtils'
 
 export type MessageStreamOnMessage<T, R = unknown> = (msg: T, streamMessage: StreamMessage<T>) => R | Promise<R>
 
-export type MessageStreamOptions = {
-    bufferSize?: number
-    name?: string
-}
-
 export class MessageStream<
     T = unknown,
     InType = StreamMessage<T>,
     OutType extends StreamMessage<T> | unknown = InType
 > extends PushPipeline<InType, OutType> {
     /** @internal */
-    constructor(context: Context, { bufferSize, name = '' }: MessageStreamOptions = {}) {
-        super(bufferSize)
-        this.id = instanceId(this, name)
+    constructor(context: Context) {
+        super(undefined)
+        this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
     }
 

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -3,7 +3,7 @@
  * Primary interface for consuming StreamMessages.
  */
 import { StreamPartID } from 'streamr-client-protocol'
-import { MessageStream, MessageStreamOptions, MessageStreamOnMessage } from './MessageStream'
+import { MessageStream, MessageStreamOnMessage } from './MessageStream'
 import { SubscriptionSession } from './SubscriptionSession'
 
 export { MessageStreamOnMessage as SubscriptionOnMessage }
@@ -17,8 +17,8 @@ export class Subscription<T = unknown> extends MessageStream<T> {
     readonly streamPartId: StreamPartID
 
     /** @internal */
-    constructor(subSession: SubscriptionSession<T>, options?: MessageStreamOptions) {
-        super(subSession, options)
+    constructor(subSession: SubscriptionSession<T>) {
+        super(subSession)
         this.context = subSession
         this.streamPartId = subSession.streamPartId
         this.onMessage.listen((msg) => {


### PR DESCRIPTION
Removed:
- `StreamMessageProcessingError`: `UnableToDecryptError` can extend `StreamMessageError` directly
- `IDecrypt`: `Decrypt` class is always used as a class, not as an interface
- `MessageStreamOptions`: not used in any constuctor call

Also renamed some classes, methods and labels in `HttpUtils`. Previous names referred to authentication, which is no longer the typically use case of `HttpUtils`.