### PR TITLE
build: remove npm prepare scripts

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -16,7 +16,6 @@
   "main": "bin/broker.js",
   "scripts": {
     "check": "tsc -p ./tsconfig.json --noEmit",
-    "prepare": "npm run build",
     "test": "jest test/unit test/integration && npm run test-sequential",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "check": "tsc -p ./tsconfig.json --noEmit",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepare": "npm run eslint && npm run build",
     "build": "tsc -b tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,6 @@
         "build": "npm run bootstrap-dist && npm run build-node",
         "build-production": "npm run clean; npm run bootstrap-dist && NODE_ENV=production npm run build-node && npm run build-browser-production",
         "check": "tsc -p ./tsconfig.json --noEmit",
-        "prepare": "npm run build",
         "vendor": "SRCDIR=`node -p \"path.dirname(require.resolve('quick-lru'))\"` bash -c 'mkdir -p vendor/quick-lru; cp -n $SRCDIR/index.d.ts vendor/quick-lru; cp -n $SRCDIR/index.js vendor/quick-lru'; true",
         "copy-package": "mkdir -p dist/; node copy-package.js; cp -f README.md LICENSE readme-header-img.png dist; mkdir -p dist/src/encryption/migrations; cp -f ./src/encryption/migrations/* dist/src/encryption/migrations; true",
         "bootstrap-dist": "npm run vendor && npm run copy-package && npm run fix-esm",

--- a/packages/network-tracker/package.json
+++ b/packages/network-tracker/package.json
@@ -21,7 +21,6 @@
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "network": "node $NODE_DEBUG_OPTION bin/network.js",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "jest",
     "test-integration": "jest test/integration/",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -26,7 +26,6 @@
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "network": "node $NODE_DEBUG_OPTION bin/network.js",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json && NODE_ENV=production webpack --mode=production",
     "pub": "node $NODE_DEBUG_OPTION bin/publisher.js",
     "pub-1": "node $NODE_DEBUG_OPTION bin/publisher.js --port=30323",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -16,7 +16,6 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "watch": "tsc --watch",
     "benchmark": "jest test/benchmarks --detectOpenHandles",
-    "prepare": "npm run build",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",
     "test-unit": "jest test/unit --detectOpenHandles",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -9,7 +9,6 @@
     "test": "jest",
     "test-unit": "npm run test",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepare": "npm run build",
     "build": "tsc --build tsconfig.node.json"
   },
   "keywords": [


### PR DESCRIPTION
Remove `prepare` script from each sub-packages' **`package.json`**.

Rationale being the undesired way it interacts with `npm ci` and `npm install` commands at monorepo root level. When you run either aforementioned command at root-level of monorepo (with the intention of installing node modules), if there is any compilation problem, all the installed `node_modules` directories will be cleared and the work undone. This is hardly helpful when trying to determine the root cause of the compilation issue...

