### PR TITLE
fix(dht, proto-rpc): clean script should not remove generated code

### DIFF
--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -b tsconfig.node.json",
     "build-browser": "webpack --mode=development --progress",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache src/proto || true",
+    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "jest test/unit test/integration test/end-to-end",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -17,7 +17,7 @@
     "build": "tsc -b tsconfig.node.json",
     "build-browser": "webpack --mode=development --progress",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache src/proto test/proto || true",
+    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "jest",


### PR DESCRIPTION
Fix `npm run clean` in both dht and proto-rpc packages to not remove generated protobuf code. Tested by hand and `npm run clean && npm run build` without any changes to git files. 