### PR TITLE
refactor(client): Remove caching from signature validation

### DIFF
--- a/packages/client/src/subscribe/SubscribePipeline.ts
+++ b/packages/client/src/subscribe/SubscribePipeline.ts
@@ -35,8 +35,7 @@ export interface SubscriptionPipelineOptions<T> {
 
 export const createSubscribePipeline = <T = unknown>(opts: SubscriptionPipelineOptions<T>): MessageStream<T> => {
     const validate = new Validator(
-        opts.streamRegistryCached,
-        opts.rootConfig.cache
+        opts.streamRegistryCached
     )
 
     const gapFillMessages = new OrderMessages<T>(

--- a/packages/client/test/unit/Validator.test.ts
+++ b/packages/client/test/unit/Validator.test.ts
@@ -24,8 +24,7 @@ const createMockValidator = () => {
         }
     }
     return new Validator(
-        new StreamRegistryCached(mockLoggerFactory(), streamRegistry as any, {} as any) as any,
-        {} as any
+        new StreamRegistryCached(mockLoggerFactory(), streamRegistry as any, {} as any) as any
     )
 }
 


### PR DESCRIPTION
Removed caching from Validator#verify. It is used via `StreamMessageValidator#assertSignatureIsValid` which is when` Validator#validate` is called. 

Caching should not be needed as we validate each message only once. As each message has a distinct signature, each call to `verify` is always a cache-miss.

The feature was originally added in v5: https://github.com/streamr-dev/streamr-client-javascript/commit/7aca0cfe6ac667c1d0c1e5f7b0694be697ac1e80