### PR TITLE
test(client): Resend historical data with existing key

### DIFF
--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -21,7 +21,7 @@ export type CacheConfig = {
     maxAge: number
 }
 
-type TimeoutsConfig = {
+export type TimeoutsConfig = {
     theGraph: {
         timeout: number
         retryInterval: number
@@ -33,7 +33,9 @@ type TimeoutsConfig = {
     jsonRpc: {
         timeout: number
         retryInterval: number
-    }
+    },
+    /** @internal */
+    encryptionKeyRequest?: number
     httpFetchTimeout: number
 }
 
@@ -279,4 +281,5 @@ export const ConfigInjectionToken = {
     Cache: Symbol('Config.Cache'),
     StorageNodeRegistry: Symbol('Config.StorageNodeRegistry'),
     Encryption: Symbol('Config.Encryption'),
+    Timeouts: Symbol('Config.Timeouts')
 }

--- a/packages/client/src/Container.ts
+++ b/packages/client/src/Container.ts
@@ -70,6 +70,8 @@ export function initContainer(
         [ConfigInjectionToken.Publish, config],
         [ConfigInjectionToken.Encryption, config],
         [ConfigInjectionToken.Cache, config.cache],
+        // eslint-disable-next-line no-underscore-dangle
+        [ConfigInjectionToken.Timeouts, config._timeouts],
     ]
 
     configTokens.forEach(([token, useValue]) => {

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -20,7 +20,7 @@ import {
     toStreamPartID
 } from 'streamr-client-protocol'
 import { range } from 'lodash'
-import { StrictStreamrClientConfig, ConfigInjectionToken } from './Config'
+import { ConfigInjectionToken, TimeoutsConfig } from './Config'
 import { PermissionAssignment, PublicPermissionQuery, UserPermissionQuery } from './permission'
 import { Subscriber } from './subscribe/Subscriber'
 import { formStorageNodeAssignmentStreamId } from './utils/utils'
@@ -89,7 +89,7 @@ class StreamrStream implements StreamMetadata {
     protected _streamRegistry: StreamRegistry
     protected _streamRegistryCached: StreamRegistryCached
     protected _nodeRegistry: StorageNodeRegistry
-    private _clientConfig: StrictStreamrClientConfig
+    private _timeoutsConfig: TimeoutsConfig
 
     /** @internal */
     constructor(
@@ -105,7 +105,7 @@ class StreamrStream implements StreamMetadata {
         this._streamRegistryCached = _container.resolve<StreamRegistryCached>(StreamRegistryCached)
         this._streamRegistry = _container.resolve<StreamRegistry>(StreamRegistry)
         this._nodeRegistry = _container.resolve<StorageNodeRegistry>(StorageNodeRegistry)
-        this._clientConfig = _container.resolve<StrictStreamrClientConfig>(ConfigInjectionToken.Root)
+        this._timeoutsConfig = _container.resolve<TimeoutsConfig>(ConfigInjectionToken.Timeouts)
     }
 
     /**
@@ -190,7 +190,7 @@ class StreamrStream implements StreamMetadata {
             await withTimeout(
                 propagationPromise,
                 // eslint-disable-next-line no-underscore-dangle
-                waitOptions.timeout ?? this._clientConfig._timeouts.storageNode.timeout,
+                waitOptions.timeout ?? this._timeoutsConfig.storageNode.timeout,
                 'timed out waiting for storage nodes to respond'
             )
         } finally {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -85,6 +85,9 @@
                 },
                 "httpFetchTimeout": {
                     "type": "number"
+                },
+                "encryptionKeyRequest": {
+                    "type": "number"
                 }
             }
         },

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -75,7 +75,7 @@ export class EncryptionUtil {
         streamMessage.groupKeyId = groupKey.id
         streamMessage.serializedContent = this.encrypt(Buffer.from(streamMessage.getSerializedContent(), 'utf8'), groupKey)
         if (nextGroupKey) {
-            streamMessage.newGroupKey = new EncryptedGroupKey(nextGroupKey.id, this.encrypt(nextGroupKey.data, groupKey))
+            streamMessage.newGroupKey = EncryptionUtil.encryptGroupKey(nextGroupKey, groupKey)
         }
         streamMessage.parsedContent = undefined
         /* eslint-enable no-param-reassign */
@@ -108,16 +108,24 @@ export class EncryptionUtil {
             if (newGroupKey) {
                 // newGroupKey should be EncryptedGroupKey | GroupKey, but GroupKey is not defined in protocol
                 // @ts-expect-error expecting EncryptedGroupKey
-                streamMessage.newGroupKey = GroupKey.from([
-                    newGroupKey.groupKeyId,
-                    this.decrypt(newGroupKey.encryptedGroupKeyHex, groupKey)
-                ])
+                streamMessage.newGroupKey = EncryptionUtil.decryptGroupKey(newGroupKey, groupKey)
             }
         } catch (err) {
             streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
             throw new UnableToDecryptError('Could not decrypt new group key: ' + err.stack, streamMessage)
         }
         /* eslint-enable no-param-reassign */
+    }
+
+    static encryptGroupKey(nextGroupKey: GroupKey, currentGroupKey: GroupKey): EncryptedGroupKey {
+        return new EncryptedGroupKey(nextGroupKey.id, this.encrypt(nextGroupKey.data, currentGroupKey))
+    }
+
+    static decryptGroupKey(newGroupKey: EncryptedGroupKey, currentGroupKey: GroupKey): GroupKey {
+        return GroupKey.from([
+            newGroupKey.groupKeyId,
+            this.decrypt(newGroupKey.encryptedGroupKeyHex, currentGroupKey)
+        ])
     }
 }
 

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -22,6 +22,7 @@ import { Subscription } from '../subscribe/Subscription'
 import { GroupKey, GroupKeyish } from './GroupKey'
 import { publishAndWaitForResponseMessage } from '../utils/waitForMessage'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
+import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
 
 export type GroupKeyId = string
 export type GroupKeysSerialized = Record<GroupKeyId, GroupKeyish>
@@ -50,7 +51,8 @@ export class KeyExchangeStream implements Context {
         @inject(AuthenticationInjectionToken) private authentication: Authentication,
         private subscriber: Subscriber,
         private destroySignal: DestroySignal,
-        @inject(delay(() => Publisher)) private publisher: Publisher
+        @inject(delay(() => Publisher)) private publisher: Publisher,
+        @inject(ConfigInjectionToken.Timeouts) private timeoutsConfig: TimeoutsConfig
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -93,6 +95,7 @@ export class KeyExchangeStream implements Context {
             () => this.createSubscription(),
             () => this.subscribe.reset(),
             this.destroySignal,
+            this.timeoutsConfig.encryptionKeyRequest
         )
     }
 

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -9,7 +9,7 @@ import { EthereumConfig, getAllStreamRegistryChainProviders, getStreamRegistryOv
 import { instanceId } from '../utils/utils'
 import { until } from '../utils/promises'
 import { Context } from '../utils/Context'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { ConfigInjectionToken, StrictStreamrClientConfig, TimeoutsConfig } from '../Config'
 import { Stream, StreamProperties } from '../Stream'
 import { ErrorCode, NotFoundError } from '../HttpUtil'
 import {
@@ -83,7 +83,8 @@ export class StreamRegistry implements Context {
         @inject(SynchronizedGraphQLClient) private graphQLClient: SynchronizedGraphQLClient,
         @inject(delay(() => StreamRegistryCached)) private streamRegistryCached: StreamRegistryCached,
         @inject(AuthenticationInjectionToken) private authentication: Authentication,
-        @inject(ConfigInjectionToken.Ethereum) private ethereumConfig: EthereumConfig
+        @inject(ConfigInjectionToken.Ethereum) private ethereumConfig: EthereumConfig,
+        @inject(ConfigInjectionToken.Timeouts) private timeoutsConfig: TimeoutsConfig
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -164,10 +165,8 @@ export class StreamRegistry implements Context {
             try {
                 await until(
                     async () => this.streamExistsOnChain(streamId),
-                    // eslint-disable-next-line no-underscore-dangle
-                    this.config._timeouts.jsonRpc.timeout,
-                    // eslint-disable-next-line no-underscore-dangle
-                    this.config._timeouts.jsonRpc.retryInterval
+                    this.timeoutsConfig.jsonRpc.timeout,
+                    this.timeoutsConfig.jsonRpc.retryInterval
                 )
             } catch (e) {
                 throw new Error(`unable to create stream "${streamId}"`)

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -18,7 +18,7 @@ import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
 import { StreamRegistryCached } from '../registry/StreamRegistryCached'
 import { random, range } from 'lodash'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
 import { HttpUtil } from '../HttpUtil'
 
 const MIN_SEQUENCE_NUMBER_VALUE = 0
@@ -71,8 +71,8 @@ export class Resends implements Context {
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(delay(() => StreamRegistryCached)) private streamRegistryCached: StreamRegistryCached,
         @inject(BrubeckContainer) private container: DependencyContainer,
-        @inject(ConfigInjectionToken.Root) private config: StrictStreamrClientConfig,
-        @inject(HttpUtil) private httpUtil: HttpUtil
+        @inject(HttpUtil) private httpUtil: HttpUtil,
+        @inject(ConfigInjectionToken.Timeouts) private timeoutsConfig: TimeoutsConfig
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -236,10 +236,8 @@ export class Resends implements Context {
     }
 
     async waitForStorage(streamMessage: StreamMessage, {
-        // eslint-disable-next-line no-underscore-dangle
-        interval = this.config._timeouts.storageNode.retryInterval,
-        // eslint-disable-next-line no-underscore-dangle
-        timeout = this.config._timeouts.storageNode.timeout,
+        interval = this.timeoutsConfig.storageNode.retryInterval,
+        timeout = this.timeoutsConfig.storageNode.timeout,
         count = 100,
         messageMatchFn = (msgTarget: StreamMessage, msgGot: StreamMessage) => {
             return msgTarget.signature === msgGot.signature

--- a/packages/client/src/utils/HttpFetcher.ts
+++ b/packages/client/src/utils/HttpFetcher.ts
@@ -1,7 +1,7 @@
 import { inject, Lifecycle, scoped } from 'tsyringe'
 import { Debugger } from 'debug'
 import { Context } from './Context'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
 import { instanceId } from './utils'
 import fetch, { Response } from 'node-fetch'
 
@@ -11,14 +11,13 @@ export class HttpFetcher {
 
     constructor(
         context: Context,
-        @inject(ConfigInjectionToken.Root) private config: StrictStreamrClientConfig
+        @inject(ConfigInjectionToken.Timeouts) private timeoutsConfig: TimeoutsConfig
     ) {
         this.debug = context.debug.extend(instanceId(this))
     }
 
     fetch(url: string, init?: Record<string, unknown>): Promise<Response> {
-        // eslint-disable-next-line no-underscore-dangle
-        const timeout = this.config._timeouts.httpFetchTimeout
+        const timeout = this.timeoutsConfig.httpFetchTimeout
         this.debug('fetching %s (timeout %d ms)', url, timeout)
         return fetch(url, {
             timeout,

--- a/packages/client/src/utils/SynchronizedGraphQLClient.ts
+++ b/packages/client/src/utils/SynchronizedGraphQLClient.ts
@@ -2,7 +2,7 @@ import { scoped, Lifecycle, inject } from 'tsyringe'
 import { Contract, ContractInterface, ContractReceipt, ContractTransaction } from '@ethersproject/contracts'
 import { Signer } from '@ethersproject/abstract-signer'
 import { GraphQLClient } from './GraphQLClient'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
 import { ObservableContract, withErrorHandlingAndLogging } from './contract'
 import { EthereumAddress } from 'streamr-client-protocol'
 import { Gate } from './Gate'
@@ -131,15 +131,13 @@ export class SynchronizedGraphQLClient {
     constructor(
         context: Context,
         @inject(GraphQLClient) delegate: GraphQLClient,
-        @inject(ConfigInjectionToken.Root) clientConfig: StrictStreamrClientConfig
+        @inject(ConfigInjectionToken.Timeouts) timeoutsConfig: TimeoutsConfig
     ) {
         this.delegate = delegate
         this.indexingState = new IndexingState(
             () => this.delegate.getIndexBlockNumber(),
-            // eslint-disable-next-line no-underscore-dangle
-            clientConfig._timeouts.theGraph.timeout,
-            // eslint-disable-next-line no-underscore-dangle
-            clientConfig._timeouts.theGraph.retryInterval,
+            timeoutsConfig.theGraph.timeout,
+            timeoutsConfig.theGraph.retryInterval,
             context.debug.extend(instanceId(this))
         )
     }

--- a/packages/client/test/integration/Encryption.test.ts
+++ b/packages/client/test/integration/Encryption.test.ts
@@ -441,43 +441,6 @@ describe('decryption', () => {
                 expect(received.map((s) => s.getParsedContent())).toEqual(contentClear)
             }, TIMEOUT * 2)
 
-            it('client.resend last can get the historical keys for previous encrypted messages', async () => {
-                // Publish encrypted messages with different keys
-                await publisher.updateEncryptionKey({
-                    streamId: stream.id,
-                    distributionMethod: 'rotate'
-                })
-                // @ts-expect-error private
-                getPublishPipeline(publisher).streamMessageQueue.forEach(async () => {
-                    await publisher.updateEncryptionKey({
-                        streamId: stream.id,
-                        distributionMethod: 'rotate'
-                    })
-                })
-                const published: any[] = []
-                // @ts-expect-error private
-                getPublishPipeline(publisher).streamMessageQueue.forEach(([streamMessage]) => {
-                    if (streamMessage.getStreamId() !== stream.id) { return }
-                    published.push(streamMessage.getParsedContent())
-                })
-                await publishTestMessages(NUM_MESSAGES, {
-                    waitForLast: true,
-                })
-
-                // resend without knowing the historical keys
-                await grantSubscriberPermissions()
-                const sub = await subscriber.resend(
-                    stream.id,
-                    {
-                        last: 2,
-                    }
-                )
-
-                const received = await sub.collect()
-
-                expect(received.map((s) => s.getParsedContent())).toEqual(published.slice(-2))
-            }, TIMEOUT * 2)
-
             it('client.subscribe with resend last can get the historical keys for previous encrypted messages', async () => {
                 // Publish encrypted messages with different keys
                 await publisher.updateEncryptionKey({

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -30,7 +30,7 @@ describe('resend with existing key', () => {
     let stream: Stream
     let initialKey: GroupKey
     let rotatedKey: GroupKey
-    let rekeydKey: GroupKey
+    let rekeyedKey: GroupKey
     let allMessages: { timestamp: number, groupKey: GroupKey, nextGroupKey?: GroupKey }[]
     let dependencyContainer: DependencyContainer
 
@@ -92,14 +92,14 @@ describe('resend with existing key', () => {
         storageNodeRegistry.addStreamToStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)
         initialKey = GroupKey.generate()
         rotatedKey = GroupKey.generate()
-        rekeydKey = GroupKey.generate()
+        rekeyedKey = GroupKey.generate()
         allMessages = [
             { timestamp: 1000, groupKey: initialKey},
             { timestamp: 2000, groupKey: initialKey, nextGroupKey: rotatedKey },
             { timestamp: 3000, groupKey: rotatedKey },
             { timestamp: 4000, groupKey: rotatedKey },
-            { timestamp: 5000, groupKey: rekeydKey },
-            { timestamp: 6000, groupKey: rekeydKey }
+            { timestamp: 5000, groupKey: rekeyedKey },
+            { timestamp: 6000, groupKey: rekeyedKey }
         ]
         for (const msg of allMessages) {
             storeMessage(msg.timestamp, msg.groupKey, msg.nextGroupKey)
@@ -151,7 +151,7 @@ describe('resend with existing key', () => {
     describe('rekeyed key available', () => {
         beforeEach(async () => {
             const keyStore = await dependencyContainer.resolve(GroupKeyStoreFactory).getStore(stream.id)
-            await keyStore.add(rekeydKey)
+            await keyStore.add(rekeyedKey)
         })
         it('can\'t decrypt initial', async () => {
             await assertNonDecryptable(1000, 2000)

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -1,0 +1,167 @@
+import 'reflect-metadata'
+import { DependencyContainer } from 'tsyringe'
+import { toStreamID } from 'streamr-client-protocol'
+import { StreamRegistry } from '../../src/registry/StreamRegistry'
+import { GroupKeyStoreFactory } from '../../src/encryption/GroupKeyStoreFactory'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { createMockMessage, createRelativeTestStreamId } from '../test-utils/utils'
+import { Stream } from '../../src/Stream'
+import { fastWallet } from 'streamr-test-utils'
+import { createFakeContainer } from '../test-utils/fake/fakeEnvironment'
+import { StreamPermission } from '../../src/permission'
+import { STREAM_CLIENT_DEFAULTS } from '../../src/Config'
+import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
+import { StorageNodeRegistry } from '../../src/registry/StorageNodeRegistry'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { Resends } from '../../src/subscribe/Resends'
+import { collect } from '../../src/utils/GeneratorUtils'
+import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
+import { ActiveNodes } from '../test-utils/fake/ActiveNodes'
+
+/*
+ * A subscriber has some GroupKeys in the local store and reads historical data 
+ * which is encrypted with those keys (or rotated keys). The publisher is offline 
+ * and therefore the subscriber can't get keys from it (all GroupKeyRequests timeout).
+ */
+describe('resend with existing key', () => {
+
+    let resends: Resends
+    let subscriberWallet = fastWallet()
+    let publisherWallet = fastWallet()
+    let stream: Stream
+    let dependencyContainer: DependencyContainer
+    let KEY_ORIGINAL: GroupKey
+    let KEY_ROTATED: GroupKey
+    let KEY_REKEYED: GroupKey
+    let ALL_MESSAGES: { timestamp: number, groupKey: GroupKey, nextGroupKey?: GroupKey }[]
+
+    const storeMessage = (timestamp: number, currentGroupKey: GroupKey, nextGroupKey?: GroupKey) => {
+        const message = createMockMessage({
+            timestamp,
+            encryptionKey: currentGroupKey,
+            newGroupKey: (nextGroupKey !== undefined) ? EncryptionUtil.encryptGroupKey(nextGroupKey, currentGroupKey) : null,
+            stream,
+            publisher: publisherWallet,
+        })
+        const storageNode = dependencyContainer.resolve(ActiveNodes).getNode(DOCKER_DEV_STORAGE_NODE) as FakeStorageNode
+        storageNode.storeMessage(message)
+    }
+
+    const resendRange = (fromTimestamp: number, toTimestamp: number) => {
+        return resends.resend(stream.getStreamParts()[0], {
+            from: {
+                timestamp: fromTimestamp
+            },
+            to: {
+                timestamp: toTimestamp
+            }
+        })
+    }
+
+    const assertDecryptable = async (fromTimestamp: number, toTimestamp: number) => {
+        const messageStream = await resendRange(fromTimestamp, toTimestamp)
+        const messages = await collect(messageStream)
+        const expectedTimestamps = ALL_MESSAGES.map((m) => m.timestamp).filter((ts) => ts >= fromTimestamp && ts <= toTimestamp)
+        expect(messages.map(m => m.getTimestamp())).toEqual(expectedTimestamps)
+    }
+
+    const assertNonDecryptable = async (fromTimestamp: number, toTimestamp: number) => {
+        const messageStream = await resendRange(fromTimestamp, toTimestamp)
+        await expect(() => collect(messageStream)).rejects.toThrowError('Unable to decrypt')
+    }
+
+    beforeEach(async () => {
+        const streamId = toStreamID(createRelativeTestStreamId(module), publisherWallet.address)
+        dependencyContainer = createFakeContainer({
+            auth: {
+                privateKey: subscriberWallet.privateKey
+            },
+            _timeouts: {
+                ...STREAM_CLIENT_DEFAULTS._timeouts,
+                encryptionKeyRequest: 50
+            }
+        })
+        const streamRegistry = dependencyContainer.resolve(StreamRegistry)
+        stream = await streamRegistry.createStream({
+            id: streamId
+        })
+        await stream.grantPermissions({
+            user: publisherWallet.address,
+            permissions: [StreamPermission.PUBLISH]
+        })
+        const storageNodeRegistry = dependencyContainer.resolve(StorageNodeRegistry)
+        storageNodeRegistry.addStreamToStorageNode(stream.id, DOCKER_DEV_STORAGE_NODE)
+        KEY_ORIGINAL = GroupKey.generate()
+        KEY_ROTATED = GroupKey.generate()
+        KEY_REKEYED = GroupKey.generate()
+        ALL_MESSAGES = [
+            { timestamp: 1000, groupKey: KEY_ORIGINAL},
+            { timestamp: 2000, groupKey: KEY_ORIGINAL, nextGroupKey: KEY_ROTATED },
+            { timestamp: 3000, groupKey: KEY_ROTATED },
+            { timestamp: 4000, groupKey: KEY_ROTATED },
+            { timestamp: 5000, groupKey: KEY_REKEYED },
+            { timestamp: 6000, groupKey: KEY_REKEYED }
+        ]
+        for (const msg of ALL_MESSAGES) {
+            storeMessage(msg.timestamp, msg.groupKey, msg.nextGroupKey)
+        }
+        resends = dependencyContainer.resolve(Resends)
+    })
+
+    describe('no keys available', () => {
+        it('can\'t decrypt', async () => {
+            await assertNonDecryptable(1000, 6000)
+        })
+    })
+
+    describe('original key available', () => {
+        beforeEach(async () => {
+            const keyStore = await dependencyContainer.resolve(GroupKeyStoreFactory).getStore(stream.id)
+            await keyStore.add(KEY_ORIGINAL)
+        })
+        it('can decrypt original', async () => {
+            await assertDecryptable(1000, 2000)
+        })
+        it('can decrypt rotated, if key rotation message is included', async () => {
+            await assertDecryptable(2000, 4000)
+        })
+        it('can\'t decrypt rotated, if key rotation message is not included', async () => {
+            await assertNonDecryptable(3000, 4000)
+        })
+        it('can\'t decrypt rekeyed', async () => {
+            await assertNonDecryptable(5000, 6000)
+        })
+    })
+
+    describe('rotated key available', () => {
+        beforeEach(async () => {
+            const keyStore = await dependencyContainer.resolve(GroupKeyStoreFactory).getStore(stream.id)
+            await keyStore.add(KEY_ROTATED)
+        })
+        it('can\'t decrypt original', async () => {
+            await assertNonDecryptable(1000, 2000)
+        })
+        it('can decrypt rotated', async () => {
+            await assertDecryptable(3000, 4000)
+        })
+        it('can\'t decrypt rekeyed', async () => {
+            await assertNonDecryptable(5000, 6000)
+        })
+    })
+
+    describe('rekeyed key available', () => {
+        beforeEach(async () => {
+            const keyStore = await dependencyContainer.resolve(GroupKeyStoreFactory).getStore(stream.id)
+            await keyStore.add(KEY_REKEYED)
+        })
+        it('can\'t decrypt original', async () => {
+            await assertNonDecryptable(1000, 2000)
+        })
+        it('can\'t decrypt rotated', async () => {
+            await assertNonDecryptable(3000, 4000)
+        })
+        it('can decrypt rekeyed', async () => {
+            await assertDecryptable(5000, 6000)
+        })
+    })
+})

--- a/packages/client/test/test-utils/fake/FakeHttpUtil.ts
+++ b/packages/client/test/test-utils/fake/FakeHttpUtil.ts
@@ -37,8 +37,8 @@ export class FakeHttpUtil implements HttpUtil {
                         fromSequenceNumber: Number(request.query!.get('fromSequenceNumber')),
                         toTimestamp: Number(request.query!.get('toTimestamp')),
                         toSequenceNumber: Number(request.query!.get('toSequenceNumber')),
-                        publisherId: request.query!.get('publisherId')!,
-                        msgChainId: request.query!.get('msgChainId')!
+                        publisherId: request.query!.get('publisherId') ?? undefined,
+                        msgChainId: request.query!.get('msgChainId') ?? undefined
                     })
                 } else {
                     throw new Error('not implemented: ' + JSON.stringify(request))

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -54,7 +54,7 @@ export class FakeStorageNode extends FakeBrubeckNode {
         })
     }
 
-    private storeMessage(msg: StreamMessage): void {
+    storeMessage(msg: StreamMessage): void {
         const streamPartId = msg.getStreamPartID()
         this.streamPartMessages.add(streamPartId, msg)
     }

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -81,14 +81,14 @@ export class FakeStorageNode extends FakeBrubeckNode {
         fromSequenceNumber: number,
         toTimestamp: number,
         toSequenceNumber: number,
-        publisherId: string,
-        msgChainId: string
+        publisherId?: string,
+        msgChainId?: string
     }): Promise<StreamMessage[]> {
         const messages = this.streamPartMessages.get(streamPartId)
         if (messages !== undefined) {
             return messages.filter((msg) => {
-                return (msg.getPublisherId() === opts.publisherId)
-                    && (msg.getMsgChainId() === opts.msgChainId)
+                return ((opts.publisherId === undefined) || (msg.getPublisherId() === opts.publisherId))
+                    && ((opts.msgChainId === undefined) || (msg.getMsgChainId() === opts.msgChainId))
                     && (
                         ((msg.getTimestamp() > opts.fromTimestamp) && (msg.getTimestamp() < opts.toTimestamp))
                         || ((msg.getTimestamp() === opts.fromTimestamp) && (msg.getSequenceNumber() >= opts.fromSequenceNumber))

--- a/packages/client/test/unit/SynchronizedGraphQLClient.test.ts
+++ b/packages/client/test/unit/SynchronizedGraphQLClient.test.ts
@@ -87,11 +87,9 @@ describe('SynchronizedGraphQLClient', () => {
                 getIndexBlockNumber
             } as any,
             {
-                _timeouts: {
-                    theGraph: {
-                        timeout: 10 * INDEXING_INTERVAL,
-                        retryInterval: POLL_INTERVAL
-                    }
+                theGraph: {
+                    timeout: 10 * INDEXING_INTERVAL,
+                    retryInterval: POLL_INTERVAL
                 }
             } as any
         )


### PR DESCRIPTION
Added a new resend integration test. 

In the test cases a subscriber does a resend and uses previously acquired group keys to decrypt the data.  In the simulated situation, the publisher is offline and therefore the subscriber can't get keys from it (all group key requests timeout).

Other changes needed to support the implementation:
- Group key requests can timeout: there is a new internal configuration field, which specifies maximum time to wait for a group key from the publisher.
- Some group key related methods extracted to new methods of `EncryptionUtil`
- A small enhancement in `FakeStorageNode#getRange`

Added also a DI config token for `TimeoutsConfig`. All classes which used the root token to get the timeout config are now using the new DI token. 

### Future improvements

The default value for group key request timeout is currently undefined. Therefore this PR doesn't change the functionality of group key requests. If we want that group key requests can timeout in production/test environment, we could specify a default value for the new setting.

All timeout configs are currently internal. Those configs are not documented and in `StreamrClientConfig` the config block has an underscore prefix to annotate that the configs are internal. We could promote the config block to be part of official configuration. That would require:
- Specify a good structure for timeout-related configs (maybe not a separate timeouts block, but e.g. the group key timeout could be inside encryption-related configs)
- Write documentation about the configs
- Add some test coverage for the config values
- Enable users to provide partial timeout configs: i.e. merge user config with defaults if only part of the config values are defined by the user