### PR TITLE
NET-900 cleanup GroupKeyStore

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -107,12 +107,12 @@ export class StreamrClient implements Context {
         const store = await this.groupKeyStoreFactory.getStore(streamId)
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {
-                return store.rotateGroupKey()
+                await store.rotateGroupKey()
             } else { // eslint-disable-line no-else-return
-                return store.setNextGroupKey(opts.key)
+                await store.setNextGroupKey(opts.key)
             }
         } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
-            return store.rekey(opts.key)
+            await store.rekey(opts.key)
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
         }

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -100,15 +100,40 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.useGroupKey()).toEqual([groupKey2, undefined])
     })
 
-    it('replaces previously queued keys', async () => {
+    it('replaces unused rotations', async () => {
         const [generatedKey, queuedKey] = await store.useGroupKey()
         expect(generatedKey).toBeTruthy()
         expect(queuedKey).toEqual(undefined)
 
-        const groupKey = GroupKey.generate()
-        const groupKey2 = GroupKey.generate()
-        await store.setNextGroupKey(groupKey)
-        await store.setNextGroupKey(groupKey2)
+        const groupKey = await store.rotateGroupKey()
+        expect(groupKey).toBeTruthy()
+        const groupKey2 = await store.rotateGroupKey()
         expect(await store.useGroupKey()).toEqual([generatedKey, groupKey2])
+    })
+
+    it('handles rotate then rekey', async () => {
+        // Set some initial key
+        const [generatedKey, queuedKey] = await store.useGroupKey()
+        expect(generatedKey).toBeTruthy()
+        expect(queuedKey).toEqual(undefined)
+
+        const rotatedKey = await store.rotateGroupKey()
+        expect(rotatedKey).toBeTruthy()
+        const rekey = await store.rekey()
+        expect(rekey).toBeTruthy()
+        expect(await store.useGroupKey()).toEqual([rekey, undefined])
+    })
+
+    it('handles rekey then rotate', async () => {
+        // Set some initial key
+        const [generatedKey, queuedKey] = await store.useGroupKey()
+        expect(generatedKey).toBeTruthy()
+        expect(queuedKey).toEqual(undefined)
+
+        const rekey = await store.rekey()
+        expect(rekey).toBeTruthy()
+        const rotatedKey = await store.rotateGroupKey()
+        expect(rotatedKey).toBeTruthy()
+        expect(await store.useGroupKey()).toEqual([rekey, rotatedKey])
     })
 })

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -86,7 +86,13 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.useGroupKey()).toEqual([groupKey2, undefined])
     })
 
-    it('replaces previously queued keys before the first call to useGroupKey', async () => {
+    it('generates a new key on first use', async () => {
+        const [generatedKey, nextKey] = await store.useGroupKey()
+        expect(generatedKey).toBeTruthy()
+        expect(nextKey).toBeUndefined()
+    })
+
+    it('only keeps the latest unused key', async () => {
         const groupKey = GroupKey.generate()
         const groupKey2 = GroupKey.generate()
         await store.setNextGroupKey(groupKey)
@@ -94,7 +100,7 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.useGroupKey()).toEqual([groupKey2, undefined])
     })
 
-    it('replaces previously queued keys after the first call to useGroupKey', async () => {
+    it('replaces previously queued keys', async () => {
         const [generatedKey, queuedKey] = await store.useGroupKey()
         expect(generatedKey).toBeTruthy()
         expect(queuedKey).toEqual(undefined)


### PR DESCRIPTION
- Refactor away unnecessary complexity in `GroupKeyStore`
- Add new unit test cases
- Changes are otherwise contained to `GroupKeyStore`, except a few return type changes leak to `StreamClient`

## Checklist

- [X] Has passing tests that demonstrate this change works
- [ ] Updated Changelog
- [ ] Updated Documentation
