### PR TITLE
UpdateEncryptionKeyOptions: rename `streamId` to `streamIdOrPath`

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -103,10 +103,10 @@ export class StreamrClient implements Context {
     }
 
     async updateEncryptionKey(opts: UpdateEncryptionKeyOptions): Promise<void> {
-        if (opts.streamId === undefined) {
+        if (opts.streamIdOrPath === undefined) {
             throw new Error('streamId required')
         }
-        const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
+        const streamId = await this.streamIdBuilder.toStreamID(opts.streamIdOrPath)
         const queue = await this.publisher.getGroupKeyQueue(streamId)
         if (opts.distributionMethod === 'rotate') {
             if (opts.key === undefined) {

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -15,7 +15,7 @@ import { pOnce } from '../utils/promises'
 // and methods to use the term EncryptionKey (except protocol-classes, which
 // should use the protocol level term GroupKey)
 export interface UpdateEncryptionKeyOptions {
-    streamId: string
+    streamIdOrPath: string
     distributionMethod: 'rotate' | 'rekey'
     key?: GroupKey
 }

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -59,7 +59,7 @@ describe('Group Key Persistence', () => {
             })
             const groupKey = GroupKey.generate()
             await publisher.updateEncryptionKey({
-                streamId: stream.id,
+                streamIdOrPath: stream.id,
                 key: groupKey,
                 distributionMethod: 'rotate'
             })

--- a/packages/client/test/integration/pre-agreed-encryption-key.test.ts
+++ b/packages/client/test/integration/pre-agreed-encryption-key.test.ts
@@ -21,7 +21,7 @@ describe('pre-agreed encryption key', () => {
         const key = GroupKey.generate()
         await publisher.updateEncryptionKey({
             key,
-            streamId: stream.id,
+            streamIdOrPath: stream.id,
             distributionMethod: 'rekey'
         })
         await subscriber.addEncryptionKey(key, stream.id)

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -52,7 +52,7 @@ describe('resend and subscribe', () => {
         })
         await publisher.updateEncryptionKey({
             key: groupKey,
-            streamId: stream.id,
+            streamIdOrPath: stream.id,
             distributionMethod: 'rekey'
         })
         await startPublisherKeyExchangeSubscription(publisher, stream.getStreamParts()[0])

--- a/packages/client/test/integration/revoke-permissions.test.ts
+++ b/packages/client/test/integration/revoke-permissions.test.ts
@@ -88,7 +88,7 @@ describe('revoke permissions', () => {
         revokeAfter?: number
     } = {}) {
         await publisher.updateEncryptionKey({
-            streamId: stream.id,
+            streamIdOrPath: stream.id,
             distributionMethod: 'rotate'
         })
         await stream.grantPermissions({
@@ -121,7 +121,7 @@ describe('revoke permissions', () => {
                         permissions: [StreamPermission.SUBSCRIBE]
                     })
                     await publisher.updateEncryptionKey({
-                        streamId: stream.id,
+                        streamIdOrPath: stream.id,
                         distributionMethod: 'rekey'
                     })
                 }

--- a/packages/client/test/integration/update-encryption-key.test.ts
+++ b/packages/client/test/integration/update-encryption-key.test.ts
@@ -55,7 +55,7 @@ describe('update encryption key', () => {
         await publisher.updateEncryptionKey({
             key: rotatedKey,
             distributionMethod: 'rotate',
-            streamId: StreamPartIDUtils.getStreamID(streamPartId)
+            streamIdOrPath: StreamPartIDUtils.getStreamID(streamPartId)
         })
 
         await publisher.publish(streamPartId, {
@@ -88,7 +88,7 @@ describe('update encryption key', () => {
         await publisher.updateEncryptionKey({
             key: rekeyedKey,
             distributionMethod: 'rekey',
-            streamId: StreamPartIDUtils.getStreamID(streamPartId)
+            streamIdOrPath: StreamPartIDUtils.getStreamID(streamPartId)
         })
 
         await publisher.publish(streamPartId, {
@@ -119,7 +119,7 @@ describe('update encryption key', () => {
             await publisher.updateEncryptionKey({
                 key: rotatedKey,
                 distributionMethod: 'rotate',
-                streamId: StreamPartIDUtils.getStreamID(streamPartId)
+                streamIdOrPath: StreamPartIDUtils.getStreamID(streamPartId)
             })
 
             await publisher.publish(streamPartId, {
@@ -147,7 +147,7 @@ describe('update encryption key', () => {
             await publisher.updateEncryptionKey({
                 key: GroupKey.generate(),
                 distributionMethod: 'rekey',
-                streamId: StreamPartIDUtils.getStreamID(streamPartId)
+                streamIdOrPath: StreamPartIDUtils.getStreamID(streamPartId)
             })
 
             await publisher.publish(streamPartId, {


### PR DESCRIPTION
Should it be named `streamIdOrPath` to be in line with rest of client's public API?