### PR TITLE
fix(network): Emit `Event.JOIN_FAILED`

### DIFF
--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -57,9 +57,9 @@ interface Metrics extends MetricsDefinition {
 export interface Node {
     on(event: Event.NODE_CONNECTED, listener: (nodeId: NodeId) => void): this
     on(event: Event.NODE_DISCONNECTED, listener: (nodeId: NodeId) => void): this
-    on<T>(event: Event.MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId) => void): this
-    on<T>(event: Event.UNSEEN_MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId) => void): this
-    on<T>(event: Event.DUPLICATE_MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId) => void): this
+    on<T>(event: Event.MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId | null) => void): this
+    on<T>(event: Event.UNSEEN_MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId | null) => void): this
+    on<T>(event: Event.DUPLICATE_MESSAGE_RECEIVED, listener: (msg: StreamMessage<T>, nodeId: NodeId | null) => void): this
     on(event: Event.NODE_SUBSCRIBED, listener: (nodeId: NodeId, streamPartId: StreamPartID) => void): this
     on(event: Event.NODE_UNSUBSCRIBED, listener: (nodeId: NodeId, streamPartId: StreamPartID) => void): this
     on(event: Event.PROXY_CONNECTION_ACCEPTED, listener: (nodeId: NodeId, streamPartId: StreamPartID, direction: ProxyDirection) => void): this

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -410,7 +410,7 @@ export class Node extends EventEmitter {
     }
 
     emitJoinFailed(streamPartId: StreamPartID, error: string): void {
-        this.emit(streamPartId, error)
+        this.emit(Event.JOIN_FAILED, streamPartId, error)
     }
 
     isProxiedStreamPart(streamPartId: StreamPartID, direction: ProxyDirection): boolean {

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -169,7 +169,6 @@ export class Node extends EventEmitter {
                 unsubscribeFromStreamPartOnNode: this.unsubscribeFromStreamPartOnNode.bind(this),
                 emitJoinCompleted: this.emitJoinCompleted.bind(this),
                 emitJoinFailed: this.emitJoinFailed.bind(this)
-
             }
         )
         this.proxyStreamConnectionManager = new ProxyStreamConnectionManager({

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -167,10 +167,6 @@ export class TrackerManager {
                 logger.trace('sent status %j to tracker %s', status.streamPart, trackerId)
             } catch (e) {
                 const error = `failed to send status to tracker ${trackerId}, reason: ${e}`
-                if (this.streamPartManager.isSetUp(streamPartId)
-                    && this.streamPartManager.isNewStream(streamPartId)) {
-                    this.subscriber.emitJoinFailed(streamPartId, error)
-                }
                 logger.trace(error)
             }
         }
@@ -230,8 +226,7 @@ export class TrackerManager {
         if (newStream) {
             if (subscribedNodeIds.length === 0) {
                 this.subscriber.emitJoinFailed(streamPartId,
-                    `Failed initial join operation to stream partition ${streamPartId},
-                            failed to form connections to all target neighbors`
+                    `Failed initial join operation to stream partition ${streamPartId}, failed to form connections to all target neighbors`
                 )
             } else {
                 this.subscriber.emitJoinCompleted(streamPartId, subscribedNodeIds.length)

--- a/packages/network/test/integration/wait-for-join-subscribe-and-publish.test.ts
+++ b/packages/network/test/integration/wait-for-join-subscribe-and-publish.test.ts
@@ -3,7 +3,7 @@ import { Tracker, startTracker } from '@streamr/network-tracker'
 import { MessageID, StreamMessage, toStreamID, toStreamPartID } from 'streamr-client-protocol'
 import { waitForEvent } from '@streamr/utils'
 
-import { createNetworkNode } from '../../src/composition'
+import { createNetworkNode, NodeToTrackerEvent } from '../../src/composition'
 import { Event as NodeEvent } from '../../src/logic/Node'
 
 /**
@@ -17,7 +17,7 @@ describe('subscribe and wait for the node to join the stream', () => {
     const stream3 = toStreamPartID(toStreamID('stream-3'), 0)
     const TIMEOUT = 5000
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         tracker = await startTracker({
             listen: {
                 hostname: '127.0.0.1',
@@ -32,7 +32,6 @@ describe('subscribe and wait for the node to join the stream', () => {
                 trackers: [trackerInfo],
                 stunUrls: [],
                 webrtcDisallowPrivateAddresses: false
-
             }),
             createNetworkNode({
                 id: 'node-1',
@@ -62,7 +61,7 @@ describe('subscribe and wait for the node to join the stream', () => {
         await Promise.all([nodes.map((node) => node.start())])
     }, 5000)
 
-    afterAll(async () => {
+    afterEach(async () => {
         await Promise.allSettled([
             tracker.stop(),
             nodes.map((node) => node.stop())
@@ -123,5 +122,47 @@ describe('subscribe and wait for the node to join the stream', () => {
         ret.map((numOfNeighbors) => {
             expect(numOfNeighbors).toEqual(4)
         })
+    })
+
+    test('fail: timeout', async () => {
+        const invalidNode = createNetworkNode({
+            id: 'node-0',
+            trackers: [{
+                id: 'mock-id',
+                http: '',
+                ws: ''
+            }],
+            stunUrls: [],
+            webrtcDisallowPrivateAddresses: false
+        })
+        invalidNode.start()
+        await expect(() => invalidNode.subscribeAndWaitForJoin(stream1, 1000)).rejects.toThrow('timed out')
+    })
+
+    test('fail: unable to handle instruction', async () => {
+        const connectNode = createNetworkNode({
+            id: 'node-0',
+            trackers: [tracker.getConfigRecord()],
+            stunUrls: [],
+            webrtcDisallowPrivateAddresses: false,
+            newWebrtcConnectionTimeout: 500
+        })
+        connectNode.start()
+        const targetNode = createNetworkNode({
+            id: 'target',
+            trackers: [tracker.getConfigRecord()],
+            stunUrls: [],
+            webrtcDisallowPrivateAddresses: false,
+        })
+        targetNode.start()
+        await targetNode.subscribeAndWaitForJoin(stream1, TIMEOUT)
+        // @ts-expect-error private
+        connectNode.trackerManager.nodeToTracker.once(NodeToTrackerEvent.TRACKER_INSTRUCTION_RECEIVED, () => {
+            setImmediate(() => {
+                targetNode.stop()
+            })
+        })
+        // eslint-disable-next-line max-len
+        await expect(() => connectNode.subscribeAndWaitForJoin(stream1, TIMEOUT)).rejects.toThrow('Failed initial join operation to stream partition stream-1#0, failed to form connections to all target neighbors')
     })
 })

--- a/packages/network/test/integration/wait-for-join-subscribe-and-publish.test.ts
+++ b/packages/network/test/integration/wait-for-join-subscribe-and-publish.test.ts
@@ -137,6 +137,7 @@ describe('subscribe and wait for the node to join the stream', () => {
         })
         invalidNode.start()
         await expect(() => invalidNode.subscribeAndWaitForJoin(stream1, 1000)).rejects.toThrow('timed out')
+        await invalidNode.stop()
     })
 
     test('fail: unable to handle instruction', async () => {
@@ -164,5 +165,6 @@ describe('subscribe and wait for the node to join the stream', () => {
         })
         // eslint-disable-next-line max-len
         await expect(() => connectNode.subscribeAndWaitForJoin(stream1, TIMEOUT)).rejects.toThrow('Failed initial join operation to stream partition stream-1#0, failed to form connections to all target neighbors')
+        await connectNode.stop()
     })
 })


### PR DESCRIPTION
Fixed event emit logic in `Node#emitJoinFailed`. The event was never emitted.

After that change two tests suites failed: `wait-for-join-subscribe-and-publish.test.ts` and `tracker-counters-are-stream-part-specific.test.ts`.  The reason was that the first `sendStatus` always failed because there was no existing tracker connection, and in that situation we emitted `JOIN_FAILED`. 

Changed the logic so that we don't emit `JOIN_FAILED` in `sendStatus` (it is emitted when the tracker instruction is handled and `subscribeAndWaitForJoin` receives the event from there).

### Other changes

Fixed event signatures of three node events which can may have `nodeId` as `null`  in the event payload.