### PR TITLE
refactor(client): remove extraneous toLowerCase

### DIFF
--- a/packages/broker/test/unit/helpers/generateMnemonicFromAddress.test.ts
+++ b/packages/broker/test/unit/helpers/generateMnemonicFromAddress.test.ts
@@ -1,6 +1,6 @@
 import { generateMnemonicFromAddress } from '../../../src/helpers/generateMnemonicFromAddress'
 import { randomEthereumAddress } from 'streamr-test-utils'
-import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
+import { toEthereumAddress } from '@streamr/utils'
 
 describe(generateMnemonicFromAddress, () => {
     it('always returns same mnemonic for the same address', () => {
@@ -10,13 +10,6 @@ describe(generateMnemonicFromAddress, () => {
         expect(result1).toEqual(result2)
         expect(result1).not.toEqual('') // is not empty
         expect(result1.trim()).toEqual(result1) // no whitespace
-    })
-
-    it('ignores address case', () => {
-        const address = randomEthereumAddress()
-        const result1 = generateMnemonicFromAddress(address.toLowerCase() as EthereumAddress)
-        const result2 = generateMnemonicFromAddress(address)
-        expect(result1).toEqual(result2)
     })
 
     it('matches hardcoded value i.e. algorithm has not changed', () => {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -117,7 +117,7 @@ export class NetworkNodeFacade {
             throw new Error(`cannot set explicit nodeId ${id} without authentication`)
         } else {
             const ethereumAddress = await this.authentication.getAddress()
-            if (!id.toLowerCase().startsWith(ethereumAddress.toLowerCase())) {
+            if (!id.toLowerCase().startsWith(ethereumAddress)) {
                 throw new Error(`given node id ${id} not compatible with authenticated wallet ${ethereumAddress}`)
             }
         }

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -58,7 +58,7 @@ export class PublisherKeyExchange {
             try {
                 const authenticatedUser = await this.authentication.getAddress()
                 const { recipient, requestId, rsaPublicKey, groupKeyIds } = GroupKeyRequest.fromStreamMessage(request) as GroupKeyRequest
-                if (recipient.toLowerCase() === authenticatedUser) {
+                if (recipient === authenticatedUser) {
                     this.logger.debug('handling group key request %s', requestId)
                     await this.validator.validate(request)
                     const keys = without(

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -115,7 +115,7 @@ export class SubscriberKeyExchange {
             try {
                 const authenticatedUser = await this.authentication.getAddress()
                 const { requestId, recipient, encryptedGroupKeys } = GroupKeyResponse.fromStreamMessage(msg) as GroupKeyResponse
-                if ((recipient.toLowerCase() === authenticatedUser) && (this.pendingRequests.has(requestId))) {
+                if ((recipient === authenticatedUser) && (this.pendingRequests.has(requestId))) {
                     this.logger.debug('handling group key response %s', requestId)
                     this.pendingRequests.delete(requestId)
                     await this.validator.validate(msg)

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -168,7 +168,7 @@ export class StreamRegistry {
 
     private async ensureStreamIdInNamespaceOfAuthenticatedUser(address: EthereumAddress, streamId: StreamID): Promise<void> {
         const userAddress = await this.authentication.getAddress()
-        if (address.toLowerCase() !== userAddress.toLowerCase()) {
+        if (address !== userAddress) {
             throw new Error(`stream id "${streamId}" not in namespace of authenticated user "${userAddress}"`)
         }
     }

--- a/packages/client/src/registry/StreamRegistryCached.ts
+++ b/packages/client/src/registry/StreamRegistryCached.ts
@@ -45,8 +45,8 @@ export class StreamRegistryCached {
         return this.streamRegistry.isStreamPublisher(streamId, ethAddress)
     }, {
         ...this.cacheOptions,
-        cacheKey([streamId, ethAddress]: any): string {
-            return [streamId, ethAddress.toLowerCase()].join(SEPARATOR)
+        cacheKey([streamId, ethAddress]): string {
+            return [streamId, ethAddress].join(SEPARATOR)
         }
     })
 
@@ -58,8 +58,8 @@ export class StreamRegistryCached {
         return this.streamRegistry.isStreamSubscriber(streamId, ethAddress)
     }, {
         ...this.cacheOptions,
-        cacheKey([streamId, ethAddress]: any): string {
-            return [streamId, ethAddress.toLowerCase()].join(SEPARATOR)
+        cacheKey([streamId, ethAddress]): string {
+            return [streamId, ethAddress].join(SEPARATOR)
         }
     })
 

--- a/packages/client/src/utils/signingUtils.ts
+++ b/packages/client/src/utils/signingUtils.ts
@@ -1,6 +1,6 @@
 import secp256k1 from 'secp256k1'
 import { Keccak } from 'sha3'
-import { EthereumAddress } from '@streamr/utils'
+import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 
 const SIGN_MAGIC = '\u0019Ethereum Signed Message:\n'
 const keccak = new Keccak(256)
@@ -71,8 +71,8 @@ export function recover(
 
 export function verify(address: EthereumAddress, payload: string, signature: string): boolean {
     try {
-        const recoveredAddress = recover(signature, payload)
-        return recoveredAddress.toLowerCase() === address.toLowerCase()
+        const recoveredAddress = toEthereumAddress(recover(signature, payload))
+        return recoveredAddress === address
     } catch (err) {
         return false
     }

--- a/packages/client/test/benchmarks/SigningUtil.test.ts
+++ b/packages/client/test/benchmarks/SigningUtil.test.ts
@@ -87,7 +87,7 @@ describe('SigningUtil', () => {
             }, true, 'Verify-our')
     
             const elapsedTimeEthers = await run(async () => {
-                return verifyMessage(payload, signature).toLowerCase() === wallet.address.toLowerCase()
+                return toEthereumAddress(verifyMessage(payload, signature)) === toEthereumAddress(wallet.address)
             }, true, 'Verify-ethers.js')
     
             expect(elapsedTimeOur).toBeLessThan(elapsedTimeEthers)

--- a/packages/client/test/browser/browser.html
+++ b/packages/client/test/browser/browser.html
@@ -270,7 +270,7 @@
         log('Added to storage node.')
         log('Loading storage nodes...')
         const storageNodes = await stream.getStorageNodes()
-        log(`Storage: ${JSON.stringify(storageNodes && storageNodes.map((s) => s.toLowerCase()))}`, 'storeResult')
+        log(`Storage: ${JSON.stringify(storageNodes)}`, 'storeResult')
     })
 
     $('#permissions').on('click', async () => {

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -48,7 +48,7 @@ describe('NodeMetrics', () => {
     it('should retrieve a metrics report', async () => {
         let report: MetricsReport | undefined
 
-        const nodeAddress = (await generatorClient.getAddress()).toLowerCase()
+        const nodeAddress = await generatorClient.getAddress()
         const partition = keyToArrayIndex(NUM_OF_PARTITIONS, nodeAddress)
 
         await subscriberClient.subscribe({ id: stream.id, partition }, (content: any) => {

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -6,6 +6,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
 import { fastWallet, fetchPrivateKeyWithGas, randomEthereumAddress } from 'streamr-test-utils'
+import { toEthereumAddress } from '@streamr/utils'
 
 jest.setTimeout(40000)
 
@@ -115,7 +116,7 @@ describe('Stream permissions', () => {
         const permissions = await stream.getPermissions()
         const owner = await client.getAddress()
         return expect(permissions).toIncludeSameMembers([{
-            user: owner.toLowerCase(),
+            user: owner,
             permissions: [
                 StreamPermission.EDIT,
                 StreamPermission.DELETE,
@@ -219,7 +220,7 @@ describe('Stream permissions', () => {
         const message = {
             foo: Date.now()
         }
-        const errorSnippet = `${otherUser.address.toLowerCase()} is not a publisher on stream ${stream.id}`
+        const errorSnippet = `${toEthereumAddress(otherUser.address)} is not a publisher on stream ${stream.id}`
         await expect(() => otherUserClient.publish(stream.id, message)).rejects.toThrow(errorSnippet)
         await client.grantPermissions(stream.id, {
             user: otherUser.address,

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -46,7 +46,7 @@ describe('StorageNodeRegistry', () => {
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         let storageNodes = await stream.getStorageNodes()
         expect(storageNodes.length).toBe(1)
-        expect(storageNodes[0]).toStrictEqual(DOCKER_DEV_STORAGE_NODE.toLowerCase())
+        expect(storageNodes[0]).toStrictEqual(DOCKER_DEV_STORAGE_NODE)
         let stored = await creatorClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
         expect(stored.streams.some((s) => s.id === stream.id)).toBe(true)
 

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -60,12 +60,12 @@ describe('StorageNodeRegistry2', () => {
     describe('getStorageNodes', () => {
         it('id', async () => {
             const storageNodeUrls = await client.getStorageNodes(createdStream.id)
-            expect(storageNodeUrls).toEqual([storageNodeAddress.toLowerCase()])
+            expect(storageNodeUrls).toEqual([storageNodeAddress])
         })
 
         it('all', async () => {
             const storageNodeUrls = await client.getStorageNodes()
-            return expect(storageNodeUrls).toContain(storageNodeAddress.toLowerCase())
+            return expect(storageNodeUrls).toContain(storageNodeAddress)
         })
     })
 

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -9,6 +9,7 @@ import { toStreamID } from 'streamr-client-protocol'
 import { collect } from '../../src/utils/GeneratorUtils'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from 'streamr-test-utils'
 import { TimeoutsConfig } from '../../src/Config'
+import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 
 jest.setTimeout(20000)
 const PARTITION_COUNT = 3
@@ -29,10 +30,12 @@ describe('StreamRegistry', () => {
 
     let client: StreamrClient
     let wallet: Wallet
+    let publicAddress: EthereumAddress
     let createdStream: Stream
 
     beforeAll(async () => {
         wallet = new Wallet(await fetchPrivateKeyWithGas())
+        publicAddress = toEthereumAddress(wallet.address)
         client = new StreamrClient({
             ...ConfigTest,
             auth: {
@@ -58,7 +61,7 @@ describe('StreamRegistry', () => {
         })
 
         it('valid id', async () => {
-            const newId = `${wallet.address.toLowerCase()}/StreamRegistry-createStream-newId-${Date.now()}`
+            const newId = `${publicAddress}/StreamRegistry-createStream-newId-${Date.now()}`
             const newStream = await client.createStream({
                 id: newId,
             })
@@ -68,7 +71,7 @@ describe('StreamRegistry', () => {
 
         it('valid path', async () => {
             const newPath = `/StreamRegistry-createStream-newPath-${Date.now()}`
-            const expectedId = `${wallet.address.toLowerCase()}${newPath}`
+            const expectedId = `${publicAddress}${newPath}`
             const newStream = await client.createStream({
                 id: newPath,
             })
@@ -122,7 +125,7 @@ describe('StreamRegistry', () => {
         })
 
         it('get a non-existing Stream', async () => {
-            const streamId = `${wallet.address.toLowerCase()}/StreamRegistry-nonexisting-${Date.now()}`
+            const streamId = `${publicAddress}/StreamRegistry-nonexisting-${Date.now()}`
             return expect(() => client.getStream(streamId)).rejects.toThrow(NotFoundError)
         })
     })
@@ -136,7 +139,7 @@ describe('StreamRegistry', () => {
         })
 
         it('new Stream by id', async () => {
-            const newId = `${wallet.address.toLowerCase()}/StreamRegistry-getOrCreate-newId-${Date.now()}`
+            const newId = `${publicAddress}/StreamRegistry-getOrCreate-newId-${Date.now()}`
             const newStream = await client.getOrCreateStream({
                 id: newId,
             })
@@ -148,7 +151,7 @@ describe('StreamRegistry', () => {
             const newStream = await client.getOrCreateStream({
                 id: newPath,
             })
-            expect(newStream.id).toEqual(`${wallet.address.toLowerCase()}${newPath}`)
+            expect(newStream.id).toEqual(`${publicAddress}${newPath}`)
 
             // ensure can get after create i.e. doesn't try create again
             const sameStream = await client.getOrCreateStream({
@@ -166,7 +169,7 @@ describe('StreamRegistry', () => {
                 await client.getOrCreateStream({
                     id: `${otherAddress}${newPath}`,
                 })
-            }).rejects.toThrow(`stream id "${otherAddress}${newPath}" not in namespace of authenticated user "${wallet.address.toLowerCase()}"`)
+            }).rejects.toThrow(`stream id "${otherAddress}${newPath}" not in namespace of authenticated user "${publicAddress}"`)
         })
     })
 

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -15,6 +15,7 @@ import {
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { fastWallet } from 'streamr-test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
+import { toEthereumAddress } from '@streamr/utils'
 
 describe('PublisherKeyExchange', () => {
 
@@ -48,7 +49,7 @@ describe('PublisherKeyExchange', () => {
             messageId: {
                 streamId: StreamPartIDUtils.getStreamID(streamPartId),
                 streamPartition: StreamPartIDUtils.getStreamPartition(streamPartId),
-                publisherId: publisherWallet.address.toLowerCase(),
+                publisherId: toEthereumAddress(publisherWallet.address),
             },
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE,
             contentType: StreamMessage.CONTENT_TYPES.JSON,

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -49,7 +49,7 @@ describe('SubscriberKeyExchange', () => {
             messageId: {
                 streamId: StreamPartIDUtils.getStreamID(streamPartId),
                 streamPartition:  StreamPartIDUtils.getStreamPartition(streamPartId),
-                publisherId: subscriberWallet.address.toLowerCase()
+                publisherId: toEthereumAddress(subscriberWallet.address)
             },
             messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
             contentType: StreamMessage.CONTENT_TYPES.JSON,

--- a/packages/client/test/integration/multiple-clients.test.ts
+++ b/packages/client/test/integration/multiple-clients.test.ts
@@ -58,7 +58,7 @@ describe('PubSub with multiple clients', () => {
         const pubClient = environment.createClient({
             id: `publisher${id}`
         })
-        const publisherId = (await pubClient.getAddress()).toLowerCase()
+        const publisherId = await pubClient.getAddress()
 
         addAfter(async () => {
             counterId.clear(publisherId) // prevent overflows in counter
@@ -133,18 +133,18 @@ describe('PubSub with multiple clients', () => {
             await otherClient.subscribe({
                 stream: stream.id,
             }, (_content, streamMessage) => {
-                const msgs = receivedMessagesOther[streamMessage.getPublisherId().toLowerCase()] || []
+                const msgs = receivedMessagesOther[streamMessage.getPublisherId()] || []
                 msgs.push(streamMessage)
-                receivedMessagesOther[streamMessage.getPublisherId().toLowerCase()] = msgs
+                receivedMessagesOther[streamMessage.getPublisherId()] = msgs
             })
 
             // subscribe to stream from main client instance
             await mainClient.subscribe({
                 stream: stream.id,
             }, (_content, streamMessage) => {
-                const msgs = receivedMessagesMain[streamMessage.getPublisherId().toLowerCase()] || []
+                const msgs = receivedMessagesMain[streamMessage.getPublisherId()] || []
                 msgs.push(streamMessage)
-                receivedMessagesMain[streamMessage.getPublisherId().toLowerCase()] = msgs
+                receivedMessagesMain[streamMessage.getPublisherId()] = msgs
             })
 
             const publishers: StreamrClient[] = []
@@ -153,7 +153,7 @@ describe('PubSub with multiple clients', () => {
             }
             const published: Record<string, StreamMessage[]> = {}
             await Promise.all(publishers.map(async (pubClient) => {
-                const publisherId = (await pubClient.getAddress()).toLowerCase()
+                const publisherId = await pubClient.getAddress()
                 addAfter(() => {
                     counterId.clear(publisherId) // prevent overflows in counter
                 })
@@ -188,7 +188,7 @@ describe('PubSub with multiple clients', () => {
             const mainSub = await mainClient.subscribe({
                 stream: stream.id,
             }, (_content, streamMessage) => {
-                const key = streamMessage.getPublisherId().toLowerCase()
+                const key = streamMessage.getPublisherId()
                 const msgs = receivedMessagesMain[key] || []
                 msgs.push(streamMessage)
                 receivedMessagesMain[key] = msgs
@@ -207,7 +207,7 @@ describe('PubSub with multiple clients', () => {
             let counter = 0
             const published: Record<string, StreamMessage[]> = {}
             await Promise.all(publishers.map(async (pubClient) => {
-                const publisherId = (await pubClient.getAddress()).toLowerCase()
+                const publisherId = await pubClient.getAddress()
                 addAfter(() => {
                     counterId.clear(publisherId) // prevent overflows in counter
                 })
@@ -231,7 +231,7 @@ describe('PubSub with multiple clients', () => {
                             from: lastMessage.getMessageRef()
                         }
                     }, (_content, streamMessage) => {
-                        const key = streamMessage.getPublisherId().toLowerCase()
+                        const key = streamMessage.getPublisherId()
                         const msgs = receivedMessagesOther[key] || []
                         msgs.push(streamMessage)
                         receivedMessagesOther[key] = msgs
@@ -280,7 +280,7 @@ describe('PubSub with multiple clients', () => {
         await otherClient.subscribe({
             stream: stream.id,
         }, (_content, streamMessage) => {
-            const key = streamMessage.getPublisherId().toLowerCase()
+            const key = streamMessage.getPublisherId()
             const msgs = receivedMessagesOther[key] || []
             msgs.push(streamMessage)
             receivedMessagesOther[key] = msgs
@@ -290,7 +290,7 @@ describe('PubSub with multiple clients', () => {
         await mainClient.subscribe({
             stream: stream.id,
         }, (_content, streamMessage) => {
-            const key = streamMessage.getPublisherId().toLowerCase()
+            const key = streamMessage.getPublisherId()
             const msgs = receivedMessagesMain[key] || []
             msgs.push(streamMessage)
             receivedMessagesMain[key] = msgs
@@ -303,7 +303,7 @@ describe('PubSub with multiple clients', () => {
 
         const published: Record<string, StreamMessage[]> = {}
         await Promise.all(publishers.map(async (pubClient) => {
-            const publisherId = (await pubClient.getAddress()).toLowerCase()
+            const publisherId = await pubClient.getAddress()
             const publishTestMessages = getPublishTestStreamMessages(pubClient, stream, {
                 waitForLast: true,
                 waitForLastTimeout: 35000,
@@ -342,7 +342,7 @@ describe('PubSub with multiple clients', () => {
         const mainSub = await mainClient.subscribe({
             stream: stream.id,
         }, (_content, streamMessage) => {
-            const key = streamMessage.getPublisherId().toLowerCase()
+            const key = streamMessage.getPublisherId()
             const msgs = receivedMessagesMain[key] || []
             msgs.push(streamMessage)
             receivedMessagesMain[key] = msgs
@@ -358,7 +358,7 @@ describe('PubSub with multiple clients', () => {
 
         let counter = 0
         await Promise.all(publishers.map(async (pubClient) => {
-            const publisherId = (await pubClient.getAddress()).toString().toLowerCase()
+            const publisherId = await pubClient.getAddress()
             const publishTestMessages = getPublishTestStreamMessages(pubClient, stream, {
                 waitForLast: true,
                 waitForLastTimeout: 35000,
@@ -374,7 +374,7 @@ describe('PubSub with multiple clients', () => {
                         from: lastMessage.getMessageRef()
                     }
                 }, (_content, streamMessage) => {
-                    const key = streamMessage.getPublisherId().toLowerCase()
+                    const key = streamMessage.getPublisherId()
                     const msgs = receivedMessagesOther[key] || []
                     msgs.push(streamMessage)
                     receivedMessagesOther[key] = msgs

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -95,12 +95,12 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         if (registryItem === undefined) {
             return false
         }
-        const targets = []
+        const targets: Array<EthereumAddress | PublicPermissionTarget> = []
         if (isPublicPermissionQuery(query) || query.allowPublic) {
             targets.push(PUBLIC_PERMISSION_TARGET)
         }
         if ((query as any).user !== undefined) {
-            targets.push((query as any).user.toLowerCase())
+            targets.push(toEthereumAddress((query as any).user))
         }
         return targets.some((target) => registryItem.permissions.get(target).includes(query.permission))
     }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -123,7 +123,7 @@ export const getGroupKeyStore = (userAddress: EthereumAddress): GroupKeyStore =>
     return new GroupKeyStore(
         mockLoggerFactory(),
         {
-            getAddress: () => userAddress.toLowerCase()
+            getAddress: () => userAddress
         } as any,
         new StreamrClientEventEmitter()
     )

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -54,7 +54,7 @@ describe('MessageFactory', () => {
         expect(msg).toMatchObject({
             messageId: {
                 msgChainId: expect.any(String),
-                publisherId: WALLET.address.toLowerCase(),
+                publisherId: toEthereumAddress(WALLET.address),
                 sequenceNumber: 0,
                 streamId: STREAM_ID,
                 streamPartition: expect.toBeWithin(0, PARTITION_COUNT),

--- a/packages/client/test/unit/Validator.test.ts
+++ b/packages/client/test/unit/Validator.test.ts
@@ -8,7 +8,7 @@ import { Validator } from '../../src/Validator'
 import { createMockMessage, mockLoggerFactory } from '../test-utils/utils'
 import { STREAM_CLIENT_DEFAULTS, SubscribeConfig } from '../../src/Config'
 import { fastWallet } from 'streamr-test-utils'
-import { EthereumAddress } from '@streamr/utils'
+import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 
 const publisherWallet = fastWallet()
 const PARTITION_COUNT = 3
@@ -21,7 +21,7 @@ const createMockValidator = (options: Partial<SubscribeConfig>) => {
             } as any
         },
         isStreamPublisher: async (_streamIdOrPath: string, userAddress: EthereumAddress) => {
-            return userAddress.toLowerCase() === publisherWallet.address.toLowerCase()
+            return userAddress === toEthereumAddress(publisherWallet.address)
         }
     }
     return new Validator(

--- a/packages/protocol/src/protocol/message_layer/signature.ts
+++ b/packages/protocol/src/protocol/message_layer/signature.ts
@@ -11,5 +11,5 @@ export const createSignaturePayload = (opts: {
     const prev = ((opts.prevMsgRef !== undefined) ? `${opts.prevMsgRef.timestamp}${opts.prevMsgRef.sequenceNumber}` : '')
     const newGroupKey = ((opts.newGroupKey !== undefined) ? opts.newGroupKey.serialize() : '')
     return `${opts.messageId.streamId}${opts.messageId.streamPartition}${opts.messageId.timestamp}${opts.messageId.sequenceNumber}`
-        + `${opts.messageId.publisherId.toLowerCase()}${opts.messageId.msgChainId}${prev}${opts.serializedContent}${newGroupKey}`
+        + `${opts.messageId.publisherId}${opts.messageId.msgChainId}${prev}${opts.serializedContent}${newGroupKey}`
 }


### PR DESCRIPTION
Remove extraneous uses of `toLowerCase` especially when coupled with `toEthereumAddress` and `EthereumAddress` types