### PR TITLE
fix(client): Validation of `nextGroupKey` in encryption

### DIFF
--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -67,12 +67,14 @@ export class EncryptionUtil {
      */
     static encryptStreamMessage(streamMessage: StreamMessage, groupKey: GroupKey, nextGroupKey?: GroupKey): void {
         GroupKey.validate(groupKey)
+        if (nextGroupKey) {
+            GroupKey.validate(nextGroupKey)
+        }
         /* eslint-disable no-param-reassign */
         streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
         streamMessage.groupKeyId = groupKey.id
         streamMessage.serializedContent = this.encrypt(Buffer.from(streamMessage.getSerializedContent(), 'utf8'), groupKey)
         if (nextGroupKey) {
-            GroupKey.validate(nextGroupKey)
             streamMessage.newGroupKey = new EncryptedGroupKey(nextGroupKey.id, this.encrypt(nextGroupKey.data, groupKey))
         }
         streamMessage.parsedContent = undefined


### PR DESCRIPTION
Group keys are validated before any `StreamMessage` properties are modified. That way the object is not modified if the validation fails.

This improvement was suggested in the previous PR: https://github.com/streamr-dev/network-monorepo/pull/738#pullrequestreview-1014866012

- [x] Has passing tests that demonstrate this change works