### PR TITLE
feat(client): Limit contract concurrency

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Method `updateEncryptionKey` to update stream encryption key
 - The client publishes metrics to the network at regular intervals (configurable with `metrics` config option)
-- There is a limit for concurrent contract calls (per contract, configurable with `maxConcurrentContractCalls` config option)
+- There is a limit for concurrent smart contract calls (per contract, configurable with `maxConcurrentContractCalls` config option)
 
 ### Changed
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Method `updateEncryptionKey` to update stream encryption key
 - The client publishes metrics to the network at regular intervals (configurable with `metrics` config option)
+- There is a limit for concurrent contract calls (per contract, configurable with `maxConcurrentContractCalls` config option)
 
 ### Changed
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -156,6 +156,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
             gasPriceStrategy: (estimatedGasPrice: BigNumber) => estimatedGasPrice.add('10000000000'),
         }
     },
+    maxConcurrentContractCalls: 10, // TODO just a placeholder value, define a valid value by executing some benchmarks
     cache: {
         maxSize: 10000,
         maxAge: 24 * 60 * 60 * 1000, // 24 hours

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -156,7 +156,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientConfig = {
             gasPriceStrategy: (estimatedGasPrice: BigNumber) => estimatedGasPrice.add('10000000000'),
         }
     },
-    maxConcurrentContractCalls: 10, // TODO just a placeholder value, define a valid value by executing some benchmarks
+    maxConcurrentContractCalls: 10,
     cache: {
         maxSize: 10000,
         maxAge: 24 * 60 * 60 * 1000, // 24 hours

--- a/packages/client/src/ContractFactory.ts
+++ b/packages/client/src/ContractFactory.ts
@@ -1,0 +1,45 @@
+import { Lifecycle, scoped } from 'tsyringe'
+import { Contract, ContractInterface, ContractReceipt, ContractTransaction } from '@ethersproject/contracts'
+import { Provider } from '@ethersproject/providers'
+import { Signer } from '@ethersproject/abstract-signer'
+import { ObservableContract, createDecoratedContract } from './utils/contract'
+import { EthereumAddress } from 'streamr-client-protocol'
+import { SynchronizedGraphQLClient } from './utils/SynchronizedGraphQLClient'
+
+@scoped(Lifecycle.ContainerScoped)
+export class ContractFactory {
+
+    private graphQLClient: SynchronizedGraphQLClient
+
+    constructor(graphQLClient: SynchronizedGraphQLClient) {
+        this.graphQLClient = graphQLClient
+    }
+
+    createReadContract<T extends Contract>(
+        address: EthereumAddress,
+        contractInterface: ContractInterface,
+        provider: Provider,
+        name: string
+    ): ObservableContract<T> {
+        return createDecoratedContract<T>(
+            new Contract(address, contractInterface, provider),
+            name
+        )
+    }
+
+    createWriteContract<T extends Contract>(
+        address: EthereumAddress,
+        contractInterface: ContractInterface,
+        signer: Signer,
+        name: string
+    ): ObservableContract<T> {
+        const contract = createDecoratedContract<T>(
+            new Contract(address, contractInterface, signer),
+            name
+        )
+        contract.eventEmitter.on('onTransactionConfirm', (_methodName: string, _tx: ContractTransaction, receipt: ContractReceipt) => {
+            this.graphQLClient.updateRequiredBlockNumber(receipt.blockNumber)
+        })
+        return contract
+    }
+}

--- a/packages/client/src/ContractFactory.ts
+++ b/packages/client/src/ContractFactory.ts
@@ -11,8 +11,8 @@ import { ConfigInjectionToken } from './Config'
 @scoped(Lifecycle.ContainerScoped)
 export class ContractFactory {
 
-    private graphQLClient: SynchronizedGraphQLClient
-    private ethereumConfig: EthereumConfig
+    private readonly graphQLClient: SynchronizedGraphQLClient
+    private readonly ethereumConfig: EthereumConfig
 
     constructor(
         graphQLClient: SynchronizedGraphQLClient,

--- a/packages/client/src/ContractFactory.ts
+++ b/packages/client/src/ContractFactory.ts
@@ -1,18 +1,25 @@
-import { Lifecycle, scoped } from 'tsyringe'
+import { inject, Lifecycle, scoped } from 'tsyringe'
 import { Contract, ContractInterface, ContractReceipt, ContractTransaction } from '@ethersproject/contracts'
 import { Provider } from '@ethersproject/providers'
 import { Signer } from '@ethersproject/abstract-signer'
 import { ObservableContract, createDecoratedContract } from './utils/contract'
 import { EthereumAddress } from 'streamr-client-protocol'
 import { SynchronizedGraphQLClient } from './utils/SynchronizedGraphQLClient'
+import { EthereumConfig } from './Ethereum'
+import { ConfigInjectionToken } from './Config'
 
 @scoped(Lifecycle.ContainerScoped)
 export class ContractFactory {
 
     private graphQLClient: SynchronizedGraphQLClient
+    private ethereumConfig: EthereumConfig
 
-    constructor(graphQLClient: SynchronizedGraphQLClient) {
+    constructor(
+        graphQLClient: SynchronizedGraphQLClient,
+        @inject(ConfigInjectionToken.Ethereum) ethereumConfig: EthereumConfig
+    ) {
         this.graphQLClient = graphQLClient
+        this.ethereumConfig = ethereumConfig
     }
 
     createReadContract<T extends Contract>(
@@ -23,7 +30,8 @@ export class ContractFactory {
     ): ObservableContract<T> {
         return createDecoratedContract<T>(
             new Contract(address, contractInterface, provider),
-            name
+            name,
+            this.ethereumConfig.maxConcurrentContractCalls
         )
     }
 
@@ -35,7 +43,12 @@ export class ContractFactory {
     ): ObservableContract<T> {
         const contract = createDecoratedContract<T>(
             new Contract(address, contractInterface, signer),
-            name
+            name,
+            // The current maxConcurrentCalls value is just a placeholder as we don't support concurrent writes (as we don't use nonces).
+            // When we add the support, we should use this.ethereumConfig.maxConcurrentContractCalls here.
+            // Also note that if we'd use a limit of 1, it wouldn't make the concurrent transactions to a sequence of transactions,
+            // because the concurrency limit covers only submits, not tx.wait() calls.
+            999999
         )
         contract.eventEmitter.on('onTransactionConfirm', (_methodName: string, _tx: ContractTransaction, receipt: ContractReceipt) => {
             this.graphQLClient.updateRequiredBlockNumber(receipt.blockNumber)

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -27,6 +27,7 @@ export interface EthereumConfig {
     streamRegistryChainRPCs: ChainConnectionInfo
     // most of the above should go into ethereumNetworks configs once ETH-184 is ready
     ethereumNetworks?: Record<string, EthereumNetworkConfig>
+    maxConcurrentContractCalls: number
 }
 
 export const generateEthereumAccount = (): { address: string, privateKey: string } => {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -108,6 +108,9 @@
         "ethereumNetworks": {
             "type": "object"
         },
+        "maxConcurrentContractCalls": {
+            "type": "number"
+        },
         "orderMessages": {
             "type": "boolean"
         },

--- a/packages/client/src/registry/StorageNodeRegistry.ts
+++ b/packages/client/src/registry/StorageNodeRegistry.ts
@@ -7,7 +7,7 @@ import { ConfigInjectionToken } from '../Config'
 import { EthereumConfig, getStreamRegistryChainProvider, getStreamRegistryOverrides } from '../Ethereum'
 import { NotFoundError } from '../HttpUtil'
 import { EthereumAddress } from 'streamr-client-protocol'
-import { waitForTx, withErrorHandlingAndLogging } from '../utils/contract'
+import { waitForTx, createDecoratedContract } from '../utils/contract'
 import { SynchronizedGraphQLClient, createWriteContract } from '../utils/SynchronizedGraphQLClient'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 
@@ -33,7 +33,7 @@ export class StorageNodeRegistry {
         @inject(ConfigInjectionToken.Ethereum) private ethereumConfig: EthereumConfig,
     ) {
         const chainProvider = getStreamRegistryChainProvider(ethereumConfig)
-        this.nodeRegistryContractReadonly = withErrorHandlingAndLogging(
+        this.nodeRegistryContractReadonly = createDecoratedContract(
             new Contract(this.ethereumConfig.storageNodeRegistryChainAddress, NodeRegistryArtifact, chainProvider),
             'storageNodeRegistry'
         ) as NodeRegistryContract

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -22,7 +22,7 @@ import { omit } from 'lodash'
 import { createWriteContract, SynchronizedGraphQLClient } from '../utils/SynchronizedGraphQLClient'
 import { searchStreams as _searchStreams, SearchStreamsPermissionFilter } from './searchStreams'
 import { filter, map } from '../utils/GeneratorUtils'
-import { ObservableContract, waitForTx, withErrorHandlingAndLogging } from '../utils/contract'
+import { ObservableContract, waitForTx, createDecoratedContract } from '../utils/contract'
 import {
     StreamPermission,
     convertChainPermissionsToStreamPermissions,
@@ -90,7 +90,7 @@ export class StreamRegistry implements Context {
         this.debug('create')
         const chainProviders = getAllStreamRegistryChainProviders(ethereumConfig)
         this.streamRegistryContractsReadonly = chainProviders.map((provider: Provider) => {
-            return withErrorHandlingAndLogging<StreamRegistryContract>(
+            return createDecoratedContract<StreamRegistryContract>(
                 new Contract(this.ethereumConfig.streamRegistryChainAddress, StreamRegistryArtifact, provider),
                 'streamRegistry'
             )

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -10,7 +10,7 @@ import { Stream, StreamProperties } from '../Stream'
 import { EthereumConfig, getStreamRegistryChainProvider, getStreamRegistryOverrides } from '../Ethereum'
 import { EthereumAddress, StreamID, toStreamID } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
-import { waitForTx, withErrorHandlingAndLogging } from '../utils/contract'
+import { waitForTx, createDecoratedContract } from '../utils/contract'
 import { SynchronizedGraphQLClient, createWriteContract } from '../utils/SynchronizedGraphQLClient'
 import { StreamrClientEventEmitter, StreamrClientEvents, initEventGateway } from '../events'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
@@ -74,7 +74,7 @@ export class StreamStorageRegistry {
         @inject(ConfigInjectionToken.Ethereum) private ethereumConfig: EthereumConfig,
     ) {
         const chainProvider = getStreamRegistryChainProvider(ethereumConfig)
-        this.streamStorageRegistryContractReadonly = withErrorHandlingAndLogging(
+        this.streamStorageRegistryContractReadonly = createDecoratedContract(
             new Contract(this.ethereumConfig.streamStorageRegistryChainAddress, StreamStorageRegistryArtifact, chainProvider),
             'streamStorageRegistry'
         ) as StreamStorageRegistryContract

--- a/packages/client/src/utils/SynchronizedGraphQLClient.ts
+++ b/packages/client/src/utils/SynchronizedGraphQLClient.ts
@@ -3,7 +3,7 @@ import { Contract, ContractInterface, ContractReceipt, ContractTransaction } fro
 import { Signer } from '@ethersproject/abstract-signer'
 import { GraphQLClient } from './GraphQLClient'
 import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
-import { ObservableContract, withErrorHandlingAndLogging } from './contract'
+import { ObservableContract, createDecoratedContract } from './contract'
 import { EthereumAddress } from 'streamr-client-protocol'
 import { Gate } from './Gate'
 import { Context } from './Context'
@@ -36,7 +36,7 @@ export const createWriteContract = <T extends Contract>(
     name: string,
     graphQLClient: SynchronizedGraphQLClient
 ): ObservableContract<T> => {
-    const contract = withErrorHandlingAndLogging<T>(
+    const contract = createDecoratedContract<T>(
         new Contract(address, contractInterface, signer),
         name
     )

--- a/packages/client/src/utils/SynchronizedGraphQLClient.ts
+++ b/packages/client/src/utils/SynchronizedGraphQLClient.ts
@@ -1,10 +1,6 @@
 import { scoped, Lifecycle, inject } from 'tsyringe'
-import { Contract, ContractInterface, ContractReceipt, ContractTransaction } from '@ethersproject/contracts'
-import { Signer } from '@ethersproject/abstract-signer'
 import { GraphQLClient } from './GraphQLClient'
 import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
-import { ObservableContract, createDecoratedContract } from './contract'
-import { EthereumAddress } from 'streamr-client-protocol'
 import { Gate } from './Gate'
 import { Context } from './Context'
 import { Debugger } from 'debug'
@@ -28,23 +24,6 @@ import { wait } from '@streamr/utils'
  * We can use the helper method `createWriteContract` to create a contract which automatically
  * updates the client when something is written to the blockchain via that contract.
  */
-
-export const createWriteContract = <T extends Contract>(
-    address: EthereumAddress,
-    contractInterface: ContractInterface,
-    signer: Signer,
-    name: string,
-    graphQLClient: SynchronizedGraphQLClient
-): ObservableContract<T> => {
-    const contract = createDecoratedContract<T>(
-        new Contract(address, contractInterface, signer),
-        name
-    )
-    contract.eventEmitter.on('onTransactionConfirm', (_methodName: string, _tx: ContractTransaction, receipt: ContractReceipt) => {
-        graphQLClient.updateRequiredBlockNumber(receipt.blockNumber)
-    })
-    return contract
-}
 
 class BlockNumberGate extends Gate {
     blockNumber: number

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -93,7 +93,7 @@ const createWrappedContractMethod = (
 }
 
 /**
- * Adds error handling and logging for each method call. Optionally limits concurrency.
+ * Adds error handling, logging and limits concurrency.
  * 
  * You can use the decorated contract normally, e.g.:
  *     const tx = await contract.createFoobar(123)
@@ -104,11 +104,11 @@ const createWrappedContractMethod = (
 export const createDecoratedContract = <T extends Contract>(
     contract: Contract,
     contractName: string,
-    maxConcurrentInvocations = 999999 // TODO just a placeholder value, define a valid value by executing some benchmarks
+    maxConcurrentCalls: number
 ): ObservableContract<T> => {
     const eventEmitter = new EventEmitter<ContractEvent>()
     const methods: Record<string, () => Promise<any>> = {}
-    const concurrencyLimit = pLimit(maxConcurrentInvocations) 
+    const concurrencyLimit = pLimit(maxConcurrentCalls)
     /*
      * Wrap each contract function. We read the list of functions from contract.functions, but
      * actually delegate each method to contract[methodName]. Those methods are almost identical

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -93,13 +93,15 @@ const createWrappedContractMethod = (
 }
 
 /**
- * You can use the wrapped contract normally, e.g.:
+ * Adds error handling and logging for each method call. Optionally limits concurrency.
+ * 
+ * You can use the decorated contract normally, e.g.:
  *     const tx = await contract.createFoobar(123)
  *     return await tx.wait()
  * or
  *     await contract.getFoobar(456)
  */
-export const withErrorHandlingAndLogging = <T extends Contract>(  // TODO rename as we do throttling, too
+export const createDecoratedContract = <T extends Contract>(
     contract: Contract,
     contractName: string,
     maxConcurrentInvocations = 999999 // TODO just a placeholder value, define a valid value by executing some benchmarks

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -102,10 +102,11 @@ const createWrappedContractMethod = (
 export const withErrorHandlingAndLogging = <T extends Contract>(  // TODO rename as we do throttling, too
     contract: Contract,
     contractName: string,
+    maxConcurrentInvocations = 999999 // TODO just a placeholder value, define a valid value by executing some benchmarks
 ): ObservableContract<T> => {
     const eventEmitter = new EventEmitter<ContractEvent>()
     const methods: Record<string, () => Promise<any>> = {}
-    const concurrencyLimit = pLimit(999999) // TODO just a placeholder value, define a valid value by executing some benchmarks
+    const concurrencyLimit = pLimit(maxConcurrentInvocations) 
     /*
      * Wrap each contract function. We read the list of functions from contract.functions, but
      * actually delegate each method to contract[methodName]. Those methods are almost identical

--- a/packages/client/test/unit/contract.test.ts
+++ b/packages/client/test/unit/contract.test.ts
@@ -1,0 +1,43 @@
+import { wait } from '@streamr/utils'
+import { range } from 'lodash'
+import { withErrorHandlingAndLogging } from '../../src/utils/contract'
+
+interface MockContract {
+    foo: () => Promise<number>
+    functions: {
+        foo: string
+    }
+}
+
+const createWrappedContract = (fooFn: () => Promise<number>, maxConcurrentInvocations?: number) => {
+    const mockContract: MockContract = {
+        foo: fooFn,
+        functions: {
+            foo: 'mock-artifact-definition'
+        }
+    } as any
+    return withErrorHandlingAndLogging(mockContract as any, 'mock-contract', maxConcurrentInvocations)
+}
+
+describe('contracts', () => {
+
+    it('happy path', async () => {
+        const wrappedContract = createWrappedContract(async () => 123)
+        expect(await wrappedContract.foo()).toBe(123)
+    })
+
+    it('concurrency limit', async () => {
+        const INVOCATION_DURATION = 50
+        const startTime = Date.now()
+        const invocationSlots: number[] = []
+        const wrappedContract = createWrappedContract(async () => {
+            invocationSlots.push(Math.round((Date.now() - startTime) / INVOCATION_DURATION))
+            await wait(INVOCATION_DURATION)
+            return 123
+        }, 2)
+
+        await Promise.all(range(5).map(() => wrappedContract.foo()))
+
+        expect(invocationSlots).toEqual([0, 0, 1, 1, 2])
+    })
+})

--- a/packages/client/test/unit/contract.test.ts
+++ b/packages/client/test/unit/contract.test.ts
@@ -9,14 +9,14 @@ interface MockContract {
     }
 }
 
-const createContract = (fooFn: () => Promise<number>, maxConcurrentInvocations?: number): ObservableContract<any> => {
+const createContract = (fooFn: () => Promise<number>, maxConcurrentCalls = 999999): ObservableContract<any> => {
     const mockContract: MockContract = {
         foo: fooFn,
         functions: {
             foo: 'mock-artifact-definition'
         }
     } as any
-    return createDecoratedContract(mockContract as any, 'mock-contract', maxConcurrentInvocations)
+    return createDecoratedContract(mockContract as any, 'mock-contract', maxConcurrentCalls)
 }
 
 describe('contracts', () => {


### PR DESCRIPTION
There is a limit for concurrent contract calls. The limit is per contract and is configurable by config option `maxConcurrentContractCalls`.

A new `ContractFactory` helper class was introduced so that e.g. registry components don't need to know the details of our contract configuration options (e.g. by reading `maxConcurrentContractCalls` from the client config and passing that value to `createDecoratedContract()`).