### PR TITLE
test(client): Fake network node

### DIFF
--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -2,7 +2,7 @@
  * Wrap a network node.
  */
 import { inject, Lifecycle, scoped } from 'tsyringe'
-import { NetworkNodeOptions, createNetworkNode, NetworkNode, MetricsContext } from 'streamr-network'
+import { NetworkNodeOptions, createNetworkNode as _createNetworkNode, MetricsContext } from 'streamr-network'
 import { uuid } from './utils/uuid'
 import { instanceId } from './utils/utils'
 import { pOnce } from './utils/promises'
@@ -32,6 +32,14 @@ export interface NetworkNodeStub {
     getMetricsContext: () => MetricsContext
     hasStreamPart: (streamPartId: StreamPartID) => boolean
     hasProxyConnection: (streamPartId: StreamPartID, contactNodeId: string, direction: ProxyDirection) => boolean
+    /** @internal */
+    start: () => void
+    /** @internal */
+    stop: () => Promise<unknown>
+    /** @internal */
+    openProxyConnection: (streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection) => Promise<void>
+    /** @internal */
+    closeProxyConnection: (streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection) => Promise<void>
 }
 
 export const getEthereumAddressFromNodeId = (nodeId: string): string => {
@@ -40,12 +48,22 @@ export const getEthereumAddressFromNodeId = (nodeId: string): string => {
 }
 
 /**
+ * The factory is used so that integration tests can replace the real network node with a fake instance
+ */
+@scoped(Lifecycle.ContainerScoped)
+export class NetworkNodeFactory {
+    createNetworkNode(opts: NetworkNodeOptions): NetworkNodeStub {
+        return _createNetworkNode(opts)
+    }
+}
+
+/**
  * Wrap a network node.
  * Lazily creates & starts node on first call to getNode().
  */
 @scoped(Lifecycle.ContainerScoped)
 export class BrubeckNode implements Context {
-    private cachedNode?: NetworkNode
+    private cachedNode?: NetworkNodeStub
     private networkConfig: NetworkConfig
     private ethereumConfig: EthereumConfig
     readonly id
@@ -56,6 +74,7 @@ export class BrubeckNode implements Context {
     constructor(
         context: Context,
         private destroySignal: DestroySignal,
+        private networkNodeFactory: NetworkNodeFactory,
         @inject(AuthenticationInjectionToken) private authentication: Authentication,
         @inject(ConfigInjectionToken.Network) networkConfig: NetworkConfig,
         @inject(ConfigInjectionToken.Ethereum) ethereumConfig: EthereumConfig
@@ -85,7 +104,7 @@ export class BrubeckNode implements Context {
         return this.networkConfig as NetworkNodeOptions
     }
 
-    private async initNode(): Promise<NetworkNode> {
+    private async initNode(): Promise<NetworkNodeStub> {
         this.assertNotDestroyed()
         if (this.cachedNode) { return this.cachedNode }
 
@@ -103,7 +122,7 @@ export class BrubeckNode implements Context {
 
         this.debug('initNode', id)
         const networkOptions = await this.getNormalizedNetworkOptions()
-        const node = createNetworkNode({
+        const node = this.networkNodeFactory.createNetworkNode({
             disconnectionWaitTime: 200,
             ...networkOptions,
             id,

--- a/packages/client/src/BrubeckNode.ts
+++ b/packages/client/src/BrubeckNode.ts
@@ -182,7 +182,7 @@ export class BrubeckNode implements Context {
         try {
             const node = await this.initNode()
             if (!this.destroySignal.isDestroyed()) {
-                await node.start()
+                node.start()
             }
 
             if (this.destroySignal.isDestroyed()) {

--- a/packages/client/test/integration/parallel-key-exchange.test.ts
+++ b/packages/client/test/integration/parallel-key-exchange.test.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata'
 import { DependencyContainer } from 'tsyringe'
 import { createFakeContainer, DEFAULT_CLIENT_OPTIONS } from './../test-utils/fake/fakeEnvironment'
 import { Subscriber } from './../../src/subscribe/Subscriber'
-import { FakeBrubeckNode } from './../test-utils/fake/FakeBrubeckNode'
+import { FakeNetworkNode } from './../test-utils/fake/FakeNetworkNode'
 import { StreamRegistry } from './../../src/registry/StreamRegistry'
 import { range } from 'lodash'
 import { fastWallet } from 'streamr-test-utils'
@@ -22,7 +22,7 @@ const GROUP_KEY_FETCH_DELAY = 1000
 interface PublisherInfo {
     wallet: Wallet
     groupKey: GroupKey
-    node?: FakeBrubeckNode
+    node?: FakeNetworkNode
 }
 
 const PUBLISHERS: PublisherInfo[] = range(PUBLISHER_COUNT).map(() => ({
@@ -74,7 +74,7 @@ describe('parallel key exchange', () => {
                     encryptionKey: publisher.groupKey,
                     prevMsgRef: (prevMessage !== undefined) ? new MessageRef(prevMessage.getTimestamp(), prevMessage.getSequenceNumber()) : null
                 })
-                publisher.node!.publishToNode(msg)
+                publisher.node!.publish(msg)
                 await wait(10)
                 prevMessage = msg
             }

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -14,7 +14,7 @@ import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Resends } from '../../src/subscribe/Resends'
 import { collect } from '../../src/utils/GeneratorUtils'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
-import { ActiveNodes } from '../test-utils/fake/ActiveNodes'
+import { FakeNetwork } from '../test-utils/fake/FakeNetwork'
 import { StreamStorageRegistry } from '../../src/registry/StreamStorageRegistry'
 
 /*
@@ -42,7 +42,7 @@ describe('resend with existing key', () => {
             stream,
             publisher: publisherWallet,
         })
-        const storageNode = dependencyContainer.resolve(ActiveNodes).getNode(DOCKER_DEV_STORAGE_NODE) as FakeStorageNode
+        const storageNode = dependencyContainer.resolve(FakeNetwork).getNode(DOCKER_DEV_STORAGE_NODE) as FakeStorageNode
         storageNode.storeMessage(message)
     }
 

--- a/packages/client/test/test-utils/fake/ActiveNodes.ts
+++ b/packages/client/test/test-utils/fake/ActiveNodes.ts
@@ -1,17 +1,18 @@
 import { EthereumAddress } from 'streamr-client-protocol'
 import { Lifecycle, scoped } from 'tsyringe'
-import { FakeBrubeckNode } from './FakeBrubeckNode'
+import { FakeNetworkNode } from './FakeNetworkNode'
 
 @scoped(Lifecycle.ContainerScoped)
 export class ActiveNodes {
 
-    private readonly nodes: Map<EthereumAddress, FakeBrubeckNode> = new Map()
+    private readonly nodes: Map<EthereumAddress, FakeNetworkNode> = new Map()
 
-    addNode(node: FakeBrubeckNode): void {
-        if (!this.nodes.has(node.id)) {
-            this.nodes.set(node.id, node)
+    addNode(node: FakeNetworkNode): void {
+        const id = node.id.toLowerCase()
+        if (!this.nodes.has(id)) {
+            this.nodes.set(id, node)
         } else {
-            throw new Error(`Duplicate node: ${node.id}`)
+            throw new Error(`Duplicate node: ${id}`)
         }
     }
 
@@ -19,11 +20,11 @@ export class ActiveNodes {
         this.nodes.delete(address)
     }
 
-    getNode(address: EthereumAddress): FakeBrubeckNode | undefined {
+    getNode(address: EthereumAddress): FakeNetworkNode | undefined {
         return this.nodes.get(address.toLowerCase())
     }
 
-    getNodes(): FakeBrubeckNode[] {
+    getNodes(): FakeNetworkNode[] {
         return Array.from(this.nodes.values())
     }
 }

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -3,7 +3,7 @@ import { Lifecycle, scoped } from 'tsyringe'
 import { FakeNetworkNode } from './FakeNetworkNode'
 
 @scoped(Lifecycle.ContainerScoped)
-export class ActiveNodes {
+export class FakeNetwork {
 
     private readonly nodes: Map<EthereumAddress, FakeNetworkNode> = new Map()
 

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -95,7 +95,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    setExtraMetadata(_metadata: Record<string, unknown>) {
+    setExtraMetadata(_metadata: Record<string, unknown>): void {
         throw new Error('not implemented')
     }
 

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -113,14 +113,12 @@ export class FakeNetworkNode implements NetworkNodeStub {
         throw new Error('not implemented')
     }
 
-    // eslint-disable-next-line class-methods-use-this
     start(): void {
-        // no-op
+        this.network.addNode(this)
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async stop(): Promise<void> {
-        // no-op
+        this.network.removeNode(this.id)
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -144,8 +142,6 @@ export class FakeNetworkNodeFactory implements NetworkNodeFactory {
     }
 
     createNetworkNode(opts: NetworkNodeOptions): FakeNetworkNode {
-        const node = new FakeNetworkNode(opts, this.network)
-        this.network.addNode(node)
-        return node
+        return new FakeNetworkNode(opts, this.network)
     }
 }

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -7,7 +7,7 @@ import {
     toStreamID
 } from 'streamr-client-protocol'
 import { FakeNetworkNode } from './FakeNetworkNode'
-import { ActiveNodes } from './ActiveNodes'
+import { FakeNetwork } from './FakeNetwork'
 import { StreamRegistry } from '../../../src/registry/StreamRegistry'
 import { formStorageNodeAssignmentStreamId } from '../../../src/utils/utils'
 import { sign } from '../../../src/utils/signingUtils'
@@ -20,10 +20,10 @@ export class FakeStorageNode extends FakeNetworkNode {
     private readonly streamPartMessages: Multimap<StreamPartID, StreamMessage> = new Multimap()
     private readonly streamRegistry: StreamRegistry
 
-    constructor(address: EthereumAddress, activeNodes: ActiveNodes, streamRegistry: StreamRegistry) {
+    constructor(address: EthereumAddress, network: FakeNetwork, streamRegistry: StreamRegistry) {
         super({
             id: address
-        } as any, activeNodes)
+        } as any, network)
         this.streamRegistry = streamRegistry
     }
 

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -32,7 +32,9 @@ export class FakeStorageNode extends FakeNetworkNode {
         stream.getStreamParts().forEach(async (streamPartId, idx) => {
             if (!this.subscriptions.has(streamPartId)) {
                 this.addMessageListener((msg: StreamMessage) => {
-                    this.storeMessage(msg)
+                    if (msg.getStreamPartID() === streamPartId) {
+                        this.storeMessage(msg)
+                    }
                 })
                 this.subscribe(streamPartId)
                 const assignmentMessage = new StreamMessage({
@@ -49,7 +51,7 @@ export class FakeStorageNode extends FakeNetworkNode {
                     }
                 })
                 const payload = assignmentMessage.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH)
-                assignmentMessage.signature = await sign(payload, PRIVATE_KEY)
+                assignmentMessage.signature = sign(payload, PRIVATE_KEY)
                 this.publish(assignmentMessage)
             }
         })

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -24,7 +24,8 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
     ) {
         this.streamIdBuilder = streamIdBuilder
         this.network = network
-        this.network.addNode(new FakeStorageNode(DOCKER_DEV_STORAGE_NODE, network, streamRegistry))
+        const node = new FakeStorageNode(DOCKER_DEV_STORAGE_NODE, network, streamRegistry)
+        node.start()
     }
 
     private async hasAssignment(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -24,7 +24,7 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
     ) {
         this.streamIdBuilder = streamIdBuilder
         this.activeNodes = activeNodes
-        this.activeNodes.addNode(new FakeStorageNode(DOCKER_DEV_STORAGE_NODE, activeNodes, 'storage', streamRegistry))
+        this.activeNodes.addNode(new FakeStorageNode(DOCKER_DEV_STORAGE_NODE, activeNodes, streamRegistry))
     }
 
     private async hasAssignment(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {

--- a/packages/client/test/test-utils/fake/fakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/fakeEnvironment.ts
@@ -64,7 +64,9 @@ export const addFakeNode = (
     mockContainer: DependencyContainer
 ): FakeNetworkNode => {
     const factory = mockContainer.resolve(FakeNetworkNodeFactory)
-    return factory.createNetworkNode({
+    const node = factory.createNetworkNode({
         id: nodeId
     } as any) as FakeNetworkNode
+    node.start()
+    return node
 }

--- a/packages/client/test/unit/Subscriber.test.ts
+++ b/packages/client/test/unit/Subscriber.test.ts
@@ -43,7 +43,7 @@ describe('Subscriber', () => {
         const sub = await subscriber.subscribe(stream.id)
 
         const publisherNode = addFakeNode(publisherWallet.address, dependencyContainer)
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publish(createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT
@@ -65,7 +65,7 @@ describe('Subscriber', () => {
         const subscriber = dependencyContainer.resolve(Subscriber)
         const sub = await subscriber.subscribe(stream.id)
 
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publish(createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT,
@@ -93,7 +93,7 @@ describe('Subscriber', () => {
         const onError = jest.fn()
         sub.on('error', onError)
 
-        publisherNode.publishToNode(createMockMessage({
+        publisherNode.publish(createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT,

--- a/packages/client/test/unit/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/unit/SubscriberKeyExchange.test.ts
@@ -15,6 +15,7 @@ import { createFakeContainer } from '../test-utils/fake/fakeEnvironment'
 import { addFakePublisherNode } from '../test-utils/fake/fakePublisherNode'
 import { nextValue } from '../../src/utils/iterators'
 import { fastWallet } from 'streamr-test-utils'
+import { addSubscriber } from '../test-utils/utils'
 
 const AVAILABLE_GROUP_KEY = GroupKey.generate()
 
@@ -37,7 +38,7 @@ describe('SubscriberKeyExchange', () => {
 
     const testSuccessRequest = async (requestedKeyId: string): Promise<GroupKey | undefined> => {
         const publisherNode = await addFakePublisherNode(publisherWallet, [AVAILABLE_GROUP_KEY], fakeContainer)
-        const receivedRequests = publisherNode.addSubscriber(KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address))
+        const receivedRequests = addSubscriber(publisherNode, KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address))
 
         const subscriberKeyExchange = fakeContainer.resolve(SubscriberKeyExchange)
         const receivedKey = subscriberKeyExchange.getGroupKey({


### PR DESCRIPTION
Refactor the fake test environment so that we use the real `BrubeckNode` in the tests. Earlier the fake environment replaced `BrubeckNode` with a custom `FakeBrubeckNode`. Now we fake only the `NetworkNode`.

The client creates a network node instance by calling `NetworkNodeFactory#createNetworkNode`. In production environment, that just calls `createNetworkNode` from `streamr-network` package. In the fake environment we replace the factory with another factory which creates `FakeNetworkNode` instances.

### Other changes

- separated initialization and startup of a fake node (the node joins the network only if `start()` is called)
- fixed a bug in `FakeStorageNode` (it stored duplicate messages from multi-partitioned streams)
- removed obsolete await calls in `BrubeckNode` and `FakeStorageNode`
- renamed `ActiveNodes` to `FakeNetwork`