### PR TITLE
refactor(client): Simplify publisher

### DIFF
--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -91,24 +91,6 @@ export class Publisher implements Context {
         }
     }
 
-    async* publishFromMetadata<T>(
-        streamDefinition: StreamDefinition, 
-        seq: AsyncIterable<PublishMetadata<T>>
-    ): AsyncGenerator<StreamMessage<T>, void, unknown> {
-        const items = CancelableGenerator(seq)
-        this.inProgress.add(items)
-        try {
-            for await (const msg of items) {
-                yield await this.publish(streamDefinition, msg.content, {
-                    timestamp: msg.timestamp,
-                    partitionKey: msg.partitionKey
-                })
-            }
-        } finally {
-            this.inProgress.delete(items)
-        }
-    }
-
     async start(): Promise<void> {
         this.pipeline.start()
     }

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -6,7 +6,6 @@ import { scoped, Lifecycle } from 'tsyringe'
 
 import { instanceId } from '../utils/utils'
 import { Context } from '../utils/Context'
-import { CancelableGenerator, ICancelable } from '../utils/iterators'
 
 import { MessageMetadata, PublishMetadata, PublishPipeline } from './PublishPipeline'
 import { StreamDefinition } from '../types'
@@ -25,7 +24,6 @@ const parseTimestamp = (metadata?: MessageMetadata): number => {
 export class Publisher implements Context {
     readonly id
     readonly debug
-    private inProgress = new Set<ICancelable>()
 
     constructor(
         context: Context,
@@ -47,58 +45,11 @@ export class Publisher implements Context {
         })
     }
 
-    async collect<T>(target: AsyncIterable<StreamMessage<T>>, n?: number): Promise<T[]> { // eslint-disable-line class-methods-use-this
-        const msgs = []
-        for await (const msg of target) {
-            if (n === 0) {
-                break
-            }
-
-            msgs.push(msg.getParsedContent())
-            if (msgs.length === n) {
-                break
-            }
-        }
-
-        return msgs
-    }
-
-    async collectMessages<T>(target: AsyncIterable<T>, n?: number): Promise<Awaited<T>[]> { // eslint-disable-line class-methods-use-this
-        const msgs = []
-        for await (const msg of target) {
-            if (n === 0) {
-                break
-            }
-
-            msgs.push(msg)
-            if (msgs.length === n) {
-                break
-            }
-        }
-
-        return msgs
-    }
-
-    async* publishFrom<T>(streamDefinition: StreamDefinition, seq: AsyncIterable<T>): AsyncGenerator<StreamMessage<T>, void, unknown> {
-        const items = CancelableGenerator(seq)
-        this.inProgress.add(items)
-        try {
-            for await (const msg of items) {
-                yield await this.publish(streamDefinition, msg)
-            }
-        } finally {
-            this.inProgress.delete(items)
-        }
-    }
-
     async start(): Promise<void> {
         this.pipeline.start()
     }
 
     async stop(): Promise<void> {
-        await Promise.allSettled([
-            this.pipeline.stop(),
-            ...[...this.inProgress].map((item) => item.cancel().catch(() => {}))
-        ])
+        return this.pipeline.stop()
     }
 }

--- a/packages/client/test/end-to-end/Basics.test.ts
+++ b/packages/client/test/end-to-end/Basics.test.ts
@@ -1,10 +1,11 @@
 import { wait } from 'streamr-test-utils'
 
-import { getCreateClient, Msg, publishManyGenerator, uid } from '../test-utils/utils'
+import { getCreateClient, Msg, publishManyGenerator, uid, publishFromMetadata } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src'
+import { collect } from '../../src/utils/GeneratorUtils'
 
 const TEST_TIMEOUT = 60 * 1000
 
@@ -80,10 +81,8 @@ describe('StreamrClient', () => {
                 streamId: stream.id,
             })
             const source = publishManyGenerator(MAX_MESSAGES, { timestamp: 1111111 })
-            // @ts-expect-error private
-            const publish = client.publisher.publishFromMetadata(stream, source)
-            // @ts-expect-error private
-            const published = await client.publisher.collectMessages(publish, MAX_MESSAGES)
+            const publish = publishFromMetadata(stream, source, client)
+            const published = await collect(publish, MAX_MESSAGES)
             const received = []
             for await (const msg of sub) {
                 received.push(msg)
@@ -102,10 +101,8 @@ describe('StreamrClient', () => {
                     streamId: testStream.id,
                 })
                 const source = publishManyGenerator(MAX_MESSAGES, { timestamp: 1111111 })
-                // @ts-expect-error private
-                const publish = client.publisher.publishFromMetadata(testStream, source)
-                // @ts-expect-error private
-                const published = await client.publisher.collectMessages(publish, MAX_MESSAGES)
+                const publish = publishFromMetadata(testStream, source, client)
+                const published = await collect(publish, MAX_MESSAGES)
                 const received = []
                 for await (const msg of sub) {
                     received.push(msg)


### PR DESCRIPTION
Refactored `Publisher` class. 
- moved method `publishFromMetadata` to `test-utils/utils.ts` as it is only used in tests
- removed methods:
  - `publishFrom` and `collect`: not used by any component 
  - `collectMessages`: used in tests, but can use `collect` from `GeneratorUtils.ts` instead