### PR TITLE
test: Use fast wallet

### DIFF
--- a/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
@@ -5,7 +5,7 @@ import express, { Request, Response} from 'express'
 import { Logger } from 'streamr-network'
 import { Tracker } from '@streamr/network-tracker'
 import { Stream, StreamPermission, StreamrClient } from 'streamr-client'
-import { waitForCondition } from 'streamr-test-utils'
+import { fastWallet, waitForCondition } from 'streamr-test-utils'
 
 import { Broker } from '../../../../src/broker'
 import { createClient, createTestStream, startBroker, startTestTracker } from '../../../utils'
@@ -78,7 +78,7 @@ describe('BrubeckMinerPlugin', () => {
         rewardStreamId = rewardStream.id
         claimServer = new MockClaimServer()
         await claimServer.start()
-        brokerWallet = Wallet.createRandom()
+        brokerWallet = fastWallet()
         broker = await startBroker({
             privateKey: brokerWallet.privateKey,
             trackerPort: TRACKER_PORT,

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -1,11 +1,11 @@
 import { Tracker } from '@streamr/network-tracker'
 import { createClient, startTestTracker } from '../../../utils'
-import { Wallet } from 'ethers'
 import { SubscriberPlugin } from '../../../../src/plugins/subscriber/SubscriberPlugin'
 import StreamrClient from 'streamr-client'
+import { fastWallet } from 'streamr-test-utils'
 
 const TRACKER_PORT = 12465
-const wallet = Wallet.createRandom()
+const wallet = fastWallet()
 
 const createMockPlugin = async (streamrClient: StreamrClient) => {
     const brokerConfig: any = {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -37,13 +37,13 @@ describe('ConfigWizard', () => {
     describe('importPrivateKey validate', () => {
         it ('happy path, prefixed', () => {
             const validate = importPrivateKeyPrompt.validate!
-            const privateKey = fastPrivateKey()
+            const privateKey = `0x${fastPrivateKey()}`
             expect(validate(privateKey)).toBe(true)
         })
 
         it ('happy path, no prefix', () => {
             const validate = importPrivateKeyPrompt.validate!
-            const privateKey = fastPrivateKey().substring(2)
+            const privateKey = fastPrivateKey()
             expect(validate(privateKey)).toBe(true)
         })
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1,4 +1,3 @@
-import { Wallet } from 'ethers'
 import { mkdtempSync, existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
@@ -17,6 +16,7 @@ import {
 import { readFileSync } from 'fs'
 import { createBroker } from '../../src/broker'
 import { needsMigration } from '../../src/config/migration'
+import { fastPrivateKey } from 'streamr-test-utils'
 
 const MOCK_PRIVATE_KEY = '0x1234567890123456789012345678901234567890123456789012345678901234'
 
@@ -37,13 +37,13 @@ describe('ConfigWizard', () => {
     describe('importPrivateKey validate', () => {
         it ('happy path, prefixed', () => {
             const validate = importPrivateKeyPrompt.validate!
-            const privateKey = Wallet.createRandom().privateKey
+            const privateKey = fastPrivateKey()
             expect(validate(privateKey)).toBe(true)
         })
 
         it ('happy path, no prefix', () => {
             const validate = importPrivateKeyPrompt.validate!
-            const privateKey = Wallet.createRandom().privateKey.substring(2)
+            const privateKey = fastPrivateKey().substring(2)
             expect(validate(privateKey)).toBe(true)
         })
 
@@ -122,7 +122,7 @@ describe('ConfigWizard', () => {
         })
 
         it ('should exercise the `import` path', () => {
-            const importPrivateKey = Wallet.createRandom().privateKey
+            const importPrivateKey = fastPrivateKey()
             const answers: PrivateKeyAnswers = {
                 generateOrImportPrivateKey: 'Import',
                 importPrivateKey

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -5,7 +5,7 @@ import { ConfigTest } from '../../src/ConfigTest'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
-import { randomEthereumAddress } from 'streamr-test-utils'
+import { fastWallet, randomEthereumAddress } from 'streamr-test-utils'
 
 jest.setTimeout(40000)
 
@@ -17,7 +17,7 @@ describe('Stream permissions', () => {
 
     beforeAll(async () => {
         const wallet = new Wallet(await fetchPrivateKeyWithGas())
-        otherUser = Wallet.createRandom()
+        otherUser = fastWallet()
         client = new StreamrClient({
             ...ConfigTest,
             auth: {

--- a/packages/client/test/end-to-end/SearchStreams.test.ts
+++ b/packages/client/test/end-to-end/SearchStreams.test.ts
@@ -1,5 +1,4 @@
-import { Wallet } from 'ethers'
-import { randomEthereumAddress } from 'streamr-test-utils'
+import { fastWallet, randomEthereumAddress } from 'streamr-test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { PermissionAssignment, StreamPermission } from '../../src/permission'
@@ -20,7 +19,7 @@ describe('SearchStreams', () => {
     let streamWithPublicPermission: Stream
     let streamWithUserAndPublicPermission: Stream
     let streamWithGrantedAndRevokedPermission: Stream
-    const searcher = Wallet.createRandom()
+    const searcher = fastWallet()
 
     const createTestStreams = async (items: {
         streamId: string,

--- a/packages/client/test/end-to-end/client-behaviour-on-invalid-messages.test.ts
+++ b/packages/client/test/end-to-end/client-behaviour-on-invalid-messages.test.ts
@@ -4,10 +4,9 @@ import { ConfigTest } from '../../src/ConfigTest'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
 import { createTestStream, fetchPrivateKeyWithGas, getCreateClient } from '../test-utils/utils'
-import { fastPrivateKey, wait } from 'streamr-test-utils'
+import { fastPrivateKey, fastWallet, wait } from 'streamr-test-utils'
 import { MessageID, SigningUtil, StreamID, StreamMessage } from 'streamr-client-protocol'
 import { createNetworkNode, NetworkNode } from 'streamr-network'
-import { Wallet } from 'ethers'
 
 const createClient = getCreateClient()
 const TIMEOUT = 20 * 1000
@@ -80,7 +79,7 @@ describe('client behaviour on invalid message', () => {
             ...ConfigTest.network as any,
             id: 'networkNode',
         })
-        const publisherWallet = Wallet.createRandom()
+        const publisherWallet = fastWallet()
         const msg = new StreamMessage({
             messageId: new MessageID(streamId, 0, Date.now(), 0, publisherWallet.address, ''),
             prevMsgRef: null,

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -1,4 +1,4 @@
-import { waitForCondition } from 'streamr-test-utils'
+import { fastWallet, waitForCondition } from 'streamr-test-utils'
 import { createTestStream, fetchPrivateKeyWithGas } from '../test-utils/utils'
 import { ConfigTest, PermissionAssignment, Stream, StreamPermission, StreamrClient } from '../../src'
 import { createNetworkNode } from 'streamr-network'
@@ -56,7 +56,7 @@ describe('publish-subscribe', () => {
     let subscriberClient: StreamrClient
 
     beforeAll(async () => {
-        subscriberWallet = Wallet.createRandom()
+        subscriberWallet = fastWallet()
         publisherPk = await fetchPrivateKeyWithGas()
     })
 

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -20,6 +20,7 @@ import { addFakeNode, createFakeContainer } from '../test-utils/fake/fakeEnviron
 import { FakeBrubeckNode } from '../test-utils/fake/FakeBrubeckNode'
 import { createMockMessage } from '../test-utils/utils'
 import { nextValue } from '../../src/utils/iterators'
+import { fastWallet } from 'streamr-test-utils'
 
 describe('PublisherKeyExchange', () => {
 
@@ -80,8 +81,8 @@ describe('PublisherKeyExchange', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = Wallet.createRandom()
-        subscriberWallet = Wallet.createRandom()
+        publisherWallet = fastWallet()
+        subscriberWallet = fastWallet()
         subscriberRsaKeyPair = await RsaKeyPair.create()
         fakeContainer = createFakeContainer({
             auth: {

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -92,7 +92,7 @@ describe('PublisherKeyExchange', () => {
         mockStream = await createStream()
         subscriberNode = addFakeNode(subscriberWallet.address, fakeContainer)
         await startPublisherKeyExchangeSubscription()
-    }, 15 * 1000)
+    })
 
     describe('responds to a group key request', () => {
 

--- a/packages/client/test/unit/Subscriber.test.ts
+++ b/packages/client/test/unit/Subscriber.test.ts
@@ -10,7 +10,7 @@ import { StreamPermission } from '../../src'
 import { createMockMessage } from '../test-utils/utils'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { nextValue } from '../../src/utils/iterators'
-import { waitForCondition } from 'streamr-test-utils'
+import { fastWallet, waitForCondition } from 'streamr-test-utils'
 
 const MOCK_CONTENT = { foo: 'bar' }
 
@@ -22,8 +22,8 @@ describe('Subscriber', () => {
     let dependencyContainer: DependencyContainer
 
     beforeEach(async () => {
-        subscriberWallet = Wallet.createRandom()
-        publisherWallet = Wallet.createRandom()
+        subscriberWallet = fastWallet()
+        publisherWallet = fastWallet()
         dependencyContainer = createFakeContainer({
             auth: {
                 privateKey: subscriberWallet.privateKey

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -14,6 +14,7 @@ import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchang
 import { createFakeContainer } from '../test-utils/fake/fakeEnvironment'
 import { addFakePublisherNode } from '../test-utils/fake/fakePublisherNode'
 import { nextValue } from '../../src/utils/iterators'
+import { fastWallet } from 'streamr-test-utils'
 
 const AVAILABLE_GROUP_KEY = GroupKey.generate()
 
@@ -69,8 +70,8 @@ describe('SubscriberKeyExchange', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = Wallet.createRandom()
-        subscriberWallet = Wallet.createRandom()
+        publisherWallet = fastWallet()
+        subscriberWallet = fastWallet()
         fakeContainer = createFakeContainer({
             auth: {
                 privateKey: subscriberWallet.privateKey


### PR DESCRIPTION
Use `fastWallet` and `fastPrivateKey` in tests instead of Wallet.createRandom(). We don't need secure keys for test runs, and therefore `fastWallet()` is a lot faster than `Wallet.createRandom()`.