### PR TITLE
feat(client): Pre-agreed encryption keys

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - method `onResent(listener)` replaced with `subscription.once('resendComplete', listener)`
 - Behavior changes:
   - resends support multiple storage nodes (the data is fetched from a random storage node)
-- Configuration parameter `groupKeys` renamed to `encryptionKeys`
 - Exported classes `GroupKey` and `GroupKeyId` renamed to `EncryptionKey` and `EncryptionKeyId`
 - When a `MessageStream` is returned from `resend()`, it doesn't reject if an encryption key is not available
 
@@ -44,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove method `unsubscribeAll()`, use `unsubscribe()` without arguments instead
 - Remove client configuration option `client.network.name`
 - Remove `subscription.onMessage`, `onStart` and `onError` methods, use `subscription.on('error', cb)` to add an error listener
+- Remove configuration option `groupKeys`
+  - use `updateEncryptionKey` and `addEncryptionKey` methods instead
 
 ### Fixed
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -653,6 +653,19 @@ In detail, the difference between the methods is:
 - In `rekey` method, the client sends the new key individually to each subscriber. Every subscriber receives a separate message which is encrypted with their public RSA key. The `StreamPermission.SUBSCRIBE` permission is checked by the publisher for each subscriber before a key is sent.
 - In optimized `rotate` method, the key is broadcasted to the network in the metadata of the next message. The key is encrypted with the previous encryption key and therefore subscribers can use it only if they know the previous key (https://en.wikipedia.org/wiki/Forward_secrecy). As the key is broadcasted to everyone, no permissions are checked. Note that recently expired subscribers most likely have the previous key, therefore they can use that new key, too.
 
+#### Pre-agreed keys
+
+If you don't want to exchange the keys via the network, you can use pre-agreed keys like this:
+
+```
+const key = new GroupKey('key-id', crypto.randomBytes(32))
+publisher.updateEncryptionKey({
+    key,
+    streamId,
+    distibutionMethod: 'rekey'
+})
+subscriber.addEncryptionKey(key, streamId)
+```
 
 ### Proxy publishing and subscribing
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -7,7 +7,6 @@ import merge from 'lodash/merge'
 
 import type { AuthConfig } from './Authentication'
 import type { EthereumConfig } from './Ethereum'
-import type { EncryptionConfig } from './encryption/KeyExchangeStream'
 
 import CONFIG_SCHEMA from './config.schema.json'
 import { EthereumAddress, SmartContractRecord } from 'streamr-client-protocol'
@@ -94,7 +93,6 @@ export type StrictStreamrClientConfig = {
     EthereumConfig
     & ConnectionConfig
     & SubscribeConfig
-    & EncryptionConfig
 )
 
 export type StreamrClientConfig = Partial<Omit<StrictStreamrClientConfig, 'network' | 'debug'> & {
@@ -124,7 +122,6 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
 
     // Encryption options
     verifySignatures: 'auto',
-    encryptionKeys: {},
 
     // Ethereum related options
     // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -29,6 +29,7 @@ import { MessageMetadata } from './index-exports'
 import { initContainer } from './Container'
 import { Authentication, AuthenticationInjectionToken } from './Authentication'
 import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
+import { GroupKey } from './encryption/GroupKey'
 
 /**
  * @category Important
@@ -116,6 +117,12 @@ export class StreamrClient implements Context {
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)
         }
+    }
+
+    async addEncryptionKey(key: GroupKey, streamIdOrPath: string): Promise<void> {
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        const store = await this.groupKeyStoreFactory.getStore(streamId)
+        await store.add(key)
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -111,10 +111,10 @@ export class EncryptionUtil {
     }
 
     static decryptGroupKey(newGroupKey: EncryptedGroupKey, currentGroupKey: GroupKey): GroupKey {
-        return GroupKey.from([
+        return new GroupKey(
             newGroupKey.groupKeyId,
             this.decryptWithAES(newGroupKey.encryptedGroupKeyHex, currentGroupKey.data)
-        ])
+        )
     }
 }
 

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -99,7 +99,7 @@ export class GroupKeyStore implements Context {
     async get(id: GroupKeyId): Promise<GroupKey | undefined> {
         const value = await this.persistence.get(id)
         if (!value) { return undefined }
-        return GroupKey.from([id, value])
+        return new GroupKey(id, value)
     }
 
     async exists(): Promise<boolean> {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -13,7 +13,6 @@ interface GroupKeyStoreOptions {
     context: Context
     clientId: string
     streamId: StreamID
-    groupKeys: [GroupKeyId, GroupKey][]
 }
 
 export class GroupKeyStore implements Context {
@@ -23,28 +22,16 @@ export class GroupKeyStore implements Context {
     private currentGroupKey: GroupKey | undefined // current key id if any
     private queuedGroupKey: GroupKey | undefined // a group key queued to be rotated into use after the call to useGroupKey
 
-    constructor({ context, clientId, streamId, groupKeys }: GroupKeyStoreOptions) {
+    constructor({ context, clientId, streamId }: GroupKeyStoreOptions) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
-        const initialData = groupKeys.reduce((o, [, groupKey]) => Object.assign(o, {
-            [groupKey.id]: groupKey.hex,
-        }), {})
         this.persistence = new ServerPersistence({
             context: this,
             tableName: 'GroupKeys',
             valueColumnName: 'groupKey',
             clientId,
             streamId,
-            initialData,
             migrationsPath: join(__dirname, 'migrations')
-        })
-
-        groupKeys.forEach(([groupKeyId, groupKey]) => {
-            if (groupKeyId !== groupKey.id) {
-                throw new Error(`Ids must match: groupKey.id: ${groupKey.id}, groupKeyId: ${groupKeyId}`)
-            }
-            // use last init key as current
-            this.currentGroupKey = groupKey
         })
     }
 

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -5,8 +5,6 @@ import { CacheAsyncFn } from '../utils/caches'
 import { inspect } from '../utils/log'
 import { Context, ContextError } from '../utils/Context'
 import { ConfigInjectionToken, CacheConfig } from '../Config'
-
-import { EncryptionConfig, GroupKeysSerialized, parseGroupKeys } from './KeyExchangeStream'
 import { GroupKeyStore } from './GroupKeyStore'
 import { GroupKey } from './GroupKey'
 import { StreamID } from 'streamr-client-protocol'
@@ -27,14 +25,12 @@ export class GroupKeyStoreFactory implements Context {
     readonly id
     readonly debug
     private cleanupFns: ((...args: any[]) => any)[] = []
-    private initialGroupKeys: Record<string, GroupKeysSerialized>
     public getStore: ((streamId: StreamID) => Promise<GroupKeyStore>)
 
     constructor(
         context: Context,
         @inject(AuthenticationInjectionToken) private authentication: Authentication,
-        @inject(ConfigInjectionToken.Cache) cacheConfig: CacheConfig,
-        @inject(ConfigInjectionToken.Encryption) encryptionConfig: EncryptionConfig
+        @inject(ConfigInjectionToken.Cache) cacheConfig: CacheConfig
     ) {
         this.id = instanceId(this)
         this.debug = context.debug.extend(this.id)
@@ -44,8 +40,6 @@ export class GroupKeyStoreFactory implements Context {
                 return streamId
             }
         })
-        // TODO the streamIds in encryptionConfig.encryptionKeys should support path-format?
-        this.initialGroupKeys = encryptionConfig.encryptionKeys
     }
 
     private async getNewStore(streamId: StreamID): Promise<GroupKeyStore> {
@@ -58,7 +52,7 @@ export class GroupKeyStoreFactory implements Context {
             context: this,
             clientId,
             streamId,
-            groupKeys: [...parseGroupKeys(this.initialGroupKeys[streamId]).entries()]
+            groupKeys: [] // TODO remove
         })
         this.cleanupFns.push(async () => {
             try {

--- a/packages/client/src/encryption/GroupKeyStoreFactory.ts
+++ b/packages/client/src/encryption/GroupKeyStoreFactory.ts
@@ -51,8 +51,7 @@ export class GroupKeyStoreFactory implements Context {
         const store = new GroupKeyStore({
             context: this,
             clientId,
-            streamId,
-            groupKeys: [] // TODO remove
+            streamId
         })
         this.cleanupFns.push(async () => {
             try {

--- a/packages/client/src/encryption/KeyExchangeStream.ts
+++ b/packages/client/src/encryption/KeyExchangeStream.ts
@@ -16,25 +16,11 @@ import { DestroySignal } from '../DestroySignal'
 import { Subscriber } from '../subscribe/Subscriber'
 import { Publisher } from '../publish/Publisher'
 import { Subscription } from '../subscribe/Subscription'
-
-import { GroupKey, GroupKeyish } from './GroupKey'
 import { publishAndWaitForResponseMessage } from '../utils/waitForMessage'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
 
 export type GroupKeyId = string
-export type GroupKeysSerialized = Record<GroupKeyId, GroupKeyish>
-
-export interface EncryptionConfig {
-    encryptionKeys: Record<string, GroupKeysSerialized>
-}
-
-export function parseGroupKeys(groupKeys: GroupKeysSerialized = {}): Map<GroupKeyId, GroupKey> {
-    return new Map<GroupKeyId, GroupKey>(Object.entries(groupKeys || {}).map(([key, value]) => {
-        if (!value || !key) { return null }
-        return [key, GroupKey.from(value)]
-    }).filter(Boolean) as [])
-}
 
 const { GROUP_KEY_RESPONSE } = StreamMessage.MESSAGE_TYPES
 

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -49,7 +49,7 @@ export {
     ChainConnectionInfo,
     EthereumNetworkConfig,
 } from './Ethereum'
-export { EncryptionConfig, GroupKeyId as EncryptionKeyId } from './encryption/KeyExchangeStream'
+export { GroupKeyId as EncryptionKeyId } from './encryption/KeyExchangeStream'
 export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/GroupKeyStoreFactory'
 

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -63,13 +63,9 @@ describe('Subscriber', () => {
         const publisher = environment.createClient({
             auth: {
                 privateKey: publisherWallet.privateKey
-            },
-            encryptionKeys: {
-                [stream.id]: {
-                    [groupKey.id]: groupKey
-                }
             }
         })
+        await publisher.addEncryptionKey(groupKey, stream.id)
         await startPublisherKeyExchangeSubscription(publisher)
 
         const sub = await subscriber.subscribe(stream.id)

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -96,13 +96,9 @@ describe('SubscriberKeyExchange', () => {
             const publisher = environment.createClient({
                 auth: {
                     privateKey: publisherWallet.privateKey
-                },
-                encryptionKeys: {
-                    [StreamPartIDUtils.getStreamID(streamPartId)]: {
-                        [groupKey.id]: groupKey
-                    }
                 }
             })
+            await publisher.addEncryptionKey(groupKey, StreamPartIDUtils.getStreamID(streamPartId))
             await startPublisherKeyExchangeSubscription(publisher)
             const publisherNode = await publisher.getNode()
             await subscriber.subscribe(streamPartId, () => {})

--- a/packages/client/test/integration/parallel-key-exchange.test.ts
+++ b/packages/client/test/integration/parallel-key-exchange.test.ts
@@ -39,17 +39,12 @@ describe('parallel key exchange', () => {
                 user: publisher.wallet.address,
                 permissions: [StreamPermission.PUBLISH]
             })
-            const groupKey = publisher.groupKey
             publisher.client = environment.createClient({
                 auth: {
                     privateKey: publisher.wallet.privateKey
-                },
-                encryptionKeys: {
-                    [stream.id]: {
-                        [groupKey.id]: groupKey
-                    }
                 }
             })
+            await publisher.client.addEncryptionKey(publisher.groupKey, stream.id)
             await startPublisherKeyExchangeSubscription(publisher.client)
         }))
     }, 20000)

--- a/packages/client/test/integration/pre-agreed-encryption-key.test.ts
+++ b/packages/client/test/integration/pre-agreed-encryption-key.test.ts
@@ -1,0 +1,38 @@
+import 'reflect-metadata'
+import { StreamMessage } from 'streamr-client-protocol'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { StreamPermission } from '../../src/permission'
+import { nextValue } from '../../src/utils/iterators'
+import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
+import { createTestStream } from '../test-utils/utils'
+
+describe('pre-agreed encryption key', () => {
+
+    it('happy path', async () => {
+        const environment = new FakeEnvironment()
+        const publisher = environment.createClient()
+        const subscriber = environment.createClient()
+        const stream = await createTestStream(publisher, module)
+        await stream.grantPermissions({
+            user: await subscriber.getAddress(),
+            permissions: [StreamPermission.SUBSCRIBE]
+        })
+
+        const key = GroupKey.generate()
+        await publisher.updateEncryptionKey({
+            key,
+            streamId: stream.id,
+            distributionMethod: 'rekey'
+        })
+        await subscriber.addEncryptionKey(key, stream.id)
+        const sub = await subscriber.subscribe(stream.id)
+        await publisher.publish(stream.id, { foo: 'bar' })
+        const receivedMessage = await nextValue(sub)
+
+        expect(receivedMessage?.groupKeyId).toBe(key.id)
+        const groupKeyRequests = environment.getNetwork().getSentMessages({
+            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+        })
+        expect(groupKeyRequests).toHaveLength(0)
+    })
+})

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { StreamMessage } from 'streamr-client-protocol'
+import { GroupKeyMessage, GroupKeyRequest, StreamMessage } from 'streamr-client-protocol'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { createMockMessage, startPublisherKeyExchangeSubscription } from '../test-utils/utils'
 import { Stream } from '../../src/Stream'
@@ -48,14 +48,13 @@ describe('resend and subscribe', () => {
         const publisher = environment.createClient({
             auth: {
                 privateKey: publisherWallet.privateKey
-            },
-            encryptionKeys: {
-                [stream.id]: {
-                    [groupKey.id]: groupKey
-                }
             }
         })
-    
+        await publisher.updateEncryptionKey({
+            key: groupKey,
+            streamId: stream.id,
+            distributionMethod: 'rekey'
+        })
         await startPublisherKeyExchangeSubscription(publisher)
 
         const historicalMessage = createMockMessage({
@@ -94,5 +93,6 @@ describe('resend and subscribe', () => {
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
         })
         expect(groupKeyRequests.length).toBe(1)
+        expect((GroupKeyMessage.fromStreamMessage(groupKeyRequests[0]) as GroupKeyRequest).groupKeyIds).toEqual([groupKey.id])
     })
 })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -143,8 +143,7 @@ export const getGroupKeyStore = (streamId: StreamID, userAddress: EthereumAddres
     return new GroupKeyStore({ 
         context: mockContext(), 
         clientId: userAddress.toLowerCase(), 
-        streamId, 
-        groupKeys: []
+        streamId
     })
 }
 

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -1,10 +1,10 @@
 import LeakDetector from 'jest-leak-detector' // requires weak-napi
-import crypto from 'crypto'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { uid,  getGroupKeyStore } from '../test-utils/utils'
 import { describeRepeats } from '../test-utils/jest-utils'
 import { StreamID, toStreamID } from 'streamr-client-protocol'
+import { randomEthereumAddress } from 'streamr-test-utils'
 
 describeRepeats('GroupKeyStore', () => {
     let clientId: string
@@ -13,7 +13,7 @@ describeRepeats('GroupKeyStore', () => {
     let leakDetector: LeakDetector
 
     beforeEach(() => {
-        clientId = `0x${crypto.randomBytes(20).toString('hex')}`
+        clientId = randomEthereumAddress()
         streamId = toStreamID(uid('stream'))
         store = getGroupKeyStore(streamId, clientId)
         leakDetector = new LeakDetector(store)

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -2,7 +2,7 @@ import LeakDetector from 'jest-leak-detector' // requires weak-napi
 import crypto from 'crypto'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
-import { uid, mockContext } from '../test-utils/utils'
+import { uid,  getGroupKeyStore } from '../test-utils/utils'
 import { describeRepeats } from '../test-utils/jest-utils'
 import { StreamID, toStreamID } from 'streamr-client-protocol'
 
@@ -15,13 +15,7 @@ describeRepeats('GroupKeyStore', () => {
     beforeEach(() => {
         clientId = `0x${crypto.randomBytes(20).toString('hex')}`
         streamId = toStreamID(uid('stream'))
-        store = new GroupKeyStore({
-            context: mockContext(),
-            clientId,
-            streamId,
-            groupKeys: [],
-        })
-
+        store = getGroupKeyStore(streamId, clientId)
         leakDetector = new LeakDetector(store)
     })
 

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -1,19 +1,10 @@
 import crypto from 'crypto'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
-import { uid, mockContext } from '../test-utils/utils'
+import { getGroupKeyStore, uid } from '../test-utils/utils'
 import { addAfterFn } from '../test-utils/jest-utils'
 import LeakDetector from 'jest-leak-detector' // requires weak-napi
 import { StreamID, toStreamID } from 'streamr-client-protocol'
-
-const createStore = (clientId: string, streamId: StreamID): GroupKeyStore => {
-    return new GroupKeyStore({
-        context: mockContext(),
-        clientId,
-        streamId,
-        groupKeys: []
-    })
-}
 
 describe('GroupKeyStore', () => {
     let clientId: string
@@ -26,7 +17,7 @@ describe('GroupKeyStore', () => {
     beforeEach(() => {
         clientId = `0x${crypto.randomBytes(20).toString('hex')}`
         streamId = toStreamID(uid('stream'))
-        store = createStore(clientId, streamId)
+        store = getGroupKeyStore(streamId, clientId)
         leakDetector = new LeakDetector(store)
     })
 
@@ -53,7 +44,7 @@ describe('GroupKeyStore', () => {
     })
 
     it('can add with multiple instances in parallel', async () => {
-        const store2 = createStore(clientId, streamId)
+        const store2 = getGroupKeyStore(streamId, clientId)
         // @ts-expect-error private
         addAfter(() => store2.persistence.destroy())
 
@@ -87,7 +78,7 @@ describe('GroupKeyStore', () => {
 
     it('does not conflict with other streamIds', async () => {
         const streamId2 = toStreamID(uid('stream'))
-        const store2 = createStore(clientId, streamId2)
+        const store2 = getGroupKeyStore(streamId2, clientId)
 
         // @ts-expect-error private
         addAfter(() => store2.persistence.destroy())
@@ -101,7 +92,7 @@ describe('GroupKeyStore', () => {
 
     it('does not conflict with other clientIds', async () => {
         const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
-        const store2 = createStore(clientId2, streamId)
+        const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
         addAfter(() => store2.persistence.destroy())
@@ -115,7 +106,7 @@ describe('GroupKeyStore', () => {
 
     it('does not conflict with other clientIds', async () => {
         const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
-        const store2 = createStore(clientId2, streamId)
+        const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
         addAfter(() => store2.persistence.destroy())
@@ -129,12 +120,12 @@ describe('GroupKeyStore', () => {
 
     it('can read previously persisted data', async () => {
         const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
-        const store2 = createStore(clientId2, streamId)
+        const store2 = getGroupKeyStore(streamId, clientId2)
         const groupKey = GroupKey.generate()
 
         await store2.add(groupKey)
 
-        const store3 = createStore(clientId2, streamId)
+        const store3 = getGroupKeyStore(streamId, clientId2)
         expect(await store3.get(groupKey.id)).toEqual(groupKey)
     })
 })

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -1,10 +1,10 @@
-import crypto from 'crypto'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { getGroupKeyStore, uid } from '../test-utils/utils'
 import { addAfterFn } from '../test-utils/jest-utils'
 import LeakDetector from 'jest-leak-detector' // requires weak-napi
 import { StreamID, toStreamID } from 'streamr-client-protocol'
+import { randomEthereumAddress } from 'streamr-test-utils'
 
 describe('GroupKeyStore', () => {
     let clientId: string
@@ -15,7 +15,7 @@ describe('GroupKeyStore', () => {
     const addAfter = addAfterFn()
 
     beforeEach(() => {
-        clientId = `0x${crypto.randomBytes(20).toString('hex')}`
+        clientId = randomEthereumAddress()
         streamId = toStreamID(uid('stream'))
         store = getGroupKeyStore(streamId, clientId)
         leakDetector = new LeakDetector(store)
@@ -91,7 +91,7 @@ describe('GroupKeyStore', () => {
     })
 
     it('does not conflict with other clientIds', async () => {
-        const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
+        const clientId2 = randomEthereumAddress()
         const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
@@ -105,7 +105,7 @@ describe('GroupKeyStore', () => {
     })
 
     it('does not conflict with other clientIds', async () => {
-        const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
+        const clientId2 = randomEthereumAddress()
         const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
@@ -119,7 +119,7 @@ describe('GroupKeyStore', () => {
     })
 
     it('can read previously persisted data', async () => {
-        const clientId2 = `0x${crypto.randomBytes(20).toString('hex')}`
+        const clientId2 = randomEthereumAddress()
         const store2 = getGroupKeyStore(streamId, clientId2)
         const groupKey = GroupKey.generate()
 

--- a/packages/client/test/unit/ServerPersistence.test.ts
+++ b/packages/client/test/unit/ServerPersistence.test.ts
@@ -1,6 +1,6 @@
 import { Database } from 'sqlite'
 import { toStreamID } from 'streamr-client-protocol'
-import { fastWallet } from 'streamr-test-utils'
+import { randomEthereumAddress } from 'streamr-test-utils'
 import ServerPersistence from '../../src/utils/persistence/ServerPersistence'
 import { mockContext } from '../test-utils/utils'
 
@@ -9,7 +9,7 @@ describe('ServerPersistence', () => {
     let persistence: ServerPersistence
 
     beforeEach(async () => {
-        const clientId = fastWallet().address
+        const clientId = randomEthereumAddress()
         const streamId = toStreamID('0x0000000000000000000000000000000000000001/path')
         persistence = new ServerPersistence({
             context: mockContext(),


### PR DESCRIPTION
If a publisher and a subscriber don't want to exchange the keys via the network, they can use pre-agreed keys like this:
```
const key = new GroupKey('key-id', crypto.randomBytes(32))
publisher.updateEncryptionKey({
    key,
    streamId,
    distibutionMethod: 'rekey'
})
subscriber.addEncryptionKey(key, streamId)
```

This way both participants have the group key available before message delivery starts. For subscriber, we just add a key to the local database. For publisher it we also mark the key to be the `currentGroupKey` which ensures that the next message is published with that key. 

Before this PR there was already the `updateEncryptionKey` method. In this PR we added the `addEncryptionKey` method.

Removed also an obsolete `encryptionKeys` config option, which was previously used to implement similar functionality.