### PR TITLE
test(client): Use `MessageFactory`

### DIFF
--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -80,7 +80,7 @@ export class MessageFactory {
         )
         const [messageId, prevMsgRef] = chain.add(metadata.timestamp)
 
-        const encryptionType = (await this.isPublicStream(this.streamId)) ? StreamMessage.ENCRYPTION_TYPES.NONE : StreamMessage.ENCRYPTION_TYPES.AES
+        const encryptionType = (await this.isPublicStream(this.streamId)) ? EncryptionType.NONE : EncryptionType.AES
         let groupKeyId: GroupKeyId | undefined
         let newGroupKey: EncryptedGroupKey | undefined
         let serializedContent = JSON.stringify(content)

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -2,16 +2,16 @@ import 'reflect-metadata'
 import { v4 as uuid } from 'uuid'
 import {
     GroupKeyResponse,
+    MessageID,
     StreamMessage,
     StreamPartID,
-    StreamPartIDUtils,
+    StreamPartIDUtils
 } from 'streamr-client-protocol'
 import { GroupKey, GroupKeyId } from '../../src/encryption/GroupKey'
 import { Wallet } from 'ethers'
 import { RSAKeyPair } from '../../src/encryption/RSAKeyPair'
 import { StreamPermission } from '../../src/permission'
 import { 
-    createMockMessage,
     createRelativeTestStreamId,
     getGroupKeyStore,
     startPublisherKeyExchangeSubscription
@@ -20,6 +20,8 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeNetworkNode } from '../test-utils/fake/FakeNetworkNode'
 import { fastWallet } from 'streamr-test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
+import { createRandomMsgChainId } from '../../src/publish/MessageChain'
+import { sign } from '../../src/utils/signingUtils'
 
 describe('PublisherKeyExchange', () => {
 
@@ -45,9 +47,9 @@ describe('PublisherKeyExchange', () => {
         publisher = subscriberWallet,
         rsaPublicKey = subscriberRSAKeyPair.getPublicKey()
     ): StreamMessage => {
-        return createMockMessage({
-            streamPartId,
-            publisher,
+        const [ streamId, partition ] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
+        const msg = new StreamMessage({
+            messageId: new MessageID(streamId, partition, 0, Date.now(), publisher.address, createRandomMsgChainId()),
             content: JSON.stringify([
                 uuid(),
                 publisherWallet.address,
@@ -58,6 +60,8 @@ describe('PublisherKeyExchange', () => {
             encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
             contentType: StreamMessage.CONTENT_TYPES.JSON,
         })
+        msg.signature = sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), publisher.privateKey)
+        return msg
     }
 
     const testSuccessResponse = async (actualResponse: StreamMessage, expectedGroupKeys: GroupKey[]): Promise<void> => {

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -43,7 +43,7 @@ describe('Subscriber', () => {
         const sub = await subscriber.subscribe(stream.id)
 
         const publisherNode = environment.startNode(publisherWallet.address)
-        publisherNode.publish(createMockMessage({
+        publisherNode.publish(await createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT
@@ -70,7 +70,7 @@ describe('Subscriber', () => {
         const sub = await subscriber.subscribe(stream.id)
 
         const publisherNode = await publisher.getNode()
-        publisherNode.publish(createMockMessage({
+        publisherNode.publish(await createMockMessage({
             stream,
             publisher: publisherWallet,
             content: MOCK_CONTENT,

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -36,7 +36,7 @@ describe('SubscriberKeyExchange', () => {
 
     const triggerGroupKeyRequest = async (key: GroupKey, publisher: StreamrClient): Promise<void> => {
         const publisherNode = await publisher.getNode()
-        publisherNode.publish(createMockMessage({
+        publisherNode.publish(await createMockMessage({
             streamPartId,
             publisher: publisherWallet,
             encryptionKey: key

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -57,7 +57,7 @@ describe('resend and subscribe', () => {
         })
         await startPublisherKeyExchangeSubscription(publisher, stream.getStreamParts()[0])
 
-        const historicalMessage = createMockMessage({
+        const historicalMessage = await createMockMessage({
             timestamp: 1000,
             encryptionKey: groupKey,
             stream,

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -28,11 +28,11 @@ describe('resend with existing key', () => {
     let allMessages: { timestamp: number, groupKey: GroupKey, nextGroupKey?: GroupKey }[]
     let environment: FakeEnvironment
 
-    const storeMessage = (timestamp: number, currentGroupKey: GroupKey, nextGroupKey: GroupKey | undefined, storageNode: FakeStorageNode) => {
-        const message = createMockMessage({
+    const storeMessage = async (timestamp: number, currentGroupKey: GroupKey, nextGroupKey: GroupKey | undefined, storageNode: FakeStorageNode) => {
+        const message = await createMockMessage({
             timestamp,
             encryptionKey: currentGroupKey,
-            newGroupKey: (nextGroupKey !== undefined) ? currentGroupKey.encryptNextGroupKey(nextGroupKey) : null,
+            nextEncryptionKey: nextGroupKey,
             stream,
             publisher: publisherWallet,
         })

--- a/packages/client/test/unit/Decrypt.test.ts
+++ b/packages/client/test/unit/Decrypt.test.ts
@@ -31,7 +31,7 @@ describe('Decrypt', () => {
             } as any
         )
         const groupKey = GroupKey.generate()
-        const msg = createMockMessage({
+        const msg = await createMockMessage({
             streamPartId: StreamPartIDUtils.parse('stream#0'),
             publisher: fastWallet(),
             encryptionKey: groupKey

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -36,14 +36,14 @@ describe('EncryptionUtil', () => {
     it('StreamMessage decryption: happy path', async () => {
         const key = GroupKey.generate()
         const nextKey = GroupKey.generate()
-        const streamMessage = createMockMessage({
+        const streamMessage = await createMockMessage({
             streamPartId: StreamPartIDUtils.parse('stream#0'),
             publisher: fastWallet(),
             content: {
                 foo: 'bar'
             },
             encryptionKey: key,
-            newGroupKey: key.encryptNextGroupKey(nextKey)
+            nextEncryptionKey: nextKey
         })
         EncryptionUtil.decryptStreamMessage(streamMessage, key)
         expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
@@ -52,9 +52,9 @@ describe('EncryptionUtil', () => {
         expect(streamMessage.newGroupKey).toEqual(nextKey)
     })
 
-    it('StreamMessage decryption throws if newGroupKey invalid', () => {
+    it('StreamMessage decryption throws if newGroupKey invalid', async () => {
         const key = GroupKey.generate()
-        const msg = createMockMessage({
+        const msg = await createMockMessage({
             publisher: fastWallet(),
             streamPartId: toStreamPartID(STREAM_ID, 0),
             encryptionKey: key


### PR DESCRIPTION
Test utility method `createMockMessage` uses `MessageFactory`.

Other related changed:
- `parallel-key-exchange.test.ts` uses `MessageFactory` directly
- `PublisherKeyExchange.test.ts` uses `StreamMessage` constructor directly

Also simplified enum usage in `MessageFactory`.