### PR TITLE
style(client): Remove obsolete `eslint` warnings

### DIFF
--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -122,7 +122,7 @@ async function fetchResponse(
 ): Promise<Response> {
     if (!debug) {
         const id = counterId('httpResponse')
-        debug = Debug('utils').extend(id) // eslint-disable-line no-param-reassign
+        debug = Debug('utils').extend(id)
     }
 
     const timeStart = Date.now()

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -147,7 +147,6 @@ export class NetworkNodeFacade implements Context {
         if (this.authentication.isAuthenticated()) {
             const address = await this.authentication.getAddress()
             return `${address}#${uuid()}`
-            // eslint-disable-next-line no-else-return
         } else {
             return generateEthereumAccount().address
         }

--- a/packages/client/src/StreamIDBuilder.ts
+++ b/packages/client/src/StreamIDBuilder.ts
@@ -13,7 +13,6 @@ import { Authentication, AuthenticationInjectionToken } from './Authentication'
 
 export const DEFAULT_PARTITION = 0
 
-/* eslint-disable no-else-return */
 function pickStreamId(definition: { id: string } | { stream: string } | { streamId: string }): StreamID {
     const obj = definition as any
     if (obj.id !== undefined) {
@@ -37,7 +36,6 @@ function parseRawDefinition(definition: StreamDefinition): [string, number | und
     }
 }
 
-/* eslint-disable no-else-return */
 @scoped(Lifecycle.ContainerScoped)
 export class StreamIDBuilder {
     constructor(@inject(AuthenticationInjectionToken) private authentication: Authentication) {}

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -112,7 +112,7 @@ export class StreamrClient implements Context {
             if (opts.key === undefined) {
                 await queue.rotate(opts.key)
             }
-        } else if (opts.distributionMethod === 'rekey') { // eslint-disable-line no-else-return
+        } else if (opts.distributionMethod === 'rekey') {
             await queue.rekey(opts.key)
         } else {
             throw new Error(`assertion failed: distribution method ${opts.distributionMethod}`)

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -91,7 +91,7 @@ export class Validator extends StreamMessageValidator implements Context {
             if (this.isStopped) { return }
 
             if (!err.streamMessage) {
-                err.streamMessage = msg // eslint-disable-line no-param-reassign
+                err.streamMessage = msg
             }
             throw err
         })

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -22,7 +22,6 @@ export class EncryptionUtil {
     /**
      * Returns a Buffer or a hex String
      */
-    /* eslint-disable no-dupe-class-members */
     static encryptWithRSAPublicKey(plaintextBuffer: Uint8Array, publicKey: crypto.KeyLike, outputInHex: true): string
     // These overrides tell ts outputInHex returns string
     static encryptWithRSAPublicKey(plaintextBuffer: Uint8Array, publicKey: crypto.KeyLike): string
@@ -35,7 +34,6 @@ export class EncryptionUtil {
         }
         return ciphertextBuffer
     }
-    /* eslint-disable no-dupe-class-members */
 
     // Returns a Buffer
     static decryptWithRSAPrivateKey(ciphertext: string | Uint8Array, privateKey: crypto.KeyLike, isHexString = false): Buffer {
@@ -66,7 +64,6 @@ export class EncryptionUtil {
             return
         }
 
-        /* eslint-disable no-param-reassign */
         try {
             streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
             const serializedContent = this.decryptWithAES(streamMessage.getSerializedContent(), groupKey.data).toString()

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -6,7 +6,6 @@ import { EncryptionUtil } from './EncryptionUtil'
 export type GroupKeyId = string
 
 export class GroupKeyError extends Error {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(message: string, public groupKey?: GroupKey) {
         super(message)
     }

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -113,7 +113,6 @@ export class RSAKeyPair {
     }
 
     private async keyPairBrowser(): Promise<void> {
-        // eslint-disable-next-line
         const { publicKey, privateKey } = await getSubtle().generateKey({
             name: 'RSA-OAEP',
             modulusLength: 4096,

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -62,7 +62,6 @@ export class SubscriberKeyExchange {
             node.addMessageListener((msg: StreamMessage) => this.onMessage(msg))
             this.debug('Started')
         })
-        // eslint-disable-next-line max-len
         this.requestGroupKey = withThrottling((groupKeyId: GroupKeyId, publisherId: EthereumAddress, streamPartId: StreamPartID) => { 
             return this.doRequestGroupKey(groupKeyId, publisherId, streamPartId)
         }, decryptionConfig.maxKeyRequestsPerSecond)

--- a/packages/client/src/permission.ts
+++ b/packages/client/src/permission.ts
@@ -86,7 +86,6 @@ export const streamPermissionToSolidityType = (permission: StreamPermission): Bi
     return BigNumber.from(0)
 }
 
-/* eslint-disable padding-line-between-statements */
 export const convertChainPermissionsToStreamPermissions = (chainPermissions: ChainPermissions): StreamPermission[] => {
     const now = Math.round(Date.now() / 1000)
     const permissions = []

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -95,7 +95,7 @@ export class OrderMessages<T> implements Context {
             if (err.code === 'NO_STORAGE_NODES') {
                 // ignore NO_STORAGE_NODES errors
                 // if stream has no storage we can't do resends
-                this.enabled = false // eslint-disable-line require-atomic-updates
+                this.enabled = false
                 this.orderingUtil.disable()
             } else {
                 this.outBuffer.endWrite(err)

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -238,10 +238,8 @@ export class Resends implements Context {
         const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamMessage.getStreamPartID())
         const streamDefinition = { streamId, partition }
 
-        /* eslint-disable no-await-in-loop */
         const start = Date.now()
         let last: StreamMessage[]
-        // eslint-disable-next-line no-constant-condition
         let found = false
         while (!found) {
             const duration = Date.now() - start

--- a/packages/client/src/utils/AggregatedError.ts
+++ b/packages/client/src/utils/AggregatedError.ts
@@ -79,7 +79,7 @@ export class AggregatedError extends Error {
         if (!newErr) {
             if (oldErr && msg) {
                 // copy message
-                oldErr.message = joinMessages([oldErr.message, msg]) // eslint-disable-line no-param-reassign
+                oldErr.message = joinMessages([oldErr.message, msg])
             }
             return oldErr
         }
@@ -88,7 +88,7 @@ export class AggregatedError extends Error {
         if (!oldErr) {
             if (newErr && msg) {
                 // copy message
-                newErr.message = joinMessages([newErr.message, msg]) // eslint-disable-line no-param-reassign
+                newErr.message = joinMessages([newErr.message, msg])
             }
             return newErr
         }

--- a/packages/client/src/utils/Defer.ts
+++ b/packages/client/src/utils/Defer.ts
@@ -37,7 +37,6 @@ export type DeferReturnType<T> = Promise<T> &
     isSettled(): boolean
 } 
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => void = noop): DeferReturnType<T> {
     let resolveFn: PromiseResolve | undefined
     let rejectFn: PromiseResolve | undefined
@@ -61,7 +60,6 @@ export function Defer<T>(executor: (...args: Parameters<Promise<T>['then']>) => 
         }
     }
 
-    // eslint-disable-next-line promise/param-names
     const p: Promise<T> = new Promise((_resolve, _reject) => {
         resolveFn = _resolve
         rejectFn = _reject

--- a/packages/client/src/utils/GraphQLClient.ts
+++ b/packages/client/src/utils/GraphQLClient.ts
@@ -54,7 +54,6 @@ export class GraphQLClient {
         do {
             const lastId = (lastResultSet !== undefined) ? lastResultSet[lastResultSet.length - 1].id : ''
             const query = createQuery(lastId, pageSize)
-            // eslint-disable-next-line no-await-in-loop
             const response = await this.sendQuery(query)
             const rootKey = Object.keys(response)[0] // there is a always a one root level property, e.g. "streams" or "permissions"
             const items: T[] = (response as any)[rootKey] as T[]

--- a/packages/client/src/utils/PatchTsyringe.ts
+++ b/packages/client/src/utils/PatchTsyringe.ts
@@ -30,13 +30,11 @@ container.constructor.prototype.resolveParams = function resolveParams(context, 
                             this.resolve(param.token, context),
                             ...param.transformArgs
                         )
-                // eslint-disable-next-line no-else-return
                 } else {
                     return param.multiple
                         ? this.resolveAll(param.token)
                         : this.resolve(param.token, context)
                 }
-            // eslint-disable-next-line no-else-return
             } else if (isTransformDescriptor(param)) {
                 return this.resolve(param.transform, context).transform(
                     this.resolve(param.token, context),

--- a/packages/client/src/utils/Pipeline.ts
+++ b/packages/client/src/utils/Pipeline.ts
@@ -72,7 +72,7 @@ class PipelineDefinition<InType, OutType = InType> {
     }
 
     setSource(source: AsyncGenerator<InType> | AsyncGeneratorWithId<InType>) {
-        const id = 'id' in source ? source.id : instanceId(source, 'Source') // eslint-disable-line no-param-reassign
+        const id = 'id' in source ? source.id : instanceId(source, 'Source')
         this.source = Object.assign(source, {
             id,
         })
@@ -172,7 +172,6 @@ export class Pipeline<InType, OutType = InType> implements IPipeline<InType, Out
     /** @internal */
     onMessage = Signal.create<[OutType]>()
 
-    // eslint-disable-next-line func-call-spacing, no-spaced-func
     /** @internal */
     onError = ErrorSignal.create<[Error, (InType | OutType)?, number?]>()
 

--- a/packages/client/src/utils/PushBuffer.ts
+++ b/packages/client/src/utils/PushBuffer.ts
@@ -216,7 +216,7 @@ export class PushBuffer<T> implements IPushBuffer<T>, Context {
                 // buffer must be empty, close readGate until more writes.
                 this.readGate.close()
                 // wait for something to be written
-                const ok = await this.readGate.check() // eslint-disable-line no-await-in-loop
+                const ok = await this.readGate.check()
                 if (!ok) {
                     // no more reading
                     break

--- a/packages/client/src/utils/Scaffold.ts
+++ b/packages/client/src/utils/Scaffold.ts
@@ -117,7 +117,6 @@ export function Scaffold(
                     collectErrors(err)
                 }
                 onDownSteps.push(onDownStep || (() => {}))
-                // eslint-disable-next-line no-return-await
                 return await nextScaffoldStep() // return await gives us a better stack trace
             }
         } else if (onDownSteps.length) {
@@ -130,11 +129,9 @@ export function Scaffold(
                 collectErrors(err)
             }
             nextSteps.push(prevSteps.pop() as StepUp)
-            // eslint-disable-next-line no-return-await
             return await nextScaffoldStep() // return await gives us a better stack trace
         } else if (error) {
             const err = error
-            // eslint-disable-next-line require-atomic-updates
             error = undefined
             isDone = true
             throw err

--- a/packages/client/src/utils/Signal.ts
+++ b/packages/client/src/utils/Signal.ts
@@ -160,7 +160,6 @@ export class Signal<ArgsType extends any[] = []> {
 
         if (this.isEnded) {
             // wait for any outstanding, ended so can't re-trigger
-            // eslint-disable-next-line promise/no-callback-in-promise
             this.getLastValue().then((args) => cb(...args)).catch(() => {})
             return this
         }
@@ -273,7 +272,6 @@ export class Signal<ArgsType extends any[] = []> {
 
     async* [Symbol.asyncIterator](): AsyncGenerator<Awaited<ArgsType[0]>, void, unknown> {
         while (!this.isEnded) {
-            // eslint-disable-next-line no-await-in-loop
             yield await this.listen()
         }
     }

--- a/packages/client/src/utils/SynchronizedGraphQLClient.ts
+++ b/packages/client/src/utils/SynchronizedGraphQLClient.ts
@@ -84,7 +84,6 @@ class IndexingState {
         return gate
     }
 
-    /* eslint-disable no-constant-condition, no-await-in-loop, padding-line-between-statements */
     private async startPolling(): Promise<void> {
         this.debug('start polling')
         while (this.gates.size > 0) {

--- a/packages/client/src/utils/WebStreamToNodeStream.ts
+++ b/packages/client/src/utils/WebStreamToNodeStream.ts
@@ -24,7 +24,7 @@ async function write(stream: PassThrough, data: any, ac: AbortController) {
  */
 async function pull(fromBrowserStream: ReadableStream, toNodeStream: PassThrough) {
     const reader = fromBrowserStream.getReader()
-    /* eslint-disable no-constant-condition, no-await-in-loop */
+    /* eslint-disable no-constant-condition */
     const ac = new AbortController()
     const cleanup = () => {
         ac.abort()

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -129,7 +129,6 @@ export const createDecoratedContract = <T extends Contract>(
         eventEmitter
     }
     // copy own properties and inherited properties (e.g. contract.removeAllListeners)
-    // eslint-disable-next-line
     for (const key in contract) {
         result[key] = methods[key] !== undefined ? methods[key] : contract[key]
     }

--- a/packages/client/src/utils/persistence/ServerPersistence.ts
+++ b/packages/client/src/utils/persistence/ServerPersistence.ts
@@ -10,9 +10,7 @@ import { Context } from '../Context'
 
 import { Persistence } from './Persistence'
 import { StreamID } from 'streamr-client-protocol'
-
-// eslint-disable-next-line promise/param-names
-const wait = (ms: number) => new Promise((resolveFn) => setTimeout(resolveFn, ms))
+import { wait } from '@streamr/utils'
 
 export interface ServerPersistenceOptions {
     context: Context

--- a/packages/client/src/utils/signingUtils.ts
+++ b/packages/client/src/utils/signingUtils.ts
@@ -60,7 +60,6 @@ export function recover(
     const payloadBuffer = Buffer.from(payload, 'utf-8')
 
     if (!publicKeyBuffer) {
-        // eslint-disable-next-line no-param-reassign
         publicKeyBuffer = recoverPublicKey(signatureBuffer, payloadBuffer)
     }
     const pubKeyWithoutFirstByte = publicKeyBuffer.subarray(1, publicKeyBuffer.length)

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -94,8 +94,6 @@ export const getEndpointUrl = (baseUrl: string, ...pathParts: string[]): string 
     return baseUrl + '/' + pathParts.map((part) => encodeURIComponent(part)).join('/')
 }
 
-/* eslint-disable object-curly-newline */
-
 export function formStorageNodeAssignmentStreamId(clusterAddress: EthereumAddress): StreamID {
     return toStreamID('/assignments', clusterAddress)
 }

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -95,7 +95,6 @@ describe('MemoryLeaks', () => {
 
         /* Uncomment to debug get all failure
         for (const [key, value] of Object.entries(Dependencies)) {
-            // eslint-disable-next-line no-loop-func
             test(`container get ${key}`, async () => {
                 const { config, childContainer, rootContext } = createContainer()
                 const destroySignal = childContainer.resolve<any>(Dependencies.DestroySignal)
@@ -129,7 +128,6 @@ describe('MemoryLeaks', () => {
             leaksDetector.addAll(rootContext.id, { config, childContainer })
             await destroySignal.trigger()
             for (const result of toStop) {
-                // eslint-disable-next-line no-await-in-loop
                 await result.stop()
             }
             childContainer.clearInstances()

--- a/packages/client/test/end-to-end/searchStreams.test.ts
+++ b/packages/client/test/end-to-end/searchStreams.test.ts
@@ -26,7 +26,6 @@ describe('searchStreams', () => {
     }[]) => {
         const streams: Stream[] = []
         for (const item of items) {
-            // eslint-disable-next-line no-await-in-loop
             streams.push(await client.createStream(item.streamId))
         }
         await client.setPermissions(...items)
@@ -40,7 +39,6 @@ describe('searchStreams', () => {
         return ids
     }
 
-    /* eslint-disable object-property-newline */
     beforeAll(async () => {
         client = new StreamrClient({
             ...ConfigTest,

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -14,7 +14,6 @@ const MAX_MESSAGES = 10
 
 function monkeypatchMessageHandler<T = any>(sub: Subscription<T>, fn: ((msg: StreamMessage<T>, count: number) => undefined | null)) {
     let count = 0
-    // eslint-disable-next-line no-param-reassign
     // @ts-expect-error private
     sub.context.pipeline.pipeBefore(async function* DropMessages(src: AsyncGenerator<any>) {
         for await (const msg of src) {
@@ -37,7 +36,6 @@ describe('GapFill', () => {
     let environment: FakeEnvironment
 
     async function setupClient(opts: StreamrClientConfig) {
-        // eslint-disable-next-line require-atomic-updates
         client = environment.createClient({
             maxGapRequests: 20,
             gapFillTimeout: 500,

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { createTestStream, startPublisherKeyExchangeSubscription } from '../test-utils/utils'
 import { getPublishTestStreamMessages } from '../test-utils/publish'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -261,7 +260,6 @@ describe('Group Key Persistence', () => {
                 })
 
                 for (let i = 0; i < NUM_STREAMS; i++) {
-                    // eslint-disable-next-line no-await-in-loop
                     const s = await createTestStream(publisher, module)
                     streams.push(s)
                 }
@@ -304,7 +302,6 @@ describe('Group Key Persistence', () => {
 
                     const s = await createTestStream(publisher, module)
                     await s.addToStorageNode(storageNode.id)
-                    // eslint-disable-next-line no-loop-func
                     streams.push(s)
                 }
             })
@@ -343,7 +340,6 @@ describe('Group Key Persistence', () => {
                 },
             })
             for (let i = 0; i < NUM_STREAMS; i++) {
-                // eslint-disable-next-line no-await-in-loop
                 const stream = await createTestStream(publisher, module)
                 await stream.grantPermissions({
                     public: true,

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -11,8 +11,6 @@ import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from './../test-utils/fake/FakeStorageNode'
 import { StreamPermission } from './../../src/permission'
 
-/* eslint-disable no-await-in-loop */
-
 const MAX_MESSAGES = 5
 
 describe('Resends2', () => {
@@ -220,7 +218,6 @@ describe('Resends2', () => {
         let published: StreamMessage[]
 
         beforeEach(async () => {
-            // eslint-disable-next-line require-atomic-updates
             published = await publishTestMessages(MAX_MESSAGES)
             // ensure last message is in storage
             await client.waitForStorage(published[published.length - 1])

--- a/packages/client/test/integration/Subscriber2.test.ts
+++ b/packages/client/test/integration/Subscriber2.test.ts
@@ -320,7 +320,6 @@ describe('Subscriber', () => {
                 for await (const m of sub) {
                     received.push(m)
                     if (received.length === published.length - 1) {
-                        // eslint-disable-next-line no-loop-func
                         t = setTimeout(() => {
                             // give it a moment to incorrectly get messages
                             sub.unsubscribe()
@@ -390,7 +389,6 @@ describe('Subscriber', () => {
                     received.push(m)
                     // after first message schedule end
                     if (received.length === 1) {
-                        // eslint-disable-next-line no-loop-func
                         t = setTimeout(() => {
                             expectedLength = received.length
                             // should not see any more messages after end

--- a/packages/client/test/integration/multiple-clients.test.ts
+++ b/packages/client/test/integration/multiple-clients.test.ts
@@ -147,12 +147,10 @@ describe('PubSub with multiple clients', () => {
                 receivedMessagesMain[streamMessage.getPublisherId().toLowerCase()] = msgs
             })
 
-            /* eslint-disable no-await-in-loop */
             const publishers: StreamrClient[] = []
             for (let i = 0; i < 3; i++) {
                 publishers.push(await createPublisher(i))
             }
-            /* eslint-enable no-await-in-loop */
             const published: Record<string, StreamMessage[]> = {}
             await Promise.all(publishers.map(async (pubClient) => {
                 const publisherId = (await pubClient.getAddress()).toLowerCase()
@@ -298,13 +296,11 @@ describe('PubSub with multiple clients', () => {
             receivedMessagesMain[key] = msgs
         })
 
-        /* eslint-disable no-await-in-loop */
         const publishers: StreamrClient[] = []
         for (let i = 0; i < 1; i++) {
             publishers.push(await createPublisher(i))
         }
 
-        /* eslint-enable no-await-in-loop */
         const published: Record<string, StreamMessage[]> = {}
         await Promise.all(publishers.map(async (pubClient) => {
             const publisherId = (await pubClient.getAddress()).toLowerCase()
@@ -355,14 +351,12 @@ describe('PubSub with multiple clients', () => {
             }
         })
 
-        /* eslint-disable no-await-in-loop */
         const publishers: StreamrClient[] = []
         for (let i = 0; i < 3; i++) {
             publishers.push(await createPublisher(i))
         }
 
         let counter = 0
-        /* eslint-enable no-await-in-loop */
         await Promise.all(publishers.map(async (pubClient) => {
             const publisherId = (await pubClient.getAddress()).toString().toLowerCase()
             const publishTestMessages = getPublishTestStreamMessages(pubClient, stream, {

--- a/packages/client/test/integration/revoke-permissions.test.ts
+++ b/packages/client/test/integration/revoke-permissions.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable padding-line-between-statements */
 import { fastPrivateKey } from 'streamr-test-utils'
 import { StreamMessage } from 'streamr-client-protocol'
 import {

--- a/packages/client/test/integration/sequential-resend-subscribe.test.ts
+++ b/packages/client/test/integration/sequential-resend-subscribe.test.ts
@@ -59,7 +59,6 @@ describe('sequential resend subscribe', () => {
         // publish messages with timestamps like 222222, 333333, etc so the
         // sequencing is clearly visible in logs
         const id = (i + 2) * 111111 // start at 222222
-        // eslint-disable-next-line no-loop-func
         test(`test ${id}`, async () => {
             const sub = await subscriber.subscribe({
                 streamId: stream.id,
@@ -74,7 +73,6 @@ describe('sequential resend subscribe', () => {
             const expectedMessageCount = published.length + 1 // the realtime message which we publish next
             setImmediate(async () => {
                 const message = Msg()
-                // eslint-disable-next-line no-await-in-loop
                 const streamMessage = await publisher.publish(stream.id, message, { // should be realtime
                     timestamp: id
                 })

--- a/packages/client/test/test-utils/fake/FakeHttpUtil.ts
+++ b/packages/client/test/test-utils/fake/FakeHttpUtil.ts
@@ -80,7 +80,6 @@ export class FakeHttpUtil implements HttpUtil {
                 streamPartId,
                 query: (queryParams !== undefined) ? new URLSearchParams(queryParams.substring(1)) : undefined
             }
-            // eslint-disable-next-line no-else-return
         } else {
             return undefined
         }

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -104,7 +104,6 @@ export class FakeStorageNode extends FakeNetworkNode {
                 const serialized = msg.serialize()
                 return StreamMessage.deserialize(serialized)
             })
-            // eslint-disable-next-line no-else-return
         } else {
             // TODO throw an error if this storage node doesn't isn't configured to store the stream?
             return []
@@ -130,7 +129,6 @@ export class FakeStorageNode extends FakeNetworkNode {
                         || ((msg.getTimestamp() === opts.toTimestamp) && (msg.getSequenceNumber() <= opts.toSequenceNumber))
                     )
             })
-            // eslint-disable-next-line no-else-return
         } else {
             // TODO throw an error if this storage node doesn't isn't configured to store the stream?
             return []

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -74,7 +74,6 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
         const registryItem = this.chain.streams.get(id)
         if (registryItem !== undefined) {
             return this.createFakeStream({ ...registryItem.metadata, id })
-            // eslint-disable-next-line no-else-return
         } else {
             throw new NotFoundError('Stream not found: id=' + id)
         }
@@ -95,7 +94,6 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
         }, this.container)
     }
 
-    /* eslint-disable padding-line-between-statements */
     async hasPermission(query: PermissionQuery): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(query.streamId)
         const registryItem = this.chain.streams.get(streamId)

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -35,7 +35,6 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
         if (streamIdOrPath !== undefined) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
             return this.chain.storageAssignments.get(streamId)
-            // eslint-disable-next-line no-else-return
         } else {
             throw new Error('not implemented')
         }
@@ -48,7 +47,6 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
             const storageNode = this.network.getNode(chosenAddress)
             if (storageNode !== undefined) {
                 return storageNode as FakeStorageNode
-                // eslint-disable-next-line no-else-return
             } else {
                 throw new Error('no storage node online: ' + chosenAddress)
             }

--- a/packages/client/test/test-utils/jest-utils.ts
+++ b/packages/client/test/test-utils/jest-utils.ts
@@ -5,7 +5,6 @@ const TEST_REPEATS = (process.env.TEST_REPEATS) ? parseInt(process.env.TEST_REPE
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function describeRepeats(msg: string, fn: any, describeFn = describe): void {
     for (let k = 0; k < TEST_REPEATS; k++) {
-        // eslint-disable-next-line no-loop-func
         describe(msg, () => {
             describeFn(`test repeat ${k + 1} of ${TEST_REPEATS}`, fn)
         })

--- a/packages/client/test/test-utils/publish.ts
+++ b/packages/client/test/test-utils/publish.ts
@@ -39,7 +39,6 @@ export async function* createTestMessages(
         }
 
         if (delay) {
-            // eslint-disable-next-line no-await-in-loop
             await wait(delay)
         }
     }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -39,7 +39,6 @@ export function mockContext(): Context {
 
 export const uid = (prefix?: string): string => counterId(`p${process.pid}${prefix ? '-' + prefix : ''}`)
 
-// eslint-disable-next-line no-undef
 const getTestName = (module: NodeModule): string => {
     const fileNamePattern = new RegExp('.*/(.*).test\\...')
     const groups = module.filename.match(fileNamePattern)

--- a/packages/client/test/unit/GroupKeyStore.test.ts
+++ b/packages/client/test/unit/GroupKeyStore.test.ts
@@ -71,7 +71,6 @@ describe('GroupKeyStore', () => {
         const assignments = range(10).map((i) => {
             return { key: GroupKey.generate(), streamId: toStreamID(`stream${i}`) }
         })
-        // eslint-disable-next-line @typescript-eslint/no-shadow
         await Promise.all(assignments.map(({ key, streamId }) => store.add(key, streamId)))
         for (const assignment of assignments) {
             expect(await store.get(assignment.key.id, assignment.streamId)).toEqual(assignment.key)

--- a/packages/client/test/unit/Mapping.test.ts
+++ b/packages/client/test/unit/Mapping.test.ts
@@ -12,7 +12,6 @@ describe('Mapping', () => {
         let evaluationIndex = 0
         const mapping = new Mapping(async (_p: string) => {
             const result = evaluationIndex
-            // eslint-disable-next-line no-plusplus
             evaluationIndex++
             return result
         })

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -174,7 +174,6 @@ describe('MessageFactory', () => {
             while (partitionCount > 0) {
                 const msg = await createMessage({}, messageFactory)
                 expect(msg.messageId.streamPartition).toBeLessThan(partitionCount)
-                // eslint-disable-next-line no-plusplus
                 partitionCount--
             }
         })

--- a/packages/client/test/unit/OrderedMsgChain.test.ts
+++ b/packages/client/test/unit/OrderedMsgChain.test.ts
@@ -700,7 +700,6 @@ describe('OrderedMsgChain', () => {
 
                 expect(received)
                 done(new Error('Was expecting to receive messages ordered per timestamp but instead received timestamps in this '
-                    // eslint-disable-next-line max-len
                     + `order:\n${receivedTimestamps}.\nThe unordered messages were processed in the following timestamp order:\n${timestamps}`))
                 return
             }

--- a/packages/client/test/unit/PushBuffer.test.ts
+++ b/packages/client/test/unit/PushBuffer.test.ts
@@ -173,19 +173,19 @@ describe.skip('PushBuffer', () => {
 
         it('errors on bad buffer size', async () => {
             expect(() => {
-                new PushBuffer(0) // eslint-disable-line no-new
+                new PushBuffer(0)
             }).toThrow('bufferSize')
             expect(() => {
-                new PushBuffer(-1) // eslint-disable-line no-new
+                new PushBuffer(-1)
             }).toThrow('bufferSize')
             expect(() => {
-                new PushBuffer(Number.MAX_SAFE_INTEGER + 10) // eslint-disable-line no-new
+                new PushBuffer(Number.MAX_SAFE_INTEGER + 10)
             }).toThrow('bufferSize')
             expect(() => {
-                new PushBuffer(1.5) // eslint-disable-line no-new
+                new PushBuffer(1.5)
             }).toThrow('bufferSize')
             expect(() => {
-                new PushBuffer(0.5) // eslint-disable-line no-new
+                new PushBuffer(0.5)
             }).toThrow('bufferSize')
         })
 

--- a/packages/client/test/unit/StreamMessageValidator.test.ts
+++ b/packages/client/test/unit/StreamMessageValidator.test.ts
@@ -55,11 +55,9 @@ describe('StreamMessageValidator', () => {
         }
     }
 
-    /* eslint-disable */
     const sign = (msgToSign: StreamMessage, privateKey: string) => {
         msgToSign.signature = nonWrappedSign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
     }
-    /* eslint-enable */
 
     beforeEach(async () => {
         // Default stubs

--- a/packages/client/test/unit/SynchronizedGraphQLClient.test.ts
+++ b/packages/client/test/unit/SynchronizedGraphQLClient.test.ts
@@ -15,7 +15,6 @@ interface IndexState {
 class EmulatedTheGraphIndex {
 
     private states: IndexState[]
-    // eslint-disable-next-line no-undef
     private timer: NodeJS.Timer | undefined
 
     constructor(states: IndexState[]) {

--- a/packages/client/test/unit/iterators.test.ts
+++ b/packages/client/test/unit/iterators.test.ts
@@ -69,7 +69,6 @@ describe('Iterator Utils', () => {
                 for await (const msg of itr) {
                     received.push(msg)
                     if (received.length === MAX_ITEMS) {
-                        // eslint-disable-next-line no-loop-func
                         setTimeout(done.wrap(() => {
                             onTimeoutReached()
                             receievedAtCallTime = received
@@ -445,7 +444,6 @@ describe('Iterator Utils', () => {
                     for await (const msg of itr) {
                         received.push(msg)
                         if (received.length === MAX_ITEMS) {
-                            // eslint-disable-next-line no-loop-func
                             setTimeout(done.wrap(async () => {
                                 receievedAtCallTime = received
                                 await itr.cancel(err)
@@ -476,7 +474,6 @@ describe('Iterator Utils', () => {
                 for await (const msg of itr) {
                     received.push(msg)
                     if (received.length === MAX_ITEMS) {
-                        // eslint-disable-next-line no-loop-func
                         setTimeout(done.wrap(async () => {
                             receievedAtCallTime = received
                             await itr.cancel()
@@ -554,7 +551,6 @@ describe('Iterator Utils', () => {
                 for await (const msg of itr) {
                     received.push(msg)
                     if (received.length === expected.length) {
-                        // eslint-disable-next-line no-loop-func
                         setTimeout(done.wrap(async () => {
                             await itr.cancel()
                             expect(onFinally).toHaveBeenCalledTimes(1)
@@ -620,7 +616,6 @@ describe('Iterator Utils', () => {
                     for await (const msg of itr) {
                         received.push(msg)
                         if (received.length === MAX_ITEMS) {
-                            // eslint-disable-next-line no-loop-func
                             setTimeout(done.wrap(async () => {
                                 receievedAtCallTime = received
                                 await itr.cancel(err)
@@ -749,7 +744,6 @@ describe('Iterator Utils', () => {
                     for await (const msg of itr) {
                         received.push(msg)
                         if (received.length === MAX_ITEMS) {
-                            // eslint-disable-next-line no-loop-func
                             setTimeout(done.wrap(async () => {
                                 receievedAtCallTime = received
                                 await itr.cancel(err)

--- a/packages/client/test/unit/promises.test.ts
+++ b/packages/client/test/unit/promises.test.ts
@@ -71,7 +71,7 @@ describe('pOrderedResolve', () => {
                 }
                 return index
             } finally {
-                active -= 1 // eslint-disable-line require-atomic-updates
+                active -= 1
             }
         })
 
@@ -107,7 +107,6 @@ describe('pOrderedResolve', () => {
         // @ts-expect-error wrong argument type
         await orderedFn(3)
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = await orderedFn('abc')
         expect(c).toEqual(3)
         orderedFn.clear()
@@ -133,7 +132,6 @@ describe('pLimitFn', () => {
         await limitedFn(3)
 
         // @ts-expect-error wrong return type
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = await limitedFn('abc')
         expect(c).toEqual(3)
         limitedFn.clear()
@@ -184,7 +182,6 @@ describe('CacheAsyncFn', () => {
         await cachedFn(3)
 
         // @ts-expect-error wrong return type
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = await cachedFn('abc')
         expect(c).toEqual(3)
         cachedFn.clearMatching((_d: string) => true)
@@ -295,7 +292,6 @@ describe('cacheFn', () => {
         cachedFn(3)
 
         // @ts-expect-error wrong return type
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = cachedFn('abc')
         expect(c).toEqual(3)
         cachedFn.clearMatching((_d: string) => true)
@@ -464,7 +460,6 @@ describe('pOnce', () => {
         await wrappedFn(3)
 
         // @ts-expect-error wrong return type
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const c: string = await wrappedFn('abc')
         expect(c).toEqual(3)
     })

--- a/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -29,7 +29,6 @@ const TARGET_STREAM = Object.freeze({
     partitions: 5
 })
 
-/* eslint-disable no-await-in-loop */
 describe(waitForAssignmentsToPropagate, () => {
     let pushPipeline: PushPipeline<StreamMessage<any>>
     let propagatePromiseState: 'rejected' | 'resolved' | 'pending'


### PR DESCRIPTION
Removed most of obsolete ignores from production code:
```
7 no-param-reassign
6 no-else-return
6 no-await-in-loop
3 no-constant-condition
2 require-atomic-updates
2 padding-line-between-statements
2 no-return-await
2 no-dupe-class-members
2 @typescript-eslint/explicit-module-boundary-types
1 promise/param-names
1 promise/no-callback-in-promise
1 object-curly-newline
1 no-spaced-func
1 max-len
1 func-call-spacing
```

(`git diff main | grep '^-' | grep -o 'eslint.*' | tr -d ',' | tr ' ' '\n' | sort | uniq -c | sort -gr`)

In the production code there are still these warnings:
```
7 no-underscore-dangle
7 no-await-in-loop
7 @typescript-eslint/explicit-module-boundary-types
5 eslint-enable
4 class-methods-use-this
2 promise/no-promise-in-callback
2 promise/catch-or-return
2 promise/always-return
2 padding-line-between-statements
2 object-curly-newline
2 no-restricted-imports
2 no-else-return
2 no-constant-condition
2 @typescript-eslint/no-extraneous-class
1 require-yield
1 require-atomic-updates
1 prefer-arrow-callback
1 no-redeclare
1 no-param-reassign
1 max-len
1 @typescript-eslint/prefer-function-type
1 @typescript-eslint/no-this-alias
1 @typescript-eslint/no-shadow
1 @typescript-eslint/default-param-last
1 @typescript-eslint/ban-types
1 @typescript-eslint/ban-ts-comment
```

(`find src -name '*.ts' | xargs grep -ho 'eslint.*' | tr -d ',' | tr ' ' '\n' | sort | uniq -c | sort -gr`)

### Future improvements

In a separate PR we'll enable these rules will be enabled or remove extraneous `eslint` comments about the rules:
- `class-methods-use-this`
- `prefer-arrow-callback`
- `promise/no-promise-in-callback`
- `promise/catch-or-return`
- `promise/always-return`