### PR TITLE
enable noImplicitOverride in Typescript

### DIFF
--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -179,7 +179,7 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
         }
     }
 
-    getConfigSchema(): Schema {
+    override getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -33,7 +33,7 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
         this.producer?.stop()
     }
 
-    getConfigSchema(): Schema {
+    override getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -30,7 +30,7 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         await this.server!.stop()
     }
 
-    getConfigSchema(): Schema {
+    override getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -29,7 +29,7 @@ class ResponseTransform extends Transform {
         this.version = version
     }
 
-    _transform(input: StreamMessage, _encoding: string, done: () => void) {
+    override _transform(input: StreamMessage, _encoding: string, done: () => void) {
         if (this.firstMessage) {
             this.firstMessage = false
             this.push(this.format.header)
@@ -40,7 +40,7 @@ class ResponseTransform extends Transform {
         done()
     }
 
-    _flush(done: () => void) {
+    override _flush(done: () => void) {
         if (this.firstMessage) {
             this.push(this.format.header)
         }

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -67,7 +67,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
         ])
     }
 
-    getConfigSchema(): Schema {
+    override getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -32,7 +32,7 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
         await this.server!.stop()
     }
 
-    getConfigSchema(): Schema {
+    override getConfigSchema(): Schema {
         return PLUGIN_CONFIG_SCHEMA
     }
 }

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -97,7 +97,7 @@ export class Validator extends StreamMessageValidator implements Context {
         })
     })
 
-    async validate(msg: StreamMessage): Promise<void> {
+    override async validate(msg: StreamMessage): Promise<void> {
         if (this.isStopped) { return }
         await this.orderedValidate(msg)
     }

--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -54,45 +54,45 @@ export class MessageStream<
     }
 
     /** @internal */
-    pipe<NewOutType>(fn: PipelineTransform<OutType, NewOutType>): MessageStream<T, InType, NewOutType> {
+    override pipe<NewOutType>(fn: PipelineTransform<OutType, NewOutType>): MessageStream<T, InType, NewOutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         super.pipe(fn)
         return this as MessageStream<T, InType, unknown> as MessageStream<T, InType, NewOutType>
     }
 
     /** @internal */
-    pipeBefore(fn: PipelineTransform<InType, InType>): MessageStream<T, InType, OutType> {
+    override pipeBefore(fn: PipelineTransform<InType, InType>): MessageStream<T, InType, OutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         super.pipeBefore(fn)
         return this
     }
 
     /** @internal */
-    map<NewOutType>(fn: G.GeneratorMap<OutType, NewOutType>): MessageStream<T, InType, NewOutType> {
+    override map<NewOutType>(fn: G.GeneratorMap<OutType, NewOutType>): MessageStream<T, InType, NewOutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         return super.map(fn) as MessageStream<T, InType, NewOutType>
     }
 
     /** @internal */
-    filterBefore(fn: G.GeneratorFilter<InType>): MessageStream<T, InType, OutType> {
+    override filterBefore(fn: G.GeneratorFilter<InType>): MessageStream<T, InType, OutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         return super.filterBefore(fn) as MessageStream<T, InType, OutType>
     }
 
     /** @internal */
-    filter(fn: G.GeneratorFilter<OutType>): MessageStream<T, InType, OutType> {
+    override filter(fn: G.GeneratorFilter<OutType>): MessageStream<T, InType, OutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         return super.filter(fn) as MessageStream<T, InType, OutType>
     }
 
     /** @internal */
-    forEach(fn: G.GeneratorForEach<OutType>): MessageStream<T, InType, OutType> {
+    override forEach(fn: G.GeneratorForEach<OutType>): MessageStream<T, InType, OutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         return super.forEach(fn) as MessageStream<T, InType, OutType>
     }
 
     /** @internal */
-    forEachBefore(fn: G.GeneratorForEach<InType>): MessageStream<T, InType, OutType> {
+    override forEachBefore(fn: G.GeneratorForEach<InType>): MessageStream<T, InType, OutType> {
         // this method override just fixes the output type to be MessageStream rather than Pipeline
         return super.forEachBefore(fn) as MessageStream<T, InType, OutType>
     }

--- a/packages/client/src/utils/PullBuffer.ts
+++ b/packages/client/src/utils/PullBuffer.ts
@@ -13,19 +13,19 @@ export class PullBuffer<InType> extends PushBuffer<InType> {
         pull(this.source, this).catch(() => {})
     }
 
-    map<NewOutType>(fn: G.GeneratorMap<InType, NewOutType>): PullBuffer<NewOutType> {
+    override map<NewOutType>(fn: G.GeneratorMap<InType, NewOutType>): PullBuffer<NewOutType> {
         return new PullBuffer<NewOutType>(G.map(this, fn), this.bufferSize)
     }
 
-    forEach(fn: G.GeneratorForEach<InType>): PullBuffer<InType> {
+    override forEach(fn: G.GeneratorForEach<InType>): PullBuffer<InType> {
         return new PullBuffer(G.forEach(this, fn), this.bufferSize)
     }
 
-    filter(fn: G.GeneratorFilter<InType>): PullBuffer<InType> {
+    override filter(fn: G.GeneratorFilter<InType>): PullBuffer<InType> {
         return new PullBuffer(G.filter(this, fn), this.bufferSize)
     }
 
-    reduce<NewOutType>(fn: G.GeneratorReduce<InType, NewOutType>, initialValue: NewOutType): PullBuffer<NewOutType> {
+    override reduce<NewOutType>(fn: G.GeneratorReduce<InType, NewOutType>, initialValue: NewOutType): PullBuffer<NewOutType> {
         return new PullBuffer(G.reduce(this, fn, initialValue), this.bufferSize)
     }
 }

--- a/packages/client/src/utils/PushPipeline.ts
+++ b/packages/client/src/utils/PushPipeline.ts
@@ -8,7 +8,7 @@ import { Pipeline, PipelineTransform } from './Pipeline'
  */
 export class PushPipeline<InType, OutType = InType> extends Pipeline<InType, OutType> implements IPushBuffer<InType, OutType> {
     /** @internal */
-    readonly source: PushBuffer<InType>
+    override readonly source: PushBuffer<InType>
 
     constructor(bufferSize = DEFAULT_BUFFER_SIZE, options?: PushBufferOptions) {
         const inputBuffer = new PushBuffer<InType>(bufferSize, options)
@@ -17,44 +17,44 @@ export class PushPipeline<InType, OutType = InType> extends Pipeline<InType, Out
     }
 
     /** @internal */
-    pipe<NewOutType>(fn: PipelineTransform<OutType, NewOutType>): PushPipeline<InType, NewOutType> {
+    override pipe<NewOutType>(fn: PipelineTransform<OutType, NewOutType>): PushPipeline<InType, NewOutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         super.pipe(fn)
         return this as PushPipeline<InType, unknown> as PushPipeline<InType, NewOutType>
     }
 
     /** @internal */
-    map<NewOutType>(fn: G.GeneratorMap<OutType, NewOutType>): PushPipeline<InType, NewOutType> {
+    override map<NewOutType>(fn: G.GeneratorMap<OutType, NewOutType>): PushPipeline<InType, NewOutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.map(fn) as PushPipeline<InType, NewOutType>
     }
 
     /** @internal */
-    mapBefore(fn: G.GeneratorMap<InType, InType>): PushPipeline<InType, OutType> {
+    override mapBefore(fn: G.GeneratorMap<InType, InType>): PushPipeline<InType, OutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.mapBefore(fn) as PushPipeline<InType, OutType>
     }
 
     /** @internal */
-    filterBefore(fn: G.GeneratorFilter<InType>): PushPipeline<InType, OutType> {
+    override filterBefore(fn: G.GeneratorFilter<InType>): PushPipeline<InType, OutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.filterBefore(fn) as PushPipeline<InType, OutType>
     }
 
     /** @internal */
-    filter(fn: G.GeneratorFilter<OutType>): PushPipeline<InType, OutType> {
+    override filter(fn: G.GeneratorFilter<OutType>): PushPipeline<InType, OutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.filter(fn) as PushPipeline<InType, OutType>
     }
 
     /** @internal */
-    forEach(fn: G.GeneratorForEach<OutType>): PushPipeline<InType, OutType> {
+    override forEach(fn: G.GeneratorForEach<OutType>): PushPipeline<InType, OutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.forEach(fn) as PushPipeline<InType, OutType>
     }
 
     /** @internal */
-    forEachBefore(fn: G.GeneratorForEach<InType>): PushPipeline<InType, OutType> {
+    override forEachBefore(fn: G.GeneratorForEach<InType>): PushPipeline<InType, OutType> {
         // this method override just fixes the output type to be PushPipeline rather than Pipeline
         return super.forEachBefore(fn) as PushPipeline<InType, OutType>
     }
@@ -72,7 +72,7 @@ export class PushPipeline<InType, OutType = InType> extends Pipeline<InType, Out
     }
 
     /** @internal */
-    async handleError(err: Error): Promise<void> {
+    override async handleError(err: Error): Promise<void> {
         try {
             await this.onError.trigger(err)
         } catch (error) {

--- a/packages/client/src/utils/Signal.ts
+++ b/packages/client/src/utils/Signal.ts
@@ -291,7 +291,7 @@ export class ErrorSignal<ArgsType extends [Error] = [Error]> extends Signal<Args
     protected ignoredErrors = new WeakSet<Error>()
     private minListeners = 1
 
-    protected async execTrigger(
+    protected override async execTrigger(
         ...args: ArgsType
     ): Promise<void> {
         if (this.isEnded) {
@@ -326,7 +326,7 @@ export class ErrorSignal<ArgsType extends [Error] = [Error]> extends Signal<Args
         }, Promise.resolve())
     }
 
-    async trigger(...args: ArgsType): Promise<void> {
+    override async trigger(...args: ArgsType): Promise<void> {
         const err = args[0]
         // don't double-handle errors
         if (this.ignoredErrors.has(err)) {

--- a/packages/network/src/helpers/Metric.ts
+++ b/packages/network/src/helpers/Metric.ts
@@ -127,7 +127,7 @@ export class AverageMetric extends Metric {
  * E.g. average count of currently active connections
  */
 class LevelSampler extends AverageSampler {
-    start(now: number): void {
+    override start(now: number): void {
         super.start(now)
         const latest = this.metric.getLatestValue()
         if (latest !== undefined) {
@@ -152,12 +152,12 @@ class RateSampler extends Sampler {
     private startTimestamp: number | undefined = undefined
     private stopTimestamp: number | undefined = undefined
 
-    start(now: number): void {
+    override start(now: number): void {
         super.start(now)
         this.startTimestamp = now
     }
 
-    stop(now: number): void {
+    override stop(now: number): void {
         super.stop(now)
         this.stopTimestamp = now
     }

--- a/packages/protocol/src/errors/InvalidJsonError.ts
+++ b/packages/protocol/src/errors/InvalidJsonError.ts
@@ -2,7 +2,7 @@ import StreamMessage from '../protocol/message_layer/StreamMessage'
 import StreamMessageError from './StreamMessageError'
 
 export default class InvalidJsonError extends StreamMessageError {
-    constructor(streamId: string, readonly parseError: Error, readonly streamMessage: StreamMessage) {
+    constructor(streamId: string, readonly parseError: Error, streamMessage: StreamMessage) {
         super(`Invalid JSON in stream ${streamId}: ${parseError}`, streamMessage)
     }
 }

--- a/packages/protocol/src/protocol/message_layer/GroupKeyAnnounce.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyAnnounce.ts
@@ -36,7 +36,7 @@ export default class GroupKeyAnnounce extends GroupKeyMessage {
         return [this.streamId, this.encryptedGroupKeys.map((it: EncryptedGroupKey)=> it.toArray())]
     }
 
-    static fromArray(arr: GroupKeyAnnounceSerialized): GroupKeyAnnounce {
+    static override fromArray(arr: GroupKeyAnnounceSerialized): GroupKeyAnnounce {
         const [streamId, encryptedGroupKeys] = arr
         return new GroupKeyAnnounce({
             streamId: toStreamID(streamId),

--- a/packages/protocol/src/protocol/message_layer/GroupKeyErrorResponse.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyErrorResponse.ts
@@ -44,7 +44,7 @@ export default class GroupKeyErrorResponse extends GroupKeyMessage {
         return [this.requestId, this.streamId, this.errorCode, this.errorMessage, this.groupKeyIds]
     }
 
-    static fromArray(arr: GroupKeyErrorResponseSerialized): GroupKeyErrorResponse {
+    static override fromArray(arr: GroupKeyErrorResponseSerialized): GroupKeyErrorResponse {
         const [requestId, streamId, errorCode, errorMessage, groupKeyIds] = arr
         return new GroupKeyErrorResponse({
             requestId,

--- a/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
@@ -36,7 +36,7 @@ export default class GroupKeyRequest extends GroupKeyMessage {
         return [this.requestId, this.streamId, this.rsaPublicKey, this.groupKeyIds]
     }
 
-    static fromArray(args: GroupKeyRequestSerialized): GroupKeyRequest {
+    static override fromArray(args: GroupKeyRequestSerialized): GroupKeyRequest {
         const [requestId, streamId, rsaPublicKey, groupKeyIds] = args
         return new GroupKeyRequest({
             requestId,

--- a/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
@@ -42,7 +42,7 @@ export default class GroupKeyResponse extends GroupKeyMessage {
         return [this.requestId, this.streamId, this.encryptedGroupKeys.map((it: EncryptedGroupKey) => it.toArray())]
     }
 
-    static fromArray(arr: GroupKeyResponseSerialized): GroupKeyResponse {
+    static override fromArray(arr: GroupKeyResponseSerialized): GroupKeyResponse {
         const [requestId, streamId, encryptedGroupKeys] = arr
         return new GroupKeyResponse({
             requestId,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,6 +7,7 @@
         "composite": true,
         "declaration": true,
         "moduleResolution": "node",
+        "noImplicitOverride": true,
         "resolveJsonModule": true,
         "types": ["node"],
         "incremental": true,


### PR DESCRIPTION
Requires use of keyword `override` when overriding a method from a super class. Enhances readability by providing the reader context that inheritance is being used.