### PR TITLE
refactor(client): Plain `client.id`

### DIFF
--- a/packages/client/src/Container.ts
+++ b/packages/client/src/Container.ts
@@ -27,7 +27,7 @@ export function initContainer(
     c: DependencyContainer
 ): Context {
     uid = uid || `${uuid().slice(-4)}${uuid().slice(0, 4)}`
-    const id = config.id ?? counterId(`StreamrClient:${uid}`)
+    const id = config.id ?? counterId(`client-${uid}`)
     const debug = Debug(id)
     // @ts-expect-error not in types
     if (!debug.inspectOpts) {

--- a/packages/client/src/Container.ts
+++ b/packages/client/src/Container.ts
@@ -27,7 +27,7 @@ export function initContainer(
     c: DependencyContainer
 ): Context {
     uid = uid || `${uuid().slice(-4)}${uuid().slice(0, 4)}`
-    const id = counterId(`StreamrClient:${uid}${config.id ? `:${config.id}` : ''}`)
+    const id = config.id ?? counterId(`StreamrClient:${uid}`)
     const debug = Debug(id)
     // @ts-expect-error not in types
     if (!debug.inspectOpts) {

--- a/packages/client/test/integration/multiple-clients.test.ts
+++ b/packages/client/test/integration/multiple-clients.test.ts
@@ -40,6 +40,7 @@ describe('PubSub with multiple clients', () => {
         environment = new FakeEnvironment()
         privateKey = fastPrivateKey()
         mainClient = environment.createClient({
+            id: 'subscriber-main',
             auth: {
                 privateKey
             }
@@ -53,8 +54,10 @@ describe('PubSub with multiple clients', () => {
         await environment.destroy()
     })
 
-    async function createPublisher() {
-        const pubClient = environment.createClient()
+    async function createPublisher(id: number) {
+        const pubClient = environment.createClient({
+            id: `publisher${id}`
+        })
         const publisherId = (await pubClient.getAddress()).toLowerCase()
 
         addAfter(async () => {
@@ -71,6 +74,7 @@ describe('PubSub with multiple clients', () => {
 
     async function createSubscriber() {
         const client = environment.createClient({
+            id: 'subscriber-other',
             auth: {
                 privateKey
             }
@@ -146,7 +150,7 @@ describe('PubSub with multiple clients', () => {
             /* eslint-disable no-await-in-loop */
             const publishers: StreamrClient[] = []
             for (let i = 0; i < 3; i++) {
-                publishers.push(await createPublisher())
+                publishers.push(await createPublisher(i))
             }
             /* eslint-enable no-await-in-loop */
             const published: Record<string, StreamMessage[]> = {}
@@ -201,7 +205,7 @@ describe('PubSub with multiple clients', () => {
             /* eslint-disable no-await-in-loop */
             const publishers: StreamrClient[] = []
             for (let i = 0; i < 3; i++) {
-                publishers.push(await createPublisher())
+                publishers.push(await createPublisher(i))
             }
 
             /* eslint-enable no-await-in-loop */
@@ -272,7 +276,7 @@ describe('PubSub with multiple clients', () => {
     })
 
     test('works with multiple publishers on one stream', async () => {
-        otherClient = environment.createClient()
+        otherClient = await createSubscriber()
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
 
         const receivedMessagesOther: Record<string, StreamMessage[]> = {}
@@ -300,7 +304,7 @@ describe('PubSub with multiple clients', () => {
         /* eslint-disable no-await-in-loop */
         const publishers: StreamrClient[] = []
         for (let i = 0; i < 1; i++) {
-            publishers.push(await createPublisher())
+            publishers.push(await createPublisher(i))
         }
 
         /* eslint-enable no-await-in-loop */
@@ -357,7 +361,7 @@ describe('PubSub with multiple clients', () => {
         /* eslint-disable no-await-in-loop */
         const publishers: StreamrClient[] = []
         for (let i = 0; i < 3; i++) {
-            publishers.push(await createPublisher())
+            publishers.push(await createPublisher(i))
         }
 
         let counter = 0

--- a/packages/client/test/unit/StreamrClient.test.ts
+++ b/packages/client/test/unit/StreamrClient.test.ts
@@ -3,21 +3,41 @@ import { container } from 'tsyringe'
 import { merge } from 'lodash'
 import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
-import { ConfigTest } from '../../src'
+import { ConfigTest, StreamrClientConfig } from '../../src'
+
+const createClient = (opts: StreamrClientConfig = {}) => {
+    return new StreamrClient(merge(
+        {},
+        ConfigTest,
+        {
+            network: {
+                trackers: [] // without this setting NetworkNodeFacade would query the tracker addresses from the contract
+            }
+        },
+        opts
+    ), container)
+}
 
 describe('StreamrClient', () => {
 
+    describe('client id', () => {
+
+        it('default', () => {
+            const client = createClient()
+            expect(client.id).toMatch(/StreamrClient:[-a-z0-9]+/)
+        })
+        
+        it('user defined', () => {
+            const client = createClient({
+                id: 'foobar'
+            })
+            expect(client.id).toBe('foobar')    
+        })
+    })
+
     describe('public API', () => {
 
-        const client = new StreamrClient(merge(
-            {},
-            ConfigTest,
-            {
-                network: {
-                    trackers: [] // without this setting NetworkNodeFacade would query the tracker addresses from the contract
-                }
-            }
-        ), container)
+        const client = createClient()
 
         it('updateEncryptionKey', async () => {
             await expect(() => {

--- a/packages/client/test/unit/StreamrClient.test.ts
+++ b/packages/client/test/unit/StreamrClient.test.ts
@@ -24,7 +24,7 @@ describe('StreamrClient', () => {
 
         it('default', () => {
             const client = createClient()
-            expect(client.id).toMatch(/StreamrClient:[-a-z0-9]+/)
+            expect(client.id).toMatch(/client-[-a-z0-9]+/)
         })
         
         it('user defined', () => {


### PR DESCRIPTION
Refactored client id. Now user-defined id doesn't have a sequence number suffix. Also a generated default id is a bit shorter.

Before:
- default: `StreamrClient:12345-0`
- user-defined: `StreamrClient:12345:foobar-0`

After:
- default: `client-12345-0`
- user-defined: `foobar`