### PR TITLE
refactor(client): Create signed message

### DIFF
--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -15,6 +15,7 @@ import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 import { ConfigInjectionToken, DecryptionConfig } from '../Config'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { createRandomMsgChainId } from '../publish/MessageChain'
+import { createSignedMessage } from '../publish/MessageFactory'
 import { Context } from '../utils/Context'
 import { Debugger } from '../utils/log'
 import { withThrottling, pOnce } from '../utils/promises'
@@ -95,7 +96,7 @@ export class SubscriberKeyExchange {
             rsaPublicKey,
             groupKeyIds: [groupKeyId],
         }).toArray()
-        const request = new StreamMessage({
+        return createSignedMessage<GroupKeyRequestSerialized>({
             messageId: new MessageID(
                 StreamPartIDUtils.getStreamID(streamPartId),
                 StreamPartIDUtils.getStreamPartition(streamPartId),
@@ -104,13 +105,11 @@ export class SubscriberKeyExchange {
                 await this.authentication.getAddress(),
                 createRandomMsgChainId()
             ),
+            serializedContent: JSON.stringify(requestContent),
             messageType: StreamMessageType.GROUP_KEY_REQUEST,
             encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
-            content: requestContent,
-            signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
+            authentication: this.authentication
         })
-        request.signature = await this.authentication.createMessagePayloadSignature(request.getPayloadToSign())
-        return request
     }
 
     private async onMessage(msg: StreamMessage<any>): Promise<void> {

--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -93,7 +93,7 @@ export class MessageFactory {
             }
         }
 
-        const message = new StreamMessage<any>({
+        const message = new StreamMessage<T>({
             content: serializedContent,
             messageId,
             prevMsgRef,

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -1,4 +1,4 @@
-import { EthereumAddress, StreamID, StreamMessage } from 'streamr-client-protocol'
+import { StreamID, StreamMessage } from 'streamr-client-protocol'
 import { scoped, Lifecycle, inject } from 'tsyringe'
 import pLimit from 'p-limit'
 import { instanceId } from '../utils/utils'
@@ -138,17 +138,11 @@ export class Publisher {
 
     /* eslint-disable @typescript-eslint/no-shadow */
     private async createMessageFactory(streamId: StreamID): Promise<MessageFactory> {
-        const queue = await this.groupKeyQueues.get(streamId)
         return new MessageFactory({
             streamId,
             authentication: this.authentication,
-            getPartitionCount: async (streamId: StreamID) => {
-                const stream = await this.streamRegistryCached.getStream(streamId)
-                return stream.partitions
-            },
-            isPublicStream: (streamId: StreamID) => this.streamRegistryCached.isPublic(streamId),
-            isPublisher: (streamId: StreamID, publisherId: EthereumAddress) => this.streamRegistryCached.isStreamPublisher(streamId, publisherId),
-            useGroupKey: () => queue.useGroupKey()
+            streamRegistry: this.streamRegistryCached,
+            groupKeyQueue: await this.groupKeyQueues.get(streamId)
         })
     } 
 }

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -140,15 +140,14 @@ export class Publisher {
     private async createMessageFactory(streamId: StreamID): Promise<MessageFactory> {
         const queue = await this.groupKeyQueues.get(streamId)
         return new MessageFactory({
-            publisherId: await this.authentication.getAddress(),
             streamId,
+            authentication: this.authentication,
             getPartitionCount: async (streamId: StreamID) => {
                 const stream = await this.streamRegistryCached.getStream(streamId)
                 return stream.partitions
             },
             isPublicStream: (streamId: StreamID) => this.streamRegistryCached.isPublic(streamId),
             isPublisher: (streamId: StreamID, publisherId: EthereumAddress) => this.streamRegistryCached.isStreamPublisher(streamId, publisherId),
-            createSignature: (payload: string) => this.authentication.createMessagePayloadSignature(payload),
             useGroupKey: () => queue.useGroupKey()
         })
     } 

--- a/packages/client/src/registry/StreamRegistryCached.ts
+++ b/packages/client/src/registry/StreamRegistryCached.ts
@@ -10,6 +10,7 @@ import { Stream } from '../Stream'
 
 const SEPARATOR = '|' // always use SEPARATOR for cache key
 
+/* eslint-disable no-underscore-dangle */
 @scoped(Lifecycle.ContainerScoped)
 export class StreamRegistryCached implements Context {
     readonly id = instanceId(this)
@@ -23,11 +24,13 @@ export class StreamRegistryCached implements Context {
         this.debug = context.debug.extend(this.id)
     }
 
-    private async getStreamPreloaded(streamId: StreamID): Promise<Stream> {
-        return this.streamRegistry.getStream(streamId)
+    getStream(streamId: StreamID): Promise<Stream> {
+        return this._getStream(streamId)
     }
 
-    getStream = CacheAsyncFn(this.getStreamPreloaded.bind(this), {
+    private _getStream = CacheAsyncFn((streamId: StreamID) => {
+        return this.streamRegistry.getStream(streamId)
+    }, {
         ...this.cacheOptions,
         cacheKey: ([streamId]: any) => {
             // see clearStream
@@ -35,37 +38,43 @@ export class StreamRegistryCached implements Context {
         }
     })
 
-    private async isStreamPublisherPreloaded(streamId: StreamID, ethAddress: EthereumAddress): Promise<boolean> {
+    isStreamPublisher(streamId: StreamID, ethAddress: EthereumAddress): Promise<boolean> {
+        return this._isStreamPublisher(streamId, ethAddress)
+    }
+
+    private _isStreamPublisher = CacheAsyncFn((streamId: StreamID, ethAddress: EthereumAddress) => {
         return this.streamRegistry.isStreamPublisher(streamId, ethAddress)
-    }
-
-    isStreamPublisher = CacheAsyncFn(this.isStreamPublisherPreloaded.bind(this), {
+    }, {
         ...this.cacheOptions,
         cacheKey([streamId, ethAddress]: any): string {
             return [streamId, ethAddress.toLowerCase()].join(SEPARATOR)
         }
     })
 
-    private async isStreamSubscriberPreloaded(streamId: StreamID, ethAddress: EthereumAddress): Promise<boolean> {
+    isStreamSubscriber(streamId: StreamID, ethAddress: EthereumAddress): Promise<boolean> {
+        return this._isStreamSubscriber(streamId, ethAddress)
+    }
+
+    private _isStreamSubscriber = CacheAsyncFn((streamId: StreamID, ethAddress: EthereumAddress) => {
         return this.streamRegistry.isStreamSubscriber(streamId, ethAddress)
-    }
-
-    isStreamSubscriber = CacheAsyncFn(this.isStreamSubscriberPreloaded.bind(this), {
+    }, {
         ...this.cacheOptions,
         cacheKey([streamId, ethAddress]: any): string {
             return [streamId, ethAddress.toLowerCase()].join(SEPARATOR)
         }
     })
 
-    private async isPublicSubscriptionStream(streamId: StreamID): Promise<boolean> {
+    async isPublic(streamId: StreamID): Promise<boolean> {
+        return this._isPublic(streamId)
+    }
+
+    private _isPublic = CacheAsyncFn((streamId: StreamID) => {
         return this.streamRegistry.hasPermission({
             streamId,
             public: true,
             permission: StreamPermission.SUBSCRIBE
         })
-    }
-
-    isPublic = CacheAsyncFn(this.isPublicSubscriptionStream.bind(this), {
+    }, {
         ...this.cacheOptions,
         cacheKey([streamId]): any {
             return ['PublicSubscribe', streamId].join(SEPARATOR)
@@ -80,8 +89,8 @@ export class StreamRegistryCached implements Context {
         // include separator so startsWith(streamid) doesn't match streamid-something
         const target = `${streamId}${SEPARATOR}`
         const matchTarget = (s: string) => s.startsWith(target)
-        this.getStream.clearMatching(matchTarget)
-        this.isStreamPublisher.clearMatching(matchTarget)
-        this.isStreamSubscriber.clearMatching(matchTarget)
+        this._getStream.clearMatching(matchTarget)
+        this._isStreamPublisher.clearMatching(matchTarget)
+        this._isStreamSubscriber.clearMatching(matchTarget)
     }
 }

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -59,8 +59,9 @@ describe('PublisherKeyExchange', () => {
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
             encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
             contentType: StreamMessage.CONTENT_TYPES.JSON,
+            signatureType: StreamMessage.SIGNATURE_TYPES.ETH
         })
-        msg.signature = sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), publisher.privateKey)
+        msg.signature = sign(msg.getPayloadToSign(), publisher.privateKey)
         return msg
     }
 

--- a/packages/client/test/integration/invalid-messages.test.ts
+++ b/packages/client/test/integration/invalid-messages.test.ts
@@ -50,7 +50,8 @@ describe('client behaviour on invalid message', () => {
             prevMsgRef: null,
             content: { not: 'allowed' }
         })
-        msg.signature = sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), publisherWallet.privateKey.substring(2))
+        msg.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
+        msg.signature = sign(msg.getPayloadToSign(), publisherWallet.privateKey.substring(2))
         networkNode.publish(msg)
         await wait(PROPAGATION_WAIT_TIME)
         expect(true).toEqual(true) // we never get here if subscriberClient crashes

--- a/packages/client/test/integration/invalid-messages.test.ts
+++ b/packages/client/test/integration/invalid-messages.test.ts
@@ -1,10 +1,9 @@
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'
-import { sign } from '../../src/utils/signingUtils'
-import { createTestStream } from '../test-utils/utils'
+import { createMockMessage, createTestStream } from '../test-utils/utils'
 import { fastWallet } from 'streamr-test-utils'
 import { wait } from '@streamr/utils'
-import { MessageID, StreamID, StreamMessage } from 'streamr-client-protocol'
+import { StreamID, toStreamPartID } from 'streamr-client-protocol'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 
 const PROPAGATION_WAIT_TIME = 2000
@@ -44,14 +43,11 @@ describe('client behaviour on invalid message', () => {
             throw new Error('should not get here')
         })
         const publisherWallet = fastWallet()
-        const networkNode = environment.startNode(publisherWallet.address)
-        const msg = new StreamMessage({
-            messageId: new MessageID(streamId, 0, Date.now(), 0, publisherWallet.address, ''),
-            prevMsgRef: null,
-            content: { not: 'allowed' }
+        const msg = await createMockMessage({
+            streamPartId: toStreamPartID(streamId, 0),
+            publisher: publisherWallet
         })
-        msg.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
-        msg.signature = sign(msg.getPayloadToSign(), publisherWallet.privateKey.substring(2))
+        const networkNode = environment.startNode(publisherWallet.address)
         networkNode.publish(msg)
         await wait(PROPAGATION_WAIT_TIME)
         expect(true).toEqual(true) // we never get here if subscriberClient crashes

--- a/packages/client/test/integration/parallel-key-exchange.test.ts
+++ b/packages/client/test/integration/parallel-key-exchange.test.ts
@@ -58,12 +58,11 @@ describe('parallel key exchange', () => {
                 privateKey: publisher.wallet.privateKey
             }, undefined as any)
             const messageFactory = new MessageFactory({
-                publisherId: publisher.wallet.address,
                 streamId: stream.id,
+                authentication,
                 getPartitionCount: async () => 1,
                 isPublicStream: async () => false,
                 isPublisher: async () => true,
-                createSignature: async (payload: string) => authentication.createMessagePayloadSignature(payload),
                 useGroupKey: async () => ({ current: publisher.groupKey })
             })
             for (let i = 0; i < MESSAGE_COUNT_PER_PUBLISHER; i++) {

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -35,6 +35,7 @@ describe('resend with existing key', () => {
             nextEncryptionKey: nextGroupKey,
             stream,
             publisher: publisherWallet,
+            msgChainId: 'mock-msgChainId'
         })
         storageNode.storeMessage(message)
     }

--- a/packages/client/test/integration/resend-with-existing-key.test.ts
+++ b/packages/client/test/integration/resend-with-existing-key.test.ts
@@ -103,7 +103,7 @@ describe('resend with existing key', () => {
             { timestamp: 6000, groupKey: rekeyedKey }
         ]
         for (const msg of allMessages) {
-            storeMessage(msg.timestamp, msg.groupKey, msg.nextGroupKey, storageNode)
+            await storeMessage(msg.timestamp, msg.groupKey, msg.nextGroupKey, storageNode)
         }
     })
 

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -1,22 +1,21 @@
 import { range } from 'lodash'
 import {
     EthereumAddress,
-    MessageID,
     StreamID,
     StreamMessage,
     StreamMessageType,
     StreamPartID,
-    toStreamID,
     toStreamPartID
 } from 'streamr-client-protocol'
 import { FakeNetworkNode } from './FakeNetworkNode'
 import { FakeNetwork } from './FakeNetwork'
 import { formStorageNodeAssignmentStreamId } from '../../../src/utils/utils'
-import { sign } from '../../../src/utils/signingUtils'
 import { Multimap } from '@streamr/utils'
 import { FakeChain } from './FakeChain'
 import { StreamPermission } from '../../../src/permission'
 import { Wallet } from 'ethers'
+import { createMockMessage } from '../utils'
+import { DEFAULT_PARTITION } from '../../../src/StreamIDBuilder'
 
 const URL_SCHEME = 'FakeStorageNode'
 
@@ -38,14 +37,14 @@ const isStorableMessage = (msg: StreamMessage): boolean => {
 export class FakeStorageNode extends FakeNetworkNode {
 
     private readonly streamPartMessages: Multimap<StreamPartID, StreamMessage> = new Multimap()
-    private readonly privateKey: string
+    private readonly wallet: Wallet
     private readonly chain: FakeChain
 
     constructor(wallet: Wallet, network: FakeNetwork, chain: FakeChain) {
         super({
             id: wallet.address
         } as any, network)
-        this.privateKey = wallet.privateKey
+        this.wallet = wallet
         this.chain = chain
         chain.storageNodeMetadatas.set(wallet.address.toLowerCase(), {
             http: createStorageNodeUrl(wallet.address)
@@ -61,7 +60,7 @@ export class FakeStorageNode extends FakeNetworkNode {
     async addAssignment(streamId: StreamID): Promise<void> {
         const partitionCount = this.chain.streams.get(streamId)!.metadata.partitions
         const streamParts = range(0, partitionCount).map((p) => toStreamPartID(streamId, p))
-        streamParts.forEach(async (streamPartId, idx) => {
+        streamParts.forEach(async (streamPartId) => {
             if (!this.subscriptions.has(streamPartId)) {
                 this.addMessageListener((msg: StreamMessage) => {
                     if ((msg.getStreamPartID() === streamPartId) && isStorableMessage(msg)) {
@@ -69,21 +68,13 @@ export class FakeStorageNode extends FakeNetworkNode {
                     }
                 })
                 this.subscribe(streamPartId)
-                const assignmentMessage = new StreamMessage({
-                    messageId: new MessageID(
-                        toStreamID(formStorageNodeAssignmentStreamId(this.id)),
-                        0,
-                        Date.now(),
-                        idx,
-                        this.id,
-                        ''
-                    ),
+                const assignmentMessage = await createMockMessage({
+                    streamPartId: toStreamPartID(formStorageNodeAssignmentStreamId(this.id), DEFAULT_PARTITION),
+                    publisher: this.wallet,
                     content: {
                         streamPart: streamPartId,
                     }
                 })
-                assignmentMessage.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
-                assignmentMessage.signature = sign(assignmentMessage.getPayloadToSign(), this.privateKey)
                 this.publish(assignmentMessage)
             }
         })

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -82,8 +82,8 @@ export class FakeStorageNode extends FakeNetworkNode {
                         streamPart: streamPartId,
                     }
                 })
-                const payload = assignmentMessage.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH)
-                assignmentMessage.signature = sign(payload, this.privateKey)
+                assignmentMessage.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
+                assignmentMessage.signature = sign(assignmentMessage.getPayloadToSign(), this.privateKey)
                 this.publish(assignmentMessage)
             }
         })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -129,7 +129,7 @@ export const createMockMessage = (
     const plainContent = opts.content ?? DEFAULT_CONTENT
     return factory.createMessage(plainContent, {
         timestamp: opts.timestamp ?? Date.now(),
-        msgChainId: opts.msgChainId ?? `mockMsgChainId-${opts.publisher.address}`
+        msgChainId: opts.msgChainId
     }, partition)
 }
 

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import { DependencyContainer } from 'tsyringe'
-import { fetchPrivateKeyWithGas } from 'streamr-test-utils'
+import { fastPrivateKey, fetchPrivateKeyWithGas } from 'streamr-test-utils'
 import { wait } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import {
@@ -23,7 +23,7 @@ import { addAfterFn } from './jest-utils'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { StreamrClientEventEmitter } from '../../src/events'
 import { MessageFactory } from '../../src/publish/MessageFactory'
-import { createAuthentication } from '../../src/Authentication'
+import { Authentication, createAuthentication } from '../../src/Authentication'
 
 const testDebugRoot = Debug('test')
 const testDebug = testDebugRoot.extend.bind(testDebugRoot)
@@ -149,4 +149,10 @@ export const startPublisherKeyExchangeSubscription = async (
     streamPartId: StreamPartID): Promise<void> => {
     const node = await publisherClient.getNode()
     node.subscribe(streamPartId)
+}
+
+export const createRandomAuthentication = (): Authentication => {
+    return createAuthentication({
+        privateKey: `0x${fastPrivateKey()}`
+    }, undefined as any)
 }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -10,7 +10,6 @@ import {
     EthereumAddress,
     MAX_PARTITION_COUNT
 } from 'streamr-client-protocol'
-import { sign } from '../../src/utils/signingUtils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
 import { Debug } from '../../src/utils/log'
@@ -24,6 +23,7 @@ import { addAfterFn } from './jest-utils'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
 import { StreamrClientEventEmitter } from '../../src/events'
 import { MessageFactory } from '../../src/publish/MessageFactory'
+import { createAuthentication } from '../../src/Authentication'
 
 const testDebugRoot = Debug('test')
 const testDebug = testDebugRoot.extend.bind(testDebugRoot)
@@ -113,12 +113,13 @@ export const createMockMessage = (
         opts.streamPartId ?? opts.stream.getStreamParts()[0]
     )
     const factory = new MessageFactory({
-        publisherId: opts.publisher.address.toLowerCase(),
+        authentication: createAuthentication({
+            privateKey: opts.publisher.privateKey
+        }, undefined as any),
         streamId,
         getPartitionCount: async () => MAX_PARTITION_COUNT,
         isPublicStream: async () => (opts.encryptionKey === undefined),
         isPublisher: async () => true,
-        createSignature: async (payload: string) => sign(payload, opts.publisher.privateKey),
         useGroupKey: async () => {
             return (opts.encryptionKey !== undefined)
                 ? ({ current: opts.encryptionKey, next: opts.nextEncryptionKey })

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -3,9 +3,12 @@ import { MAX_PARTITION_COUNT, StreamMessage, toStreamID } from 'streamr-client-p
 import { fastWallet } from 'streamr-test-utils'
 import { keyToArrayIndex } from '@streamr/utils'
 import { GroupKey } from '../../src/encryption/GroupKey'
-import { MessageFactory, MessageFactoryOptions } from '../../src/publish/MessageFactory'
+import { MessageFactory } from '../../src/publish/MessageFactory'
 import { MessageMetadata } from '../../src'
 import { createAuthentication } from '../../src/Authentication'
+import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
+import { createGroupKeyQueue, createStreamRegistryCached } from '../test-utils/utils'
+import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
 
 const WALLET = fastWallet()
 const STREAM_ID = toStreamID('/path', WALLET.address)
@@ -14,20 +17,22 @@ const TIMESTAMP = Date.parse('2001-02-03T04:05:06Z')
 const PARTITION_COUNT = 50
 const GROUP_KEY = GroupKey.generate()
 
-const createMessageFactory = (overridenOpts?: Partial<MessageFactoryOptions>) => {
-    const defaultOpts = {
+const createMessageFactory = async (opts?: {
+    streamRegistry?: StreamRegistryCached
+    groupKeyQueue?: GroupKeyQueue
+}) => {
+    return new MessageFactory({
         streamId: STREAM_ID,
         authentication: createAuthentication({ 
             privateKey: WALLET.privateKey
         }, undefined as any),
-        getPartitionCount: async () => PARTITION_COUNT,
-        isPublicStream: async () => false,
-        isPublisher: async () => true,
-        useGroupKey: async () => ({ current: GROUP_KEY })
-    }
-    return new MessageFactory({
-        ...defaultOpts,
-        ...overridenOpts
+        streamRegistry: createStreamRegistryCached({
+            partitionCount: PARTITION_COUNT,
+            isPublicStream: false,
+            isStreamPublisher: true
+        }),
+        groupKeyQueue: await createGroupKeyQueue(GROUP_KEY),
+        ...opts
     })
 }
 
@@ -44,7 +49,7 @@ const createMessage = async (
 describe('MessageFactory', () => {
 
     it('happy path', async () => {
-        const messageFactory = createMessageFactory()
+        const messageFactory = await createMessageFactory()
         const msg = await createMessage({}, messageFactory)
         expect(msg).toMatchObject({
             messageId: {
@@ -68,9 +73,10 @@ describe('MessageFactory', () => {
     })
 
     it('public stream', async () => {
-        const messageFactory = createMessageFactory({
-            isPublicStream: async () => true,
-            useGroupKey: () => Promise.reject()
+        const messageFactory = await createMessageFactory({
+            streamRegistry: createStreamRegistryCached({
+                isPublicStream: true
+            })
         })
         const msg = await createMessage({}, messageFactory)
         expect(msg).toMatchObject({
@@ -81,7 +87,7 @@ describe('MessageFactory', () => {
     })
 
     it('metadata', async () => {
-        const messageFactory = createMessageFactory()
+        const messageFactory = await createMessageFactory()
         const partitionKey = 'mock-partitionKey'
         const msgChainId = 'mock-msgChainId'
         const msg = await createMessage({
@@ -98,8 +104,8 @@ describe('MessageFactory', () => {
 
     it('next group key', async () => {
         const nextGroupKey = GroupKey.generate()
-        const messageFactory = createMessageFactory({
-            useGroupKey: async () => ({ current: GROUP_KEY, next: nextGroupKey })
+        const messageFactory = await createMessageFactory({
+            groupKeyQueue: await createGroupKeyQueue(GROUP_KEY, nextGroupKey)
         })
         const msg = await createMessage({}, messageFactory)
         expect(msg.groupKeyId).toBe(GROUP_KEY.id)
@@ -110,9 +116,11 @@ describe('MessageFactory', () => {
         expect(GROUP_KEY.decryptNextGroupKey(msg.newGroupKey!)).toEqual(nextGroupKey)
     })
 
-    it('not a publisher', () => {
-        const messageFactory = createMessageFactory({
-            isPublisher: async () => false
+    it('not a publisher', async () => {
+        const messageFactory = await createMessageFactory({
+            streamRegistry: createStreamRegistryCached({
+                isStreamPublisher: false
+            })
         })
         return expect(() => 
             createMessage({}, messageFactory)
@@ -122,7 +130,7 @@ describe('MessageFactory', () => {
     describe('partitions', () => {
 
         it('out of range', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             await expect(() => 
                 createMessage({ explicitPartition: -1 }, messageFactory)
             ).rejects.toThrow(/out of range/)
@@ -132,21 +140,21 @@ describe('MessageFactory', () => {
         })
 
         it('partition and partitionKey', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             return expect(() => 
                 createMessage({ partitionKey: 'mockPartitionKey', explicitPartition: 0 }, messageFactory)
             ).rejects.toThrow('Invalid combination of "partition" and "partitionKey"')
         })
 
         it('no partition key: uses same partition for all messages', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const msg1 = await createMessage({}, messageFactory)
             const msg2 = await createMessage({}, messageFactory)
             expect(msg1!.messageId.streamPartition).toBe(msg2!.messageId.streamPartition)
         })
 
         it('same partition key maps to same partition', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const partitionKey = `mock-partition-key-${random(Number.MAX_SAFE_INTEGER)}`
             const msg1 = await createMessage({ partitionKey }, messageFactory)
             const msg2 = await createMessage({ partitionKey }, messageFactory)
@@ -154,14 +162,14 @@ describe('MessageFactory', () => {
         })
 
         it('numeric partition key maps to the partition if in range', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const partitionKey = 10
             const msg = await createMessage({ partitionKey }, messageFactory)
             expect(msg!.messageId.streamPartition).toBe(partitionKey)
         })
 
         it('numeric partition key maps to partition range', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const partitionOffset = 20
             const msg = await createMessage({ partitionKey: PARTITION_COUNT + partitionOffset }, messageFactory)
             expect(msg!.messageId.streamPartition).toBe(partitionOffset)
@@ -169,8 +177,10 @@ describe('MessageFactory', () => {
 
         it('selected random partition in range when partition count decreases', async () => {
             let partitionCount: number = MAX_PARTITION_COUNT - 1
-            const messageFactory = createMessageFactory({
-                getPartitionCount: async () => partitionCount
+            const messageFactory = await createMessageFactory({
+                streamRegistry: createStreamRegistryCached({
+                    partitionCount: 1
+                })
             })
             while (partitionCount > 0) {
                 const msg = await createMessage({}, messageFactory)
@@ -182,7 +192,7 @@ describe('MessageFactory', () => {
 
     describe('message chains', () => {
         it('happy path', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const msg1 = await createMessage({}, messageFactory)
             const msg2 = await createMessage({}, messageFactory)
             expect(msg2.getMessageID().msgChainId).toBe(msg1.getMessageID().msgChainId)
@@ -190,7 +200,7 @@ describe('MessageFactory', () => {
         })
 
         it('partitions have separate chains', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const msg1 = await createMessage({ explicitPartition: 10 }, messageFactory)
             const msg2 = await createMessage({ partitionKey: 'mock-key' }, messageFactory)
             const msg3 = await createMessage({ msgChainId: msg2.getMsgChainId(), explicitPartition: 20 }, messageFactory)
@@ -201,7 +211,7 @@ describe('MessageFactory', () => {
         })
 
         it('explicit msgChainId', async () => {
-            const messageFactory = createMessageFactory()
+            const messageFactory = await createMessageFactory()
             const msg1 = await createMessage({ msgChainId: 'mock-id' }, messageFactory)
             const msg2 = await createMessage({}, messageFactory)
             const msg3 = await createMessage({ msgChainId: 'mock-id' }, messageFactory)

--- a/packages/client/test/unit/StreamMessageValidator.test.ts
+++ b/packages/client/test/unit/StreamMessageValidator.test.ts
@@ -56,7 +56,8 @@ describe('StreamMessageValidator', () => {
     }
 
     const sign = (msgToSign: StreamMessage, privateKey: string) => {
-        msgToSign.signature = nonWrappedSign(msgToSign.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), privateKey)
+        msgToSign.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
+        msgToSign.signature = nonWrappedSign(msgToSign.getPayloadToSign(), privateKey)
     }
 
     beforeEach(async () => {

--- a/packages/client/test/unit/StreamMessageValidator.test.ts
+++ b/packages/client/test/unit/StreamMessageValidator.test.ts
@@ -12,17 +12,28 @@ import {
     GroupKeyResponse,
     ValidationError
 } from 'streamr-client-protocol'
+import { Authentication } from '../../src/Authentication'
+import { createSignedMessage } from '../../src/publish/MessageFactory'
 import StreamMessageValidator, { StreamMetadata } from '../../src/StreamMessageValidator'
-import { sign as nonWrappedSign } from '../../src/utils/signingUtils'
+import { createRandomAuthentication } from '../test-utils/utils'
 
-const groupKeyMessageToStreamMessage = (groupKeyMessage: GroupKeyMessage, messageId: MessageID, prevMsgRef: MessageRef | null): StreamMessage => {
-    return new StreamMessage({
+const groupKeyMessageToStreamMessage = async (
+    groupKeyMessage: GroupKeyMessage, 
+    messageId: MessageID, 
+    prevMsgRef: MessageRef | null,
+    authentication: Authentication
+): Promise<StreamMessage> => {
+    return createSignedMessage({
         messageId,
         prevMsgRef,
-        content: groupKeyMessage.serialize(),
+        serializedContent: groupKeyMessage.serialize(),
         messageType: groupKeyMessage.messageType,
+        authentication
     })
 }
+
+const publisherAuthentication = createRandomAuthentication()
+const subscriberAuthentication = createRandomAuthentication()
 
 describe('StreamMessageValidator', () => {
     let getStream: (streamId: string) => Promise<StreamMetadata>
@@ -32,12 +43,6 @@ describe('StreamMessageValidator', () => {
     let msg: StreamMessage
     let msgWithNewGroupKey: StreamMessage
     let msgWithPrevMsgRef: StreamMessage
-
-    const publisherPrivateKey = 'd462a6f2ccd995a346a841d110e8c6954930a1c22851c0032d3116d8ccd2296a'
-    const publisher = '0x6807295093ac5da6fb2a10f7dedc5edd620804fb'
-    const subscriberPrivateKey = '81fe39ed83c4ab997f64564d0c5a630e34c621ad9bbe51ad2754fac575fc0c46'
-    const subscriber = '0xbe0ab87a1f5b09afe9101b09e3c86fd8f4162527'
-
     let groupKeyRequest: StreamMessage
     let groupKeyResponse: StreamMessage
 
@@ -55,12 +60,9 @@ describe('StreamMessageValidator', () => {
         }
     }
 
-    const sign = (msgToSign: StreamMessage, privateKey: string) => {
-        msgToSign.signatureType = StreamMessage.SIGNATURE_TYPES.ETH
-        msgToSign.signature = nonWrappedSign(msgToSign.getPayloadToSign(), privateKey)
-    }
-
     beforeEach(async () => {
+        const publisher = await publisherAuthentication.getAddress()
+        const subscriber = await subscriberAuthentication.getAddress()
         // Default stubs
         getStream = jest.fn().mockResolvedValue(defaultGetStreamResponse)
         isPublisher = async (address: EthereumAddress, streamId: string) => {
@@ -71,46 +73,43 @@ describe('StreamMessageValidator', () => {
         }
         verify = undefined // use default impl by default
 
-        msg = new StreamMessage({
+        msg = await createSignedMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'),
-            content: '{}',
+            serializedContent: JSON.stringify({}),
+            authentication: publisherAuthentication
         })
 
-        sign(msg, publisherPrivateKey)
-
-        msgWithNewGroupKey = new StreamMessage({
+        msgWithNewGroupKey = await createSignedMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'),
-            content: '{}',
-            newGroupKey: new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex')
+            serializedContent: JSON.stringify({}),
+            newGroupKey: new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex'),
+            authentication: publisherAuthentication
         })
-        sign(msgWithNewGroupKey, publisherPrivateKey)
         assert.notStrictEqual(msg.signature, msgWithNewGroupKey.signature)
 
-        msgWithPrevMsgRef = new StreamMessage({
+        msgWithPrevMsgRef = await createSignedMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 2000, 0, publisher, 'msgChainId'),
-            content: '{}',
-            prevMsgRef: new MessageRef(1000, 0)
+            serializedContent: JSON.stringify({}),
+            prevMsgRef: new MessageRef(1000, 0),
+            authentication: publisherAuthentication
         })
-        sign(msgWithPrevMsgRef, publisherPrivateKey)
         assert.notStrictEqual(msg.signature, msgWithPrevMsgRef.signature)
 
-        groupKeyRequest = groupKeyMessageToStreamMessage(new GroupKeyRequest({
+        groupKeyRequest = await groupKeyMessageToStreamMessage(new GroupKeyRequest({
             requestId: 'requestId',
             recipient: publisher.toLowerCase(),
             rsaPublicKey: 'rsaPublicKey',
-            groupKeyIds: ['groupKeyId1', 'groupKeyId2'],
-        }), new MessageID(toStreamID('streamId'), 0, 0, 0, subscriber, 'msgChainId'), null)
-        sign(groupKeyRequest, subscriberPrivateKey)
+            groupKeyIds: ['groupKeyId1', 'groupKeyId2']
+        }), new MessageID(toStreamID('streamId'), 0, 0, 0, subscriber, 'msgChainId'), null, subscriberAuthentication)
 
-        groupKeyResponse = groupKeyMessageToStreamMessage(new GroupKeyResponse({
+        groupKeyResponse = await groupKeyMessageToStreamMessage(new GroupKeyResponse({
             requestId: 'requestId',
             recipient: subscriber.toLowerCase(),
             encryptedGroupKeys: [
                 new EncryptedGroupKey('groupKeyId1', 'encryptedKey1'),
                 new EncryptedGroupKey('groupKeyId2', 'encryptedKey2')
             ],
-        }), new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'), null)
-        sign(groupKeyResponse, publisherPrivateKey)
+        }), new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'), null, publisherAuthentication)
     })
 
     describe('validate(unknown message type)', () => {
@@ -257,6 +256,7 @@ describe('StreamMessageValidator', () => {
 
         it('rejects messages to invalid publishers', async () => {
             isPublisher = jest.fn().mockResolvedValue(false)
+            const publisher = await publisherAuthentication.getAddress()
 
             await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
@@ -267,6 +267,7 @@ describe('StreamMessageValidator', () => {
 
         it('rejects messages from unpermitted subscribers', async () => {
             isSubscriber = jest.fn().mockResolvedValue(false)
+            const subscriber = await subscriberAuthentication.getAddress()
 
             await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
@@ -340,6 +341,7 @@ describe('StreamMessageValidator', () => {
 
         it('rejects messages from invalid publishers', async () => {
             isPublisher = jest.fn().mockResolvedValue(false)
+            const publisher = await publisherAuthentication.getAddress()
 
             await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
@@ -350,6 +352,7 @@ describe('StreamMessageValidator', () => {
 
         it('rejects messages to unpermitted subscribers', async () => {
             isSubscriber = jest.fn().mockResolvedValue(false)
+            const subscriber = await subscriberAuthentication.getAddress()
 
             await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)

--- a/packages/client/test/unit/SubscribePipeline.test.ts
+++ b/packages/client/test/unit/SubscribePipeline.test.ts
@@ -12,6 +12,7 @@ import { Stream } from '../../src'
 import { DestroySignal } from '../../src/DestroySignal'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { createAuthentication } from '../../src/Authentication'
+import { StreamrClientEventEmitter } from '../../src/events'
 
 const CONTENT = {
     foo: 'bar'
@@ -74,7 +75,7 @@ describe('SubscribePipeline', () => {
                 isStreamPublisher: async () => true,
                 clearStream: () => {}
             } as any,
-            streamrClientEventEmitter: undefined as any,
+            streamrClientEventEmitter: new StreamrClientEventEmitter(),
             destroySignal: new DestroySignal(context),
             rootConfig: {
                 decryption: {
@@ -137,6 +138,7 @@ describe('SubscribePipeline', () => {
         expect(onError).toBeCalledTimes(1)
         const error = onError.mock.calls[0][0]
         expect(error).toBeInstanceOf(DecryptError)
+        expect(error.message).toMatch(/timed out/)
         expect(output).toEqual([])
     })
 })

--- a/packages/client/test/unit/SubscribePipeline.test.ts
+++ b/packages/client/test/unit/SubscribePipeline.test.ts
@@ -1,17 +1,17 @@
 import 'reflect-metadata'
-import { GroupKey } from './../../src/encryption/GroupKey'
-import { StreamPartID, StreamPartIDUtils, toStreamID } from 'streamr-client-protocol'
+import { GroupKey, GroupKeyId } from './../../src/encryption/GroupKey'
+import { EncryptionType, MessageID, StreamMessage, StreamPartID, StreamPartIDUtils, toStreamID } from 'streamr-client-protocol'
 import { Wallet } from '@ethersproject/wallet'
-import { createMockMessage } from './../test-utils/utils'
 import { MessageStream } from './../../src/subscribe/MessageStream'
 import { fastWallet, randomEthereumAddress } from "streamr-test-utils"
 import { createSubscribePipeline } from "../../src/subscribe/SubscribePipeline"
 import { mockContext } from '../test-utils/utils'
 import { collect } from '../../src/utils/GeneratorUtils'
-import { DecryptError } from '../../src/encryption/EncryptionUtil'
+import { DecryptError, EncryptionUtil } from '../../src/encryption/EncryptionUtil'
 import { Stream } from '../../src'
 import { DestroySignal } from '../../src/DestroySignal'
-import { sign } from '../../src/utils/signingUtils'
+import { createSignedMessage } from '../../src/publish/MessageFactory'
+import { createAuthentication } from '../../src/Authentication'
 
 const CONTENT = {
     foo: 'bar'
@@ -23,6 +23,29 @@ describe('SubscribePipeline', () => {
     let input: MessageStream
     let streamPartId: StreamPartID
     let publisher: Wallet
+
+    const createMessage = async (opts: { 
+        serializedContent?: string
+        encryptionType?: EncryptionType
+        groupKeyId?: GroupKeyId
+    } = {}): Promise<StreamMessage<unknown>> => {
+        const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
+        return createSignedMessage({
+            messageId: new MessageID(
+                streamId,
+                partition,
+                Date.now(),
+                0,
+                publisher.address,
+                'mock-msgChainId'
+            ),
+            serializedContent: JSON.stringify(CONTENT),
+            authentication: createAuthentication({
+                privateKey: publisher.privateKey
+            }, undefined as any),
+            ...opts
+        })
+    }
 
     beforeEach(async () => {
         streamPartId = StreamPartIDUtils.parse(`${randomEthereumAddress()}/path#0`)
@@ -62,11 +85,8 @@ describe('SubscribePipeline', () => {
     })
 
     it('happy path', async () => {
-        await input.push(await createMockMessage({
-            publisher,
-            streamPartId,
-            content: CONTENT
-        }))
+        const msg = await createMessage()
+        await input.push(msg)
         input.endWrite()
         const output = await collect(pipeline)
         expect(output).toHaveLength(1)
@@ -74,11 +94,7 @@ describe('SubscribePipeline', () => {
     })
 
     it('error: invalid signature', async () => {
-        const msg = await createMockMessage({
-            publisher,
-            streamPartId,
-            content: CONTENT
-        })
+        const msg = await createMessage()
         msg.signature = 'invalid-signature'
         await input.push(msg)
         input.endWrite()
@@ -92,12 +108,9 @@ describe('SubscribePipeline', () => {
     })
 
     it('error: invalid content', async () => {
-        const msg = await createMockMessage({
-            publisher,
-            streamPartId
+        const msg = await createMessage({
+            serializedContent: '{ invalid-json',
         })
-        msg.serializedContent = '{ invalid-json'
-        msg.signature = sign(msg.getPayloadToSign(), publisher.privateKey)
         await input.push(msg)
         input.endWrite()
         const onError = jest.fn()
@@ -111,11 +124,11 @@ describe('SubscribePipeline', () => {
 
     it('error: no encryption key available', async () => {
         const encryptionKey = GroupKey.generate()
-        await input.push(await createMockMessage({
-            publisher,
-            streamPartId,
-            content: CONTENT,
-            encryptionKey
+        const serializedContent = EncryptionUtil.encryptWithAES(Buffer.from(JSON.stringify(CONTENT), 'utf8'), encryptionKey.data)
+        await input.push(await createMessage({
+            serializedContent,
+            encryptionType: EncryptionType.AES,
+            groupKeyId: encryptionKey.id
         }))
         input.endWrite()
         const onError = jest.fn()

--- a/packages/client/test/unit/SubscribePipeline.test.ts
+++ b/packages/client/test/unit/SubscribePipeline.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import { GroupKey } from './../../src/encryption/GroupKey'
-import { StreamMessage, StreamPartID, StreamPartIDUtils, toStreamID } from 'streamr-client-protocol'
+import { StreamPartID, StreamPartIDUtils, toStreamID } from 'streamr-client-protocol'
 import { Wallet } from '@ethersproject/wallet'
 import { createMockMessage } from './../test-utils/utils'
 import { MessageStream } from './../../src/subscribe/MessageStream'
@@ -97,7 +97,7 @@ describe('SubscribePipeline', () => {
             streamPartId
         })
         msg.serializedContent = '{ invalid-json'
-        msg.signature = sign(msg.getPayloadToSign(StreamMessage.SIGNATURE_TYPES.ETH), publisher.privateKey)
+        msg.signature = sign(msg.getPayloadToSign(), publisher.privateKey)
         await input.push(msg)
         input.endWrite()
         const onError = jest.fn()

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -65,22 +65,6 @@ export interface ObjectType<T> {
 }
 
 /**
- * Unsigned StreamMessage.
- */
-export type StreamMessageUnsigned<T> = StreamMessage<T> & {
-    signatureType: SignatureType.NONE
-    signature: '' | null
-}
-
-/**
- * Signed StreamMessage.
- */
-export type StreamMessageSigned<T> = StreamMessage<T> & {
-    signatureType: SignatureType.ETH
-    signature: string
-}
-
-/**
  *  Encrypted StreamMessage.
  */
 export type StreamMessageEncrypted<T> = StreamMessage<T> & {
@@ -409,14 +393,6 @@ export default class StreamMessage<T = unknown> {
                 `prevMessageRef must come before current. Current: ${messageId.toMessageRef().toArray()} Previous: ${prevMsgRef.toArray()}`
             )
         }
-    }
-
-    static isUnsigned<T = unknown>(msg: StreamMessage<T>): msg is StreamMessageUnsigned<T> {
-        return !this.isSigned(msg)
-    }
-
-    static isSigned<T = unknown>(msg: StreamMessage<T>): msg is StreamMessageSigned<T> {
-        return !!(msg && msg.signature && msg.signatureType !== SignatureType.NONE)
     }
 
     static isEncrypted<T = unknown>(msg: StreamMessage<T>): msg is StreamMessageEncrypted<T> {

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -296,27 +296,19 @@ export default class StreamMessage<T = unknown> {
      * e.g.
      * ```
      * const signedMessage: StreamMessageSigned = Object.assign(unsigedMessage, {
-     *     signature: unsigedMessage.getPayloadToSign(SignatureType.ETH),
+     *     signature: unsigedMessage.getPayloadToSign(),
      * })
      * ```
      */
-    getPayloadToSign(newSignatureType?: SignatureType): string {
-        if (newSignatureType != null) {
-            StreamMessage.validateSignatureType(newSignatureType)
-            this.signatureType = newSignatureType
-        }
-
-        const { signatureType } = this
-        if (signatureType === StreamMessage.SIGNATURE_TYPES.ETH) {
+    getPayloadToSign(): string {
+        if (this.signatureType === StreamMessage.SIGNATURE_TYPES.ETH) {
             // Nullable fields
             const prev = (this.prevMsgRef ? `${this.prevMsgRef.timestamp}${this.prevMsgRef.sequenceNumber}` : '')
             const newGroupKey = (this.newGroupKey ? this.newGroupKey.serialize() : '')
-
             return `${this.getStreamId()}${this.getStreamPartition()}${this.getTimestamp()}${this.messageId.sequenceNumber}`
                 + `${this.getPublisherId().toLowerCase()}${this.messageId.msgChainId}${prev}${this.getSerializedContent()}${newGroupKey}`
         }
-        
-        throw new ValidationError(`Unrecognized signature type: ${signatureType}`)
+        throw new ValidationError(`Unrecognized signature type: ${this.signatureType}`)
     }
 
     static registerSerializer(version: number, serializer: Serializer<StreamMessage<unknown>>): void {

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -89,27 +89,15 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getSerializedContent(), JSON.stringify(content))
         })
 
-        it('can detect signed/encrypted etc', () => {
+        it('can detect encrypted', () => {
             const streamMessage = new StreamMessage({
-                messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, 'publisherId', 'msgChainId'),
-                content: JSON.stringify(content),
-            })
-            expect(StreamMessage.isEncrypted(streamMessage)).toBe(false)
-            expect(StreamMessage.isUnencrypted(streamMessage)).toBe(true)
-            expect(StreamMessage.isSigned(streamMessage)).toBe(false)
-            expect(StreamMessage.isUnsigned(streamMessage)).toBe(true)
-
-            const signedMessage = new StreamMessage({
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, 'publisherId', 'msgChainId'),
                 content: JSON.stringify(content),
                 signatureType: StreamMessage.SIGNATURE_TYPES.ETH,
                 signature: 'something'
             })
-
-            expect(StreamMessage.isEncrypted(signedMessage)).toBe(false)
-            expect(StreamMessage.isUnencrypted(signedMessage)).toBe(true)
-            expect(StreamMessage.isSigned(signedMessage)).toBe(true)
-            expect(StreamMessage.isUnsigned(signedMessage)).toBe(false)
+            expect(StreamMessage.isEncrypted(streamMessage)).toBe(false)
+            expect(StreamMessage.isUnencrypted(streamMessage)).toBe(true)
             const encryptedMessage = new StreamMessage({
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, 'publisherId', 'msgChainId'),
                 content: JSON.stringify(content),
@@ -120,8 +108,6 @@ describe('StreamMessage', () => {
 
             expect(StreamMessage.isEncrypted(encryptedMessage)).toBe(true)
             expect(StreamMessage.isUnencrypted(encryptedMessage)).toBe(false)
-            expect(StreamMessage.isSigned(encryptedMessage)).toBe(true)
-            expect(StreamMessage.isUnsigned(encryptedMessage)).toBe(false)
         })
 
         it('should throw if required fields are not defined', () => {


### PR DESCRIPTION
Sign `StreamMessage` instances with new `createSignedMessage` utility function.

Also related refactoring:
- removed parameter from `StreamMessage#getPayloadToSign` which mutated the message object
- remove `StreamMessageUnsigned` and `StreamMessageSigned` interface
- `MessageFactory` has more abstract dependencies:
  - `authentication`, `streamRegistry` and `groupKeyQueue` instead of multiple functions
  - easier to see the big picture of `MessageFactory` dependencies
  - can pass test stub instances easily (added `createStreamRegistryCached` and `createGroupKeyQueue` utility methods)
  - uses a bit less test-only code as we use a real `GroupKeyQueue`
- encapsulate caching functions of `StreamRegistryCached`
  - users of that component aren't supposed to call `getStream#clearMatching` etc.
  
### Future improvements
  
- `MessageChain` is actually just a wrapper to `prevMsgRef`. We could store a `prevMsgRef` for each `partition`+`msgChain` pair instead of storing a `MessageChain`. If we do that createSignedMessage could also get the publisherId directly from authentication (instead of `MessageID` created by `MessageChain`)