### PR TITLE
fix(broker): subscriber plugin only joins the topology, does not process messages

### DIFF
--- a/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
+++ b/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
@@ -30,12 +30,10 @@ export class SubscriberPlugin extends Plugin<SubscriberPluginConfig> {
     }
 
     private async subscribeToStreamParts(): Promise<void> {
+        const node = await this.streamrClient!.getNode()
         await Promise.all([
             ...this.streamParts.map(async (streamPart) => {
-                const isAlreadySubscribed = (await this.streamrClient!.getSubscriptions(streamPart)).length > 0
-                if (!isAlreadySubscribed) {
-                    await this.streamrClient!.subscribe(streamPart, (_message: any) => {})
-                }
+                node.subscribe(streamPart)
             })
         ])
     }

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -2,7 +2,7 @@ import { Tracker } from '@streamr/network-tracker'
 import { createClient, startTestTracker } from '../../../utils'
 import { SubscriberPlugin } from '../../../../src/plugins/subscriber/SubscriberPlugin'
 import StreamrClient from 'streamr-client'
-import { fastWallet } from 'streamr-test-utils'
+import { fastWallet, waitForCondition } from 'streamr-test-utils'
 
 const TRACKER_PORT = 12465
 const wallet = fastWallet()
@@ -62,7 +62,14 @@ describe('Subscriber Plugin', () => {
     })
 
     it('subscribes to the configured list of streams', async () => {
-        expect(await plugin.streamrClient.getSubscriptions('stream-0')).toBeArrayOfSize(2)
-        expect(await plugin.streamrClient.getSubscriptions('stream-1')).toBeArrayOfSize(1)
+        const nodeId = (await client.getNode()).getNodeId()
+        await waitForCondition(() => {
+            const overlays = tracker.getOverlayPerStreamPart() as any
+            return (overlays["stream-0#0"]?.nodes[nodeId] !== undefined)
+                && (overlays["stream-0#1"]?.nodes[nodeId] !== undefined)
+                && (overlays["stream-1#0"]?.nodes[nodeId] !== undefined)
+        })
+        // If waitForCondition succeeds we are okay
+        expect(true).toEqual(true)
     })
 })


### PR DESCRIPTION
The `subscriber` plugin no longer uses the `StreamrClient` directly to subscribe to streams. Now it uses the internal `NetworkNode` to join the stream without attaching a message listener.

This means that the broker will no longer query the contract to check the permissions, request group keys and try to validate each message.
