### PR TITLE
fix(client): Test environment sidechain id

### DIFF
--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -6,7 +6,7 @@ function toNumber(value: any): number | undefined {
 
 const sideChainConfig = {
     name: 'streamr',
-    chainId: 8995,
+    chainId: 8997,
     rpcs: [{
         url: process.env.SIDECHAIN_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST || '10.200.10.1'}:8546`,
         timeout: toNumber(process.env.TEST_TIMEOUT) ?? 30 * 1000,


### PR DESCRIPTION
Updated sidechain id to 8997, see https://github.com/streamr-dev/network-contracts/blob/8b50f04f39ebe2873eda6a4bb012da6d199dfe69/packages/config/src/networks.json#L31.

We should maybe also update `streamr-docker-dev` README (https://github.com/streamr-dev/streamr-docker-dev/blob/3a8e652413155963448f24c2868eb8b19fe06f70/README.md#interacting-with-the-local-blockchain). If a user wants to create streams in docker dev environment, chainId 8997 and RPC url at port 8546 must be used.