### PR TITLE
fix(client): Timestamp unit bug in permission filters

### DIFF
--- a/packages/client/src/permission.ts
+++ b/packages/client/src/permission.ts
@@ -88,7 +88,7 @@ export const streamPermissionToSolidityType = (permission: StreamPermission): Bi
 
 /* eslint-disable padding-line-between-statements */
 export const convertChainPermissionsToStreamPermissions = (chainPermissions: ChainPermissions): StreamPermission[] => {
-    const now = Date.now()
+    const now = Math.round(Date.now() / 1000)
     const permissions = []
     if (chainPermissions.canEdit) {
         permissions.push(StreamPermission.EDIT)

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -281,7 +281,7 @@ export class StreamRegistry implements Context {
     ): string {
         const query = `
         {
-            permissions (first: ${pageSize}, where: {stream: "${streamId}" ${fieldName}_gt: "${Date.now()}" id_gt: "${lastId}"}) {
+            permissions (first: ${pageSize}, where: {stream: "${streamId}" ${fieldName}_gt: "${Math.round(Date.now() / 1000)}" id_gt: "${lastId}"}) {
                 id
                 userAddress
                 stream {

--- a/packages/client/src/registry/searchStreams.ts
+++ b/packages/client/src/registry/searchStreams.ts
@@ -107,7 +107,7 @@ const buildQuery = (
             variables.userAddress_in.push(PUBLIC_PERMISSION_ADDRESS)
         }
         if (permissionFilter.allOf !== undefined) {
-            const now = String(Date.now())
+            const now = String(Math.round(Date.now() / 1000))
             variables.canEdit = permissionFilter.allOf.includes(StreamPermission.EDIT)
             variables.canDelete = permissionFilter.allOf.includes(StreamPermission.DELETE)
             variables.publishExpiration_gt = permissionFilter.allOf.includes(StreamPermission.PUBLISH) ? now : undefined


### PR DESCRIPTION
Ported a fix from `v6.0.10`.