### PR TITLE
feat: add logging for message buffering and failed instruction handling

### DIFF
--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -236,7 +236,9 @@ export class TrackerManager {
         logger.trace('subscribed to %j and unsubscribed from %j (streamPartId=%s, counter=%d)',
             subscribedNodeIds, unsubscribedNodeIds, streamPartId, counter)
 
-        if (subscribedNodeIds.length !== nodeIds.length) {
+        if (nodeIds.length > 0 && subscribedNodeIds.length === 0) {
+            logger.warn('error: failed to open any stream connections on (streamPartId=%s, counter=%d)', streamPartId, counter)
+        } else if (subscribedNodeIds.length !== nodeIds.length) {
             logger.trace('error: failed to fulfill all tracker instructions (streamPartId=%s, counter=%d)', streamPartId, counter)
         } else {
             logger.trace('Tracker instructions fulfilled (streamPartId=%s, counter=%d)', streamPartId, counter)

--- a/packages/network/src/logic/propagation/Propagation.ts
+++ b/packages/network/src/logic/propagation/Propagation.ts
@@ -1,6 +1,7 @@
 import { StreamPartID, StreamMessage } from 'streamr-client-protocol'
 import { NodeId } from '../../identifiers'
 import { PropagationTask, PropagationTaskStore } from './PropagationTaskStore'
+import { Logger } from '@streamr/utils'
 
 type GetNeighborsFn = (streamPartId: StreamPartID) => ReadonlyArray<NodeId>
 
@@ -16,6 +17,7 @@ interface ConstructorOptions {
 
 const DEFAULT_MAX_MESSAGES = 10000
 const DEFAULT_TTL = 30 * 1000
+const logger = new Logger(module)
 
 /**
  * Message propagation logic of a node. Given a message, this class will actively attempt to propagate it to
@@ -57,6 +59,12 @@ export class Propagation {
         const neighbors = this.getNeighbors(message.getStreamPartID())
         for (const neighborId of neighbors) {
             this.sendAndAwaitThenMark(task, neighborId)
+        }
+        if (neighbors.length === 0) {
+            logger.warn(
+                `Message queued in stream ${message.getStreamPartID()} due to no connected neighbors.`
+                + ` It will be delivered once there is at least one neighbor.`
+            )
         }
     }
 

--- a/packages/network/src/logic/propagation/PropagationTaskStore.ts
+++ b/packages/network/src/logic/propagation/PropagationTaskStore.ts
@@ -1,6 +1,9 @@
 import { MessageID, StreamPartID, StreamMessage } from 'streamr-client-protocol'
 import { FifoMapWithTtl } from './FifoMapWithTtl'
 import { NodeId } from '../../identifiers'
+import { Logger } from '@streamr/utils'
+
+const logger = new Logger(module)
 
 export interface PropagationTask {
     message: StreamMessage
@@ -33,6 +36,11 @@ export class PropagationTaskStore {
                         this.streamPartLookup.delete(streamPartId)
                     }
                 }
+                logger.warn(
+                    `ERROR - failed to propagate message from buffer on stream ${streamPartId}.`
+                    + ` No peers successfully connected before timeout or buffer max size exceeded`
+                )
+
             }
         })
     }


### PR DESCRIPTION
<!--- Provide a general summary of the changes -->

Add logging when messages are added to and dropped from propagation buffers. Add warnings for cases where fulfilling all tracker instructions fail.
