### PR TITLE
deps: rm jest-circus

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,5 @@ module.exports = {
             tsconfig: 'tsconfig.jest.json',
         }
     },
-    testRunner: 'jest-circus/runner',
     setupFilesAfterEnv: ['jest-extended']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
                 "eslint-plugin-promise": "^6.0.0",
                 "husky": "^6.0.0",
                 "jest": "^28.1.2",
-                "jest-circus": "^28.1.2",
                 "jest-extended": "^0.11.5",
                 "lerna": "^4.0.0",
                 "node-gyp-build": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "eslint-plugin-promise": "^6.0.0",
         "husky": "^6.0.0",
         "jest": "^28.1.2",
-        "jest-circus": "^28.1.2",
         "jest-extended": "^0.11.5",
         "lerna": "^4.0.0",
         "node-gyp-build": "^4.3.0",

--- a/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
@@ -1,6 +1,5 @@
 import { StorageEventListener } from '../../../../src/plugins/storage/StorageEventListener'
 import { StorageNodeAssignmentEvent, Stream, StreamrClient, StreamrClientEvents } from 'streamr-client'
-import { afterEach } from 'jest-circus'
 import { wait } from '@streamr/utils'
 
 describe(StorageEventListener, () => {

--- a/packages/network/simulator.jest.config.js
+++ b/packages/network/simulator.jest.config.js
@@ -25,9 +25,6 @@ module.exports = {
     testTimeout: 15000,
     maxWorkers: 3,
 
-    // This option allows use of a custom test runner
-    testRunner: 'jest-circus/runner',
-
     testPathIgnorePatterns: ["/browser/","/fixtures/","/benchmarks/",
         "/integration/webrtc-endpoint-back-pressure-handling.test.ts", 
         "/integration/ws-endpoint-back-pressure-handling.test.ts", 


### PR DESCRIPTION
Remove `jest-circus`. It is now the default runner of `jest` anyways so no need to explicitly include into package.json and jest.config.js. 

### >> Old Description, keeping for context
Remove `jest-circus`. I think it was brought in to alleviate some weird issues back in the day, but not sure it's really needed anymore.

It causes problems when you accidentally import it in code. If you accidentally `import { beforeEach } from 'jest-circus'` the `beforeEach` block will actually not get executed by jest :disappointed:. 

I could alternatively make an eslint rule forbidding import from `jest-circus` that would help us not run into the situation, but I want to see if our tests pass just fine without it. 

### Update
Found context here https://linear.app/streamr/issue/NET-176/test-jest-circus-and-adopt-in-projects which links to PRs https://github.com/streamr-dev/network/pull/509 and https://github.com/streamr-dev/broker/pull/214. I'll try to find if these are still relevant.

### Update 2
Ah looks like jest-circus is the default runner nowadays anyways https://jestjs.io/docs/configuration#testrunner-string and we are using an (almost) up-to-date version of jest. So that clears it.
