### PR TITLE
refactor(client): Do not use `length = 0` to clear arrays

### DIFF
--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -129,7 +129,7 @@ export class GroupKeyStore implements Context {
 
     async clear(): Promise<boolean> {
         this.currentGroupKeyId = undefined
-        this.nextGroupKeys.length = 0
+        this.nextGroupKeys = []
 
         return this.persistence.clear()
     }
@@ -155,7 +155,7 @@ export class GroupKeyStore implements Context {
     async rekey(newKey = GroupKey.generate()): Promise<void> {
         await this.storeKey(newKey)
         this.currentGroupKeyId = newKey.id
-        this.nextGroupKeys.length = 0
+        this.nextGroupKeys = []
     }
 
     async size(): Promise<number> {

--- a/packages/client/src/utils/Pipeline.ts
+++ b/packages/client/src/utils/Pipeline.ts
@@ -67,8 +67,8 @@ class PipelineDefinition<InType, OutType = InType> {
     }
 
     clearTransforms() {
-        this.transforms.length = 0
-        this.transformsBefore.length = 0
+        this.transforms = []
+        this.transformsBefore = []
     }
 
     setSource(source: AsyncGenerator<InType> | AsyncGeneratorWithId<InType>) {

--- a/packages/client/src/utils/PushBuffer.ts
+++ b/packages/client/src/utils/PushBuffer.ts
@@ -48,7 +48,7 @@ export class PushBuffer<T> implements IPushBuffer<T>, Context {
     readonly id
     readonly debug
 
-    protected readonly buffer: (T | Error)[] = []
+    protected buffer: (T | Error)[] = []
     readonly bufferSize: number
 
     /** open when writable */
@@ -229,7 +229,7 @@ export class PushBuffer<T> implements IPushBuffer<T>, Context {
                 throw error
             }
         } finally {
-            this.buffer.length = 0
+            this.buffer = []
             this.lock()
         }
     }
@@ -240,7 +240,7 @@ export class PushBuffer<T> implements IPushBuffer<T>, Context {
 
     // clears any pending items in buffer
     clear(): void {
-        this.buffer.length = 0
+        this.buffer = []
     }
 
     // AsyncGenerator implementation

--- a/packages/client/src/utils/Signal.ts
+++ b/packages/client/src/utils/Signal.ts
@@ -205,7 +205,7 @@ export class Signal<ArgsType extends any[] = []> {
      * Remove all callback listeners from this Signal.
      */
     unlistenAll(): void {
-        this.listeners.length = 0
+        this.listeners = []
     }
 
     // TODO better return type?
@@ -238,7 +238,7 @@ export class Signal<ArgsType extends any[] = []> {
         const tasks = this.listeners.slice()
         if (this.triggerType === TRIGGER_TYPE.ONCE) {
             // remove all listeners
-            this.listeners.length = 0
+            this.listeners = []
             this.end(...args)
         }
 
@@ -304,7 +304,7 @@ export class ErrorSignal<ArgsType extends [Error] = [Error]> extends Signal<Args
         const tasks = this.listeners.slice()
         if (this.triggerType === TRIGGER_TYPE.ONCE) {
             // remove all listeners
-            this.listeners.length = 0
+            this.listeners = []
             this.end(...args)
         }
 

--- a/packages/client/test/test-utils/jest-utils.ts
+++ b/packages/client/test/test-utils/jest-utils.ts
@@ -21,10 +21,10 @@ describeRepeats.only = (msg: any, fn: any) => {
 }
 
 export function addAfterFn(): (fn: any) => void {
-    const afterFns: any[] = []
+    let afterFns: any[] = []
     afterEach(async () => {
         const fns = afterFns.slice()
-        afterFns.length = 0
+        afterFns = []
         // @ts-expect-error invalid parameter
         AggregatedError.throwAllSettled(await Promise.allSettled(fns.map((fn) => fn())))
     })

--- a/packages/client/test/test-utils/publish.ts
+++ b/packages/client/test/test-utils/publish.ts
@@ -90,12 +90,12 @@ export function getPublishTestStreamMessages(
         }
 
         const publishStream = publishTestMessagesGenerator(client, streamDefinition, maxMessages, options)
-        const streamMessages = []
+        let streamMessages = []
         let count = 0
         for await (const streamMessage of publishStream) {
             count += 1
             if (!retainMessages) {
-                streamMessages.length = 0 // only keep last message
+                streamMessages = [] // only keep last message
             }
             streamMessages.push(streamMessage)
             if (count === maxMessages) {


### PR DESCRIPTION
Assign empty array instead. That wait it is more readable. 

This could change behaviour if the value of the variable is referenced by multiple variables (then length = 0 would clear all referenced arrays, not just the one we execute the statement on). 

Also changed visibility of some fields.