### PR TITLE
feat(tracker): Unicast and multicast messages

### DIFF
--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -2,13 +2,13 @@
  * Wrap a network node.
  */
 import { inject, Lifecycle, scoped } from 'tsyringe'
-import { NetworkNodeOptions, createNetworkNode as _createNetworkNode, MetricsContext } from 'streamr-network'
+import { NetworkNodeOptions, createNetworkNode as _createNetworkNode, MetricsContext, NodeId, UserId } from 'streamr-network'
 import { uuid } from './utils/uuid'
 import { instanceId } from './utils/utils'
 import { pOnce } from './utils/promises'
 import { Context } from './utils/Context'
 import { NetworkConfig, ConfigInjectionToken, TrackerRegistrySmartContract } from './Config'
-import { StreamMessage, StreamPartID, ProxyDirection } from 'streamr-client-protocol'
+import { StreamMessage, StreamPartID, ProxyDirection, } from 'streamr-client-protocol'
 import { DestroySignal } from './DestroySignal'
 import { EthereumConfig, generateEthereumAccount, getMainnetProvider } from './Ethereum'
 import { getTrackerRegistryFromContract } from './registry/getTrackerRegistryFromContract'
@@ -40,6 +40,10 @@ export interface NetworkNodeStub {
     openProxyConnection: (streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection) => Promise<void>
     /** @internal */
     closeProxyConnection: (streamPartId: StreamPartID, nodeId: string, direction: ProxyDirection) => Promise<void>
+    sendUnicastMessage: (streamMessage: StreamMessage, recipient: NodeId) => Promise<void>
+    addUnicastMessageListener: (listener: (streamMessage: StreamMessage) => void) => void
+    sendMulticastMessage: (streamMessage: StreamMessage, recipient: UserId) => Promise<void>
+    addMulticastMessageListener: (listener: (streamMessage: StreamMessage) => void) => void
 }
 
 export const getEthereumAddressFromNodeId = (nodeId: string): string => {

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -115,6 +115,26 @@ export class FakeNetworkNode implements NetworkNodeStub {
     async closeProxyConnection(_streamPartId: StreamPartID, _nodeId: string, _direction: ProxyDirection): Promise<void> {
         throw new Error('not implemented')
     }
+
+    // eslint-disable-next-line class-methods-use-this
+    async sendUnicastMessage() {
+        throw new Error('not implemented')
+    }
+    
+    // eslint-disable-next-line class-methods-use-this
+    addUnicastMessageListener() {
+        throw new Error('not implemented')
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async sendMulticastMessage() {
+        throw new Error('not implemented')
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    addMulticastMessageListener() {
+        throw new Error('not implemented')
+    }
 }
 
 @scoped(Lifecycle.ContainerScoped)

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -117,22 +117,22 @@ export class FakeNetworkNode implements NetworkNodeStub {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async sendUnicastMessage() {
+    async sendUnicastMessage(): Promise<void> {
         throw new Error('not implemented')
     }
     
     // eslint-disable-next-line class-methods-use-this
-    addUnicastMessageListener() {
+    addUnicastMessageListener(): void {
         throw new Error('not implemented')
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async sendMulticastMessage() {
+    async sendMulticastMessage(): Promise<void> {
         throw new Error('not implemented')
     }
 
     // eslint-disable-next-line class-methods-use-this
-    addMulticastMessageListener() {
+    addMulticastMessageListener(): void {
         throw new Error('not implemented')
     }
 }

--- a/packages/network-tracker/src/logic/OverlayTopology.ts
+++ b/packages/network-tracker/src/logic/OverlayTopology.ts
@@ -91,6 +91,10 @@ export class OverlayTopology {
         return this.nodes
     }
 
+    getNodeIds(predicate: (nodeId: NodeId) => boolean): NodeId[] {
+        return Object.keys(this.nodes).filter(predicate)
+    }
+
     state(): TopologyState {
         const objects = Object.entries(this.nodes).map(([nodeId, neighbors]) => {
             return {

--- a/packages/network-tracker/src/protocol/TrackerServer.ts
+++ b/packages/network-tracker/src/protocol/TrackerServer.ts
@@ -7,7 +7,8 @@ import {
     StreamPartID,
     StreamPartIDUtils,
     TrackerMessage,
-    TrackerMessageType
+    TrackerMessageType,
+    UnicastMessage
 } from 'streamr-client-protocol'
 import {
     decode,
@@ -26,18 +27,24 @@ export enum Event {
     NODE_CONNECTED = 'streamr:tracker:send-peers',
     NODE_DISCONNECTED = 'streamr:tracker:node-disconnected',
     NODE_STATUS_RECEIVED = 'streamr:tracker:peer-status',
-    RELAY_MESSAGE_RECEIVED = 'streamr:tracker:relay-message-received'
+    RELAY_MESSAGE_RECEIVED = 'streamr:tracker:relay-message-received',
+    UNICAST_MESSAGE_RECEIVED = 'streamr:tracker:unicast-message-received',
+    MULTICAST_MESSAGE_RECEIVED = 'streamr:tracker:multicast-message-received'
 }
 
 const eventPerType: Record<number, string> = {}
 eventPerType[TrackerMessage.TYPES.StatusMessage] = Event.NODE_STATUS_RECEIVED
 eventPerType[TrackerMessage.TYPES.RelayMessage] = Event.RELAY_MESSAGE_RECEIVED
+eventPerType[TrackerMessage.TYPES.UnicastMessage] = Event.UNICAST_MESSAGE_RECEIVED
+eventPerType[TrackerMessage.TYPES.MulticastMessage] = Event.MULTICAST_MESSAGE_RECEIVED
 
 export interface NodeToTracker {
     on(event: Event.NODE_CONNECTED, listener: (nodeId: NodeId) => void): this
     on(event: Event.NODE_DISCONNECTED, listener: (nodeId: NodeId) => void): this
     on(event: Event.NODE_STATUS_RECEIVED, listener: (msg: StatusMessage, nodeId: NodeId) => void): this
     on(event: Event.RELAY_MESSAGE_RECEIVED, listener: (msg: RelayMessage, nodeId: NodeId) => void): this
+    on(event: Event.UNICAST_MESSAGE_RECEIVED, listener: (msg: UnicastMessage) => void): this
+    on(event: Event.MULTICAST_MESSAGE_RECEIVED, listener: (msg: UnicastMessage) => void): this
 }
 
 export class TrackerServer extends EventEmitter {

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -45,3 +45,7 @@ export {
     ServerWsEndpoint,
     startHttpServer
 } from './connection/ws/ServerWsEndpoint'
+export {
+    UserId,
+    parseUserIdFromNodeId
+} from './logic/UserId'

--- a/packages/network/src/logic/NetworkNode.ts
+++ b/packages/network/src/logic/NetworkNode.ts
@@ -101,8 +101,8 @@ export class NetworkNode extends Node {
         await this.trackerManager.sendUnicastMessage(streamMessage, this.peerInfo.peerId, recipient)
     }
 
-    addUnicastMessageListener(listener: (streamMessage: StreamMessage) => void): void {
-        const wrappedListener = (from: UnicastMessage) => listener(from.payload)
+    addUnicastMessageListener(listener: (streamMessage: StreamMessage, sender: NodeId) => void): void {
+        const wrappedListener = (from: UnicastMessage) => listener(from.payload, from.senderNodeId)
         this.trackerManager.nodeToTracker.on(NodeToTrackerEvent.UNICAST_MESSAGE_RECEIVED, wrappedListener)
     }
 
@@ -110,8 +110,8 @@ export class NetworkNode extends Node {
         await this.trackerManager.sendMulticastMessage(streamMessage, this.peerInfo.peerId, recipient)
     }
 
-    addMulticastMessageListener(listener: (streamMessage: StreamMessage) => void): void {
-        const wrappedListener = (from: MulticastMessage) => listener(from.payload)
+    addMulticastMessageListener(listener: (streamMessage: StreamMessage, sender: NodeId) => void): void {
+        const wrappedListener = (from: MulticastMessage) => listener(from.payload, from.senderNodeId)
         this.trackerManager.nodeToTracker.on(NodeToTrackerEvent.MULTICAST_MESSAGE_RECEIVED, wrappedListener)
     }
 }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -79,7 +79,7 @@ export class Node extends EventEmitter {
     protected readonly streamPartManager: StreamPartManager
     private readonly disconnectionManager: DisconnectionManager
     private readonly propagation: Propagation
-    private readonly trackerManager: TrackerManager
+    protected readonly trackerManager: TrackerManager
     private readonly consecutiveDeliveryFailures: Record<NodeId, number> // id => counter
     private readonly metricsContext: MetricsContext
     private readonly metrics: Metrics

--- a/packages/network/src/logic/UserId.ts
+++ b/packages/network/src/logic/UserId.ts
@@ -1,0 +1,15 @@
+/*
+ * Node id is one of these formats:
+ * - userId
+ * - userId#sessionId
+ */
+
+import { NodeId } from '../identifiers'
+
+export type UserId = string // typically an Ethereum address
+
+// TODO should we return lowercased string if we decide that userIds are case-insensitive?
+export const parseUserIdFromNodeId = (nodeId: NodeId): UserId => {
+    const parts = nodeId.split('#')
+    return parts[0]
+}

--- a/packages/network/test/integration/unicast-and-multicast.test.ts
+++ b/packages/network/test/integration/unicast-and-multicast.test.ts
@@ -1,0 +1,114 @@
+import { startTracker, Tracker } from '@streamr/network-tracker'
+import { wait } from '@streamr/utils'
+import { MessageID, StreamMessage, StreamPartIDUtils } from 'streamr-client-protocol'
+import { waitForCondition } from 'streamr-test-utils'
+import { NetworkNode } from '../../src/browser'
+import { createNetworkNode } from '../../src/createNetworkNode'
+
+const STREAM_PART_ID = StreamPartIDUtils.parse('mock-stream#3')
+const TRACKER_PORT = 32901
+
+const createMockMessage = (): StreamMessage => {
+    return new StreamMessage({
+        messageId: new MessageID(
+            StreamPartIDUtils.getStreamID(STREAM_PART_ID),
+            StreamPartIDUtils.getStreamPartition(STREAM_PART_ID),
+            Date.now(),
+            0,
+            'sender',
+            'mock-msgChainId'
+        ),
+        content: {
+            foo: 'bar'
+        }
+    })
+}
+
+describe('unicast and multicast', () => {
+
+    let tracker: Tracker
+    let sender: NetworkNode
+    let recipient1: NetworkNode
+    let recipient2: NetworkNode
+    let nonRecipient: NetworkNode
+
+    beforeEach(async () => {
+        tracker = await startTracker({
+            listen: {
+                hostname: '127.0.0.1',
+                port: TRACKER_PORT
+            }
+        })
+        const trackerConfig = tracker.getConfigRecord()
+        sender = createNetworkNode({
+            id: 'sender#mock-session-000',
+            trackers: [trackerConfig],
+            webrtcDisallowPrivateAddresses: false
+        })
+        sender.start()
+        recipient1 = createNetworkNode({
+            id: 'recipient#mock-session-111',
+            trackers: [trackerConfig],
+            webrtcDisallowPrivateAddresses: false
+        })
+        recipient1.start()
+        recipient2 = createNetworkNode({
+            id: 'recipient#mock-session-222',
+            trackers: [trackerConfig],
+            webrtcDisallowPrivateAddresses: false
+        })
+        recipient2.start()
+        nonRecipient = createNetworkNode({
+            id: 'non-recipient#mock-session-333',
+            trackers: [trackerConfig],
+            webrtcDisallowPrivateAddresses: false
+        })
+        nonRecipient.start()
+        await recipient1.subscribeAndWaitForJoin(STREAM_PART_ID)
+        await recipient2.subscribeAndWaitForJoin(STREAM_PART_ID)
+        await nonRecipient.subscribeAndWaitForJoin(STREAM_PART_ID)
+    })
+
+    afterEach(async () => {
+        await Promise.all([sender, recipient1, recipient2, nonRecipient].map((node) => node.stop()))
+        await tracker.stop()
+    })
+
+    it('unicast', async () => {
+        const onUnicastMessage1 = jest.fn()
+        recipient1.addUnicastMessageListener(onUnicastMessage1)
+        const onUnicastMessage2 = jest.fn()
+        recipient2.addUnicastMessageListener(onUnicastMessage2)
+
+        const message = createMockMessage()
+        await sender.sendUnicastMessage(message as any, 'recipient#mock-session-111')
+
+        await waitForCondition(() => onUnicastMessage1.mock.calls.length > 0)
+        expect(onUnicastMessage1).toBeCalledTimes(1)
+        expect(onUnicastMessage1.mock.calls[0][0].getParsedContent()).toEqual(message.getParsedContent())
+        // wait some time so that recipient2 could possibly receive the message
+        await wait(500)
+        expect(onUnicastMessage2).not.toBeCalled()
+    })
+
+    it('multicast', async () => {
+        const onMulticastMessage1 = jest.fn()
+        recipient1.addMulticastMessageListener(onMulticastMessage1)
+        const onMulticastMessage2 = jest.fn()
+        recipient2.addMulticastMessageListener(onMulticastMessage2)
+        const onMulticastMessage_nonRecipient = jest.fn()
+        nonRecipient.addMulticastMessageListener(onMulticastMessage_nonRecipient)
+
+        const message = createMockMessage()
+        await sender.sendMulticastMessage(message as any, 'recipient')
+
+        await waitForCondition(() => (onMulticastMessage1.mock.calls.length > 0) && (onMulticastMessage2.mock.calls.length > 0)) 
+        expect(onMulticastMessage1).toBeCalledTimes(1)
+        expect(onMulticastMessage1.mock.calls[0][0].getParsedContent()).toEqual(message.getParsedContent())
+        expect(onMulticastMessage2).toBeCalledTimes(1)
+        expect(onMulticastMessage2.mock.calls[0][0].getParsedContent()).toEqual(message.getParsedContent())
+        // wait some time so that nonRecipient could possibly receive the message
+        await wait(500)
+        expect(onMulticastMessage_nonRecipient).not.toBeCalled()
+    })
+})

--- a/packages/protocol/src/protocol/tracker_layer/TrackerMessage.ts
+++ b/packages/protocol/src/protocol/tracker_layer/TrackerMessage.ts
@@ -11,7 +11,9 @@ export enum TrackerMessageType {
     StatusMessage = 1,
     InstructionMessage = 2,
     RelayMessage = 5,
-    ErrorMessage = 6
+    ErrorMessage = 6,
+    UnicastMessage = 7,
+    MulticastMessage = 8
 }
 
 export interface TrackerMessageOptions {

--- a/packages/protocol/src/protocol/tracker_layer/index.ts
+++ b/packages/protocol/src/protocol/tracker_layer/index.ts
@@ -8,6 +8,8 @@ import RelayMessage, {
     RtcAnswerMessage
 } from "./relay_message/RelayMessage"
 import StatusMessage from "./status_message/StatusMessage"
+import UnicastMessage from './unicast_message/UnicastMessage'
+import MulticastMessage from './multicast_message/MulticastMessage'
 import TrackerMessage from "./TrackerMessage"
 import { TrackerMessageType } from "./TrackerMessage"
 import { Originator } from "./Originator"
@@ -17,6 +19,8 @@ import './error_message/ErrorMessageSerializerV2'
 import './instruction_message/InstructionMessageSerializerV2'
 import './relay_message/RelayMessageSerializerV2'
 import './status_message/StatusMessageSerializerV2'
+import './unicast_message/UnicastMessageSerializerV2'
+import './multicast_message/MulticastMessageSerializerV2'
 
 export {
     InstructionMessage,
@@ -30,5 +34,7 @@ export {
     RtcIceCandidateMessage,
     RtcConnectMessage,
     RtcOfferMessage,
-    RtcAnswerMessage
+    RtcAnswerMessage,
+    UnicastMessage,
+    MulticastMessage
 }

--- a/packages/protocol/src/protocol/tracker_layer/multicast_message/MulticastMessage.ts
+++ b/packages/protocol/src/protocol/tracker_layer/multicast_message/MulticastMessage.ts
@@ -1,0 +1,30 @@
+import {
+    validateIsNotEmptyString,
+    validateIsNotNullOrUndefined
+} from '../../../utils/validations'
+import TrackerMessage, { TrackerMessageOptions } from '../TrackerMessage'
+import StreamMessage from '../../message_layer/StreamMessage'
+
+export interface Options extends TrackerMessageOptions {
+    senderNodeId: string
+    recipientUserId: string
+    payload: StreamMessage
+}
+
+export default class MulticastMessage extends TrackerMessage {
+    senderNodeId: string
+    recipientUserId: string
+    payload: StreamMessage
+
+    constructor({ version = TrackerMessage.LATEST_VERSION, requestId, senderNodeId, recipientUserId: recipientNodeId, payload }: Options) {
+        super(version, TrackerMessage.TYPES.MulticastMessage, requestId)
+
+        validateIsNotEmptyString('senderNodeId', senderNodeId)
+        validateIsNotEmptyString('recipientUserId', recipientNodeId)
+        validateIsNotNullOrUndefined('payload', payload)
+
+        this.senderNodeId = senderNodeId
+        this.recipientUserId = recipientNodeId
+        this.payload = payload
+    }
+}

--- a/packages/protocol/src/protocol/tracker_layer/multicast_message/MulticastMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/multicast_message/MulticastMessageSerializerV2.ts
@@ -1,0 +1,38 @@
+import TrackerMessage from '../TrackerMessage'
+
+import MulticastMessage from './MulticastMessage'
+
+import { Serializer } from '../../../Serializer'
+import StreamMessage from '../../message_layer/StreamMessage'
+
+const VERSION = 2
+
+export default class MulticastMessageSerializerV2 extends Serializer<MulticastMessage> {
+    toArray(message: MulticastMessage): any[] {
+        return [
+            VERSION,
+            TrackerMessage.TYPES.MulticastMessage,
+            message.requestId,
+            message.senderNodeId,
+            message.recipientUserId,
+            message.payload.serialize()
+        ]
+    }
+
+    fromArray(arr: any[]): MulticastMessage {
+        const [
+            version,
+            type, // eslint-disable-line @typescript-eslint/no-unused-vars
+            requestId,
+            senderNodeId,
+            recipientNodeId,
+            payload
+        ] = arr
+
+        return new MulticastMessage({
+            version, requestId, senderNodeId, recipientUserId: recipientNodeId, payload: StreamMessage.deserialize(payload)
+        })
+    }
+}
+
+TrackerMessage.registerSerializer(VERSION, TrackerMessage.TYPES.MulticastMessage, new MulticastMessageSerializerV2())

--- a/packages/protocol/src/protocol/tracker_layer/unicast_message/UnicastMessage.ts
+++ b/packages/protocol/src/protocol/tracker_layer/unicast_message/UnicastMessage.ts
@@ -1,0 +1,30 @@
+import {
+    validateIsNotEmptyString,
+    validateIsNotNullOrUndefined
+} from '../../../utils/validations'
+import TrackerMessage, { TrackerMessageOptions } from '../TrackerMessage'
+import StreamMessage from '../../message_layer/StreamMessage'
+
+export interface Options extends TrackerMessageOptions {
+    senderNodeId: string
+    recipientNodeId: string
+    payload: StreamMessage
+}
+
+export default class UnicastMessage extends TrackerMessage {
+    senderNodeId: string
+    recipientNodeId: string
+    payload: StreamMessage
+
+    constructor({ version = TrackerMessage.LATEST_VERSION, requestId, senderNodeId, recipientNodeId, payload }: Options) {
+        super(version, TrackerMessage.TYPES.UnicastMessage, requestId)
+
+        validateIsNotEmptyString('senderNodeId', senderNodeId)
+        validateIsNotEmptyString('recipientNodeId', recipientNodeId)
+        validateIsNotNullOrUndefined('payload', payload)
+
+        this.senderNodeId = senderNodeId
+        this.recipientNodeId = recipientNodeId
+        this.payload = payload
+    }
+}

--- a/packages/protocol/src/protocol/tracker_layer/unicast_message/UnicastMessageSerializerV2.ts
+++ b/packages/protocol/src/protocol/tracker_layer/unicast_message/UnicastMessageSerializerV2.ts
@@ -1,0 +1,38 @@
+import TrackerMessage from '../TrackerMessage'
+
+import UnicastMessage from './UnicastMessage'
+
+import { Serializer } from '../../../Serializer'
+import StreamMessage from '../../message_layer/StreamMessage'
+
+const VERSION = 2
+
+export default class UnicastMessageSerializerV2 extends Serializer<UnicastMessage> {
+    toArray(message: UnicastMessage): any[] {
+        return [
+            VERSION,
+            TrackerMessage.TYPES.UnicastMessage,
+            message.requestId,
+            message.senderNodeId,
+            message.recipientNodeId,
+            message.payload.serialize()
+        ]
+    }
+
+    fromArray(arr: any[]): UnicastMessage {
+        const [
+            version,
+            type, // eslint-disable-line @typescript-eslint/no-unused-vars
+            requestId,
+            senderNodeId,
+            recipientNodeId,
+            payload
+        ] = arr
+
+        return new UnicastMessage({
+            version, requestId, senderNodeId, recipientNodeId, payload: StreamMessage.deserialize(payload)
+        })
+    }
+}
+
+TrackerMessage.registerSerializer(VERSION, TrackerMessage.TYPES.UnicastMessage, new UnicastMessageSerializerV2())


### PR DESCRIPTION
Nodes can send  and receive unicast message and multicast messages to/from the network.

- new concept: `userId`, which is a prefix in nodeId
  - TODO `userId` is typically an Ethereum address, should we make it case-insensitive, or e.g. limit that nodeIds can only contain lowercase addresses? 

- should  `sendUnicastMessage`/`sendMulticastMessage` return void or Promise<void>? (publish returns void)

### TODO

- tests for `UnicastMessage` and `MulticastMessage`
- rename `addMessageListener` to `addBroadcastMessageListener` or `on('broadcastMessageReceive')`
  - and removeMessageListener
  - and if we use `on` method, then also unicast and multicast listener with that style
- should `parseUserIdFromNodeId` return lowercased string if we decide that userIds are case-insensitive?
- rename `NodeId` type to `NodeID` (and `TrackerId` and `UserId`)
- should `TrackerManager#nodeToTracker` should be private field?