### PR TITLE
refactor(client): Simplify `GroupKey` data model

### DIFF
--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -34,11 +34,9 @@ export class GroupKey {
         if (!groupKeyId) {
             throw new GroupKeyError(`groupKeyId must not be falsey ${groupKeyId}`)
         }
-
         if (!groupKeyBufferOrHexString) {
             throw new GroupKeyError(`groupKeyBufferOrHexString must not be falsey ${groupKeyBufferOrHexString}`)
         }
-
         if (typeof groupKeyBufferOrHexString === 'string') {
             this.hex = groupKeyBufferOrHexString
             this.data = Buffer.from(this.hex, 'hex')
@@ -46,7 +44,6 @@ export class GroupKey {
             this.data = groupKeyBufferOrHexString
             this.hex = Buffer.from(this.data).toString('hex')
         }
-
         GroupKey.validate(this)
     }
 
@@ -54,30 +51,24 @@ export class GroupKey {
         if (!maybeGroupKey) {
             throw new GroupKeyError(`value must be a ${this.name}: ${maybeGroupKey}`, maybeGroupKey)
         }
-
         if (!(maybeGroupKey instanceof this)) {
             throw new GroupKeyError(`value must be a ${this.name}: ${maybeGroupKey}`, maybeGroupKey)
         }
-
         if (!maybeGroupKey.id || typeof maybeGroupKey.id !== 'string') {
             throw new GroupKeyError(`${this.name} id must be a string: ${maybeGroupKey}`, maybeGroupKey)
         }
-
         if (maybeGroupKey.id.includes('---BEGIN')) {
             throw new GroupKeyError(
                 `${this.name} public/private key is not a valid group key id: ${maybeGroupKey}`,
                 maybeGroupKey
             )
         }
-
         if (!maybeGroupKey.data || !Buffer.isBuffer(maybeGroupKey.data)) {
             throw new GroupKeyError(`${this.name} data must be a Buffer: ${maybeGroupKey}`, maybeGroupKey)
         }
-
         if (!maybeGroupKey.hex || typeof maybeGroupKey.hex !== 'string') {
             throw new GroupKeyError(`${this.name} hex must be a string: ${maybeGroupKey}`, maybeGroupKey)
         }
-
         if (maybeGroupKey.data.length !== 32) {
             throw new GroupKeyError(`Group key must have a size of 256 bits, not ${maybeGroupKey.data.length * 8}`, maybeGroupKey)
         }
@@ -87,7 +78,6 @@ export class GroupKey {
         if (!(other instanceof GroupKey)) {
             return false
         }
-
         return this === other || (this.hex === other.hex && this.id === other.id)
     }
 

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -69,25 +69,6 @@ export class GroupKey {
         }
     }
 
-    equals(other: GroupKey): boolean {
-        if (!(other instanceof GroupKey)) {
-            return false
-        }
-        return this === other || (this.hex === other.hex && this.id === other.id)
-    }
-
-    toString(): string {
-        return this.id
-    }
-
-    toArray(): string[] {
-        return [this.id, this.hex]
-    }
-
-    serialize(): string {
-        return JSON.stringify(this.toArray())
-    }
-
     static generate(id = uuid('GroupKey')): GroupKey {
         const keyBytes = crypto.randomBytes(32)
         return new GroupKey(id, keyBytes)

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -14,18 +14,12 @@ export class GroupKeyError extends Error {
 /**
  * GroupKeys are AES cipher keys, which are used to encrypt/decrypt StreamMessages (when encryptionType is AES).
  * Each group key contains 256 random bits of key data and an UUID.
- *
- * A group key stores the same key data in two fields: the bytes as hex-encoded string, and as a raw Uint8Array.
- * TODO: If this data duplication doesn't give us any performance improvement we could store the key data only
- * in one field.
  */
 
 export class GroupKey {
 
     /** @internal */
     readonly id: GroupKeyId
-    /** @internal */
-    readonly hex: string
     /** @internal */
     readonly data: Uint8Array
 
@@ -38,7 +32,6 @@ export class GroupKey {
             throw new GroupKeyError(`groupKeyBufferOrHexString must not be falsey ${data}`)
         }
         this.data = data
-        this.hex = Buffer.from(this.data).toString('hex')
         GroupKey.validate(this)
     }
 
@@ -60,9 +53,6 @@ export class GroupKey {
         }
         if (!maybeGroupKey.data || !Buffer.isBuffer(maybeGroupKey.data)) {
             throw new GroupKeyError(`${this.name} data must be a Buffer: ${maybeGroupKey}`, maybeGroupKey)
-        }
-        if (!maybeGroupKey.hex || typeof maybeGroupKey.hex !== 'string') {
-            throw new GroupKeyError(`${this.name} hex must be a string: ${maybeGroupKey}`, maybeGroupKey)
         }
         if (maybeGroupKey.data.length !== 32) {
             throw new GroupKeyError(`Group key must have a size of 256 bits, not ${maybeGroupKey.data.length * 8}`, maybeGroupKey)

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -29,21 +29,16 @@ export class GroupKey {
     /** @internal */
     readonly data: Uint8Array
 
-    constructor(groupKeyId: GroupKeyId, groupKeyBufferOrHexString: Uint8Array | string) {
+    constructor(groupKeyId: GroupKeyId, data: Uint8Array) {
         this.id = groupKeyId
         if (!groupKeyId) {
             throw new GroupKeyError(`groupKeyId must not be falsey ${groupKeyId}`)
         }
-        if (!groupKeyBufferOrHexString) {
-            throw new GroupKeyError(`groupKeyBufferOrHexString must not be falsey ${groupKeyBufferOrHexString}`)
+        if (!data) {
+            throw new GroupKeyError(`groupKeyBufferOrHexString must not be falsey ${data}`)
         }
-        if (typeof groupKeyBufferOrHexString === 'string') {
-            this.hex = groupKeyBufferOrHexString
-            this.data = Buffer.from(this.hex, 'hex')
-        } else {
-            this.data = groupKeyBufferOrHexString
-            this.hex = Buffer.from(this.data).toString('hex')
-        }
+        this.data = data
+        this.hex = Buffer.from(this.data).toString('hex')
         GroupKey.validate(this)
     }
 

--- a/packages/client/src/encryption/GroupKeyStore.ts
+++ b/packages/client/src/encryption/GroupKeyStore.ts
@@ -50,13 +50,13 @@ export class GroupKeyStore implements Context {
         await this.ensureInitialized()
         const value = await this.persistence!.get(keyId, streamId)
         if (value === undefined) { return undefined }
-        return new GroupKey(keyId, value)
+        return new GroupKey(keyId, Buffer.from(value, 'hex'))
     }
 
     async add(key: GroupKey, streamId: StreamID): Promise<void> {
         await this.ensureInitialized()
         this.debug('Add key %s', key.id)
-        await this.persistence!.set(key.id, key.hex, streamId)
+        await this.persistence!.set(key.id, Buffer.from(key.data).toString('hex'), streamId)
         this.eventEmitter.emit('addGroupKey', key)
     }
 


### PR DESCRIPTION
Removed `GroupKey#hex` field. It contained the data of `GroupKey#data` but in different format.

There is no need to store the data in two different formats. The only component which used the `hex` format was `GroupKeyStore`. But as all other components used `data` format, we always converted the data between the two formats in practice.

Removed also obsolete methods of `GroupKey`.