### PR TITLE
refactor(client): Stream factory

### DIFF
--- a/packages/client/src/Container.ts
+++ b/packages/client/src/Container.ts
@@ -8,13 +8,6 @@ import { Context } from './utils/Context'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from './Config'
 import { AuthenticationInjectionToken, createAuthentication } from './Authentication'
 
-/**
- * DI Token for injecting the Client container.
- * Use sparingly, but can be necessary for factories
- * or to work around circular dependencies.
- */
-export const BrubeckContainer = Symbol('BrubeckContainer')
-
 let uid: string = process.pid != null
     // Use process id in node uid.
     ? `${process.pid}`
@@ -23,7 +16,7 @@ let uid: string = process.pid != null
     : ''
 
 export function initContainer(
-    config: StrictStreamrClientConfig, 
+    config: StrictStreamrClientConfig,
     c: DependencyContainer
 ): Context {
     uid = uid || `${uuid().slice(-4)}${uuid().slice(0, 4)}`
@@ -38,10 +31,6 @@ export function initContainer(
 
     c.register(Context as any, {
         useValue: rootContext
-    })
-
-    c.register(BrubeckContainer, {
-        useValue: c
     })
 
     c.register(AuthenticationInjectionToken, {

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -77,13 +77,13 @@ class StreamrStream implements StreamMetadata {
     partitions!: number
     storageDays?: number
     inactivityThresholdHours?: number
-    private readonly resends: Resends
-    private readonly publisher: Publisher
-    private readonly subscriber: Subscriber
-    private readonly streamRegistry: StreamRegistry
-    private readonly streamRegistryCached: StreamRegistryCached
-    private readonly streamStorageRegistry: StreamStorageRegistry
-    private readonly timeoutsConfig: TimeoutsConfig
+    private readonly _resends: Resends
+    private readonly _publisher: Publisher
+    private readonly _subscriber: Subscriber
+    private readonly _streamRegistry: StreamRegistry
+    private readonly _streamRegistryCached: StreamRegistryCached
+    private readonly _streamStorageRegistry: StreamStorageRegistry
+    private readonly _timeoutsConfig: TimeoutsConfig
 
     /** @internal */
     constructor(
@@ -99,13 +99,13 @@ class StreamrStream implements StreamMetadata {
         Object.assign(this, props)
         this.id = props.id
         this.partitions = props.partitions ? props.partitions : 1
-        this.resends = resends
-        this.publisher = publisher
-        this.subscriber = subscriber
-        this.streamRegistryCached = streamRegistryCached
-        this.streamRegistry = streamRegistry
-        this.streamStorageRegistry = streamStorageRegistry
-        this.timeoutsConfig = timeoutsConfig
+        this._resends = resends
+        this._publisher = publisher
+        this._subscriber = subscriber
+        this._streamRegistryCached = streamRegistryCached
+        this._streamRegistry = streamRegistry
+        this._streamStorageRegistry = streamStorageRegistry
+        this._timeoutsConfig = timeoutsConfig
     }
 
     /**
@@ -113,13 +113,13 @@ class StreamrStream implements StreamMetadata {
      */
     async update(props: Omit<StreamProperties, 'id'>): Promise<void> {
         try {
-            await this.streamRegistry.updateStream({
+            await this._streamRegistry.updateStream({
                 ...this.toObject(),
                 ...props,
                 id: this.id
             })
         } finally {
-            this.streamRegistryCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
         for (const key of Object.keys(props)) {
             (this as any)[key] = (props as any)[key]
@@ -141,15 +141,15 @@ class StreamrStream implements StreamMetadata {
 
     async delete(): Promise<void> {
         try {
-            await this.streamRegistry.deleteStream(this.id)
+            await this._streamRegistry.deleteStream(this.id)
         } finally {
-            this.streamRegistryCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
     }
 
     async detectFields(): Promise<void> {
         // Get last message of the stream to be used for field detecting
-        const sub = await this.resends.resend(
+        const sub = await this._resends.resend(
             this.id,
             {
                 last: 1,
@@ -185,17 +185,17 @@ class StreamrStream implements StreamMetadata {
         let assignmentSubscription
         const normalizedNodeAddress = toEthereumAddress(nodeAddress)
         try {
-            assignmentSubscription = await this.subscriber.subscribe(formStorageNodeAssignmentStreamId(normalizedNodeAddress))
+            assignmentSubscription = await this._subscriber.subscribe(formStorageNodeAssignmentStreamId(normalizedNodeAddress))
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, this)
-            await this.streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
+            await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(
                 propagationPromise,
                 // eslint-disable-next-line no-underscore-dangle
-                waitOptions.timeout ?? this.timeoutsConfig.storageNode.timeout,
+                waitOptions.timeout ?? this._timeoutsConfig.storageNode.timeout,
                 'storage node did not respond'
             )
         } finally {
-            this.streamRegistryCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
             await assignmentSubscription?.unsubscribe() // should never reject...
         }
     }
@@ -205,21 +205,21 @@ class StreamrStream implements StreamMetadata {
      */
     async removeFromStorageNode(nodeAddress: string): Promise<void> {
         try {
-            return this.streamStorageRegistry.removeStreamFromStorageNode(this.id, toEthereumAddress(nodeAddress))
+            return this._streamStorageRegistry.removeStreamFromStorageNode(this.id, toEthereumAddress(nodeAddress))
         } finally {
-            this.streamRegistryCached.clearStream(this.id)
+            this._streamRegistryCached.clearStream(this.id)
         }
     }
 
     async getStorageNodes(): Promise<string[]> {
-        return this.streamStorageRegistry.getStorageNodes(this.id)
+        return this._streamStorageRegistry.getStorageNodes(this.id)
     }
 
     /**
      * @category Important
      */
     async publish<T>(content: T, metadata?: MessageMetadata): Promise<StreamMessage<T>> {
-        return this.publisher.publish(this.id, content, metadata)
+        return this._publisher.publish(this.id, content, metadata)
     }
 
     /** @internal */
@@ -235,7 +235,7 @@ class StreamrStream implements StreamMetadata {
      * @category Important
      */
     async hasPermission(query: Omit<UserPermissionQuery, 'streamId'> | Omit<PublicPermissionQuery, 'streamId'>): Promise<boolean> {
-        return this.streamRegistry.hasPermission({
+        return this._streamRegistry.hasPermission({
             streamId: this.id,
             ...query
         })
@@ -245,21 +245,21 @@ class StreamrStream implements StreamMetadata {
      * @category Important
      */
     async getPermissions(): Promise<PermissionAssignment[]> {
-        return this.streamRegistry.getPermissions(this.id)
+        return this._streamRegistry.getPermissions(this.id)
     }
 
     /**
      * @category Important
      */
     async grantPermissions(...assignments: PermissionAssignment[]): Promise<void> {
-        return this.streamRegistry.grantPermissions(this.id, ...assignments)
+        return this._streamRegistry.grantPermissions(this.id, ...assignments)
     }
 
     /**
      * @category Important
      */
     async revokePermissions(...assignments: PermissionAssignment[]): Promise<void> {
-        return this.streamRegistry.revokePermissions(this.id, ...assignments)
+        return this._streamRegistry.revokePermissions(this.id, ...assignments)
     }
 
 }

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -1,12 +1,9 @@
 /**
  * Wrapper for Stream metadata and (some) methods.
  */
-import { DependencyContainer, inject } from 'tsyringe'
-
 import { Resends } from './subscribe/Resends'
 import { Publisher } from './publish/Publisher'
 import { StreamRegistry } from './registry/StreamRegistry'
-import { BrubeckContainer } from './Container'
 import { StreamRegistryCached } from './registry/StreamRegistryCached'
 import {
     StreamID,
@@ -15,7 +12,7 @@ import {
     toStreamPartID
 } from 'streamr-client-protocol'
 import { range } from 'lodash'
-import { ConfigInjectionToken, TimeoutsConfig } from './Config'
+import { TimeoutsConfig } from './Config'
 import { PermissionAssignment, PublicPermissionQuery, UserPermissionQuery } from './permission'
 import { Subscriber } from './subscribe/Subscriber'
 import { formStorageNodeAssignmentStreamId } from './utils/utils'
@@ -91,18 +88,24 @@ class StreamrStream implements StreamMetadata {
     /** @internal */
     constructor(
         props: StreamrStreamConstructorOptions,
-        @inject(BrubeckContainer) _container: DependencyContainer
+        resends: Resends,
+        publisher: Publisher,
+        subscriber: Subscriber,
+        streamRegistryCached: StreamRegistryCached,
+        streamRegistry: StreamRegistry,
+        streamStorageRegistry: StreamStorageRegistry,
+        timeoutsConfig: TimeoutsConfig
     ) {
         Object.assign(this, props)
         this.id = props.id
         this.partitions = props.partitions ? props.partitions : 1
-        this._resends = _container.resolve<Resends>(Resends)
-        this._publisher = _container.resolve<Publisher>(Publisher)
-        this._subscriber = _container.resolve<Subscriber>(Subscriber)
-        this._streamRegistryCached = _container.resolve<StreamRegistryCached>(StreamRegistryCached)
-        this._streamRegistry = _container.resolve<StreamRegistry>(StreamRegistry)
-        this._streamStorageRegistry = _container.resolve<StreamStorageRegistry>(StreamStorageRegistry)
-        this._timeoutsConfig = _container.resolve<TimeoutsConfig>(ConfigInjectionToken.Timeouts)
+        this._resends = resends
+        this._publisher = publisher
+        this._subscriber = subscriber
+        this._streamRegistryCached = streamRegistryCached
+        this._streamRegistry = streamRegistry
+        this._streamStorageRegistry = streamStorageRegistry
+        this._timeoutsConfig = timeoutsConfig
     }
 
     /**

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -77,13 +77,13 @@ class StreamrStream implements StreamMetadata {
     partitions!: number
     storageDays?: number
     inactivityThresholdHours?: number
-    protected _resends: Resends
-    protected _publisher: Publisher
-    protected _subscriber: Subscriber
-    protected _streamRegistry: StreamRegistry
-    protected _streamRegistryCached: StreamRegistryCached
-    protected _streamStorageRegistry: StreamStorageRegistry
-    private _timeoutsConfig: TimeoutsConfig
+    private readonly _resends: Resends
+    private readonly _publisher: Publisher
+    private readonly _subscriber: Subscriber
+    private readonly _streamRegistry: StreamRegistry
+    private readonly _streamRegistryCached: StreamRegistryCached
+    private readonly _streamStorageRegistry: StreamStorageRegistry
+    private readonly _timeoutsConfig: TimeoutsConfig
 
     /** @internal */
     constructor(

--- a/packages/client/src/StreamFactory.ts
+++ b/packages/client/src/StreamFactory.ts
@@ -1,4 +1,4 @@
-import { inject, Lifecycle, scoped } from 'tsyringe'
+import { delay, inject, Lifecycle, scoped } from 'tsyringe'
 import { ConfigInjectionToken, TimeoutsConfig } from './Config'
 import { Publisher } from './publish/Publisher'
 import { StreamRegistry } from './registry/StreamRegistry'
@@ -21,10 +21,10 @@ export class StreamFactory {
 
     constructor(
         resends: Resends,
-        publisher: Publisher,
+        @inject(delay(() => Publisher)) publisher: Publisher,
         subscriber: Subscriber,
-        streamRegistryCached: StreamRegistryCached,
-        streamRegistry: StreamRegistry,
+        @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached,
+        @inject(delay(() => StreamRegistry)) streamRegistry: StreamRegistry,
         streamStorageRegistry: StreamStorageRegistry,
         @inject(ConfigInjectionToken.Timeouts) timeoutsConfig: TimeoutsConfig
     ) {

--- a/packages/client/src/StreamFactory.ts
+++ b/packages/client/src/StreamFactory.ts
@@ -1,0 +1,52 @@
+import { inject, Lifecycle, scoped } from 'tsyringe'
+import { ConfigInjectionToken, TimeoutsConfig } from './Config'
+import { Publisher } from './publish/Publisher'
+import { StreamRegistry } from './registry/StreamRegistry'
+import { StreamRegistryCached } from './registry/StreamRegistryCached'
+import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
+import { Stream, StreamrStreamConstructorOptions } from './Stream'
+import { Resends } from './subscribe/Resends'
+import { Subscriber } from './subscribe/Subscriber'
+
+@scoped(Lifecycle.ContainerScoped)
+export class StreamFactory {
+
+    private readonly resends: Resends
+    private readonly publisher: Publisher
+    private readonly subscriber: Subscriber
+    private readonly streamRegistryCached: StreamRegistryCached
+    private readonly streamRegistry: StreamRegistry
+    private readonly streamStorageRegistry: StreamStorageRegistry
+    private readonly timeoutsConfig: TimeoutsConfig
+
+    constructor(
+        resends: Resends,
+        publisher: Publisher,
+        subscriber: Subscriber,
+        streamRegistryCached: StreamRegistryCached,
+        streamRegistry: StreamRegistry,
+        streamStorageRegistry: StreamStorageRegistry,
+        @inject(ConfigInjectionToken.Timeouts) timeoutsConfig: TimeoutsConfig
+    ) {
+        this.resends = resends
+        this.publisher = publisher
+        this.subscriber = subscriber
+        this.streamRegistryCached = streamRegistryCached
+        this.streamRegistry = streamRegistry
+        this.streamStorageRegistry = streamStorageRegistry
+        this.timeoutsConfig = timeoutsConfig
+    }
+
+    createStream(props: StreamrStreamConstructorOptions): Stream {
+        return new Stream(
+            props,
+            this.resends,
+            this.publisher,
+            this.subscriber,
+            this.streamRegistryCached,
+            this.streamRegistry,
+            this.streamStorageRegistry,
+            this.timeoutsConfig
+        )
+    }
+}

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -2,7 +2,7 @@ import debug from 'debug'
 import type { StreamStorageRegistry as StreamStorageRegistryContract } from '../ethereumArtifacts/StreamStorageRegistry'
 import StreamStorageRegistryArtifact from '../ethereumArtifacts/StreamStorageRegistry.json'
 import { StreamQueryResult } from './StreamRegistry'
-import { scoped, Lifecycle, inject } from 'tsyringe'
+import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { ConfigInjectionToken } from '../Config'
 import { Stream, StreamProperties } from '../Stream'
 import { EthereumConfig, getStreamRegistryChainProvider, getStreamRegistryOverrides } from '../Ethereum'
@@ -68,7 +68,7 @@ export class StreamStorageRegistry {
 
     constructor(
         private contractFactory: ContractFactory,
-        private streamFactory: StreamFactory,
+        @inject(delay(() => StreamFactory)) private streamFactory: StreamFactory,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(SynchronizedGraphQLClient) private graphQLClient: SynchronizedGraphQLClient,
         @inject(StreamrClientEventEmitter) eventEmitter: StreamrClientEventEmitter,

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -2,8 +2,7 @@ import debug from 'debug'
 import type { StreamStorageRegistry as StreamStorageRegistryContract } from '../ethereumArtifacts/StreamStorageRegistry'
 import StreamStorageRegistryArtifact from '../ethereumArtifacts/StreamStorageRegistry.json'
 import { StreamQueryResult } from './StreamRegistry'
-import { scoped, Lifecycle, inject, DependencyContainer } from 'tsyringe'
-import { BrubeckContainer } from '../Container'
+import { scoped, Lifecycle, inject } from 'tsyringe'
 import { ConfigInjectionToken } from '../Config'
 import { Stream, StreamProperties } from '../Stream'
 import { EthereumConfig, getStreamRegistryChainProvider, getStreamRegistryOverrides } from '../Ethereum'
@@ -15,6 +14,7 @@ import { StreamrClientEventEmitter, StreamrClientEvents, initEventGateway } from
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 import { ContractFactory } from '../ContractFactory'
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
+import { StreamFactory } from '../StreamFactory'
 
 /**
  * Stores storage node assignments (mapping of streamIds <-> storage nodes addresses)
@@ -68,7 +68,7 @@ export class StreamStorageRegistry {
 
     constructor(
         private contractFactory: ContractFactory,
-        @inject(BrubeckContainer) private container: DependencyContainer,
+        private streamFactory: StreamFactory,
         @inject(StreamIDBuilder) private streamIdBuilder: StreamIDBuilder,
         @inject(SynchronizedGraphQLClient) private graphQLClient: SynchronizedGraphQLClient,
         @inject(StreamrClientEventEmitter) eventEmitter: StreamrClientEventEmitter,
@@ -152,7 +152,7 @@ export class StreamStorageRegistry {
         const res = await this.graphQLClient.sendQuery(query) as StorageNodeQueryResult
         const streams = res.node.storedStreams.map((stream) => {
             const props: StreamProperties = Stream.parsePropertiesFromMetadata(stream.metadata)
-            return new Stream({ ...props, id: toStreamID(stream.id) }, this.container) // toStreamID() not strictly necessary
+            return this.streamFactory.createStream({ ...props, id: toStreamID(stream.id) }) // toStreamID() not strictly necessary
         })
         return {
             streams,

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -28,11 +28,11 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
     private readonly streamRegistryCached: StreamRegistryCached
 
     constructor(
-        @inject(FakeChain) chain: FakeChain,
-        @inject(StreamIDBuilder) streamIdBuilder: StreamIDBuilder,
-        @inject(AuthenticationInjectionToken) authentication: Authentication,
+        chain: FakeChain,
+        streamIdBuilder: StreamIDBuilder,
         streamFactory: StreamFactory,
-        @inject(StreamRegistryCached) streamRegistryCached: StreamRegistryCached
+        streamRegistryCached: StreamRegistryCached,
+        @inject(AuthenticationInjectionToken) authentication: Authentication
     ) {
         this.chain = chain
         this.streamIdBuilder = streamIdBuilder

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -1,4 +1,4 @@
-import { inject, DependencyContainer, scoped, Lifecycle } from 'tsyringe'
+import { inject, scoped, Lifecycle } from 'tsyringe'
 import { StreamID } from 'streamr-client-protocol'
 import { Stream, StreamProperties } from '../../../src/Stream'
 import {
@@ -9,7 +9,6 @@ import {
     PermissionQuery
 } from '../../../src/permission'
 import { StreamIDBuilder } from '../../../src/StreamIDBuilder'
-import { BrubeckContainer } from '../../../src/Container'
 import { StreamRegistry } from '../../../src/registry/StreamRegistry'
 import { NotFoundError, SearchStreamsPermissionFilter } from '../../../src'
 import { StreamRegistryCached } from '../../../src/registry/StreamRegistryCached'
@@ -17,6 +16,7 @@ import { Authentication, AuthenticationInjectionToken } from '../../../src/Authe
 import { Methods } from '../types'
 import { EthereumAddress, Multimap, toEthereumAddress } from '@streamr/utils'
 import { FakeChain, PUBLIC_PERMISSION_TARGET, PublicPermissionTarget, StreamRegistryItem } from './FakeChain'
+import { StreamFactory } from '../../../src/StreamFactory'
 
 @scoped(Lifecycle.ContainerScoped)
 export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'> {
@@ -24,20 +24,20 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
     private readonly chain: FakeChain
     private readonly streamIdBuilder: StreamIDBuilder
     private readonly authentication: Authentication
-    private readonly container: DependencyContainer
+    private readonly streamFactory: StreamFactory
     private readonly streamRegistryCached: StreamRegistryCached
 
     constructor(
         @inject(FakeChain) chain: FakeChain,
         @inject(StreamIDBuilder) streamIdBuilder: StreamIDBuilder,
         @inject(AuthenticationInjectionToken) authentication: Authentication,
-        @inject(BrubeckContainer) container: DependencyContainer,
+        streamFactory: StreamFactory,
         @inject(StreamRegistryCached) streamRegistryCached: StreamRegistryCached
     ) {
         this.chain = chain
         this.streamIdBuilder = streamIdBuilder
         this.authentication = authentication
-        this.container = container
+        this.streamFactory = streamFactory
         this.streamRegistryCached = streamRegistryCached
     }
 
@@ -59,21 +59,16 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
             permissions
         }
         this.chain.streams.set(streamId, registryItem)
-        return this.createFakeStream({
+        return this.streamFactory.createStream({
             ...props,
             id: streamId
         })
     }
 
-    private createFakeStream = (props: StreamProperties & { id: StreamID }) => {
-        const s = new Stream(props, this.container)
-        return s
-    }
-
     async getStream(id: StreamID): Promise<Stream> {
         const registryItem = this.chain.streams.get(id)
         if (registryItem !== undefined) {
-            return this.createFakeStream({ ...registryItem.metadata, id })
+            return this.streamFactory.createStream({ ...registryItem.metadata, id })
         } else {
             throw new NotFoundError('Stream not found: id=' + id)
         }
@@ -88,10 +83,10 @@ export class FakeStreamRegistry implements Omit<Methods<StreamRegistry>, 'debug'
         } else {
             registryItem.metadata = props
         }
-        return new Stream({
+        return this.streamFactory.createStream({
             ...props,
             id: streamId
-        }, this.container)
+        })
     }
 
     async hasPermission(query: PermissionQuery): Promise<boolean> {

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -18,6 +18,27 @@ describe('Stream', () => {
         expect(stream.config.fields).toEqual([])
     })
 
+    it('toObject', () => {
+        const mockContainer = rootContainer.createChildContainer()
+        initContainer(createStrictConfig({}), mockContainer)
+        const factory = mockContainer.resolve(StreamFactory)
+        const stream = factory.createStream({
+            id: toStreamID('mock-id'),
+            partitions: 10,
+            storageDays: 20
+        })
+        expect(stream.toObject()).toEqual({
+            id: 'mock-id',
+            partitions: 10,
+            storageDays: 20,
+            // currently we get also this field, which was not set by the user
+            // (maybe the test should pass also if this field is not present)
+            config: {
+                fields: []
+            }
+        })
+    })
+
     describe('update', () => {
         it('fields not updated if transaction fails', async () => {
             const config = createStrictConfig({})

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -2,18 +2,19 @@ import 'reflect-metadata'
 import { container as rootContainer } from 'tsyringe'
 import { toStreamID } from 'streamr-client-protocol'
 import { initContainer } from '../../src/Container'
-import { Stream } from '../../src/Stream'
 import { StreamRegistry } from '../../src/registry/StreamRegistry'
 import { createStrictConfig } from '../../src/Config'
+import { StreamFactory } from './../../src/StreamFactory'
 
 describe('Stream', () => {
-    
+
     it('initial fields', () => {
         const mockContainer = rootContainer.createChildContainer()
         initContainer(createStrictConfig({}), mockContainer)
-        const stream = new Stream({
+        const factory = mockContainer.resolve(StreamFactory)
+        const stream = factory.createStream({
             id: toStreamID('mock-id')
-        }, mockContainer as any)
+        })
         expect(stream.config.fields).toEqual([])
     })
 
@@ -25,10 +26,11 @@ describe('Stream', () => {
             mockContainer.registerInstance(StreamRegistry, {
                 updateStream: jest.fn().mockRejectedValue(new Error('mock-error'))
             } as any)
-            const stream = new Stream({
+            const factory = mockContainer.resolve(StreamFactory)
+            const stream = factory.createStream({
                 id: toStreamID('mock-id'),
                 description: 'original-description'
-            }, mockContainer as any)
+            })
 
             await expect(() => {
                 return stream.update({

--- a/packages/client/test/unit/SubscribePipeline.test.ts
+++ b/packages/client/test/unit/SubscribePipeline.test.ts
@@ -26,7 +26,7 @@ describe('SubscribePipeline', () => {
     let streamPartId: StreamPartID
     let publisher: Wallet
 
-    const createMessage = async (opts: { 
+    const createMessage = async (opts: {
         serializedContent?: string
         encryptionType?: EncryptionType
         groupKeyId?: GroupKeyId
@@ -52,12 +52,19 @@ describe('SubscribePipeline', () => {
     beforeEach(async () => {
         streamPartId = StreamPartIDUtils.parse(`${randomEthereumAddress()}/path#0`)
         publisher = fastWallet()
-        const stream = new Stream({
-            id: toStreamID(streamPartId),
-            partitions: 1
-        }, {
-            resolve: () => {}
-        } as any)
+        const stream = new Stream(
+            {
+                id: toStreamID(streamPartId),
+                partitions: 1,
+            },
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any,
+            undefined as any
+        )
         const context = mockContext()
         input = new MessageStream(context)
         pipeline = createSubscribePipeline({


### PR DESCRIPTION
Streams are now created  by calling `StreamFactory#createStream`. There is no state handling in the factory: it just stores the  DI dependencies required by a `Stream` constructor and passes those to the constructor when `createStream` is called.

Before this PR the dependencies were injected by passing a `BrubeckContainer` (i.e. a DI container) instance to the Stream constructor. `BrubeckContainer` is no longer needed, and it is now removed.

Changed also Stream DI fields visibility to private.

### Future improvement

Currently we need to prefix the DI field with underscore so that the field are excluded by `Stream#toObject`. Rename the fields, if/when that is no longer needed.