### PR TITLE
feat(utils):  Enhance `waitForEvent` and `withTimeout`

### DIFF
--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -8,7 +8,7 @@ import { Wallet } from '@ethersproject/wallet'
 import { waitForEvent } from '@streamr/utils'
 import fetch from 'node-fetch'
 
-export type Event = string | symbol
+export type Event = string
 
 /**
  * Collect data of a stream into an array. The array is wrapped in a

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -7,12 +7,13 @@ import { scheduleAtInterval } from './scheduleAtInterval'
 import { BrandedString } from './types'
 import { wait } from './wait'
 import { waitForEvent } from './waitForEvent'
-import { TimeoutError, withTimeout } from './withTimeout'
+import { AbortError, TimeoutError, withTimeout } from './withTimeout'
 
 export {
     BrandedString,
     Logger,
     Multimap,
+    AbortError,
     TimeoutError,
     keyToArrayIndex,
     randomString,

--- a/packages/utils/src/waitForEvent.ts
+++ b/packages/utils/src/waitForEvent.ts
@@ -1,21 +1,39 @@
-import { EventEmitter, once } from 'events'
+import { EventEmitter } from 'events'
 import { withTimeout } from './withTimeout'
 
 /**
  * Wait for an event to be emitted on emitter within timeout.
  *
  * @param emitter emitter of event
- * @param event event to wait for
+ * @param eventName event to wait for
  * @param timeout amount of time in milliseconds to wait for
- * @returns {Promise<unknown[]>} resolves with event arguments if event occurred
- * within timeout else rejects
+ * @param predicate function that gets passed the event arguments, should return true if event accepted
+ * @param abortController
+ * @returns {Promise<unknown[]>} resolves with event arguments if event occurred within timeout else rejects
  */
-export function waitForEvent(emitter: EventEmitter, event: string | symbol, timeout = 5000): Promise<unknown[]> {
-    const abortController = new AbortController()
+export async function waitForEvent(
+    emitter: EventEmitter,
+    eventName: string,
+    timeout = 5000,
+    predicate: (...eventArgs: any[]) => boolean = () => true,
+    abortController?: AbortController
+): Promise<unknown[]> {
+    let listener: (eventArgs: any[]) => void
+    // eslint-disable-next-line no-async-promise-executor
+    const task: Promise<unknown[]> = new Promise((resolve) => {
+        listener = (...eventArgs: any[]) => {
+            if (predicate(...eventArgs)) {
+                resolve(eventArgs)
+            }
+        }
+        emitter.on(eventName, listener)
+    })
     return withTimeout(
-        once(emitter, event, { signal: abortController.signal }),
+        task,
         timeout,
         'waitForEvent',
         abortController
-    )
+    ).finally(() => {
+        emitter.off(eventName, listener)
+    })
 }

--- a/packages/utils/src/waitForEvent.ts
+++ b/packages/utils/src/waitForEvent.ts
@@ -15,8 +15,7 @@ export function waitForEvent(emitter: EventEmitter, event: string | symbol, time
     return withTimeout(
         once(emitter, event, { signal: abortController.signal }),
         timeout,
-        'waitForEvent'
-    ).finally(() => {
-        abortController.abort()
-    })
+        'waitForEvent',
+        abortController
+    )
 }

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -8,20 +8,46 @@ export class TimeoutError extends Error {
     }
 }
 
+export class AbortError extends Error {
+    readonly code = 'AbortError'
+    constructor(customErrorContext?: string) {
+        super(customErrorContext === undefined
+            ? `aborted`
+            : `${customErrorContext} aborted`)
+        Error.captureStackTrace(this, AbortError)
+    }
+}
+
 export const withTimeout = <T>(
     task: Promise<T>,
     timeoutInMs: number,
-    customErrorContext?: string
+    customErrorContext?: string,
+    abortController?: AbortController
 ): Promise<T> => {
+    if (abortController?.signal?.aborted === true) {
+        return Promise.reject(new AbortError(customErrorContext))
+    }
+    let timeoutRef: NodeJS.Timeout
+    let abortListener: () => void
     return Promise.race([
         task,
         new Promise<T>((_resolve, reject) => {
-            const timeoutRef = setTimeout(() => {
+            timeoutRef = setTimeout(() => {
                 reject(new TimeoutError(timeoutInMs, customErrorContext))
             }, timeoutInMs)
-            task.finally(() => {
-                clearTimeout(timeoutRef) // clear timeout if promise wins race
-            }).catch(() => {})
+            if (abortController !== undefined) {
+                // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+                abortListener = () => {
+                    reject(new AbortError(customErrorContext))
+                }
+                (abortController.signal as any).addEventListener('abort', abortListener)
+            }
         })
-    ])
+    ]).finally(() => {
+        clearTimeout(timeoutRef) // clear timeout if promise wins race
+        if (abortListener !== undefined) {
+            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
+            (abortController!.signal as any).removeEventListener('abort', abortListener)
+        }
+    })
 }

--- a/packages/utils/test/waitForEvent.test.ts
+++ b/packages/utils/test/waitForEvent.test.ts
@@ -15,6 +15,18 @@ describe(waitForEvent, () => {
         expect(recordedArgs).toEqual([1337, "leet"])
     })
 
+    it("waits for correct filtered event and records the arguments of invocation", async () => {
+        const emitter = new EventEmitter()
+        setTimeout(() => {
+            emitter.emit("eventName", 666, "beast")
+        }, 0)
+        setTimeout(() => {
+            emitter.emit("eventName", 1337, "leet")
+        }, 5)
+        const recordedArgs = await waitForEvent(emitter, "eventName", 100, (value: number) => value > 1000)
+        expect(recordedArgs).toEqual([1337, "leet"])
+    })
+
     it("works on events with zero arguments", async () => {
         const emitter = new EventEmitter()
         setTimeout(() => {


### PR DESCRIPTION
Added event filter support to `waitForEvent`. A predicate function is called for each received event. The waiting resolves when the predicate returns true for some event. 

The new implementation required us to limit `eventName` to be `string` instead of not `string | symbol`.

Added `AbortController` support to `waitForEvent` and `withTimeout`.

### Future improvements

The type information for `AbortController` does not yet have definition for `AbortController#signal`. When the type information is available, we can remove "as any" type casting from `withTimeout.ts`.