### PR TITLE
refactor: move metrics to `@streamr/utils`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30253,6 +30253,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "eventemitter3": "^4.0.7",
                 "lodash": "^4.17.21",
                 "pino": "^6.11.3",
                 "pino-pretty": "^5.0.2"
@@ -34280,6 +34281,7 @@
                 "@types/lodash": "^4.14.175",
                 "@types/pino": "^6.3.8",
                 "@types/pino-pretty": "^4.7.0",
+                "eventemitter3": "^4.0.7",
                 "lodash": "^4.17.21",
                 "pino": "^6.11.3",
                 "pino-pretty": "^5.0.2"

--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -1,8 +1,7 @@
 import { Schema } from 'ajv'
 import { Plugin } from '../../Plugin'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
-import { MetricsReport } from 'streamr-network'
-import { Logger } from '@streamr/utils'
+import { Logger, MetricsReport } from '@streamr/utils'
 import { omit } from 'lodash'
 
 const logger = new Logger(module)

--- a/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
+++ b/packages/broker/src/plugins/storage/DataQueryEndpoints.ts
@@ -3,8 +3,7 @@
  */
 import express, { Request, Response, Router } from 'express'
 import { StreamMessage } from 'streamr-client-protocol'
-import { Metric, MetricsContext, RateMetric } from 'streamr-network'
-import { Logger } from '@streamr/utils'
+import { Logger, Metric, MetricsContext, RateMetric } from '@streamr/utils'
 import { Readable, Transform, pipeline } from 'stream'
 import { Storage } from './Storage'
 import { Format, getFormat } from './DataQueryFormat'

--- a/packages/broker/src/plugins/storage/Storage.ts
+++ b/packages/broker/src/plugins/storage/Storage.ts
@@ -1,5 +1,5 @@
 import { auth, Client, types, tracker } from 'cassandra-driver'
-import { MetricsContext, RateMetric } from 'streamr-network'
+import { MetricsContext, RateMetric } from '@streamr/utils'
 import { BatchManager } from './BatchManager'
 import { Readable, Transform } from 'stream'
 import { EventEmitter } from 'events'

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -7,8 +7,7 @@ import { Storage, startCassandraStorage } from './Storage'
 import { StorageConfig } from './StorageConfig'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { Schema } from 'ajv'
-import { MetricsContext } from 'streamr-network'
-import { EthereumAddress, Logger } from '@streamr/utils'
+import { EthereumAddress, Logger, MetricsContext } from '@streamr/utils'
 import { formStorageNodeAssignmentStreamId, Stream } from 'streamr-client'
 
 const logger = new Logger(module)

--- a/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
+++ b/packages/broker/test/unit/plugins/storage/DataQueryEndpoints.test.ts
@@ -1,4 +1,3 @@
-import { MetricsContext } from 'streamr-network'
 import express from 'express'
 import request from 'supertest'
 import { toReadableStream } from 'streamr-test-utils'
@@ -10,7 +9,7 @@ import {
 import { Storage } from '../../../../src/plugins/storage/Storage'
 import { PassThrough } from 'stream'
 import { MessageID, StreamMessage, toStreamID } from 'streamr-client-protocol'
-import { toEthereumAddress } from '@streamr/utils'
+import { MetricsContext, toEthereumAddress } from '@streamr/utils'
 
 const createEmptyStream = () => {
     const stream = new PassThrough()

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -1,12 +1,11 @@
 import { scoped, Lifecycle, inject } from 'tsyringe'
 import { StreamrClientEventEmitter } from './events'
 import { DestroySignal } from './DestroySignal'
-import { MetricsReport } from 'streamr-network'
 import { NetworkNodeFacade, getEthereumAddressFromNodeId } from './NetworkNodeFacade'
 import { Publisher } from './publish/Publisher'
 import { ConfigInjectionToken, MetricsConfig, StrictStreamrClientConfig } from './Config'
 import { pOnce } from './utils/promises'
-import { wait } from '@streamr/utils'
+import { MetricsReport, wait } from '@streamr/utils'
 
 @scoped(Lifecycle.ContainerScoped)
 export class MetricsPublisher {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -3,7 +3,8 @@
  */
 import { inject, Lifecycle, scoped } from 'tsyringe'
 import EventEmitter from 'eventemitter3'
-import { NetworkNodeOptions, createNetworkNode as _createNetworkNode, MetricsContext } from 'streamr-network'
+import { NetworkNodeOptions, createNetworkNode as _createNetworkNode } from 'streamr-network'
+import { MetricsContext } from '@streamr/utils'
 import { uuid } from './utils/uuid'
 import { pOnce } from './utils/promises'
 import { NetworkConfig, ConfigInjectionToken, TrackerRegistrySmartContract } from './Config'

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -1,5 +1,4 @@
-import { keyToArrayIndex } from '@streamr/utils'
-import { MetricsReport } from 'streamr-network'
+import { keyToArrayIndex, MetricsReport } from '@streamr/utils'
 import { fetchPrivateKeyWithGas, waitForCondition } from 'streamr-test-utils'
 import { StreamPermission } from '../../src/permission'
 import { Stream } from '../../src/Stream'

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -1,8 +1,8 @@
 import { Lifecycle, scoped } from 'tsyringe'
 import { pull } from 'lodash'
 import { ProxyDirection, StreamMessage, StreamPartID } from 'streamr-client-protocol'
-import { MetricsContext, NodeId } from 'streamr-network'
-import { NetworkNodeOptions } from 'streamr-network'
+import { MetricsContext } from '@streamr/utils'
+import { NodeId, NetworkNodeOptions } from 'streamr-network'
 import { NetworkNodeFactory, NetworkNodeStub } from '../../../src/NetworkNodeFacade'
 import { FakeNetwork } from './FakeNetwork'
 

--- a/packages/network-tracker/src/logic/InstructionAndStatusAckSender.ts
+++ b/packages/network-tracker/src/logic/InstructionAndStatusAckSender.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import { StreamPartID } from 'streamr-client-protocol'
-import { NodeId, MetricsContext, MetricsDefinition, Metric, RateMetric } from 'streamr-network'
-import { Logger } from '@streamr/utils'
+import { NodeId } from 'streamr-network'
+import { Logger, MetricsContext, MetricsDefinition, Metric, RateMetric } from '@streamr/utils'
 import { TopologyStabilizationOptions } from './Tracker'
 
 /**

--- a/packages/network-tracker/src/logic/Tracker.ts
+++ b/packages/network-tracker/src/logic/Tracker.ts
@@ -15,13 +15,9 @@ import {
     StreamPartStatus,
     DisconnectionCode,
     DisconnectionReason,
-    MetricsContext,
     COUNTER_UNSUBSCRIBE,
-    MetricsDefinition,
-    Metric,
-    RateMetric
 } from 'streamr-network'
-import { Logger } from '@streamr/utils'
+import { Logger, MetricsContext, MetricsDefinition, Metric, RateMetric } from '@streamr/utils'
 import { InstructionAndStatusAckSender } from './InstructionAndStatusAckSender'
 import { StatusValidator } from '../helpers/SchemaValidators'
 

--- a/packages/network-tracker/src/startTracker.ts
+++ b/packages/network-tracker/src/startTracker.ts
@@ -5,12 +5,12 @@ import { trackerHttpEndpoints } from './logic/trackerHttpEndpoints'
 import {
     AbstractNodeOptions,
     HttpServerConfig,
-    MetricsContext,
     PeerInfo,
     ServerWsEndpoint,
     startHttpServer,
     DEFAULT_MAX_NEIGHBOR_COUNT
 } from 'streamr-network'
+import { MetricsContext } from '@streamr/utils'
 
 export interface TrackerOptions extends AbstractNodeOptions {
     listen: HttpServerConfig

--- a/packages/network-tracker/test/unit/InstructionAndStatusAckSender.test.ts
+++ b/packages/network-tracker/test/unit/InstructionAndStatusAckSender.test.ts
@@ -5,7 +5,7 @@ import {
     SendInstructionFn,
     SendStatusAckFn, StatusAck,
 } from '../../src/logic/InstructionAndStatusAckSender'
-import { MetricsContext } from 'streamr-network'
+import { MetricsContext } from '@streamr/utils'
 
 const MOCK_STREAM_PART_1 = StreamPartIDUtils.parse('stream-id#1')
 const MOCK_STREAM_PART_2 = StreamPartIDUtils.parse('stream-id#2')

--- a/packages/network/src/browser.ts
+++ b/packages/network/src/browser.ts
@@ -1,9 +1,6 @@
 import 'setimmediate'
 export { NameDirectory } from './NameDirectory'
-export { Logger } from '@streamr/utils'
-export { 
-    MetricsContext
-} from './helpers/Metric'
+export { Logger, MetricsContext } from '@streamr/utils'
 export { Location, AbstractNodeOptions } from './identifiers'
 export { createNetworkNode, NetworkNodeOptions } from './createNetworkNode'
 export { NetworkNode } from './logic/NetworkNode'

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -1,17 +1,6 @@
 import 'setimmediate'
 import NodeClientWsEndpoint from './connection/ws/NodeClientWsEndpoint'
 export { NodeClientWsEndpoint }
-export { 
-    Metric, 
-    MetricsDefinition, 
-    Sampler,
-    CountMetric, 
-    AverageMetric, 
-    LevelMetric, 
-    RateMetric,
-    MetricsContext, 
-    MetricsReport
-} from './helpers/Metric'
 export {
     Location,
     AbstractNodeOptions,

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -4,7 +4,7 @@ import { Logger } from "@streamr/utils"
 import { PeerId, PeerInfo } from '../PeerInfo'
 import { DeferredConnectionAttempt } from './DeferredConnectionAttempt'
 import { WebRtcConnection, ConstructorOptions, isOffering } from './WebRtcConnection'
-import { CountMetric, LevelMetric, Metric, MetricsContext, MetricsDefinition, RateMetric } from '../../helpers/Metric'
+import { CountMetric, LevelMetric, Metric, MetricsContext, MetricsDefinition, RateMetric } from '@streamr/utils'
 import {
     AnswerOptions,
     ConnectOptions,

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
-import { MetricsContext } from './helpers/Metric'
+import { MetricsContext } from '@streamr/utils'
 
 import { AbstractNodeOptions } from './identifiers'
 import { NodeToTracker } from './protocol/NodeToTracker'

--- a/packages/network/src/identifiers.ts
+++ b/packages/network/src/identifiers.ts
@@ -1,5 +1,5 @@
 import { StreamID } from 'streamr-client-protocol'
-import { MetricsContext } from './helpers/Metric'
+import { MetricsContext } from '@streamr/utils'
 
 export type NodeId = string
 export type TrackerId = string

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -9,7 +9,7 @@ import {
 } from 'streamr-client-protocol'
 import { Event as NodeToNodeEvent, NodeToNode } from '../protocol/NodeToNode'
 import { NodeToTracker } from '../protocol/NodeToTracker'
-import { Metric, MetricsContext, MetricsDefinition, RateMetric } from '../helpers/Metric'
+import { Metric, MetricsContext, MetricsDefinition, RateMetric } from '@streamr/utils'
 import { StreamPartManager } from './StreamPartManager'
 import { GapMisMatchError, InvalidNumberingError } from './DuplicateMessageDetector'
 import { Logger, withTimeout } from "@streamr/utils"

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -20,7 +20,7 @@ import { Event as NodeToTrackerEvent, NodeToTracker } from '../../src/protocol/N
 import { PeerInfo } from '../../src/connection/PeerInfo'
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { NegotiatedProtocolVersions } from '../../src/connection/NegotiatedProtocolVersions'
-import { MetricsContext } from '../../src/helpers/Metric'
+import { MetricsContext } from '@streamr/utils'
 import { WebRtcEndpoint } from '../../src/connection/webrtc/WebRtcEndpoint'
 import { webRtcConnectionFactory } from '../../src/connection/webrtc/NodeWebRtcConnection'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'

--- a/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
+++ b/packages/network/test/integration/node-to-node-protocol-version-negotiation.test.ts
@@ -1,6 +1,6 @@
 import { Event as wrtcEvent } from '../../src/connection/webrtc/IWebRtcEndpoint'
 import { PeerInfo, PeerType } from '../../src/connection/PeerInfo'
-import { MetricsContext } from '../../src/helpers/Metric'
+import { MetricsContext } from '@streamr/utils'
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { Tracker, startTracker } from '@streamr/network-tracker'
 import { NodeToTracker } from '../../src/protocol/NodeToTracker'

--- a/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/packages/network/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -1,6 +1,6 @@
 import { Event } from '../../src/connection/webrtc/IWebRtcEndpoint'
 import { PeerInfo } from '../../src/connection/PeerInfo'
-import { MetricsContext } from '../../src/helpers/Metric'
+import { MetricsContext } from '@streamr/utils'
 import { RtcSignaller } from '../../src/logic/RtcSignaller'
 import { startTracker, Tracker } from '@streamr/network-tracker'
 import NodeClientWsEndpoint from '../../src/connection/ws/NodeClientWsEndpoint'

--- a/packages/network/test/integration/webrtc-multi-signaller.test.ts
+++ b/packages/network/test/integration/webrtc-multi-signaller.test.ts
@@ -1,4 +1,4 @@
-import { MetricsContext } from '../../src/composition'
+import { MetricsContext } from '@streamr/utils'
 import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { Tracker, TrackerEvent, startTracker } from '@streamr/network-tracker'
 import { PeerInfo } from '../../src/connection/PeerInfo'

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -1,4 +1,4 @@
-import { MetricsContext } from '../../src/composition'
+import { MetricsContext } from '@streamr/utils'
 import { NodeToTracker } from '../../src/protocol/NodeToTracker'
 import { Tracker, TrackerEvent, startTracker } from '@streamr/network-tracker'
 import { PeerInfo } from '../../src/connection/PeerInfo'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,6 +28,7 @@
   "author": "Streamr <contact@streamr.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "eventemitter3": "^4.0.7",
     "lodash": "^4.17.21",
     "pino": "^6.11.3",
     "pino-pretty": "^5.0.2"

--- a/packages/utils/src/Metric.ts
+++ b/packages/utils/src/Metric.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3'
 import { set } from 'lodash'
-import { scheduleAtFixedRate } from '@streamr/utils'
+import { scheduleAtFixedRate } from './scheduleAtFixedRate'
 
 export type MetricsDefinition = Record<string, Metric>
 

--- a/packages/utils/src/Metric.ts
+++ b/packages/utils/src/Metric.ts
@@ -8,7 +8,7 @@ interface MetricEvents {
     record: (value: number) => void
 }
 
-export abstract class Sampler {
+abstract class Sampler {
 
     protected readonly metric: Metric
     private readonly listener: any

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -4,6 +4,15 @@ import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
 import { isENSName } from './isENSName'
 import { keyToArrayIndex } from './keyToArrayIndex'
 import { Logger } from './Logger'
+import {
+    CountMetric,
+    Metric,
+    LevelMetric,
+    MetricsContext,
+    MetricsDefinition,
+    MetricsReport,
+    RateMetric
+} from './Metric'
 import { Multimap } from './Multimap'
 import { randomString } from './randomString'
 import { scheduleAtFixedRate } from './scheduleAtFixedRate'
@@ -34,4 +43,14 @@ export {
     wait,
     waitForEvent,
     withTimeout,
+}
+
+export {
+    CountMetric,
+    LevelMetric,
+    Metric,
+    MetricsContext,
+    MetricsDefinition,
+    MetricsReport,
+    RateMetric
 }

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -1,6 +1,6 @@
 import { waitForCondition } from 'streamr-test-utils'
 import { wait } from '@streamr/utils'
-import { AverageMetric, CountMetric, LevelMetric, MetricsContext, MetricsReport, RateMetric } from '../../src/helpers/Metric'
+import { AverageMetric, CountMetric, LevelMetric, MetricsContext, MetricsReport, RateMetric } from '../src/Metric'
 
 const REPORT_INTERVAL = 100
 const ONE_SECOND = 1000


### PR DESCRIPTION
Move metrics related code from network to utils package.

## Changes

- Move `Metrics.ts` and the accompanying unit test to `@streamr/utils`.
- Fix imports in network, client, and broker packages accordingly.
- Network package no longer exports metrics related classes and functions.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
