### PR TITLE
fix(client): Remove duplicate handling of `newGroupKey`

### DIFF
--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -70,13 +70,6 @@ export class EncryptionUtil {
         /* eslint-disable no-param-reassign */
         streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
         streamMessage.groupKeyId = groupKey.id
-
-        if (nextGroupKey) {
-            GroupKey.validate(nextGroupKey)
-            // @ts-expect-error expecting EncryptedGroupKey
-            streamMessage.newGroupKey = nextGroupKey
-        }
-
         streamMessage.serializedContent = this.encrypt(Buffer.from(streamMessage.getSerializedContent(), 'utf8'), groupKey)
         if (nextGroupKey) {
             GroupKey.validate(nextGroupKey)


### PR DESCRIPTION
`EnrcryptionUtils#encryptStreamMessage` has the following implementation:
```ts
...
if (nextGroupKey) {
    GroupKey.validate(nextGroupKey)
    // @ts-expect-error expecting EncryptedGroupKey
    streamMessage.newGroupKey = nextGroupKey
}
streamMessage.serializedContent = this.encrypt(Buffer.from(streamMessage.getSerializedContent(), 'utf8'), groupKey)
if (nextGroupKey) {
    GroupKey.validate(nextGroupKey)
    streamMessage.newGroupKey = new EncryptedGroupKey(nextGroupKey.id, this.encrypt(nextGroupKey.data, groupKey))
}
...
```

The should be no need for the first `if`-block. Currently we:
- do `GroupKey.validate(nextGroupKey)` twice
- set `streamMessage.newGroupKey`, and then overwrite it with the new value (the value is not used in the line which does `streamMessage.serializedContent = ...`)

The duplicated process was introduced in this commit:
https://github.com/streamr-dev/streamr-client-javascript/commit/14e0a57f3297686d35447c990574ac1555d04d9f