### PR TITLE
add base tsconfig.json files to faciliate IDEs

### DIFF
--- a/packages/broker/tsconfig.jest.json
+++ b/packages/broker/tsconfig.jest.json
@@ -5,10 +5,15 @@
     },
     "include": [
         "src/**/*",
+        "src/**/*.json",
         "package.json",
         "test/**/*"
     ],
     "references": [
-        { "path": "tsconfig.node.json" }
+        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../protocol/tsconfig.node.json" },
+        { "path": "../network/tsconfig.node.json" },
+        { "path": "../network-tracker/tsconfig.node.json" },
+        { "path": "../client/tsconfig.node.json" }
     ]
 }

--- a/packages/broker/tsconfig.json
+++ b/packages/broker/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/broker/tsconfig.json
+++ b/packages/broker/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }

--- a/packages/cli-tools/tsconfig.json
+++ b/packages/cli-tools/tsconfig.json
@@ -10,6 +10,8 @@
         "bin/**/*"
     ],
     "references": [
+        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../protocol/tsconfig.node.json" },
         { "path": "../client/tsconfig.node.json" }
     ]
 }

--- a/packages/client/tsconfig.jest.json
+++ b/packages/client/tsconfig.jest.json
@@ -24,6 +24,8 @@
         "src/index-esm.mjs"
     ],
     "references": [
-        { "path": "tsconfig.node.json" }
+        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../protocol/tsconfig.node.json" },
+        { "path": "../network/tsconfig.node.json" }
     ]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }

--- a/packages/network-tracker/tsconfig.jest.json
+++ b/packages/network-tracker/tsconfig.jest.json
@@ -8,6 +8,8 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "tsconfig.node.json" }
+        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../protocol/tsconfig.node.json" },
+        { "path": "../network/tsconfig.node.json" }
     ]
 }

--- a/packages/network-tracker/tsconfig.json
+++ b/packages/network-tracker/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/network-tracker/tsconfig.json
+++ b/packages/network-tracker/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }

--- a/packages/network/tsconfig.jest.json
+++ b/packages/network/tsconfig.jest.json
@@ -12,8 +12,8 @@
       "test/**/BrowserWebRtcConnection.test.ts",
       "test/**/IntegrationBrowserWebRtcConnection.test.ts"
     ],
-    "references": [
-      { "path": "tsconfig.node.json" },
-      { "path":  "../network-tracker/tsconfig.jest.json"}
-    ]
+  "references": [
+    { "path": "../protocol/tsconfig.node.json" },
+    { "path": "../test-utils/tsconfig.node.json" }
+  ]
 }

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/network/tsconfig.json
+++ b/packages/network/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }

--- a/packages/protocol/tsconfig.jest.json
+++ b/packages/protocol/tsconfig.jest.json
@@ -8,6 +8,6 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "tsconfig.node.json" }
+        { "path": "../test-utils/tsconfig.node.json" }
     ]
 }

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }

--- a/packages/test-utils/jest.config.js
+++ b/packages/test-utils/jest.config.js
@@ -1,4 +1,9 @@
 module.exports = {
     preset: 'ts-jest',
-    testEnvironment: 'node'
+    testEnvironment: 'node',
+    globals: {
+        'ts-jest': {
+            tsconfig: 'tsconfig.jest.json',
+        }
+    }
 }

--- a/packages/test-utils/tsconfig.jest.json
+++ b/packages/test-utils/tsconfig.jest.json
@@ -6,8 +6,5 @@
     "include": [
         "src/**/*",
         "test/**/*"
-    ],
-    "references": [
-        { "path": "tsconfig.node.json" }
     ]
 }

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig.node.json"
+}

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig.node.json"
+  "extends": "./tsconfig.jest.json"
 }


### PR DESCRIPTION
Add to each sub-package a **`tsconfig.json`** file to facilitate IDE language services.

### Future improvements

IntellijJ and VS Code show many errors like this in "Errors" view: `Cannot write file '/Users/teogeb/workspace/network-monorepo/packages/client/dist/types/src/Authentication.d.ts' because it would overwrite input file.`
