### PR TITLE
Signature handling with ethers library (poc)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25984,6 +25984,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
+                "@ethersproject/wallet": "^5.5.0",
                 "debug": "^4.3.2",
                 "heap": "^0.2.6",
                 "secp256k1": "^4.0.2",
@@ -26004,6 +26005,548 @@
                 "typedoc": "^0.22.5",
                 "typescript": "^4.5.2"
             }
+        },
+        "packages/protocol/node_modules/@ethersproject/abstract-provider": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
+            "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/networks": "^5.6.3",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/transactions": "^5.6.2",
+                "@ethersproject/web": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/abstract-signer": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
+            "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.6.1",
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/address": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+            "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/rlp": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/base64": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
+            "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/basex": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
+            "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/properties": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/bignumber": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
+            "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "bn.js": "^5.2.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/bytes": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+            "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/constants": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
+            "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bignumber": "^5.6.2"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/hash": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
+            "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.6.2",
+                "@ethersproject/address": "^5.6.1",
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/strings": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/hdnode": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
+            "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.6.2",
+                "@ethersproject/basex": "^5.6.1",
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/pbkdf2": "^5.6.1",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/sha2": "^5.6.1",
+                "@ethersproject/signing-key": "^5.6.2",
+                "@ethersproject/strings": "^5.6.1",
+                "@ethersproject/transactions": "^5.6.2",
+                "@ethersproject/wordlists": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/json-wallets": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
+            "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/abstract-signer": "^5.6.2",
+                "@ethersproject/address": "^5.6.1",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/hdnode": "^5.6.2",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/pbkdf2": "^5.6.1",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/random": "^5.6.1",
+                "@ethersproject/strings": "^5.6.1",
+                "@ethersproject/transactions": "^5.6.2",
+                "aes-js": "3.0.0",
+                "scrypt-js": "3.0.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/keccak256": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
+            "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "js-sha3": "0.8.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/logger": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+            "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ]
+        },
+        "packages/protocol/node_modules/@ethersproject/networks": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.3.tgz",
+            "integrity": "sha512-QZxRH7cA5Ut9TbXwZFiCyuPchdWi87ZtVNHWZd0R6YFgYtes2jQ3+bsslJ0WdyDe0i6QumqtoYqvY3rrQFRZOQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/pbkdf2": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
+            "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/sha2": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/properties": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
+            "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/random": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
+            "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/rlp": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
+            "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/sha2": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
+            "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "hash.js": "1.1.7"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/signing-key": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
+            "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "bn.js": "^5.2.1",
+                "elliptic": "6.5.4",
+                "hash.js": "1.1.7"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/strings": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
+            "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/constants": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/transactions": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
+            "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/address": "^5.6.1",
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/constants": "^5.6.1",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/rlp": "^5.6.1",
+                "@ethersproject/signing-key": "^5.6.2"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/wallet": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
+            "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/abstract-provider": "^5.6.1",
+                "@ethersproject/abstract-signer": "^5.6.2",
+                "@ethersproject/address": "^5.6.1",
+                "@ethersproject/bignumber": "^5.6.2",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/hash": "^5.6.1",
+                "@ethersproject/hdnode": "^5.6.2",
+                "@ethersproject/json-wallets": "^5.6.1",
+                "@ethersproject/keccak256": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/random": "^5.6.1",
+                "@ethersproject/signing-key": "^5.6.2",
+                "@ethersproject/transactions": "^5.6.2",
+                "@ethersproject/wordlists": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/web": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
+            "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/base64": "^5.6.1",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/strings": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/@ethersproject/wordlists": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
+            "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "dependencies": {
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/hash": "^5.6.1",
+                "@ethersproject/logger": "^5.6.0",
+                "@ethersproject/properties": "^5.6.0",
+                "@ethersproject/strings": "^5.6.1"
+            }
+        },
+        "packages/protocol/node_modules/bn.js": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "packages/test-utils": {
             "name": "streamr-test-utils",
@@ -41843,6 +42386,7 @@
             "version": "file:packages/protocol",
             "requires": {
                 "@ethersproject/hdnode": "^5.4.0",
+                "@ethersproject/wallet": "^5.5.0",
                 "@streamr/dev-config": "^1.0.0",
                 "@types/debug": "^4.1.7",
                 "@types/heap": "^0.2.28",
@@ -41860,6 +42404,300 @@
                 "ts-jest": "^27.0.5",
                 "typedoc": "^0.22.5",
                 "typescript": "^4.5.2"
+            },
+            "dependencies": {
+                "@ethersproject/abstract-provider": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
+                    "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/networks": "^5.6.3",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/transactions": "^5.6.2",
+                        "@ethersproject/web": "^5.6.1"
+                    }
+                },
+                "@ethersproject/abstract-signer": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
+                    "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+                    "requires": {
+                        "@ethersproject/abstract-provider": "^5.6.1",
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0"
+                    }
+                },
+                "@ethersproject/address": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+                    "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/keccak256": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/rlp": "^5.6.1"
+                    }
+                },
+                "@ethersproject/base64": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
+                    "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1"
+                    }
+                },
+                "@ethersproject/basex": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
+                    "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/properties": "^5.6.0"
+                    }
+                },
+                "@ethersproject/bignumber": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
+                    "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "bn.js": "^5.2.1"
+                    }
+                },
+                "@ethersproject/bytes": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+                    "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/constants": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
+                    "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+                    "requires": {
+                        "@ethersproject/bignumber": "^5.6.2"
+                    }
+                },
+                "@ethersproject/hash": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
+                    "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+                    "requires": {
+                        "@ethersproject/abstract-signer": "^5.6.2",
+                        "@ethersproject/address": "^5.6.1",
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/keccak256": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/strings": "^5.6.1"
+                    }
+                },
+                "@ethersproject/hdnode": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
+                    "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+                    "requires": {
+                        "@ethersproject/abstract-signer": "^5.6.2",
+                        "@ethersproject/basex": "^5.6.1",
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/pbkdf2": "^5.6.1",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/sha2": "^5.6.1",
+                        "@ethersproject/signing-key": "^5.6.2",
+                        "@ethersproject/strings": "^5.6.1",
+                        "@ethersproject/transactions": "^5.6.2",
+                        "@ethersproject/wordlists": "^5.6.1"
+                    }
+                },
+                "@ethersproject/json-wallets": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
+                    "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+                    "requires": {
+                        "@ethersproject/abstract-signer": "^5.6.2",
+                        "@ethersproject/address": "^5.6.1",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/hdnode": "^5.6.2",
+                        "@ethersproject/keccak256": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/pbkdf2": "^5.6.1",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/random": "^5.6.1",
+                        "@ethersproject/strings": "^5.6.1",
+                        "@ethersproject/transactions": "^5.6.2",
+                        "aes-js": "3.0.0",
+                        "scrypt-js": "3.0.1"
+                    }
+                },
+                "@ethersproject/keccak256": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
+                    "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "js-sha3": "0.8.0"
+                    }
+                },
+                "@ethersproject/logger": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+                    "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+                },
+                "@ethersproject/networks": {
+                    "version": "5.6.3",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.3.tgz",
+                    "integrity": "sha512-QZxRH7cA5Ut9TbXwZFiCyuPchdWi87ZtVNHWZd0R6YFgYtes2jQ3+bsslJ0WdyDe0i6QumqtoYqvY3rrQFRZOQ==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/pbkdf2": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
+                    "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/sha2": "^5.6.1"
+                    }
+                },
+                "@ethersproject/properties": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
+                    "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+                    "requires": {
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/random": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
+                    "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/rlp": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
+                    "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/sha2": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
+                    "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "hash.js": "1.1.7"
+                    }
+                },
+                "@ethersproject/signing-key": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
+                    "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "bn.js": "^5.2.1",
+                        "elliptic": "6.5.4",
+                        "hash.js": "1.1.7"
+                    }
+                },
+                "@ethersproject/strings": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
+                    "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/constants": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0"
+                    }
+                },
+                "@ethersproject/transactions": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
+                    "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+                    "requires": {
+                        "@ethersproject/address": "^5.6.1",
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/constants": "^5.6.1",
+                        "@ethersproject/keccak256": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/rlp": "^5.6.1",
+                        "@ethersproject/signing-key": "^5.6.2"
+                    }
+                },
+                "@ethersproject/wallet": {
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
+                    "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+                    "requires": {
+                        "@ethersproject/abstract-provider": "^5.6.1",
+                        "@ethersproject/abstract-signer": "^5.6.2",
+                        "@ethersproject/address": "^5.6.1",
+                        "@ethersproject/bignumber": "^5.6.2",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/hash": "^5.6.1",
+                        "@ethersproject/hdnode": "^5.6.2",
+                        "@ethersproject/json-wallets": "^5.6.1",
+                        "@ethersproject/keccak256": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/random": "^5.6.1",
+                        "@ethersproject/signing-key": "^5.6.2",
+                        "@ethersproject/transactions": "^5.6.2",
+                        "@ethersproject/wordlists": "^5.6.1"
+                    }
+                },
+                "@ethersproject/web": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
+                    "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+                    "requires": {
+                        "@ethersproject/base64": "^5.6.1",
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/strings": "^5.6.1"
+                    }
+                },
+                "@ethersproject/wordlists": {
+                    "version": "5.6.1",
+                    "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
+                    "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+                    "requires": {
+                        "@ethersproject/bytes": "^5.6.1",
+                        "@ethersproject/hash": "^5.6.1",
+                        "@ethersproject/logger": "^5.6.0",
+                        "@ethersproject/properties": "^5.6.0",
+                        "@ethersproject/strings": "^5.6.1"
+                    }
+                },
+                "bn.js": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+                    "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+                }
             }
         },
         "streamr-network": {

--- a/packages/client/src/publish/Signer.ts
+++ b/packages/client/src/publish/Signer.ts
@@ -2,13 +2,14 @@
  * StreamMessage Signing in-place.
  */
 import { inject, Lifecycle, scoped } from 'tsyringe'
-import { StreamMessage, StreamMessageSigned, SignatureType, SigningUtil } from 'streamr-client-protocol'
+import { StreamMessage, StreamMessageSigned, SignatureType } from 'streamr-client-protocol'
 import { Web3Provider } from '@ethersproject/providers'
 import { Bytes } from '@ethersproject/bytes'
 
 import { pLimitFn, wait } from '../utils'
 import type { AuthenticatedConfig } from '../Ethereum'
 import { ConfigInjectionToken } from '../Config'
+import { Wallet } from '@ethersproject/wallet'
 
 @scoped(Lifecycle.ContainerScoped)
 export class Signer {
@@ -20,7 +21,8 @@ export class Signer {
 
     private static getSigningFunction(options: AuthenticatedConfig): (d: string) => Promise<string> {
         if ('privateKey' in options && options.privateKey) {
-            return async (d: string) => SigningUtil.sign(d, options.privateKey)
+            const wallet = new Wallet(options.privateKey)
+            return async (d: string) => wallet.signMessage(d)
         }
 
         if ('ethereum' in options && options.ethereum) {

--- a/packages/client/src/publish/Signer.ts
+++ b/packages/client/src/publish/Signer.ts
@@ -20,11 +20,7 @@ export class Signer {
 
     private static getSigningFunction(options: AuthenticatedConfig): (d: string) => Promise<string> {
         if ('privateKey' in options && options.privateKey) {
-            const { privateKey } = options
-            const key = (typeof privateKey === 'string' && privateKey.startsWith('0x'))
-                ? privateKey.slice(2) // strip leading 0x
-                : privateKey
-            return async (d: string) => SigningUtil.sign(d, key.toString())
+            return async (d: string) => SigningUtil.sign(d, options.privateKey)
         }
 
         if ('ethereum' in options && options.ethereum) {

--- a/packages/client/test/test-utils/fake/fakePublisherNode.ts
+++ b/packages/client/test/test-utils/fake/fakePublisherNode.ts
@@ -39,7 +39,7 @@ const createGroupKeyErrorResponse = (
     errorCode: string,
     requestMessage: StreamMessage<GroupKeyRequestSerialized>,
     publisherWallet: Wallet,
-): StreamMessage<any> => {
+): Promise<StreamMessage<any>> => {
     const request = GroupKeyRequest.fromArray(requestMessage.getParsedContent())
     const { requestId, streamId, groupKeyIds } = request
     return createMockMessage({
@@ -72,7 +72,7 @@ export const addFakePublisherNode = async (
             const errorCode = getError(request)
             const response = (errorCode === undefined)
                 ? await createGroupKeySuccessResponse(request, groupKeys, publisherWallet, streamRegistry)
-                : createGroupKeyErrorResponse(errorCode, request, publisherWallet)
+                : await createGroupKeyErrorResponse(errorCode, request, publisherWallet)
             publisherNode.publishToNode(response)
         }
     })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -684,10 +684,10 @@ type CreateMockMessageOptionsBase = Omit<Partial<StreamMessageOptions<any>>, 'me
     encryptionKey?: GroupKey
 }
 
-export const createMockMessage = (  
+export const createMockMessage = async (  
     opts: CreateMockMessageOptionsBase 
     & ({ streamPartId: StreamPartID, stream?: never } | { stream: Stream, streamPartId?: never })
-): StreamMessage<any> => {
+): Promise<StreamMessage<any>> => {
     const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(
         opts.streamPartId ?? opts.stream.getStreamParts()[0]
     )
@@ -707,6 +707,6 @@ export const createMockMessage = (
     if (opts.encryptionKey !== undefined) {
         EncryptionUtil.encryptStreamMessage(msg, opts.encryptionKey)
     }
-    msg.signature = SigningUtil.sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), opts.publisher.privateKey)
+    msg.signature = await SigningUtil.sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), opts.publisher.privateKey)
     return msg
 }

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -45,7 +45,7 @@ describe('PublisherKeyExchange', () => {
         return stream
     }
 
-    const createGroupKeyRequest = (groupKeyId: string): StreamMessage => {
+    const createGroupKeyRequest = (groupKeyId: string): Promise<StreamMessage> => {
         return createMockMessage({
             streamPartId: KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address),
             publisher: subscriberWallet,
@@ -106,7 +106,7 @@ describe('PublisherKeyExchange', () => {
 
             const receivedResponses = subscriberNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
 
-            const request = createGroupKeyRequest(key.id)
+            const request = await createGroupKeyRequest(key.id)
             subscriberNode.publishToNode(request)
 
             const response = await nextValue(receivedResponses)
@@ -116,7 +116,7 @@ describe('PublisherKeyExchange', () => {
         it('no group key in store', async () => {
             const receivedResponses = subscriberNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
 
-            const request = createGroupKeyRequest(GroupKey.generate().id)
+            const request = await createGroupKeyRequest(GroupKey.generate().id)
             subscriberNode.publishToNode(request)
 
             const response = await nextValue(receivedResponses)
@@ -127,7 +127,7 @@ describe('PublisherKeyExchange', () => {
             const groupKey = GroupKey.generate()
             const receivedResponses = subscriberNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
 
-            const request: any = createGroupKeyRequest(groupKey.id)
+            const request: any = await createGroupKeyRequest(groupKey.id)
             delete request.signature
             subscriberNode.publishToNode(request)
 

--- a/packages/client/test/unit/Subscriber.test.ts
+++ b/packages/client/test/unit/Subscriber.test.ts
@@ -43,7 +43,7 @@ describe('Subscriber', () => {
         const sub = await subscriber.subscribe(stream.id)
 
         const publisherNode = addFakeNode(publisherWallet.address, dependencyContainer)
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publishToNode(await createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT
@@ -65,7 +65,7 @@ describe('Subscriber', () => {
         const subscriber = dependencyContainer.resolve(Subscriber)
         const sub = await subscriber.subscribe(stream.id)
 
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publishToNode(await createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT,
@@ -93,7 +93,7 @@ describe('Subscriber', () => {
         const onError = jest.fn()
         sub.on('error', onError)
 
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publishToNode(await createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT,

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@ethersproject/hdnode": "^5.4.0",
+    "@ethersproject/wallet": "^5.5.0",
     "debug": "^4.3.2",
     "heap": "^0.2.6",
     "secp256k1": "^4.0.2",

--- a/packages/protocol/src/utils/SigningUtil.ts
+++ b/packages/protocol/src/utils/SigningUtil.ts
@@ -1,70 +1,22 @@
-import secp256k1 from 'secp256k1'
-import { Keccak } from 'sha3'
+import { verifyMessage, Wallet  } from '@ethersproject/wallet'
 import { EthereumAddress } from './types'
 
-const SIGN_MAGIC = '\u0019Ethereum Signed Message:\n'
-const keccak = new Keccak(256)
-
-function hash(messageBuffer: Buffer) {
-    const prefixString = SIGN_MAGIC + messageBuffer.length
-    const merged = Buffer.concat([Buffer.from(prefixString, 'utf-8'), messageBuffer])
-    keccak.reset()
-    keccak.update(merged)
-    return keccak.digest('binary')
-}
-
-function recoverPublicKey(signatureBuffer: Buffer, payloadBuffer: Buffer) {
-    const recoveryId = signatureBuffer.readUInt8(signatureBuffer.length - 1) - 27
-    return secp256k1.ecdsaRecover(
-        signatureBuffer.subarray(0, signatureBuffer.length - 1),
-        recoveryId,
-        hash(payloadBuffer),
-        false,
-        Buffer.alloc,
-    )
-}
-
 export default class SigningUtil {
-    static sign(payload: string, privateKey: string): string {
-        const payloadBuffer = Buffer.from(payload, 'utf-8')
-        const privateKeyBuffer = Buffer.from(SigningUtil.normalize(privateKey), 'hex')
-
-        const msgHash = hash(payloadBuffer)
-        const sigObj = secp256k1.ecdsaSign(msgHash, privateKeyBuffer)
-        const result = Buffer.alloc(sigObj.signature.length + 1, Buffer.from(sigObj.signature))
-        result.writeInt8(27 + sigObj.recid, result.length - 1)
-        return '0x' + result.toString('hex')
-    }
-
-    static recover(
-        signature: string,
-        payload: string,
-        publicKeyBuffer: Buffer | Uint8Array | undefined = undefined
-    ): string {
-        const signatureBuffer = Buffer.from(SigningUtil.normalize(signature), 'hex') // remove '0x' prefix
-        const payloadBuffer = Buffer.from(payload, 'utf-8')
-
-        if (!publicKeyBuffer) {
-            // eslint-disable-next-line no-param-reassign
-            publicKeyBuffer = recoverPublicKey(signatureBuffer, payloadBuffer)
-        }
-        const pubKeyWithoutFirstByte = publicKeyBuffer.subarray(1, publicKeyBuffer.length)
-        keccak.reset()
-        keccak.update(Buffer.from(pubKeyWithoutFirstByte))
-        const hashOfPubKey = keccak.digest('binary')
-        return '0x' + hashOfPubKey.subarray(12, hashOfPubKey.length).toString('hex')
+    static async sign(payload: string, privateKey: string): Promise<string> {
+        // TODO calculating the wallet address may be slow?
+        // therefor users could instead call these directly:
+        // - create one Wallet instance
+        // - for each message call wallet.signMessage(payload)
+        //
+        return new Wallet(privateKey).signMessage(payload)
     }
 
     static verify(address: EthereumAddress, payload: string, signature: string): boolean {
         try {
-            const recoveredAddress = SigningUtil.recover(signature, payload)
+            const recoveredAddress = verifyMessage(payload, signature)
             return recoveredAddress.toLowerCase() === address.toLowerCase()
         } catch (err) {
             return false
         }
-    }
-
-    private static normalize(privateKeyOrAddress: string): string {
-        return privateKeyOrAddress.startsWith('0x') ? privateKeyOrAddress.substring(2) : privateKeyOrAddress
     }
 }

--- a/packages/protocol/test/unit/utils/SigningUtil.test.ts
+++ b/packages/protocol/test/unit/utils/SigningUtil.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 
 import SigningUtil from '../../../src/utils/SigningUtil'
 
-const privateKey = '23bead9b499af21c4c16e4511b3b6b08c3e22e76e0591f5ab5ba8d4c3a5b1820'
+const privateKey = '0x23bead9b499af21c4c16e4511b3b6b08c3e22e76e0591f5ab5ba8d4c3a5b1820'
 
 describe('SigningUtil', () => {
     describe('sign', () => {
@@ -12,11 +12,25 @@ describe('SigningUtil', () => {
             const signature = await SigningUtil.sign(payload, privateKey)
             assert.strictEqual(signature, '0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
         })
+
+        it('private key without prefix', async () => {
+            const payload = 'data-to-sign'
+            const signature = await SigningUtil.sign(payload, privateKey.substring(2))
+            assert.strictEqual(signature, '0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
+        })
     })
 
     describe('verify', () => {
         it('returns true on valid signature', async () => {
             const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
+            const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
+            const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
+            const isValid = SigningUtil.verify(address, payload, signature)
+            assert(isValid)
+        })
+
+        it('case insensitive address', async () => {
+            const address = '0x752c8dcac0788759acb1b4bb7a9103596bee3e6C'
             const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
             const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
             const isValid = SigningUtil.verify(address, payload, signature)

--- a/packages/protocol/test/unit/utils/SigningUtil.test.ts
+++ b/packages/protocol/test/unit/utils/SigningUtil.test.ts
@@ -9,40 +9,8 @@ describe('SigningUtil', () => {
     describe('sign', () => {
         it('produces correct signature', async () => {
             const payload = 'data-to-sign'
-            const signature = SigningUtil.sign(payload, privateKey)
+            const signature = await SigningUtil.sign(payload, privateKey)
             assert.strictEqual(signature, '0x787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b')
-        })
-    })
-
-    describe('recover', () => {
-        it('recovers correct address', async () => {
-            const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-            const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
-            const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = SigningUtil.recover(signature, payload)
-            assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
-        })
-
-        it('can handle missing 0x in signature', async () => {
-            const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-            const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
-            const signature = 'c97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = SigningUtil.recover(signature, payload)
-            assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
-        })
-
-        it('throws if the address can not be recovered (invalid signature)', async () => {
-            const payload = 'ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
-            const signature = '0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            expect(() => SigningUtil.recover(signature, payload)).toThrowError()
-        })
-
-        it('returns a different address if the content is tampered', async () => {
-            const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-            const payload = 'foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}'
-            const signature = '0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b'
-            const recoveredAddress = SigningUtil.recover(signature, payload)
-            assert.notStrictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
         })
     })
 

--- a/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
+++ b/packages/protocol/test/unit/utils/StreamMessageValidator.test.ts
@@ -57,8 +57,8 @@ describe('StreamMessageValidator', () => {
     }
 
     /* eslint-disable */
-    const sign = (msgToSign: StreamMessage, privateKey: string) => {
-        msgToSign.signature = SigningUtil.sign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
+    const sign = async (msgToSign: StreamMessage, privateKey: string) => {
+        msgToSign.signature = await SigningUtil.sign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
     }
     /* eslint-enable */
 
@@ -78,14 +78,14 @@ describe('StreamMessageValidator', () => {
             content: '{}',
         })
 
-        sign(msg, publisherPrivateKey)
+        await sign(msg, publisherPrivateKey)
 
         msgWithNewGroupKey = new StreamMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'),
             content: '{}',
             newGroupKey: new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex')
         })
-        sign(msgWithNewGroupKey, publisherPrivateKey)
+        await sign(msgWithNewGroupKey, publisherPrivateKey)
         assert.notStrictEqual(msg.signature, msgWithNewGroupKey.signature)
 
         groupKeyRequest = groupKeyMessageToStreamMessage(new GroupKeyRequest({
@@ -94,7 +94,7 @@ describe('StreamMessageValidator', () => {
             rsaPublicKey: 'rsaPublicKey',
             groupKeyIds: ['groupKeyId1', 'groupKeyId2'],
         }), new MessageID(toStreamID(`SYSTEM/keyexchange/${publisher.toLowerCase()}`), 0, 0, 0, subscriber, 'msgChainId'), null)
-        sign(groupKeyRequest, subscriberPrivateKey)
+        await sign(groupKeyRequest, subscriberPrivateKey)
 
         groupKeyResponse = groupKeyMessageToStreamMessage(new GroupKeyResponse({
             requestId: 'requestId',
@@ -104,7 +104,7 @@ describe('StreamMessageValidator', () => {
                 new EncryptedGroupKey('groupKeyId2', 'encryptedKey2')
             ],
         }), new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null)
-        sign(groupKeyResponse, publisherPrivateKey)
+        await sign(groupKeyResponse, publisherPrivateKey)
 
         groupKeyAnnounce = groupKeyMessageToStreamMessage(new GroupKeyAnnounce({
             streamId: toStreamID('streamId'),
@@ -113,7 +113,7 @@ describe('StreamMessageValidator', () => {
                 new EncryptedGroupKey('groupKeyId2', 'encryptedKey2')
             ],
         }), new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null)
-        sign(groupKeyAnnounce, publisherPrivateKey)
+        await sign(groupKeyAnnounce, publisherPrivateKey)
 
         groupKeyErrorResponse = groupKeyMessageToStreamMessage(new GroupKeyErrorResponse({
             requestId: 'requestId',
@@ -122,7 +122,7 @@ describe('StreamMessageValidator', () => {
             errorMessage: 'errorMessage',
             groupKeyIds: ['groupKeyId1', 'groupKeyId2'],
         }), new MessageID(toStreamID(`SYSTEM/keyexchange/${subscriber.toLowerCase()}`), 0, 0, 0, publisher, 'msgChainId'), null)
-        sign(groupKeyErrorResponse, publisherPrivateKey)
+        await sign(groupKeyErrorResponse, publisherPrivateKey)
     })
 
     describe('validate(unknown message type)', () => {


### PR DESCRIPTION
Maybe we could use `@ethersproject/wallet` library directly instead of `SigningUtils`.

The signature is a standard Ethereum signature (https://github.com/streamr-dev/streamr-specs/blob/master/PROTOCOL.md), which we could easily produce by calling `Wallet#signMessage`:
```
const privateKey = '0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709'
const custom = SigningUtil.sign(payload, privateKey.substring(2).toString())  // 0x084b3a...
const ethers = await (new Wallet(privateKey).signMessage(payload))  // 0x084b3a...
```
