### PR TITLE
fix(client): Key exchange stream permissions

### DIFF
--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -184,10 +184,19 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     async isStreamPublisher(streamIdOrPath: string, user: EthereumAddress): Promise<boolean> {
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
+            return true
+        }
         return this.hasPermission({ streamId: streamIdOrPath, user, permission: StreamPermission.PUBLISH, allowPublic: true })
     }
 
     async isStreamSubscriber(streamIdOrPath: string, user: EthereumAddress): Promise<boolean> {
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
+            const recipient = KeyExchangeStreamIDUtils.getRecipient(streamId)
+            return user.toLowerCase() === recipient!.toLowerCase()
+        }
         return this.hasPermission({ streamId: streamIdOrPath, user, permission: StreamPermission.SUBSCRIBE, allowPublic: true })
     }
 


### PR DESCRIPTION
Updated `StreamRegistry` to handle queries about key exchange streams. 

There was already a handler `getStream`, and in this PR we added support for `isStreamPublisher`, `isStreamSubscriber`, `getStreamPublishers` and `getStreamSubscribers`.

- all users can publish to all key exchange streams (to send a `GroupKeyRequest` or a `GroupKeyResponse`)
- only recipient of a key exchange stream can publish to a key exchange stream (to receive a `GroupKeyRequest` or a `GroupKeyResponse`) 
- `getStreamPublishers` and `getStreamSubscribers` throw an error because it is impossible to return a valid response for `getStreamSubscribers` query (it should return all possible user addresses)
  - `getStreamPublishers` could return the only address, but as that kind of query is not relevant to make. Therefore it is possible to throw an error also in this case. Maybe this unified behavior between the two methods is better?

- [x] Has passing tests that demonstrate this change works
