### PR TITLE
refactor(client): Remove `onDestroy` cache clearing

### DIFF
--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -104,7 +104,6 @@ export class Validator extends StreamMessageValidator implements Context {
 
     stop(): void {
         this.isStopped = true
-        this.cachedVerify.clear()
         this.orderedValidate.clear()
     }
 }

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -28,7 +28,7 @@ export class GroupKeyStoreFactory implements Context {
     readonly debug
     private cleanupFns: ((...args: any[]) => any)[] = []
     private initialGroupKeys: Record<string, GroupKeysSerialized>
-    public getStore: ((streamId: StreamID) => Promise<GroupKeyStore>) & { clear(): void }
+    public getStore: ((streamId: StreamID) => Promise<GroupKeyStore>)
 
     constructor(
         context: Context,
@@ -72,7 +72,6 @@ export class GroupKeyStoreFactory implements Context {
     }
 
     async stop(): Promise<void> {
-        this.getStore.clear()
         const { cleanupFns } = this
         this.cleanupFns = []
         await Promise.allSettled(cleanupFns)

--- a/packages/client/src/publish/MessageChain.ts
+++ b/packages/client/src/publish/MessageChain.ts
@@ -20,7 +20,6 @@ export type MessageChainOptions = {
 
 export function getCachedMessageChain(cacheConfig: CacheConfig):
     ((streamPartId: StreamPartID, msgChainOptions: MessageChainOptions) => MessageChain) & {
-    clear: () => void,
     clearMatching: (matchFn: (key: string) => boolean) => void
 } {
     // one chainer per streamId + streamPartition + publisherId + msgChainId

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -83,7 +83,6 @@ export class MessageCreator {
     }
 
     async stop(): Promise<void> {
-        this.streamPartitioner.clear()
         this.queue.clear()
         this.getMsgChain.clear()
     }

--- a/packages/client/src/publish/MessageCreator.ts
+++ b/packages/client/src/publish/MessageCreator.ts
@@ -84,6 +84,5 @@ export class MessageCreator {
 
     async stop(): Promise<void> {
         this.queue.clear()
-        this.getMsgChain.clear()
     }
 }

--- a/packages/client/src/publish/StreamPartitioner.ts
+++ b/packages/client/src/publish/StreamPartitioner.ts
@@ -32,10 +32,6 @@ export class StreamPartitioner {
         return this.computeStreamPartition(stream.id, stream.partitions, partitionKey)
     }
 
-    public clear(): void {
-        this.computeStreamPartition.clear()
-    }
-
     protected computeStreamPartition = CacheFn((_streamId: StreamID, partitionCount: number, partitionKey: PartitionKey) => {
         if (!(Number.isSafeInteger(partitionCount) && partitionCount > 0)) {
             throw new Error(`partitionCount is not a safe positive integer! ${partitionCount}`)

--- a/packages/client/src/registry/StreamRegistryCached.ts
+++ b/packages/client/src/registry/StreamRegistryCached.ts
@@ -84,14 +84,4 @@ export class StreamRegistryCached implements Context {
         this.isStreamPublisher.clearMatching(matchTarget)
         this.isStreamSubscriber.clearMatching(matchTarget)
     }
-
-    /**
-     * Clear all cached data
-     */
-    clear(): void {
-        this.debug('clear')
-        this.getStream.clear()
-        this.isStreamPublisher.clear()
-        this.isStreamSubscriber.clear()
-    }
 }

--- a/packages/client/src/utils/caches.ts
+++ b/packages/client/src/utils/caches.ts
@@ -41,7 +41,7 @@ export function CacheAsyncFn<ArgsType extends any[], ReturnType, KeyType = ArgsT
     cachePromiseRejection?: boolean
     onEviction?: (...args: any[]) => void
     cacheKey?: (args: ArgsType) => KeyType
-} = {}): ((...args: ArgsType) => Promise<ReturnType>) & { clear: () => void; clearMatching: (matchFn: (key: KeyType) => boolean) => void } {
+} = {}): ((...args: ArgsType) => Promise<ReturnType>) & { clearMatching: (matchFn: (key: KeyType) => boolean) => void } {
     const cache = new LRU<KeyType, { data: ReturnType, maxAge: number }>({
         maxSize,
         maxAge,
@@ -54,10 +54,6 @@ export function CacheAsyncFn<ArgsType extends any[], ReturnType, KeyType = ArgsT
         cacheKey,
         ...opts,
     }), {
-        clear: () => {
-            pMemoize.clear(cachedFn as any)
-            cache.clear()
-        },
         clearMatching: (matchFn: ((key: KeyType) => boolean)) => clearMatching(cache, matchFn),
     })
 
@@ -89,7 +85,7 @@ export function CacheFn<ArgsType extends any[], ReturnType, KeyType = ArgsType[0
     maxAge?: number
     onEviction?: (...args: any[]) => void
     cacheKey?: (args: ArgsType) => KeyType
-} = {}): ((...args: ArgsType) => ReturnType) & { clear: () => void; clearMatching: (matchFn: (key: KeyType) => boolean) => void } {
+} = {}): ((...args: ArgsType) => ReturnType) & { clearMatching: (matchFn: (key: KeyType) => boolean) => void } {
     const cache = new LRU<KeyType, { data: ReturnType, maxAge: number }>({
         maxSize,
         maxAge,
@@ -101,10 +97,6 @@ export function CacheFn<ArgsType extends any[], ReturnType, KeyType = ArgsType[0
         cacheKey,
         ...opts,
     }), {
-        clear: () => {
-            mem.clear(cachedFn as any)
-            cache.clear()
-        },
         clearMatching: (matchFn: ((key: KeyType) => boolean)) => clearMatching(cache, matchFn),
     })
 

--- a/packages/client/test/integration/Partitions.test.ts
+++ b/packages/client/test/integration/Partitions.test.ts
@@ -38,25 +38,22 @@ describe('Partition', () => {
 
     it('publishing to different streams should get different random partitions', async () => {
         const NUM_PARTITIONS = 3
-        const partitionStream = await createStream({
+        const stream1 = await createStream({
             partitions: NUM_PARTITIONS
         })
-        const partitionStream2 = await createStream({
-            partitions: NUM_PARTITIONS
-        })
-
-        const publishTestStreamMessages = getPublishTestStreamMessages(client, partitionStream)
-        const publishTestStreamMessages2 = getPublishTestStreamMessages(client, partitionStream2)
+        const publishTestStreamMessages = getPublishTestStreamMessages(client, stream1)
+        const published1 = await publishTestStreamMessages(1)
+        const foundPartition1 = published1[0].getStreamPartition()
 
         // publishing to different streams should get different random partitions
         let gotDifferentPartitions = false
         for (let i = 0; i < 100; i++) {
+            const stream2 = await createStream({
+                partitions: NUM_PARTITIONS
+            })
+            const publishTestStreamMessages2 = getPublishTestStreamMessages(client, stream2)
             // eslint-disable-next-line no-await-in-loop
-            const [published1, published2] = await Promise.all([
-                publishTestStreamMessages(1),
-                publishTestStreamMessages2(1)
-            ])
-            const foundPartition1 = published1[0].getStreamPartition()
+            const published2 = await publishTestStreamMessages2(1)
             const foundPartition2 = published2[0].getStreamPartition()
             if (foundPartition1 !== foundPartition2) {
                 gotDifferentPartitions = true

--- a/packages/client/test/integration/Partitions.test.ts
+++ b/packages/client/test/integration/Partitions.test.ts
@@ -34,25 +34,6 @@ describe('Partition', () => {
         // should use same partition
         expect(published1.map((s) => s.getStreamPartition())).toEqual(published1.map(() => selectedPartition))
         expect(published2.map((s) => s.getStreamPartition())).toEqual(published1.map(() => selectedPartition))
-
-        // clear message creator cache and retry should get another
-        // partition unless we're really unlucky and get 100 of the
-        // same partition in a row.
-        const foundPartitions: boolean[] = Array(NUM_PARTITIONS).fill(false)
-        for (let i = 0; i < 100; i++) {
-            // @ts-expect-error private
-            client.publisher.pipeline.messageCreator.streamPartitioner.clear()
-            // eslint-disable-next-line no-await-in-loop
-            const published3 = await publishTestStreamMessages(1)
-            expect(published3).toHaveLength(1)
-            const foundPartition = published3[0].getStreamPartition()
-            foundPartitions[foundPartition] = true
-            if (foundPartitions.every((v) => v)) {
-                break
-            }
-        }
-
-        expect(foundPartitions).toEqual(Array(NUM_PARTITIONS).fill(true))
     })
 
     it('publishing to different streams should get different random partitions', async () => {
@@ -68,11 +49,8 @@ describe('Partition', () => {
         const publishTestStreamMessages2 = getPublishTestStreamMessages(client, partitionStream2)
 
         // publishing to different streams should get different random partitions
-        // clear message creator cache and retry should get another
         let gotDifferentPartitions = false
         for (let i = 0; i < 100; i++) {
-            // @ts-expect-error private
-            client.publisher.pipeline.messageCreator.streamPartitioner.clear()
             // eslint-disable-next-line no-await-in-loop
             const [published1, published2] = await Promise.all([
                 publishTestStreamMessages(1),
@@ -130,12 +108,9 @@ describe('Partition', () => {
 
         // publish many times with same key
         // should always be the same
-        // even if cache is cleared
         const targetPartition = published[0].getStreamPartition()
         const foundPartitions: number[] = []
         for (let i = 0; i < 50; i++) {
-            // @ts-expect-error private
-            client.publisher.pipeline.messageCreator.streamPartitioner.clear()
             // eslint-disable-next-line no-await-in-loop
             const published2 = await publishTestStreamMessages(1, {
                 partitionKey,

--- a/packages/client/test/unit/MessageCreator.test.ts
+++ b/packages/client/test/unit/MessageCreator.test.ts
@@ -13,7 +13,7 @@ const MOCK_USER_ADDRESS = '0xAbcdeabCDE123456789012345678901234567890'
 describe('MessageCreator', () => {
 
     let creator: MessageCreator
-    let streamPartitioner: Pick<StreamPartitioner, 'compute' | 'clear'>
+    let streamPartitioner: Pick<StreamPartitioner, 'compute'>
 
     const createMockMessage = async (
         opts: Omit<MessageCreateOptions<any>, 'content' | 'timestamp'> = {}
@@ -27,8 +27,7 @@ describe('MessageCreator', () => {
 
     beforeEach(() => {
         streamPartitioner = {
-            compute: jest.fn().mockResolvedValue(MOCK_STREAM_PARTITION),
-            clear: () => {}
+            compute: jest.fn().mockResolvedValue(MOCK_STREAM_PARTITION)
         }
         const authentication: Pick<Authentication, 'getAddress'> = {
             getAddress: async (): Promise<EthereumAddress> => {

--- a/packages/client/test/unit/promises.test.ts
+++ b/packages/client/test/unit/promises.test.ts
@@ -154,17 +154,16 @@ describe('CacheAsyncFn', () => {
         expect(fn).toHaveBeenCalledTimes(2)
         await cachedFn(2)
         expect(fn).toHaveBeenCalledTimes(3)
-        cachedFn.clear()
+        await cachedFn(1)
+        expect(fn).toHaveBeenCalledTimes(3)
+        await cachedFn(2)
+        expect(fn).toHaveBeenCalledTimes(3)
+        cachedFn.clearMatching((v) => v === 1)
         await cachedFn(1)
         expect(fn).toHaveBeenCalledTimes(4)
-        await cachedFn(2)
+        cachedFn.clearMatching((v) => v === 1)
+        await cachedFn(1)
         expect(fn).toHaveBeenCalledTimes(5)
-        cachedFn.clearMatching((v) => v === 1)
-        await cachedFn(1)
-        expect(fn).toHaveBeenCalledTimes(6)
-        cachedFn.clearMatching((v) => v === 1)
-        await cachedFn(1)
-        expect(fn).toHaveBeenCalledTimes(7)
     })
 
     it('adopts type of wrapped function', async () => {
@@ -188,8 +187,6 @@ describe('CacheAsyncFn', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = await cachedFn('abc')
         expect(c).toEqual(3)
-        const d = cachedFn.clear()
-        expect(d).toBe(undefined)
         cachedFn.clearMatching((_d: string) => true)
         // @ts-expect-error wrong match argument type
         cachedFn.clearMatching((_d: number) => true)
@@ -302,8 +299,6 @@ describe('cacheFn', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = cachedFn('abc')
         expect(c).toEqual(3)
-        const d = cachedFn.clear()
-        expect(d).toBe(undefined)
         cachedFn.clearMatching((_d: string) => true)
         // @ts-expect-error wrong match argument type
         cachedFn.clearMatching((_d: number) => true)


### PR DESCRIPTION
When `client.destroy()` is called, it cleans up many resources. As it is not allowed to interact with the client after `destroy()` call, it is very likely that the `StreamrClient` will be garbage collected from memory very soon after the call (if the application doesn't keep a reference to it). Therefore it is not necessary need to explicitly clean up some of the memory resources which `StreamrClient` has allocated.

In this PR we removed cache clearing functionality which was triggered via `client.destroy()`.

Before this PR there were explicit cache clearing for these methods:
- `MessageCreator#getMsgChain`
- `StreamPartitioner#computeStreamPartition`
- `Validator#cachedVerify`
- `GroupKeyStoreFactory.getStore`

There was also a `StreamRegistryCached#clear` method, which was not called by any component (all callers used `StreamRegistryCached#clearStream`)

### Future improvements

- Each component could listen `destroySignal` independently, and clean up timers/promises it allocated. Currently it is typical that an external component calls a `stop()` method of a component to trigger the cleanup.
- We could rename all `stop()` methods to `destroy()`
- We could convert **test/integration/Partitions.test.ts** to unit test