### PR TITLE
refactor(client): Key exchange stream support in `StreamRegistry`

### DIFF
--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -16,8 +16,7 @@ import {
     StreamID,
     EthereumAddress,
     StreamIDUtils, 
-    toStreamID,
-    KeyExchangeStreamIDUtils
+    toStreamID
 } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { omit } from 'lodash'
@@ -224,9 +223,6 @@ export class StreamRegistry implements Context {
     async getStream(streamIdOrPath: string): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
         this.debug('Getting stream %s', streamId)
-        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(streamId)) {
-            return new Stream({ id: streamId, partitions: 1 }, this.container)
-        }
         let metadata
         try {
             metadata = await this.queryAllReadonlyContracts((contract: StreamRegistryContract) => {

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -41,6 +41,13 @@ import {
 import { StreamRegistryCached } from './StreamRegistryCached'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 
+/* 
+ * On-chain registry of stream metadata and permissions.
+ *
+ * Does not support system streams (the key exchange stream) or legacy streams (streamIds 
+ * like '7wa7APtlTq6EC5iTCBy6dw')
+ */
+
 export type StreamQueryResult = {
     id: string,
     metadata: string

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -44,8 +44,7 @@ import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 /* 
  * On-chain registry of stream metadata and permissions.
  *
- * Does not support system streams (the key exchange stream) or legacy streams (streamIds 
- * like '7wa7APtlTq6EC5iTCBy6dw')
+ * Does not support system streams (the key exchange stream)
  */
 
 export type StreamQueryResult = {

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -1,5 +1,5 @@
 import { inject, DependencyContainer, scoped, Lifecycle } from 'tsyringe'
-import { EthereumAddress, KeyExchangeStreamIDUtils, StreamID } from 'streamr-client-protocol'
+import { EthereumAddress, StreamID } from 'streamr-client-protocol'
 import { Stream, StreamProperties } from '../../../src/Stream'
 import {
     StreamPermission,
@@ -86,9 +86,6 @@ export class FakeStreamRegistry implements Omit<StreamRegistry,
     }
 
     async getStream(id: StreamID): Promise<Stream> {
-        if (KeyExchangeStreamIDUtils.isKeyExchangeStream(id)) {
-            return new Stream({ id, partitions: 1 }, this.container)
-        }
         const registryItem = this.registryItems.get(id)
         if (registryItem !== undefined) {
             return this.createFakeStream({ ...registryItem.metadata, id })

--- a/packages/client/test/unit/PublisherKeyExchange.test.ts
+++ b/packages/client/test/unit/PublisherKeyExchange.test.ts
@@ -46,14 +46,18 @@ describe('PublisherKeyExchange', () => {
         return stream
     }
 
-    const createGroupKeyRequest = (groupKeyId: string): StreamMessage => {
+    const createGroupKeyRequest = (
+        groupKeyId: string,
+        publisher = subscriberWallet,
+        rsaPublicKey = subscriberRsaKeyPair.getPublicKey()
+    ): StreamMessage => {
         return createMockMessage({
             streamPartId: KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address),
-            publisher: subscriberWallet,
+            publisher,
             content: JSON.stringify([
                 uuid(),
                 mockStream.id,
-                subscriberRsaKeyPair.getPublicKey(),
+                rsaPublicKey,
                 [groupKeyId]
             ]),
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
@@ -78,6 +82,32 @@ describe('PublisherKeyExchange', () => {
         })
         const actualKeys = await getGroupKeysFromStreamMessage(actualResponse, subscriberRsaKeyPair.getPrivateKey())
         expect(actualKeys).toEqual(expectedGroupKeys)
+    }
+
+    const testErrorResponse = async (
+        actualResponse: StreamMessage, 
+        expectedGroupKeyIds: string[],
+        expectedRecipientAddress = subscriberWallet.address
+    ): Promise<void> => {
+        const subscriberKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(expectedRecipientAddress)
+        expect(actualResponse).toMatchObject({
+            messageId: {
+                streamId: StreamPartIDUtils.getStreamID(subscriberKeyExchangeStreamPartId),
+                streamPartition: StreamPartIDUtils.getStreamPartition(subscriberKeyExchangeStreamPartId),
+                publisherId: publisherWallet.address.toLowerCase(),
+            },
+            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_ERROR_RESPONSE,
+            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
+            signature: expect.any(String)
+        })
+        expect(GroupKeyErrorResponse.fromArray(actualResponse!.getParsedContent() as any)).toMatchObject({
+            requestId: expect.any(String),
+            errorCode: expect.any(String),
+            errorMessage: expect.any(String),
+            groupKeyIds: expectedGroupKeyIds
+        })
     }
 
     beforeEach(async () => {
@@ -124,6 +154,19 @@ describe('PublisherKeyExchange', () => {
             await testSuccessResponse(response!, [])
         })
 
+        it('request from non-subscriber', async () => {
+            const groupKey = GroupKey.generate()
+            const otherWallet = fastWallet()
+            const otherNode = addFakeNode(otherWallet.address, fakeContainer)
+            const receivedResponses = otherNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(otherWallet.address))
+
+            const request = createGroupKeyRequest(groupKey.id, otherWallet, (await RsaKeyPair.create()).getPublicKey())
+            otherNode.publishToNode(request)
+
+            const response = await nextValue(receivedResponses)
+            await testErrorResponse(response!, [ groupKey.id ], otherWallet.address)
+        })
+
         it('invalid request', async () => {
             const groupKey = GroupKey.generate()
             const receivedResponses = subscriberNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
@@ -133,25 +176,7 @@ describe('PublisherKeyExchange', () => {
             subscriberNode.publishToNode(request)
 
             const response = await nextValue(receivedResponses)
-            const subscriberKeyExchangeStreamPartId = KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address)
-            expect(response).toMatchObject({
-                messageId: {
-                    streamId: StreamPartIDUtils.getStreamID(subscriberKeyExchangeStreamPartId),
-                    streamPartition: StreamPartIDUtils.getStreamPartition(subscriberKeyExchangeStreamPartId),
-                    publisherId: publisherWallet.address.toLowerCase(),
-                },
-                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_ERROR_RESPONSE,
-                contentType: StreamMessage.CONTENT_TYPES.JSON,
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
-                signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
-                signature: expect.any(String)
-            })
-            expect(GroupKeyErrorResponse.fromArray(response!.getParsedContent() as any)).toMatchObject({
-                requestId: expect.any(String),
-                errorCode: expect.any(String),
-                errorMessage: expect.any(String),
-                groupKeyIds: [ groupKey.id ]
-            })
+            await testErrorResponse(response!, [ groupKey.id ])
         })
     })
 })


### PR DESCRIPTION
The `StreamRegistry` doesn't support key exchange streams. Removed an exception where we returned a simulated stream if `getStream` was used to query a metadata of a key exchange stream. 

In https://github.com/streamr-dev/network-monorepo/pull/708 we started to use explicit stream partition for key exchange streams. Therefore we don't need the exception as we don't call `StreamPartitioner` for key exchange streams anymore: https://github.com/streamr-dev/network-monorepo/blob/02a38664d944fac13e0d9a08aeb52c8ebb82e72d/packages/client/src/publish/StreamPartitioner.ts#L31

Added also a new test case to `PublisherKeyExchange.test.ts`.