### PR TITLE
refactor(client): Simplify `Persistence`

### DIFF
--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -113,13 +113,6 @@ export class GroupKeyStore implements Context {
         return this.persistence.exists()
     }
 
-    async clear(): Promise<boolean> {
-        this.currentGroupKey = undefined
-        this.queuedGroupKey = undefined
-
-        return this.persistence.clear()
-    }
-
     async rotateGroupKey(): Promise<GroupKey> {
         return this.setNextGroupKey(GroupKey.generate())
     }

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -130,8 +130,4 @@ export class GroupKeyStore implements Context {
         this.queuedGroupKey = undefined
         return newKey
     }
-
-    async size(): Promise<number> {
-        return this.persistence.size()
-    }
 }

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -74,13 +74,6 @@ export class GroupKeyStore implements Context {
         return this.persistence.has(id)
     }
 
-    async isEmpty(): Promise<boolean> {
-        // a queued key means it's not empty
-        if (this.queuedGroupKey) { return false }
-
-        return (await this.persistence.size()) === 0
-    }
-
     async useGroupKey(): Promise<[GroupKey, GroupKey | undefined]> {
         // Ensure we have a current key by picking a queued key or generating a new one
         if (!this.currentGroupKey) {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -130,4 +130,8 @@ export class GroupKeyStore implements Context {
         this.queuedGroupKey = undefined
         return newKey
     }
+
+    async destroy(): Promise<void> {
+        return this.persistence.destroy()
+    }
 }

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -26,7 +26,7 @@ export default class BrowserPersistence implements Persistence<string, string> {
         return had
     }
 
-    async clear(): Promise<boolean> {
+    private async clear(): Promise<boolean> {
         const size = await this.size()
         await clear(this.store)
         return !!size

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -1,4 +1,4 @@
-import { get, set,  clear, keys, createStore, UseStore } from 'idb-keyval'
+import { get, set,  clear, createStore, UseStore } from 'idb-keyval'
 import { Persistence } from './Persistence'
 import { StreamID } from 'streamr-client-protocol'
 
@@ -26,15 +26,8 @@ export default class BrowserPersistence implements Persistence<string, string> {
         return had
     }
 
-    private async clear(): Promise<boolean> {
-        const size = await this.size()
+    private async clear(): Promise<void> {
         await clear(this.store)
-        return !!size
-    }
-
-    async size(): Promise<number> {
-        const allKeys = await keys(this.store)
-        return allKeys.length
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -20,10 +20,8 @@ export default class BrowserPersistence implements Persistence<string, string> {
         return get(key, this.store)
     }
 
-    async set(key: string, value: string): Promise<boolean> {
-        const had = await this.has(key)
+    async set(key: string, value: string): Promise<void> {
         await set(key, value, this.store)
-        return had
     }
 
     private async clear(): Promise<void> {

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -1,4 +1,4 @@
-import { get, set, del, clear, keys, createStore, UseStore } from 'idb-keyval'
+import { get, set,  clear, keys, createStore, UseStore } from 'idb-keyval'
 import { Persistence } from './Persistence'
 import { StreamID } from 'streamr-client-protocol'
 
@@ -24,15 +24,6 @@ export default class BrowserPersistence implements Persistence<string, string> {
         const had = await this.has(key)
         await set(key, value, this.store)
         return had
-    }
-
-    async delete(key: string): Promise<boolean> {
-        if (!await this.has(key)) {
-            return false
-        }
-
-        await del(key, this.store)
-        return true
     }
 
     async clear(): Promise<boolean> {

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -2,7 +2,6 @@ export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<boolean>
     has(key: K): Promise<boolean>
-    clear(): Promise<boolean>
     size(): Promise<number>
     close(): Promise<void>
     destroy(): Promise<void>

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -2,7 +2,6 @@ export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<boolean>
     has(key: K): Promise<boolean>
-    size(): Promise<number>
     close(): Promise<void>
     destroy(): Promise<void>
     exists(): Promise<boolean>

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -1,6 +1,6 @@
 export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
-    set(key: K, value: V): Promise<boolean>
+    set(key: K, value: V): Promise<void>
     has(key: K): Promise<boolean>
     close(): Promise<void>
     destroy(): Promise<void>

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -2,7 +2,6 @@ export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<boolean>
     has(key: K): Promise<boolean>
-    delete(key: K): Promise<boolean>
     clear(): Promise<boolean>
     size(): Promise<number>
     close(): Promise<void>

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -189,27 +189,15 @@ export default class ServerPersistence implements Persistence<string, string>, C
         return this.setKeyValue(key, value)
     }
 
-    private async clear(): Promise<boolean> {
+    private async clear(): Promise<void> {
         this.debug('clear')
         if (!this.initCalled) {
             // nothing to clear if doesn't exist
-            if (!(await this.exists())) { return false }
+            if (!(await this.exists())) { return }
         }
 
         await this.init()
-        const result = await this.store!.run(`DELETE FROM ${this.tableName} WHERE streamId = ?`, this.streamId)
-        return !!result?.changes
-    }
-
-    async size(): Promise<number> {
-        if (!this.initCalled) {
-            // can only have size 0 if doesn't exist
-            if (!(await this.exists())) { return 0 }
-        }
-
-        await this.init()
-        const size = await this.store!.get(`SELECT COUNT(*) FROM ${this.tableName} WHERE streamId = ?;`, this.streamId)
-        return size && size['COUNT(*)']
+        await this.store!.run(`DELETE FROM ${this.tableName} WHERE streamId = ?`, this.streamId)
     }
 
     async close(): Promise<void> {

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -189,7 +189,7 @@ export default class ServerPersistence implements Persistence<string, string>, C
         return this.setKeyValue(key, value)
     }
 
-    async clear(): Promise<boolean> {
+    private async clear(): Promise<boolean> {
         this.debug('clear')
         if (!this.initCalled) {
             // nothing to clear if doesn't exist

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -170,9 +170,9 @@ export default class ServerPersistence implements Persistence<string, string>, C
         return !!(value && value['COUNT(*)'] != null && value['COUNT(*)'] !== 0)
     }
 
-    private async setKeyValue(key: string, value: string): Promise<boolean> {
+    private async setKeyValue(key: string, value: string): Promise<void> {
         // set, but without init so init can insert initialData
-        const result = await this.store!.run(
+        await this.store!.run(
             `INSERT INTO ${this.tableName} VALUES ($id, $${this.valueColumnName}, $streamId) ON CONFLICT DO NOTHING`, 
             {
                 $id: key,
@@ -180,11 +180,9 @@ export default class ServerPersistence implements Persistence<string, string>, C
                 $streamId: this.streamId,
             }
         )
-
-        return !!result?.changes
     }
 
-    async set(key: string, value: string): Promise<boolean> {
+    async set(key: string, value: string): Promise<void> {
         await this.init()
         return this.setKeyValue(key, value)
     }

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -189,17 +189,6 @@ export default class ServerPersistence implements Persistence<string, string>, C
         return this.setKeyValue(key, value)
     }
 
-    async delete(key: string): Promise<boolean> {
-        if (!this.initCalled) {
-            // can't delete if if db doesn't exist
-            if (!(await this.exists())) { return false }
-        }
-
-        await this.init()
-        const result = await this.store!.run(`DELETE FROM ${this.tableName} WHERE id = ? AND streamId = ?`, key, this.streamId)
-        return !!result?.changes
-    }
-
     async clear(): Promise<boolean> {
         this.debug('clear')
         if (!this.initCalled) {

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -27,7 +27,8 @@ describeRepeats('GroupKeyStore', () => {
 
     afterEach(async () => {
         if (!store) { return }
-        await store.clear()
+        // @ts-expect-error private
+        await store.persistence.destroy()
         // @ts-expect-error doesn't want us to unassign, but it's ok
         store = undefined // eslint-disable-line require-atomic-updates
     })
@@ -41,7 +42,6 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.exists()).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
-        expect(await store.clear()).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
         expect(await store.close()).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
@@ -49,9 +49,6 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.add(groupKey)).toBeTruthy()
         expect(await store.exists()).toBeTruthy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
-        expect(await store.clear()).toBeTruthy()
-        expect(await store.clear()).toBeFalsy()
-        expect(await store.get(groupKey.id)).toBeFalsy()
     })
 
     it('does not exist until write', async () => {
@@ -63,8 +60,6 @@ describeRepeats('GroupKeyStore', () => {
         expect(await store.has(groupKey.id)).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.clear()).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
         expect(await store.close()).toBeFalsy()
         expect(await store.exists()).toBeFalsy()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -36,7 +36,7 @@ describeRepeats('GroupKeyStore', () => {
         expect(await leakDetector.isLeaking()).toBeFalsy()
     })
 
-    it('can get set and delete', async () => {
+    it('can get and set', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.exists()).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -54,9 +54,6 @@ describeRepeats('GroupKeyStore', () => {
     it('does not exist until write', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.exists()).toBeFalsy()
-
-        expect(await store.isEmpty()).toBeTruthy()
-        expect(await store.exists()).toBeFalsy()
         expect(await store.has(groupKey.id)).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -27,8 +27,7 @@ describeRepeats('GroupKeyStore', () => {
 
     afterEach(async () => {
         if (!store) { return }
-        // @ts-expect-error private
-        await store.persistence.destroy()
+        await store.destroy()
         // @ts-expect-error doesn't want us to unassign, but it's ok
         store = undefined // eslint-disable-line require-atomic-updates
     })

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -47,16 +47,12 @@ describe('GroupKeyStore', () => {
         expect(await store.has(groupKey.id)).toBeFalsy()
         expect(await store.size()).toBe(0)
         expect(await store.get(groupKey.id)).toBeFalsy()
-        expect(await store.clear()).toBeFalsy()
 
         expect(await store.add(groupKey)).toBe(groupKey)
         expect(await store.add(groupKey)).toEqual(groupKey)
         expect(await store.has(groupKey.id)).toBeTruthy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
         expect(await store.size()).toBe(1)
-
-        expect(await store.clear()).toBeTruthy()
-        expect(await store.size()).toBe(0)
     })
 
     it('can add with multiple instances in parallel', async () => {

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -45,14 +45,12 @@ describe('GroupKeyStore', () => {
     it('can get and set', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.has(groupKey.id)).toBeFalsy()
-        expect(await store.size()).toBe(0)
         expect(await store.get(groupKey.id)).toBeFalsy()
 
         expect(await store.add(groupKey)).toBe(groupKey)
         expect(await store.add(groupKey)).toEqual(groupKey)
         expect(await store.has(groupKey.id)).toBeTruthy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
-        expect(await store.size()).toBe(1)
     })
 
     it('can add with multiple instances in parallel', async () => {
@@ -99,7 +97,6 @@ describe('GroupKeyStore', () => {
         await store.add(groupKey)
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
-        expect(await store2.size()).toBe(0)
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 
@@ -114,7 +111,6 @@ describe('GroupKeyStore', () => {
         await store.add(groupKey)
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
-        expect(await store2.size()).toBe(0)
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 
@@ -129,7 +125,6 @@ describe('GroupKeyStore', () => {
         await store.add(groupKey)
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
-        expect(await store2.size()).toBe(0)
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -42,13 +42,11 @@ describe('GroupKeyStore', () => {
         expect(await leakDetector.isLeaking()).toBeFalsy()
     })
 
-    it('can get set and delete', async () => {
+    it('can get and set', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.has(groupKey.id)).toBeFalsy()
         expect(await store.size()).toBe(0)
         expect(await store.get(groupKey.id)).toBeFalsy()
-        // @ts-expect-error private
-        expect(await store.persistence.delete(groupKey.id)).toBeFalsy()
         expect(await store.clear()).toBeFalsy()
 
         expect(await store.add(groupKey)).toBe(groupKey)
@@ -56,22 +54,12 @@ describe('GroupKeyStore', () => {
         expect(await store.has(groupKey.id)).toBeTruthy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
         expect(await store.size()).toBe(1)
-        // @ts-expect-error private
-        expect(await store.persistence.delete(groupKey.id)).toBeTruthy()
 
-        expect(await store.has(groupKey.id)).toBeFalsy()
-        expect(await store.size()).toBe(0)
-
-        expect(await store.get(groupKey.id)).toBeFalsy()
-        // @ts-expect-error private
-        expect(await store.persistence.delete(groupKey.id)).toBeFalsy()
-        expect(await store.add(groupKey)).toBeTruthy()
-        expect(await store.size()).toBe(1)
         expect(await store.clear()).toBeTruthy()
         expect(await store.size()).toBe(0)
     })
 
-    it('can get set and delete with multiple instances in parallel', async () => {
+    it('can add with multiple instances in parallel', async () => {
         const store2 = createStore(clientId, streamId)
         // @ts-expect-error private
         addAfter(() => store2.persistence.destroy())
@@ -116,10 +104,6 @@ describe('GroupKeyStore', () => {
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store2.size()).toBe(0)
-        // @ts-expect-error private
-        expect(await store2.persistence.delete(groupKey.id)).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 
@@ -135,10 +119,6 @@ describe('GroupKeyStore', () => {
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store2.size()).toBe(0)
-        // @ts-expect-error private
-        expect(await store2.persistence.delete(groupKey.id)).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 
@@ -154,10 +134,6 @@ describe('GroupKeyStore', () => {
         expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store2.size()).toBe(0)
-        // @ts-expect-error private
-        expect(await store2.persistence.delete(groupKey.id)).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
-        expect(await store2.clear()).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -32,8 +32,7 @@ describe('GroupKeyStore', () => {
 
     afterEach(async () => {
         if (!store) { return }
-        // @ts-expect-error private
-        await store.persistence.destroy()
+        await store.destroy()
         // @ts-expect-error doesn't want us to unassign, but it's ok
         store = undefined // eslint-disable-line require-atomic-updates
     })


### PR DESCRIPTION
Removed obsolete methods from `Persistence` interface, and the implementations of the interface (`ServerPersistence` and `BrowserPersistence`)
- `delete`
- `clear`
- `size`

Removed also related obsolete methods from GroupKeyStore:
- `clear`
- `size`
- `isEmpty`

Added `GroupKeyStore#destroy` so that tests can remove the generated data in test teardown (it uses `ServerPersistence#clear`/`BrowserPersistence#clear` internally and closes the connection).

Refactored `Persistence.set` to return `Promise<void>` instead of `Promise<boolean>`