### PR TITLE
refactor(client): Group key validation

### DIFF
--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -46,7 +46,6 @@ export class EncryptionUtil {
      * Both 'data' and 'groupKey' must be Buffers. Returns a hex string without the '0x' prefix.
      */
     private static encrypt(data: Uint8Array, groupKey: GroupKey): string {
-        GroupKey.validate(groupKey)
         const iv = crypto.randomBytes(16) // always need a fresh IV when using CTR mode
         const cipher = crypto.createCipheriv('aes-256-ctr', groupKey.data, iv)
         return hexlify(iv).slice(2) + cipher.update(data, undefined, 'hex') + cipher.final('hex')
@@ -56,7 +55,6 @@ export class EncryptionUtil {
      * 'ciphertext' must be a hex string (without '0x' prefix), 'groupKey' must be a GroupKey. Returns a Buffer.
      */
     private static decrypt(ciphertext: string, groupKey: GroupKey): Buffer {
-        GroupKey.validate(groupKey)
         const iv = arrayify(`0x${ciphertext.slice(0, 32)}`)
         const decipher = crypto.createDecipheriv('aes-256-ctr', groupKey.data, iv)
         return Buffer.concat([decipher.update(ciphertext.slice(32), 'hex'), decipher.final()])
@@ -66,10 +64,6 @@ export class EncryptionUtil {
      * Sets the content of 'streamMessage' with the encryption result of the old content with 'groupKey'.
      */
     static encryptStreamMessage(streamMessage: StreamMessage, groupKey: GroupKey, nextGroupKey?: GroupKey): void {
-        GroupKey.validate(groupKey)
-        if (nextGroupKey) {
-            GroupKey.validate(nextGroupKey)
-        }
         /* eslint-disable no-param-reassign */
         streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
         streamMessage.groupKeyId = groupKey.id
@@ -84,12 +78,6 @@ export class EncryptionUtil {
     static decryptStreamMessage(streamMessage: StreamMessage, groupKey: GroupKey): void | never {
         if ((streamMessage.encryptionType !== StreamMessage.ENCRYPTION_TYPES.AES)) {
             return
-        }
-
-        try {
-            GroupKey.validate(groupKey)
-        } catch (err) {
-            throw new UnableToDecryptError(`${err.message}`, streamMessage)
         }
 
         /* eslint-disable no-param-reassign */

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -50,11 +50,11 @@ export class GroupKey {
     static InvalidGroupKeyError = InvalidGroupKeyError
 
     /** @internal */
-    id: string
+    readonly id: string
     /** @internal */
-    hex: string
+    readonly hex: string
     /** @internal */
-    data: Uint8Array
+    readonly data: Uint8Array
 
     constructor(groupKeyId: string, groupKeyBufferOrHexString: Uint8Array | string) {
         this.id = groupKeyId

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -69,7 +69,7 @@ export class GroupKey {
         (this.constructor as typeof GroupKey).validate(this)
     }
 
-    static validate(maybeGroupKey: GroupKey): void | never {
+    private static validate(maybeGroupKey: GroupKey): void | never {
         if (!maybeGroupKey) {
             throw new InvalidGroupKeyError(`value must be a ${this.name}: ${inspect(maybeGroupKey)}`, maybeGroupKey)
         }

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -45,7 +45,6 @@ export type GroupKeyish = GroupKey | GroupKeyObject | ConstructorParameters<type
  * in one field.
  */
 
-// eslint-disable-next-line no-redeclare
 export class GroupKey {
     /** @internal */
     static InvalidGroupKeyError = InvalidGroupKeyError

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -41,6 +41,34 @@ export class GroupKey {
     /** @internal */
     static InvalidGroupKeyError = InvalidGroupKeyError
 
+    /** @internal */
+    id: string
+    /** @internal */
+    hex: string
+    /** @internal */
+    data: Uint8Array
+
+    constructor(groupKeyId: string, groupKeyBufferOrHexString: Uint8Array | string) {
+        this.id = groupKeyId
+        if (!groupKeyId) {
+            throw new InvalidGroupKeyError(`groupKeyId must not be falsey ${inspect(groupKeyId)}`)
+        }
+
+        if (!groupKeyBufferOrHexString) {
+            throw new InvalidGroupKeyError(`groupKeyBufferOrHexString must not be falsey ${inspect(groupKeyBufferOrHexString)}`)
+        }
+
+        if (typeof groupKeyBufferOrHexString === 'string') {
+            this.hex = groupKeyBufferOrHexString
+            this.data = Buffer.from(this.hex, 'hex')
+        } else {
+            this.data = groupKeyBufferOrHexString
+            this.hex = Buffer.from(this.data).toString('hex')
+        }
+
+        (this.constructor as typeof GroupKey).validate(this)
+    }
+
     static validate(maybeGroupKey: GroupKey): void | never {
         if (!maybeGroupKey) {
             throw new InvalidGroupKeyError(`value must be a ${this.name}: ${inspect(maybeGroupKey)}`, maybeGroupKey)
@@ -72,35 +100,6 @@ export class GroupKey {
         if (maybeGroupKey.data.length !== 32) {
             throw new InvalidGroupKeyError(`Group key must have a size of 256 bits, not ${maybeGroupKey.data.length * 8}`, maybeGroupKey)
         }
-
-    }
-
-    /** @internal */
-    id: string
-    /** @internal */
-    hex: string
-    /** @internal */
-    data: Uint8Array
-
-    constructor(groupKeyId: string, groupKeyBufferOrHexString: Uint8Array | string) {
-        this.id = groupKeyId
-        if (!groupKeyId) {
-            throw new InvalidGroupKeyError(`groupKeyId must not be falsey ${inspect(groupKeyId)}`)
-        }
-
-        if (!groupKeyBufferOrHexString) {
-            throw new InvalidGroupKeyError(`groupKeyBufferOrHexString must not be falsey ${inspect(groupKeyBufferOrHexString)}`)
-        }
-
-        if (typeof groupKeyBufferOrHexString === 'string') {
-            this.hex = groupKeyBufferOrHexString
-            this.data = Buffer.from(this.hex, 'hex')
-        } else {
-            this.data = groupKeyBufferOrHexString
-            this.hex = Buffer.from(this.data).toString('hex')
-        }
-
-        (this.constructor as typeof GroupKey).validate(this)
     }
 
     equals(other: GroupKey): boolean {

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -36,6 +36,15 @@ function GroupKeyObjectFromProps(data: GroupKeyProps | GroupKeyObject): GroupKey
 
 export type GroupKeyish = GroupKey | GroupKeyObject | ConstructorParameters<typeof GroupKey>
 
+/**
+ * GroupKeys are AES cipher keys, which are used to encrypt/decrypt StreamMessages (when encryptionType is AES).
+ * Each group key contains 256 random bits of key data and an UUID.
+ *
+ * A group key stores the same key data in two fields: the bytes as hex-encoded string, and as a raw Uint8Array.
+ * TODO: If this data duplication doesn't give us any performance improvement we could store the key data only
+ * in one field.
+ */
+
 // eslint-disable-next-line no-redeclare
 export class GroupKey {
     /** @internal */

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -74,7 +74,7 @@ export class GroupKey {
             this.hex = Buffer.from(this.data).toString('hex')
         }
 
-        (this.constructor as typeof GroupKey).validate(this)
+        GroupKey.validate(this)
     }
 
     private static validate(maybeGroupKey: GroupKey): void | never {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -41,7 +41,6 @@ export class GroupKeyPersistence implements PersistentStore<string, GroupKey> {
     }
 
     async set(groupKeyId: string, value: GroupKey): Promise<boolean> {
-        GroupKey.validate(value)
         return this.store.set(groupKeyId, value.hex)
     }
 
@@ -86,7 +85,6 @@ export class GroupKeyStore implements Context {
         this.store = new GroupKeyPersistence({ context: this, clientId, streamId, initialData })
 
         groupKeys.forEach(([groupKeyId, groupKey]) => {
-            GroupKey.validate(groupKey)
             if (groupKeyId !== groupKey.id) {
                 throw new Error(`Ids must match: groupKey.id: ${groupKey.id}, groupKeyId: ${groupKeyId}`)
             }
@@ -96,7 +94,6 @@ export class GroupKeyStore implements Context {
     }
 
     private async storeKey(groupKey: GroupKey): Promise<GroupKey> {
-        GroupKey.validate(groupKey)
         const existingKey = await this.store.get(groupKey.id)
         if (existingKey) {
             if (!existingKey.equals(groupKey)) {
@@ -189,7 +186,6 @@ export class GroupKeyStore implements Context {
     }
 
     async setNextGroupKey(newKey: GroupKey): Promise<void> {
-        GroupKey.validate(newKey)
         this.nextGroupKeys.unshift(newKey)
         this.nextGroupKeys.length = Math.min(this.nextGroupKeys.length, 2)
         await this.storeKey(newKey)

--- a/packages/client/test/unit/GroupKey.test.ts
+++ b/packages/client/test/unit/GroupKey.test.ts
@@ -4,6 +4,11 @@ import { GroupKey } from '../../src/encryption/GroupKey'
 describe('GroupKey', () => {
 
     describe('constructor', () => {
+
+        it('does not throw with valid values', () => {
+            new GroupKey('mockId', Buffer.from('aB123456789012345678901234567890'))
+        })
+
         it('throws if key is the wrong size', () => {
             expect(() => {
                 new GroupKey('test', crypto.randomBytes(16))
@@ -15,12 +20,6 @@ describe('GroupKey', () => {
                 // @ts-expect-error expected error below is desirable, show typecheks working as intended
                 new GroupKey('test', Array.from(crypto.randomBytes(32)))
             }).toThrow('Buffer')
-        })
-    })
-
-    describe('validate', () => {
-        it('does not throw with valid values', () => {
-            GroupKey.validate(GroupKey.generate())
         })
     })
 })

--- a/packages/client/test/unit/GroupKey.test.ts
+++ b/packages/client/test/unit/GroupKey.test.ts
@@ -3,23 +3,24 @@ import { GroupKey } from '../../src/encryption/GroupKey'
 
 describe('GroupKey', () => {
 
-    describe('validate', () => {
+    describe('constructor', () => {
         it('throws if key is the wrong size', () => {
             expect(() => {
-                GroupKey.validate(GroupKey.from(['test', crypto.randomBytes(16)]))
+                new GroupKey('test', crypto.randomBytes(16))
             }).toThrow('size')
         })
-    
+
         it('throws if key is not a buffer', () => {
             expect(() => {
                 // @ts-expect-error expected error below is desirable, show typecheks working as intended
-                GroupKey.validate(GroupKey.from(['test', Array.from(crypto.randomBytes(32))]))
+                new GroupKey('test', Array.from(crypto.randomBytes(32)))
             }).toThrow('Buffer')
         })
-    
+    })
+
+    describe('validate', () => {
         it('does not throw with valid values', () => {
             GroupKey.validate(GroupKey.generate())
         })
-    
     })
 })


### PR DESCRIPTION
Removed calls to `GroupKey#validate`. A `GroupKey` object is always in valid state, because the constructor calls `validate()` method internally. Therefore users of that object don't need to revalidate the object. The `GroupKey#validate` is now a private method.

### Future improvements

Is there a good reason to store the byte data of a `GroupKey` in two separate fields, which contain the same information in two different formats? 

Do we need `GroupKeyish` type?

- [x] Has passing tests that demonstrate this change works
