### PR TITLE
fix(client): Rotate explicit group key

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -110,9 +110,7 @@ export class StreamrClient implements Context {
         const streamId = await this.streamIdBuilder.toStreamID(opts.streamId)
         const queue = await this.publisher.getGroupKeyQueue(streamId)
         if (opts.distributionMethod === 'rotate') {
-            if (opts.key === undefined) {
-                await queue.rotate(opts.key)
-            }
+            await queue.rotate(opts.key)
         } else if (opts.distributionMethod === 'rekey') {
             await queue.rekey(opts.key)
         } else {

--- a/packages/client/test/integration/update-encryption-key.test.ts
+++ b/packages/client/test/integration/update-encryption-key.test.ts
@@ -65,6 +65,8 @@ describe('update encryption key', () => {
         expect(msg2!.getParsedContent()).toEqual({
             mockId: 2
         })
+        // @ts-expect-error the type definition defines that newGroupKey EncryptedGroupKey (see EncryptionUtil:82)
+        expect(msg2!.newGroupKey!.id).toBe(rotatedKey.id)
 
         await publisher.publish(streamPartId, {
             mockId: 3
@@ -73,6 +75,7 @@ describe('update encryption key', () => {
         expect(msg3!.getParsedContent()).toEqual({
             mockId: 3
         })
+        expect(msg3?.groupKeyId).toBe(rotatedKey.id)
     })
 
     it('rekey', async () => {
@@ -98,6 +101,7 @@ describe('update encryption key', () => {
         expect(msg2!.getParsedContent()).toEqual({
             mockId: 2
         })
+        expect(msg2?.groupKeyId).toBe(rekeyedKey.id)
     })
 
     describe('permission revoked', () => {


### PR DESCRIPTION
Removed wrong `undefined` check from `StreamrClient` which caused `updateEncryptionKey` method call to be ignored if an explicit key was given.