### PR TITLE
refactor(client): Simplify encrypt

### DIFF
--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -133,10 +133,6 @@ export class Ethereum {
         return (this._getAddress !== undefined)
     }
 
-    canEncrypt(): boolean {
-        return !!(this._getAddress && this._getSigner)
-    }
-
     async getAddress(): Promise<EthereumAddress> {
         if (!this._getAddress) {
             // _getAddress is assigned in constructor

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -71,7 +71,6 @@ export class Ethereum {
     }
 
     private _getAddress?: () => Promise<string>
-    private _getSigner?: () => Signer
     private _getStreamRegistryChainSigner?: () => Promise<Signer>
 
     constructor(
@@ -82,7 +81,6 @@ export class Ethereum {
             const key = authConfig.privateKey
             const address = getAddress(computeAddress(key))
             this._getAddress = async () => address
-            this._getSigner = () => new Wallet(key, this.getMainnetProvider())
             this._getStreamRegistryChainSigner = async () => new Wallet(key, this.getStreamRegistryChainProvider())
         } else if ('ethereum' in authConfig && authConfig.ethereum) {
             const { ethereum } = authConfig
@@ -97,11 +95,6 @@ export class Ethereum {
                 } catch {
                     throw new Error('no addresses connected+selected in Metamask')
                 }
-            }
-            this._getSigner = () => {
-                const metamaskProvider = new Web3Provider(ethereum)
-                const metamaskSigner = metamaskProvider.getSigner()
-                return metamaskSigner
             }
             this._getStreamRegistryChainSigner = async () => {
                 if (!ethereumConfig.streamRegistryChainRPCs || ethereumConfig.streamRegistryChainRPCs.chainId === undefined) {
@@ -140,15 +133,6 @@ export class Ethereum {
         }
 
         return (await this._getAddress()).toLowerCase()
-    }
-
-    getSigner(): Signer {
-        if (!this._getSigner) {
-            // _getSigner is assigned in constructor
-            throw new Error("StreamrClient not authenticated! Can't send transactions or sign messages.")
-        }
-
-        return this._getSigner()
     }
 
     async getStreamRegistryChainSigner(): Promise<Signer> {

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -6,7 +6,6 @@ import { PublisherKeyExchange } from '../encryption/PublisherKeyExchange'
 import { StreamRegistryCached } from '../StreamRegistryCached'
 import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { EncryptionUtil } from '../encryption/EncryptionUtil'
-import { Ethereum } from '../Ethereum'
 
 @scoped(Lifecycle.ContainerScoped)
 export class Encrypt {
@@ -15,7 +14,6 @@ export class Encrypt {
     constructor(
         private streamRegistryCached: StreamRegistryCached,
         @inject(delay(() => PublisherKeyExchange)) private keyExchange: PublisherKeyExchange,
-        private ethereum: Ethereum,
     ) {
     }
 
@@ -24,10 +22,6 @@ export class Encrypt {
 
         if (StreamMessage.isEncrypted(streamMessage)) {
             // already encrypted
-            return
-        }
-
-        if (!this.ethereum.canEncrypt()) {
             return
         }
 

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -52,13 +52,11 @@ export class Encrypt {
             return
         }
 
-        const stream = await this.streamRegistryCached.getStream(streamId)
-
-        const [groupKey, nextGroupKey] = await this.keyExchange.useGroupKey(stream.id)
+        const [groupKey, nextGroupKey] = await this.keyExchange.useGroupKey(streamId)
         if (this.isStopped) { return }
 
         if (!groupKey) {
-            throw new Error(`Tried to use group key but no group key found for stream: ${stream.id}`)
+            throw new Error(`Tried to use group key but no group key found for stream: ${streamId}`)
         }
 
         EncryptionUtil.encryptStreamMessage(streamMessage, groupKey, nextGroupKey)

--- a/packages/client/src/publish/Encrypt.ts
+++ b/packages/client/src/publish/Encrypt.ts
@@ -31,16 +31,6 @@ export class Encrypt {
             return
         }
 
-        const { messageType } = streamMessage
-        if (
-            messageType === StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE
-            || messageType === StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
-            || messageType === StreamMessage.MESSAGE_TYPES.GROUP_KEY_ERROR_RESPONSE
-        ) {
-            // never encrypt
-            return
-        }
-
         if (streamMessage.messageType !== StreamMessage.MESSAGE_TYPES.MESSAGE) {
             return
         }


### PR DESCRIPTION
Removed redundant call to `streamRegistryCached#getStream` as the method already knows streamId.  The reason for the original call is unclear. If it was there to check the existence of the stream, it is maybe no longer needed here as the existence is implicitly checked when we query from `StreamRegistry` that the publisher has the publish permission.

Removed duplicate `messageType` check. We already have a guard `(messageType !== MESSAGE_TYPES.MESSAGE)`.

Removed redundant call to Ethereum#canEncrypt. In practice that returned false if user wasn't authenticated. The encryption logic doesn't need e.g. user's ethereum address, and therefore we don't need to check that here. We already use address in `MessageCreator:62`, and therefore publishing without authentication fails as expected.

Removed obsolete `Ethereum#getSigner` method. It was not called by any component (e.g. `Signer#getSigningFunction` could maybe call it, but it doesn't). The method `getStreamRegistryChainSigner` was not removed as it is used by `StreamRegistry`.