### PR TITLE
deps(broker): remove `streamr-network`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29673,7 +29673,6 @@
                 "qs": "^6.10.1",
                 "streamr-client": "7.0.0-beta.0",
                 "streamr-client-protocol": "^13.0.0",
-                "streamr-network": "^36.0.0",
                 "uuid": "^8.3.2",
                 "ws": "^7.5.0"
             },
@@ -51446,7 +51445,6 @@
                 "stream-to-array": "^2.3.0",
                 "streamr-client": "7.0.0-beta.0",
                 "streamr-client-protocol": "^13.0.0",
-                "streamr-network": "^36.0.0",
                 "streamr-test-utils": "^2.0.0",
                 "supertest": "^6.1.3",
                 "uuid": "^8.3.2",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -52,7 +52,6 @@
     "qs": "^6.10.1",
     "streamr-client": "7.0.0-beta.0",
     "streamr-client-protocol": "^13.0.0",
-    "streamr-network": "^36.0.0",
     "uuid": "^8.3.2",
     "ws": "^7.5.0"
   },


### PR DESCRIPTION
## Summary

Remove `streamr-network` as depdency from broker package as it is not used there (directly).

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
