### PR TITLE
refactor(client): Hide `ResendSubscription` from public API

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -121,18 +121,10 @@ export class StreamrClient {
     /**
      * @category Important
      */
-    subscribe<T>(
-        options: StreamDefinition & { resend: ResendOptions },
-        onMessage?: SubscriptionOnMessage<T>
-    ): Promise<ResendSubscription<T>>
-    subscribe<T>(
-        options: StreamDefinition,
-        onMessage?: SubscriptionOnMessage<T>
-    ): Promise<Subscription<T>>
     async subscribe<T>(
         options: StreamDefinition & { resend?: ResendOptions },
         onMessage?: SubscriptionOnMessage<T>
-    ): Promise<Subscription<T> | ResendSubscription<T>> {
+    ): Promise<Subscription<T>> {
         let result
         if (options.resend !== undefined) {
             result = await this.resendSubscribe(options, options.resend, onMessage)

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -6,10 +6,9 @@ export * from './Stream'
 export { DecryptError } from './encryption/EncryptionUtil'
 export { StreamrClientEvents } from './events'
 export { MessageMetadata } from './publish/Publisher'
-export { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
+export { Subscription, SubscriptionEvents, SubscriptionOnMessage } from './subscribe/Subscription'
 export { MessageStreamOnMessage } from './subscribe/MessageStream'
 export type { MessageStream } from './subscribe/MessageStream'
-export { ResendSubscription, ResendSubscriptionEvents } from './subscribe/ResendSubscription'
 export { ResendOptions, ResendLastOptions, ResendFromOptions, ResendRangeOptions, ResendRef } from './subscribe/Resends'
 export {
     StreamPermission,

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -5,17 +5,11 @@ import { StreamMessage, StreamPartIDUtils } from 'streamr-client-protocol'
 import { ConfigInjectionToken } from '../Config'
 import { OrderMessages } from './OrderMessages'
 import { ResendOptions, Resends } from './Resends'
-import EventEmitter from 'eventemitter3'
 import { DestroySignal } from '../DestroySignal'
 import { LoggerFactory } from '../utils/LoggerFactory'
 
-export interface ResendSubscriptionEvents {
-    resendComplete: () => void
-}
-
 export class ResendSubscription<T> extends Subscription<T> {
     private orderMessages: OrderMessages<T>
-    private eventEmitter: EventEmitter<ResendSubscriptionEvents>
 
     /** @internal */
     constructor(
@@ -25,7 +19,6 @@ export class ResendSubscription<T> extends Subscription<T> {
         container: DependencyContainer
     ) {
         super(subSession, container.resolve(LoggerFactory))
-        this.eventEmitter = new EventEmitter<ResendSubscriptionEvents>()
         this.resendThenRealtime = this.resendThenRealtime.bind(this)
         this.orderMessages = new OrderMessages<T>(
             container.resolve(ConfigInjectionToken.Subscribe),
@@ -57,14 +50,6 @@ export class ResendSubscription<T> extends Subscription<T> {
         })
 
         return resentMsgs
-    }
-
-    once<E extends keyof ResendSubscriptionEvents>(eventName: E, listener: ResendSubscriptionEvents[E]): void {
-        this.eventEmitter.once(eventName, listener as any)
-    }
-
-    off<E extends keyof ResendSubscriptionEvents>(eventName: E, listener: ResendSubscriptionEvents[E]): void {
-        this.eventEmitter.off(eventName, listener as any)
     }
 
     /** @internal */

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -7,8 +7,14 @@ import { MessageStream, MessageStreamOnMessage } from './MessageStream'
 import { SubscriptionSession } from './SubscriptionSession'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { Logger } from '@streamr/utils'
+import EventEmitter from 'eventemitter3'
 
 export { MessageStreamOnMessage as SubscriptionOnMessage }
+
+export interface SubscriptionEvents {
+    error: (err: Error) => void
+    resendComplete: () => void
+}
 
 /**
  * @category Important
@@ -19,17 +25,20 @@ export class Subscription<T = unknown> extends MessageStream<T> {
     /** @internal */
     private readonly logger: Logger
     readonly streamPartId: StreamPartID
+    protected eventEmitter: EventEmitter<SubscriptionEvents>
 
     /** @internal */
     constructor(subSession: SubscriptionSession<T>, loggerFactory: LoggerFactory) {
         super()
         this.subSession = subSession
         this.streamPartId = subSession.streamPartId
+        this.eventEmitter = new EventEmitter<SubscriptionEvents>()
         this.logger = loggerFactory.createLogger(module)
         this.onMessage.listen((msg) => {
             this.logger.debug('onMessage %j', msg.serializedContent)
         })
         this.onError.listen((err) => {
+            this.eventEmitter.emit('error', err)
             this.logger.debug('onError %s', err)
         })
     }
@@ -44,7 +53,15 @@ export class Subscription<T = unknown> extends MessageStream<T> {
         return this.subSession.waitForNeighbours(numNeighbours, timeout)
     }
 
-    on(_eventName: 'error', cb: (err: Error) => void): void {
-        this.onError.listen(cb)
+    on<E extends keyof SubscriptionEvents>(eventName: E, listener: SubscriptionEvents[E]): void {
+        this.eventEmitter.on(eventName, listener as any)
+    }
+
+    once<E extends keyof SubscriptionEvents>(eventName: E, listener: SubscriptionEvents[E]): void {
+        this.eventEmitter.once(eventName, listener as any)
+    }
+
+    off<E extends keyof SubscriptionEvents>(eventName: E, listener: SubscriptionEvents[E]): void {
+        this.eventEmitter.off(eventName, listener as any)
     }
 }


### PR DESCRIPTION
Changed the public API of `StreamrClient#subscribe` to return a Subscription instead of `Subscription` | `ResendSubscription`. 

The `ResendSubscription` is a subclass of `Subscription`, and are no extra methods in that class. There is just an extra event type `resendComplete`. Of course non-resend subscription won't emit that message, but in the big picture our public API is more understandable if we don't have a separate class for resends.

Moved all event types to `Subscription` class. Now `error` event type is just one of the event types.