### PR TITLE
test(client): Use `FakeNetwork#waitForSentMessages`

### DIFF
--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -123,6 +123,10 @@ describe('PublisherKeyExchange', () => {
         await startPublisherKeyExchangeSubscription(publisherClient)
     })
 
+    afterEach(async () => {
+        await environment.destroy()
+    })
+
     describe('responds to a group key request', () => {
 
         /*

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -4,15 +4,14 @@ import {
     GroupKeyErrorResponse,
     KeyExchangeStreamIDUtils,
     StreamMessage,
+    StreamPartID,
     StreamPartIDUtils,
 } from 'streamr-client-protocol'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { Wallet } from 'ethers'
 import { RSAKeyPair } from '../../src/encryption/RSAKeyPair'
-import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
 import { 
-    addSubscriber,
     createMockMessage,
     createRelativeTestStreamId,
     getGroupKeyStore,
@@ -21,7 +20,6 @@ import {
 import { getGroupKeysFromStreamMessage } from '../../src/encryption/SubscriberKeyExchange'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeNetworkNode } from '../test-utils/fake/FakeNetworkNode'
-import { nextValue } from '../../src/utils/iterators'
 import { fastWallet } from 'streamr-test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
@@ -32,7 +30,7 @@ describe('PublisherKeyExchange', () => {
     let subscriberWallet: Wallet
     let subscriberRSAKeyPair: RSAKeyPair
     let subscriberNode: FakeNetworkNode
-    let mockStream: Stream
+    let streamPartId: StreamPartID
     let environment: FakeEnvironment
 
     const createStream = async () => {
@@ -54,7 +52,7 @@ describe('PublisherKeyExchange', () => {
             publisher,
             content: JSON.stringify([
                 uuid(),
-                mockStream.id,
+                StreamPartIDUtils.getStreamID(streamPartId),
                 rsaPublicKey,
                 [groupKeyId]
             ]),
@@ -118,7 +116,8 @@ describe('PublisherKeyExchange', () => {
                 privateKey: publisherWallet.privateKey
             }
         })
-        mockStream = await createStream()
+        const stream = await createStream()
+        streamPartId = stream.getStreamParts()[0]
         subscriberNode = environment.startNode(subscriberWallet.address)
         await startPublisherKeyExchangeSubscription(publisherClient)
     })
@@ -135,24 +134,24 @@ describe('PublisherKeyExchange', () => {
          */
         it('happy path', async () => {
             const key = GroupKey.generate()
-            await getGroupKeyStore(mockStream.id, publisherWallet.address).add(key)
-
-            const receivedResponses = addSubscriber(subscriberNode, KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
+            await getGroupKeyStore(StreamPartIDUtils.getStreamID(streamPartId), publisherWallet.address).add(key)
 
             const request = createGroupKeyRequest(key.id)
             subscriberNode.publish(request)
 
-            const response = await nextValue(receivedResponses)
+            const response = await environment.getNetwork().waitForSentMessage({
+                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE
+            })
             await testSuccessResponse(response!, [key])
         })
 
         it('no group key in store', async () => {
-            const receivedResponses = addSubscriber(subscriberNode, KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
-
             const request = createGroupKeyRequest(GroupKey.generate().id)
             subscriberNode.publish(request)
 
-            const response = await nextValue(receivedResponses)
+            const response = await environment.getNetwork().waitForSentMessage({
+                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE
+            })
             await testSuccessResponse(response!, [])
         })
 
@@ -160,24 +159,26 @@ describe('PublisherKeyExchange', () => {
             const groupKey = GroupKey.generate()
             const otherWallet = fastWallet()
             const otherNode = environment.startNode(otherWallet.address)
-            const receivedResponses = addSubscriber(otherNode, KeyExchangeStreamIDUtils.formStreamPartID(otherWallet.address))
 
             const request = createGroupKeyRequest(groupKey.id, otherWallet, (await RSAKeyPair.create()).getPublicKey())
             otherNode.publish(request)
 
-            const response = await nextValue(receivedResponses)
+            const response = await environment.getNetwork().waitForSentMessage({
+                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_ERROR_RESPONSE
+            })
             await testErrorResponse(response!, [ groupKey.id ], otherWallet.address)
         })
 
         it('invalid request', async () => {
             const groupKey = GroupKey.generate()
-            const receivedResponses = addSubscriber(subscriberNode, KeyExchangeStreamIDUtils.formStreamPartID(subscriberWallet.address))
 
             const request: any = createGroupKeyRequest(groupKey.id)
             delete request.signature
             subscriberNode.publish(request)
 
-            const response = await nextValue(receivedResponses)
+            const response = await environment.getNetwork().waitForSentMessage({
+                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_ERROR_RESPONSE
+            })
             await testErrorResponse(response!, [ groupKey.id ])
         })
     })

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -30,6 +30,10 @@ describe('Subscriber', () => {
         stream = await subscriber.createStream('/path')
     })
 
+    afterEach(async () => {
+        await environment.destroy()
+    })
+
     it('without encryption', async () => {
         await stream.grantPermissions({
             permissions: [StreamPermission.PUBLISH],

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 import {
     KeyExchangeStreamIDUtils,
     StreamMessage,
+    StreamPartID,
     StreamPartIDUtils,
 } from 'streamr-client-protocol'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -9,10 +10,8 @@ import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
-import { nextValue } from '../../src/utils/iterators'
 import { fastWallet, waitForCondition } from 'streamr-test-utils'
 import { 
-    addSubscriber,
     createMockMessage,
     createRelativeTestStreamId,
     getGroupKeyStore,
@@ -26,7 +25,7 @@ describe('SubscriberKeyExchange', () => {
     let publisherWallet: Wallet
     let subscriberWallet: Wallet
     let subscriber: StreamrClient
-    let stream: Stream
+    let streamPartId: StreamPartID
     let environment: FakeEnvironment
 
     const createStream = async (): Promise<Stream> => {
@@ -40,7 +39,7 @@ describe('SubscriberKeyExchange', () => {
 
     const triggerGroupKeyRequest = (key: GroupKey, publisherNode: NetworkNodeStub): void => {
         publisherNode.publish(createMockMessage({
-            stream,
+            streamPartId,
             publisher: publisherWallet,
             encryptionKey: key
         }))
@@ -62,7 +61,7 @@ describe('SubscriberKeyExchange', () => {
         })
         expect(request!.getParsedContent()).toEqual([
             expect.any(String),
-            stream.id,
+            StreamPartIDUtils.getStreamID(streamPartId),
             expect.any(String),
             expectedRequestedKeyIds
         ])
@@ -77,7 +76,8 @@ describe('SubscriberKeyExchange', () => {
                 privateKey: subscriberWallet.privateKey
             }
         })
-        stream = await createStream()
+        const stream = await createStream()
+        streamPartId = stream.getStreamParts()[0]
     })
 
     afterEach(async () => {
@@ -98,22 +98,23 @@ describe('SubscriberKeyExchange', () => {
                     privateKey: publisherWallet.privateKey
                 },
                 encryptionKeys: {
-                    [stream.id]: {
+                    [StreamPartIDUtils.getStreamID(streamPartId)]: {
                         [groupKey.id]: groupKey
                     }
                 }
             })
             await startPublisherKeyExchangeSubscription(publisher)
             const publisherNode = await publisher.getNode()
-            const groupKeyRequests = addSubscriber(publisherNode, KeyExchangeStreamIDUtils.formStreamPartID(publisherWallet.address))
-            await subscriber.subscribe(stream.id, () => {})
+            await subscriber.subscribe(streamPartId, () => {})
 
             triggerGroupKeyRequest(groupKey, publisherNode)
             
-            const request = await nextValue(groupKeyRequests)
-            assertGroupKeyRequest(request!, [groupKey.id])
-            const keyPersistence = getGroupKeyStore(stream.id, subscriberWallet.address)
+            const request = await environment.getNetwork().waitForSentMessage({
+                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+            })
+            await assertGroupKeyRequest(request!, [groupKey.id])
+            const keyPersistence = getGroupKeyStore(StreamPartIDUtils.getStreamID(streamPartId), subscriberWallet.address)
             await waitForCondition(async () => (await keyPersistence.get(groupKey.id)) !== undefined)
-        })
+        }) 
     })
 })

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -80,6 +80,10 @@ describe('SubscriberKeyExchange', () => {
         stream = await createStream()
     })
 
+    afterEach(async () => {
+        await environment.destroy()
+    })
+
     describe('requests a group key', () => {
 
         /*

--- a/packages/client/test/integration/invalid-messages.test.ts
+++ b/packages/client/test/integration/invalid-messages.test.ts
@@ -36,10 +36,7 @@ describe('client behaviour on invalid message', () => {
     })
 
     afterEach(async () => {
-        await Promise.allSettled([
-            publisherClient?.destroy(),
-            subscriberClient?.destroy()
-        ])
+        await environment.destroy()
     })
 
     it('publishing with insufficient permissions prevents message from being sent to network (NET-773)', async () => {

--- a/packages/client/test/integration/multiple-clients.test.ts
+++ b/packages/client/test/integration/multiple-clients.test.ts
@@ -50,7 +50,7 @@ describe('PubSub with multiple clients', () => {
     })
 
     afterEach(async () => {
-        await mainClient?.destroy()
+        await environment.destroy()
     })
 
     async function createPublisher() {
@@ -113,8 +113,6 @@ describe('PubSub with multiple clients', () => {
             // messages should arrive on both clients?
             expect(receivedMessagesMain).toEqual([message])
             expect(receivedMessagesOther).toEqual([message])
-
-            await otherClient.destroy()
         })
     })
 
@@ -174,9 +172,6 @@ describe('PubSub with multiple clients', () => {
 
             checkMessages(published, receivedMessagesMain)
             checkMessages(published, receivedMessagesOther)
-
-            await otherClient.destroy()
-            await Promise.all(publishers.map((p) => p.destroy()))
         })
 
         // late subscriber test is super unreliable. Doesn't seem to be a good way to make the

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -90,8 +90,8 @@ describe('resend and subscribe', () => {
             mockId: 2
         })
         expect(receivedMessage2!.groupKeyId).toBe(groupKey.id)
-        const groupKeyRequests = environment.getNetwork().getSentMessages().filter((m) => {
-            return m.messageType === StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+        const groupKeyRequests = environment.getNetwork().getSentMessages({
+            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
         })
         expect(groupKeyRequests.length).toBe(1)
     })

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -39,6 +39,10 @@ describe('resend and subscribe', () => {
         subscriber.addStreamToStorageNode(stream.id, storageNode.id)
     })
 
+    afterAll(async () => {
+        await environment.destroy()
+    })
+
     it('happy path', async () => {
         const groupKey = GroupKey.generate()
         const publisher = environment.createClient({

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -52,7 +52,10 @@ describe('resend with existing key', () => {
 
     const assertDecryptable = async (fromTimestamp: number, toTimestamp: number) => {
         const messageStream = await resendRange(fromTimestamp, toTimestamp)
+        const onError = jest.fn()
+        messageStream.onError.listen(onError)
         const messages = await collect(messageStream)
+        expect(onError).not.toBeCalled()
         const expectedTimestamps = allMessages.map((m) => m.timestamp).filter((ts) => ts >= fromTimestamp && ts <= toTimestamp)
         expect(messages.map((m) => m.getTimestamp())).toEqual(expectedTimestamps)
     }

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -104,6 +104,10 @@ describe('resend with existing key', () => {
         }
     })
 
+    afterEach(async () => {
+        await environment.destroy()
+    })
+
     describe('no keys available', () => {
         it('can\'t decrypt', async () => {
             await assertNonDecryptable(1000, 6000)

--- a/packages/client/test/integration/revoke-permissions.test.ts
+++ b/packages/client/test/integration/revoke-permissions.test.ts
@@ -39,6 +39,10 @@ describe('revoke permissions', () => {
         environment = new FakeEnvironment()
     })
 
+    afterEach(async () => {
+        await environment.destroy()
+    })
+
     async function setupStream() {
         stream = await createTestStream(publisher, module)
         const storageNode = environment.startStorageNode()

--- a/packages/client/test/integration/sequential-resend-subscribe.test.ts
+++ b/packages/client/test/integration/sequential-resend-subscribe.test.ts
@@ -44,8 +44,7 @@ describe('sequential resend subscribe', () => {
     })
 
     afterAll(async () => {
-        await publisher?.destroy()
-        await subscriber?.destroy()
+        await environment.destroy()
     })
 
     afterEach(async () => {

--- a/packages/client/test/integration/update-encryption-key.test.ts
+++ b/packages/client/test/integration/update-encryption-key.test.ts
@@ -18,9 +18,10 @@ describe('update encryption key', () => {
     let subscriber: StreamrClient
     let streamPartId: StreamPartID
     let sub: Subscription
+    let environment = new FakeEnvironment()
 
     beforeEach(async () => {
-        const environment = new FakeEnvironment()
+        environment = new FakeEnvironment()
         publisher = environment.createClient()
         subscriber = environment.createClient()
         const stream = await publisher.createStream('/path')
@@ -30,6 +31,10 @@ describe('update encryption key', () => {
         })
         streamPartId = stream.getStreamParts()[0]
         sub = await subscriber.subscribe(streamPartId)
+    })
+
+    afterEach(async () => {
+        await environment.destroy()
     })
 
     it('rotate', async () => {

--- a/packages/client/test/test-utils/fake/FakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/FakeEnvironment.ts
@@ -9,7 +9,6 @@ import { FakeStorageNodeRegistry } from './FakeStorageNodeRegistry'
 import { FakeStreamRegistry } from './FakeStreamRegistry'
 import { FakeHttpUtil } from './FakeHttpUtil'
 import { HttpUtil } from '../../../src/HttpUtil'
-import { EthereumAddress } from 'streamr-client-protocol'
 import { StreamStorageRegistry } from '../../../src/registry/StreamStorageRegistry'
 import { FakeStreamStorageRegistry } from './FakeStreamStorageRegistry'
 import { FakeNetworkNodeFactory, FakeNetworkNode } from './FakeNetworkNode'
@@ -17,6 +16,7 @@ import { NetworkNodeFactory } from '../../../src/NetworkNodeFacade'
 import { FakeNetwork } from './FakeNetwork'
 import { FakeChain } from './FakeChain'
 import { FakeStorageNode } from './FakeStorageNode'
+import { NodeId } from 'streamr-network'
 
 const DEFAULT_CLIENT_OPTIONS: StreamrClientConfig = {
     network: {
@@ -60,7 +60,7 @@ export class FakeEnvironment {
         return client
     }
 
-    startNode(nodeId: EthereumAddress): FakeNetworkNode {
+    startNode(nodeId: NodeId): FakeNetworkNode {
         const node = new FakeNetworkNode({
             id: nodeId
         } as any, this.network)

--- a/packages/client/test/test-utils/fake/FakeEnvironment.ts
+++ b/packages/client/test/test-utils/fake/FakeEnvironment.ts
@@ -29,6 +29,7 @@ export class FakeEnvironment {
     private network: FakeNetwork
     private chain: FakeChain
     private dependencyContainer: DependencyContainer
+    private clients: StreamrClient[] = []
 
     constructor() {
         this.network = new FakeNetwork()
@@ -54,7 +55,9 @@ export class FakeEnvironment {
             }
         }
         const configWithDefaults = merge({}, DEFAULT_CLIENT_OPTIONS, authOpts, opts)
-        return new StreamrClient(configWithDefaults, this.dependencyContainer)
+        const client = new StreamrClient(configWithDefaults, this.dependencyContainer)
+        this.clients.push(client)
+        return client
     }
 
     startNode(nodeId: EthereumAddress): FakeNetworkNode {
@@ -74,5 +77,9 @@ export class FakeEnvironment {
 
     getNetwork(): FakeNetwork {
         return this.network
+    }
+
+    destroy(): Promise<unknown> {
+        return Promise.all(this.clients.map((client) => client.destroy()))
     }
 }

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -1,9 +1,10 @@
-import { EthereumAddress, StreamMessage } from 'streamr-client-protocol'
+import { StreamMessage, StreamMessageType } from 'streamr-client-protocol'
+import { NodeId } from 'streamr-network'
 import { FakeNetworkNode } from './FakeNetworkNode'
 
 export class FakeNetwork {
 
-    private readonly nodes: Map<EthereumAddress, FakeNetworkNode> = new Map()
+    private readonly nodes: Map<NodeId, FakeNetworkNode> = new Map()
     private sentMessages: StreamMessage[] = []
 
     addNode(node: FakeNetworkNode): void {
@@ -14,12 +15,12 @@ export class FakeNetwork {
         }
     }
 
-    removeNode(address: EthereumAddress): void {
-        this.nodes.delete(address)
+    removeNode(id: NodeId): void {
+        this.nodes.delete(id)
     }
 
-    getNode(address: EthereumAddress): FakeNetworkNode | undefined {
-        return this.nodes.get(address)
+    getNode(id: NodeId): FakeNetworkNode | undefined {
+        return this.nodes.get(id)
     }
 
     getNodes(): FakeNetworkNode[] {

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -1,11 +1,23 @@
 import { StreamMessage, StreamMessageType } from 'streamr-client-protocol'
 import { NodeId } from 'streamr-network'
+import { waitForCondition } from 'streamr-test-utils'
 import { FakeNetworkNode } from './FakeNetworkNode'
+
+interface Send {
+    message: StreamMessage
+    sender: NodeId
+    recipients: NodeId[]
+}
+
+interface SentMessagesFilter {
+    messageType?: StreamMessageType
+    count?: number
+}
 
 export class FakeNetwork {
 
     private readonly nodes: Map<NodeId, FakeNetworkNode> = new Map()
-    private sentMessages: StreamMessage[] = []
+    private sends: Send[] = []
 
     addNode(node: FakeNetworkNode): void {
         if (!this.nodes.has(node.id)) {
@@ -27,25 +39,54 @@ export class FakeNetwork {
         return Array.from(this.nodes.values())
     }
 
-    sendMessage(msg: StreamMessage): void {
+    send(msg: StreamMessage, sender: NodeId, isRecipient: (networkNode: FakeNetworkNode) => boolean): void {
+        const recipients = this.getNodes().filter((n) => isRecipient(n))
         /*
-         * This serialization+serialization is needed in test/integration/Encryption.ts
-         * as it expects that the EncryptedGroupKey format changes in the process.
-         * TODO: should we change the serialization or the test? Or keep this hack?
-         */
+        * This serialization+serialization is needed in test/integration/Encryption.ts
+        * as it expects that the EncryptedGroupKey format changes in the process.
+        * TODO: should we change the serialization or the test? Or keep this hack?
+        */
         const serialized = msg.serialize()
-        this.getNodes().forEach(async (networkNode) => {
-            if (networkNode.subscriptions.has(msg.getStreamPartID())) {
-                networkNode.messageListeners.forEach((listener) => {
-                    const deserialized = StreamMessage.deserialize(serialized)
-                    listener(deserialized)
-                })
-            }
+        recipients.forEach((n) => {
+            n.messageListeners.forEach((listener) => {
+                // return a clone as client mutates message when it decrypts messages
+                const deserialized = StreamMessage.deserialize(serialized)
+                listener(deserialized)
+            })
         })
-        this.sentMessages.push(msg)
+        this.sends.push({
+            message: msg,
+            sender,
+            recipients: recipients.map((n) => n.id)
+        })
     }
 
-    getSentMessages(): StreamMessage[] {
-        return this.sentMessages
+    getSentMessages(predicate: SentMessagesFilter): StreamMessage[] {
+        return this.sends
+            .filter((send: Send) => {
+                const msg = send.message
+                return (predicate.messageType === undefined) || (msg.messageType === predicate.messageType)
+            })
+            .map((m) => m.message)
+    }
+
+    async waitForSentMessages(opts: SentMessagesFilter & { count: number }, timeout = 60 * 1000): Promise<StreamMessage[]> { 
+        let found: StreamMessage[] = []
+        const count = opts.count
+        await waitForCondition(() => {
+            found = this.getSentMessages(opts)
+            return found.length >= count
+        }, timeout, timeout / 100, () => {
+            return `waitForSentMessages timed out: ${JSON.stringify(opts)} matches ${found.length}/${count}`
+        })
+        return found.slice(0, count)
+    }
+    
+    async waitForSentMessage(opts: SentMessagesFilter, timeout?: number): Promise<StreamMessage> {
+        const messages = await this.waitForSentMessages({
+            ...opts,
+            count: 1
+        }, timeout)
+        return messages[0]
     }
 }

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -53,7 +53,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
     }
 
     publish(msg: StreamMessage): void {
-        this.network.sendMessage(msg)
+        this.network.send(msg, this.id, (node: FakeNetworkNode) => node.subscriptions.has(msg.getStreamPartID()))
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -1,7 +1,7 @@
 import { Lifecycle, scoped } from 'tsyringe'
 import { pull } from 'lodash'
 import { ProxyDirection, StreamMessage, StreamPartID } from 'streamr-client-protocol'
-import { MetricsContext } from 'streamr-network'
+import { MetricsContext, NodeId } from 'streamr-network'
 import { NetworkNodeOptions } from 'streamr-network'
 import { NetworkNodeFactory, NetworkNodeStub } from '../../../src/NetworkNodeFacade'
 import { FakeNetwork } from './FakeNetwork'
@@ -10,7 +10,7 @@ type MessageListener = (msg: StreamMessage) => void
 
 export class FakeNetworkNode implements NetworkNodeStub {
 
-    public readonly id: string
+    public readonly id: NodeId
     readonly subscriptions: Set<StreamPartID> = new Set()
     readonly messageListeners: MessageListener[] = []
     private readonly network: FakeNetwork

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -24,8 +24,6 @@ import { StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { EncryptionUtil } from '../../src/encryption/EncryptionUtil'
 import { addAfterFn } from './jest-utils'
-import { TransformStream } from 'node:stream/web'
-import { NetworkNodeStub } from '../../src/NetworkNodeFacade'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { PublisherKeyExchange } from '../../src/encryption/PublisherKeyExchange'
 
@@ -139,18 +137,6 @@ export const createMockMessage = (
     }
     msg.signature = sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), opts.publisher.privateKey)
     return msg
-}
-
-export const addSubscriber = <T>(networkNodeStub: NetworkNodeStub, ...streamPartIds: StreamPartID[]): AsyncIterableIterator<StreamMessage<T>> => {
-    const messages = new TransformStream()
-    const messageWriter = messages.writable.getWriter()
-    networkNodeStub.addMessageListener((msg: StreamMessage) => {
-        if (streamPartIds.includes(msg.getStreamPartID())) {
-            messageWriter.write(msg)
-        }
-    })
-    streamPartIds.forEach((id) => networkNodeStub.subscribe(id))
-    return messages.readable[Symbol.asyncIterator]()
 }
 
 export const getGroupKeyStore = (streamId: StreamID, userAddress: EthereumAddress): GroupKeyStore => {


### PR DESCRIPTION
Added a test utility which allows us to assert conditions about the messages sent in the `FakeNetwork`. It replaces the previous `addSubscriber` utility which operated just on single network node.

Updated tests to use the utility. E.g. some group key tests wait for explicit message type instead of observing a specific stream partition.

This utility and the updated tests are needed in https://github.com/streamr-dev/network-monorepo/pull/808.

### Other changes

- Added `FakeEnvironment#destroy` which destroys all clients created in the environment
- Updated type annotations about node id in the fake environment
- Added an assertion to `resend-with-existing-key.test.ts#assertDecryptable`
