### PR TITLE
fix(network): fix flaky proxy-connection test

### DIFF
--- a/packages/network/test/integration/proxy-connections.test.ts
+++ b/packages/network/test/integration/proxy-connections.test.ts
@@ -290,7 +290,7 @@ describe('Proxy connection tests', () => {
         await onewayNode.openProxyConnection(defaultStreamPartId, 'contact-node', ProxyDirection.PUBLISH)
 
         await Promise.all([
-            waitForEvent(onewayNode, NodeEvent.NODE_CONNECTED, 20000),
+            waitForEvent(contactNode, NodeEvent.NODE_CONNECTED, 20000),
             // @ts-expect-error private
             contactNode.nodeToNode.disconnectFromNode('publisher', 'testing')
         ])


### PR DESCRIPTION
Fixes a flakyness issue with the test case `will reconnect after lost connectivity`. There was a timing related issue where the reconnection could happen so fast that the other end would not emit `NODE_CONNECTED`, causing the test to time out.
