### PR TITLE
refactor(client): Minimal `Persistence` interface

### DIFF
--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -70,10 +70,6 @@ export class GroupKeyStore implements Context {
         return new GroupKey(id, value)
     }
 
-    async exists(): Promise<boolean> {
-        return this.persistence.exists()
-    }
-
     async add(groupKey: GroupKey): Promise<GroupKey> {
         return this.storeKey(groupKey)
     }

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -45,12 +45,6 @@ export class GroupKeyStore implements Context {
         return groupKey
     }
 
-    async has(id: GroupKeyId): Promise<boolean> {
-        if (this.currentGroupKey?.id === id) { return true }
-        if (this.queuedGroupKey?.id === id) { return true }
-        return this.persistence.has(id)
-    }
-
     async useGroupKey(): Promise<[GroupKey, GroupKey | undefined]> {
         // Ensure we have a current key by picking a queued key or generating a new one
         if (!this.currentGroupKey) {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -94,8 +94,4 @@ export class GroupKeyStore implements Context {
         this.queuedGroupKey = undefined
         return newKey
     }
-
-    async destroy(): Promise<void> {
-        return this.persistence.destroy()
-    }
 }

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -1,4 +1,4 @@
-import { get, set,  clear, createStore, UseStore } from 'idb-keyval'
+import { get, set, createStore, UseStore } from 'idb-keyval'
 import { Persistence } from './Persistence'
 import { StreamID } from 'streamr-client-protocol'
 
@@ -17,10 +17,6 @@ export default class BrowserPersistence implements Persistence<string, string> {
 
     async set(key: string, value: string): Promise<void> {
         await set(key, value, this.store)
-    }
-
-    private async clear(): Promise<void> {
-        await clear(this.store)
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -28,11 +28,6 @@ export default class BrowserPersistence implements Persistence<string, string> {
         // noop
     }
 
-    async destroy(): Promise<void> {
-        await this.clear()
-        await this.close()
-    }
-
     async exists(): Promise<boolean> { // eslint-disable-line class-methods-use-this
         // always true for browser
         // can't currently implement without opening db, defeating purpose

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -11,11 +11,6 @@ export default class BrowserPersistence implements Persistence<string, string> {
         this.store = createStore(this.dbName, 'GroupKeys')
     }
 
-    async has(key: string): Promise<boolean> {
-        const val = await this.get(key)
-        return val !== undefined
-    }
-
     async get(key: string): Promise<string | undefined> {
         return get(key, this.store)
     }

--- a/packages/client/src/utils/persistence/BrowserPersistence.ts
+++ b/packages/client/src/utils/persistence/BrowserPersistence.ts
@@ -28,13 +28,6 @@ export default class BrowserPersistence implements Persistence<string, string> {
         // noop
     }
 
-    async exists(): Promise<boolean> { // eslint-disable-line class-methods-use-this
-        // always true for browser
-        // can't currently implement without opening db, defeating purpose
-        // waiting for indexedDB.databases() to gain browser support.
-        return true
-    }
-
     get [Symbol.toStringTag](): string {
         return this.constructor.name
     }

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -2,6 +2,5 @@ export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<void>
     close(): Promise<void>
-    destroy(): Promise<void>
     exists(): Promise<boolean>
 }

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -1,7 +1,6 @@
 export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<void>
-    has(key: K): Promise<boolean>
     close(): Promise<void>
     destroy(): Promise<void>
     exists(): Promise<boolean>

--- a/packages/client/src/utils/persistence/Persistence.ts
+++ b/packages/client/src/utils/persistence/Persistence.ts
@@ -2,5 +2,4 @@ export interface Persistence<K, V> {
     get(key: K): Promise<V | undefined>
     set(key: K, value: V): Promise<void>
     close(): Promise<void>
-    exists(): Promise<boolean>
 }

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -152,17 +152,6 @@ export default class ServerPersistence implements Persistence<string, string>, C
         return value?.[this.valueColumnName]
     }
 
-    async has(key: string): Promise<boolean> {
-        if (!this.initCalled) {
-            // can't have if doesn't exist
-            if (!(await this.exists())) { return false }
-        }
-
-        await this.init()
-        const value = await this.store!.get(`SELECT COUNT(*) FROM ${this.tableName} WHERE id = ? AND streamId = ?`, key, this.streamId)
-        return !!(value && value['COUNT(*)'] != null && value['COUNT(*)'] !== 0)
-    }
-
     async set(key: string, value: string): Promise<void> {
         await this.init()
         await this.store!.run(

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -164,17 +164,6 @@ export default class ServerPersistence implements Persistence<string, string>, C
         )
     }
 
-    private async clear(): Promise<void> {
-        this.debug('clear')
-        if (!this.initCalled) {
-            // nothing to clear if doesn't exist
-            if (!(await this.exists())) { return }
-        }
-
-        await this.init()
-        await this.store!.run(`DELETE FROM ${this.tableName} WHERE streamId = ?`, this.streamId)
-    }
-
     async close(): Promise<void> {
         this.debug('close')
         if (!this.initCalled) {
@@ -184,18 +173,6 @@ export default class ServerPersistence implements Persistence<string, string>, C
 
         await this.init()
         await this.store!.close()
-    }
-
-    async destroy(): Promise<void> {
-        this.debug('destroy')
-        if (!this.initCalled) {
-            // nothing to destroy if doesn't exist
-            if (!(await this.exists())) { return }
-        }
-
-        await this.clear()
-        await this.close()
-        this.init = pOnce(Object.getPrototypeOf(this).init.bind(this))
     }
 
     get [Symbol.toStringTag](): string {

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -30,9 +30,8 @@ describe('GroupKeyStore', () => {
 
     it('can rotate and use', async () => {
         const groupKey = GroupKey.generate()
-        expect(await store.exists()).toBeFalsy()
         await store.rotate(groupKey)
-        expect(await store.exists()).toBeTruthy()
+        expect(await store.get(groupKey.id)).toEqual(groupKey)
         expect(await store.useGroupKey()).toEqual([groupKey, undefined])
         expect(await store.useGroupKey()).toEqual([groupKey, undefined])
         const groupKey2 = GroupKey.generate()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -19,8 +19,7 @@ describe('GroupKeyStore', () => {
     })
 
     afterEach(async () => {
-        if (!store) { return }
-        await store.destroy()
+        await store.close()
         // @ts-expect-error doesn't want us to unassign, but it's ok
         store = undefined // eslint-disable-line require-atomic-updates
     })

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -28,32 +28,6 @@ describe('GroupKeyStore', () => {
         expect(await leakDetector.isLeaking()).toBeFalsy()
     })
 
-    it('can get and set', async () => {
-        const groupKey = GroupKey.generate()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.get(groupKey.id)).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.close()).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        // should only start existing now
-        expect(await store.add(groupKey)).toBeTruthy()
-        expect(await store.exists()).toBeTruthy()
-        expect(await store.get(groupKey.id)).toEqual(groupKey)
-    })
-
-    it('does not exist until write', async () => {
-        const groupKey = GroupKey.generate()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.get(groupKey.id)).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        expect(await store.close()).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
-        // should only start existing now
-        expect(await store.add(groupKey)).toBeTruthy()
-        expect(await store.exists()).toBeTruthy()
-    })
-
     it('can rotate and use', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.exists()).toBeFalsy()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -47,8 +47,6 @@ describeRepeats('GroupKeyStore', () => {
     it('does not exist until write', async () => {
         const groupKey = GroupKey.generate()
         expect(await store.exists()).toBeFalsy()
-        expect(await store.has(groupKey.id)).toBeFalsy()
-        expect(await store.exists()).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()
         expect(await store.exists()).toBeFalsy()
         expect(await store.close()).toBeFalsy()

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -2,11 +2,10 @@ import LeakDetector from 'jest-leak-detector' // requires weak-napi
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { uid, getGroupKeyStore } from '../test-utils/utils'
-import { describeRepeats } from '../test-utils/jest-utils'
 import { StreamID, toStreamID } from 'streamr-client-protocol'
 import { randomEthereumAddress } from 'streamr-test-utils'
 
-describeRepeats('GroupKeyStore', () => {
+describe('GroupKeyStore', () => {
     let clientId: string
     let streamId: StreamID
     let store: GroupKeyStore

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -34,12 +34,10 @@ describe('GroupKeyStore', () => {
 
     it('can get and set', async () => {
         const groupKey = GroupKey.generate()
-        expect(await store.has(groupKey.id)).toBeFalsy()
         expect(await store.get(groupKey.id)).toBeFalsy()
 
         expect(await store.add(groupKey)).toBe(groupKey)
         expect(await store.add(groupKey)).toEqual(groupKey)
-        expect(await store.has(groupKey.id)).toBeTruthy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
 
@@ -56,17 +54,17 @@ describe('GroupKeyStore', () => {
                 // add key to store1 twice in parallel
                 store.add(groupKey).then(async () => {
                     // immediately check exists in store2
-                    expect(await store2.has(groupKey.id)).toBeTruthy()
+                    expect(await store2.get(groupKey.id)).toBeTruthy()
                 }),
                 store.add(groupKey).then(async () => {
                     // immediately check exists in store2
-                    expect(await store2.has(groupKey.id)).toBeTruthy()
+                    expect(await store2.get(groupKey.id)).toBeTruthy()
                 }),
                 // test adding to another store at same time doesn't break
                 // add to store2 in parallel
                 store2.add(groupKey).then(async () => {
                     // immediately check exists in store1
-                    expect(await store.has(groupKey.id)).toBeTruthy()
+                    expect(await store.get(groupKey.id)).toBeTruthy()
                 }),
             ]
 
@@ -85,7 +83,6 @@ describe('GroupKeyStore', () => {
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)
-        expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
@@ -99,7 +96,6 @@ describe('GroupKeyStore', () => {
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)
-        expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })
@@ -113,7 +109,6 @@ describe('GroupKeyStore', () => {
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)
-        expect(await store2.has(groupKey.id)).toBeFalsy()
         expect(await store2.get(groupKey.id)).toBeFalsy()
         expect(await store.get(groupKey.id)).toEqual(groupKey)
     })

--- a/packages/client/test/unit/GroupKeyStore2.test.ts
+++ b/packages/client/test/unit/GroupKeyStore2.test.ts
@@ -22,8 +22,7 @@ describe('GroupKeyStore', () => {
     })
 
     afterEach(async () => {
-        if (!store) { return }
-        await store.destroy()
+        await store.close()
         // @ts-expect-error doesn't want us to unassign, but it's ok
         store = undefined // eslint-disable-line require-atomic-updates
     })
@@ -44,7 +43,7 @@ describe('GroupKeyStore', () => {
     it('can add with multiple instances in parallel', async () => {
         const store2 = getGroupKeyStore(streamId, clientId)
         // @ts-expect-error private
-        addAfter(() => store2.persistence.destroy())
+        addAfter(() => store2.persistence.close())
 
         for (let i = 0; i < 5; i++) {
             const groupKey = GroupKey.generate()
@@ -79,7 +78,7 @@ describe('GroupKeyStore', () => {
         const store2 = getGroupKeyStore(streamId2, clientId)
 
         // @ts-expect-error private
-        addAfter(() => store2.persistence.destroy())
+        addAfter(() => store2.persistence.close())
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)
@@ -92,7 +91,7 @@ describe('GroupKeyStore', () => {
         const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
-        addAfter(() => store2.persistence.destroy())
+        addAfter(() => store2.persistence.close())
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)
@@ -105,7 +104,7 @@ describe('GroupKeyStore', () => {
         const store2 = getGroupKeyStore(streamId, clientId2)
 
         // @ts-expect-error private
-        addAfter(() => store2.persistence.destroy())
+        addAfter(() => store2.persistence.close())
 
         const groupKey = GroupKey.generate()
         await store.add(groupKey)

--- a/packages/client/test/unit/ServerPersistence.test.ts
+++ b/packages/client/test/unit/ServerPersistence.test.ts
@@ -24,7 +24,7 @@ describe('ServerPersistence', () => {
     })
 
     afterEach(async () => {
-        await persistence.destroy()
+        await persistence.close()
     })
 
     it('happy path', async () => {

--- a/packages/client/test/unit/ServerPersistence.test.ts
+++ b/packages/client/test/unit/ServerPersistence.test.ts
@@ -23,6 +23,10 @@ describe('ServerPersistence', () => {
         })
     })
 
+    afterEach(async () => {
+        await persistence.destroy()
+    })
+
     it('happy path', async () => {
         await persistence.set('foo', 'bar')
         expect(await persistence.get('foo')).toBe('bar')

--- a/packages/client/test/unit/ServerPersistence.test.ts
+++ b/packages/client/test/unit/ServerPersistence.test.ts
@@ -35,4 +35,31 @@ describe('ServerPersistence', () => {
     it('no value', async () => {
         expect(await persistence.get('non-existing')).toBeUndefined()
     })
+
+    it('can get and set', async () => {
+        const key = 'mock-key'
+        const value = 'mock-value'
+        expect(await persistence.exists()).toBeFalsy()
+        expect(await persistence.get(key)).toBeFalsy()
+        expect(await persistence.exists()).toBeFalsy()
+        expect(await persistence.exists()).toBeFalsy()
+        expect(await persistence.close()).toBeFalsy()
+        expect(await persistence.exists()).toBeFalsy()
+        // should only start existing now
+        await persistence.set(key, value)
+        expect(await persistence.exists()).toBeTruthy()
+        expect(await persistence.get(key)).toEqual(value)
+    })
+
+    it('does not exist until write', async () => {
+        const key = 'mock-key'
+        expect(await persistence.exists()).toBeFalsy()
+        expect(await persistence.get(key)).toBeUndefined()
+        expect(await persistence.exists()).toBeFalsy()
+        expect(await persistence.close()).toBeFalsy()
+        expect(await persistence.exists()).toBeFalsy()
+        // should only start existing now
+        await persistence.set(key, 'dummy')
+        expect(await persistence.exists()).toBeTruthy()
+    })
 })


### PR DESCRIPTION
Removed:
- `Persistence#has` (not used by any component)
- `Persistence#exists` (was used in tests, now using `ServerPersistence#exists `directly)
- `Persistence#destroy` (was used in tests, now using `Persistence#close`). Now some unit tests don't remove the generated test data from the DB. Maybe that is ok, as most of other tests don't do that kind of cleanup anyway.

Removed the same methods also from the `GroupKeyStore` wrapper class.

Also moved some test cases from `GroupKeyStore` test to `ServerPersistence` test.