### PR TITLE
test(protocol): Signing benchmark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25991,6 +25991,7 @@
                 "strict-event-emitter-types": "^2.0.0"
             },
             "devDependencies": {
+                "@ethersproject/wallet": "^5.5.0",
                 "@streamr/dev-config": "^1.0.0",
                 "@types/debug": "^4.1.7",
                 "@types/heap": "^0.2.28",
@@ -41843,6 +41844,7 @@
             "version": "file:packages/protocol",
             "requires": {
                 "@ethersproject/hdnode": "^5.4.0",
+                "@ethersproject/wallet": "^5.5.0",
                 "@streamr/dev-config": "^1.0.0",
                 "@types/debug": "^4.1.7",
                 "@types/heap": "^0.2.28",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -26,6 +26,7 @@
   "author": "Streamr",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@ethersproject/wallet": "^5.5.0",
     "@streamr/dev-config": "^1.0.0",
     "@types/debug": "^4.1.7",
     "@types/heap": "^0.2.28",

--- a/packages/protocol/src/utils/SigningUtil.ts
+++ b/packages/protocol/src/utils/SigningUtil.ts
@@ -24,6 +24,17 @@ function recoverPublicKey(signatureBuffer: Buffer, payloadBuffer: Buffer) {
     )
 }
 
+/**
+ * Creates and verifies Ethereum signatures. This is a faster implementation 
+ * of standard Ethereum signing, and therefore compatible with 
+ * e.g. ether.js's verifyMessage and signMessage functions.
+ * 
+ * In Node environment the performance is significantly better compared 
+ * to ether.js v5.5.0.
+ * 
+ * See test/benchmark/SigningUtils.ts and the original PR:
+ * https://github.com/streamr-dev/streamr-client-protocol-js/pull/35
+ */
 export default class SigningUtil {
     static sign(payload: string, privateKey: string): string {
         const payloadBuffer = Buffer.from(payload, 'utf-8')

--- a/packages/protocol/src/utils/SigningUtil.ts
+++ b/packages/protocol/src/utils/SigningUtil.ts
@@ -25,9 +25,9 @@ function recoverPublicKey(signatureBuffer: Buffer, payloadBuffer: Buffer) {
 }
 
 /**
- * Creates and verifies Ethereum signatures. This is a faster implementation 
- * of standard Ethereum signing, and therefore compatible with 
- * e.g. ether.js's verifyMessage and signMessage functions.
+ * Creates and verifies standard Ethereum signatures. This is a faster 
+ * implementation than found in ether.js library. It is compatible
+ * with e.g. ether.js's verifyMessage and signMessage functions.
  * 
  * In Node environment the performance is significantly better compared 
  * to ether.js v5.5.0.

--- a/packages/protocol/test/benchmark/SigningUtil.test.ts
+++ b/packages/protocol/test/benchmark/SigningUtil.test.ts
@@ -1,0 +1,114 @@
+import { verifyMessage, Wallet } from '@ethersproject/wallet'
+import SigningUtil from '../../src/utils/SigningUtil'
+
+/*
+ * Benchmarking SigningUtil against ether.js implementation. This test is skipped
+ * because we don't need to run this in CI. It is reasonable to run this
+ * test e.g. when ethers.js releases a new major version. (If that version
+ * provides equal performance compared to our implementation we could start to
+ * use it.)
+ * 
+ * Compared to ethers v5.5.0 typical test results are:
+ * 
+ * Payload size 100 bytes:
+ * - sign: ~400x faster
+ * - verify: ~1600x faster
+ * 
+ * Payload size 10000 bytes:
+ * - sign: ~50x faster
+ * - verify: ~150x faster
+ */
+
+// From: https://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
+function randomString(
+    length: number,
+    chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+): string {
+    let result = ''
+    for (let i = length; i > 0; --i) {
+        result += chars[Math.floor(Math.random() * chars.length)]
+    }
+    return result
+}
+
+const ITERATIONS = 1000
+const PAYLOAD_SIZES = [100, 10000]
+
+describe.skip('SigningUtil', () => {
+    
+    describe.each(PAYLOAD_SIZES)('payload size: %s', (payloadSize: number) => {
+
+        let wallet: Wallet
+        let signature: string
+        let payload: string
+
+        beforeEach(async () => {
+            wallet = Wallet.createRandom()
+            payload = randomString(payloadSize)
+            signature = await wallet.signMessage(payload)
+        })
+
+        const run = async <T>(
+            functionToTest: () => Promise<T>,
+            expectedResult: T,
+            name: string
+        ): Promise<number> => {
+            const start = Date.now()
+        
+            let resultString = `${name} payloadSize=${payloadSize}\n`
+        
+            for (let i = 0; i < ITERATIONS; i++) {
+                const result = await functionToTest()
+                if (result !== expectedResult) {
+                    throw new Error(`invalid result in ${name}`)
+                }
+            }
+        
+            const elapsed = Date.now() - start
+        
+            resultString += `Execution time: ${elapsed} ms\n`
+            resultString += `Iterations: ${ITERATIONS}\n`
+            resultString += `Iterations / second: ${ITERATIONS / (elapsed / 1000)}\n`
+            const used: any = process.memoryUsage()
+            Object.keys(used).forEach((key) => {
+                resultString += `${key} ${Math.round((used[key] as number) / 1024 / 1024 * 100) / 100} MB\n`
+            })
+            console.info(resultString)
+            return elapsed
+        }
+        
+        it('sign', async () => {
+    
+            const elapsedTimeOur = await run(async () => {
+                return SigningUtil.sign(payload, wallet.privateKey)
+            }, signature, 'Sign-our')
+    
+            const elapsedTimeEthers = await run(async () => {
+                return await wallet.signMessage(payload)
+            }, signature, 'Sign-ethers.js')
+    
+            expect(elapsedTimeOur).toBeLessThan(elapsedTimeEthers)
+    
+            console.info(`Sign payloadSize=${payloadSize} is ${elapsedTimeEthers/elapsedTimeOur}x faster`)
+    
+        })
+    
+        it('verify', async () => {
+    
+            const elapsedTimeOur = await run(async () => {
+                return SigningUtil.verify(wallet.address, payload, signature)
+            }, true, 'Verify-our')
+    
+            const elapsedTimeEthers = await run(async () => {
+                return verifyMessage(payload, signature).toLowerCase() === wallet.address.toLowerCase()
+            }, true, 'Verify-ethers.js')
+    
+            expect(elapsedTimeOur).toBeLessThan(elapsedTimeEthers)
+            
+            console.info(`Verify payloadSize=${payloadSize} is ${elapsedTimeEthers/elapsedTimeOur}x faster`)
+            
+        })
+    
+    })
+
+})


### PR DESCRIPTION
Added a benchmark test which compares the performance of `SigningUtils` against ethers.js implementation. Also documented `SigningUtils`.

The test is based on these PRs:
- https://github.com/streamr-dev/streamr-client-protocol-js/pull/35
- https://github.com/streamr-dev/network-monorepo/pull/390