### PR TITLE
feat(utils): abortable wait and `asAbortable`

### DIFF
--- a/packages/utils/src/AbortError.ts
+++ b/packages/utils/src/AbortError.ts
@@ -1,0 +1,9 @@
+export class AbortError extends Error {
+    readonly code = 'AbortError'
+    constructor(customErrorContext?: string) {
+        super(customErrorContext === undefined
+            ? `aborted`
+            : `${customErrorContext} aborted`)
+        Error.captureStackTrace(this, AbortError)
+    }
+}

--- a/packages/utils/src/AbortError.ts
+++ b/packages/utils/src/AbortError.ts
@@ -1,9 +1,0 @@
-export class AbortError extends Error {
-    readonly code = 'AbortError'
-    constructor(customErrorContext?: string) {
-        super(customErrorContext === undefined
-            ? `aborted`
-            : `${customErrorContext} aborted`)
-        Error.captureStackTrace(this, AbortError)
-    }
-}

--- a/packages/utils/src/asAbortable.ts
+++ b/packages/utils/src/asAbortable.ts
@@ -1,0 +1,44 @@
+export class AbortError extends Error {
+    readonly code = 'AbortError'
+    constructor(customErrorContext?: string) {
+        super(customErrorContext === undefined
+            ? `aborted`
+            : `${customErrorContext} aborted`)
+        Error.captureStackTrace(this, AbortError)
+    }
+}
+
+/**
+ * Wraps a Promise into one that can be aborted with `AbortController`.
+ * Aborting causes the returned Promise to reject with `AbortError` unless
+ * the underlying promise itself has already resolved or rejected.
+ *
+ * Notice that it is the user's responsibility to implement any custom cleanup
+ * logic in a `finally` or `catch` block in case of resources that need to be
+ * freed up.
+ */
+export function asAbortable<T>(
+    promise: Promise<T>,
+    abortController?: AbortController,
+    customErrorContext?: string
+): Promise<T> {
+    if (abortController?.signal.aborted === true) {
+        return Promise.reject(new AbortError(customErrorContext))
+    }
+    let abortListener: () => void
+    return new Promise<T>((resolve, reject) => {
+        if (abortController?.signal !== undefined) {
+            abortListener = () => {
+                reject(new AbortError(customErrorContext))
+            }
+            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+            (abortController.signal as any).addEventListener('abort', abortListener)
+        }
+        promise.then(resolve, reject)
+    }).finally(() => {
+        if (abortListener !== undefined) {
+            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
+            (abortController!.signal as any).removeEventListener('abort', abortListener)
+        }
+    })
+}

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -1,4 +1,4 @@
-import { AbortError } from './AbortError'
+import { AbortError, asAbortable } from './asAbortable'
 import { Defer } from './Defer'
 import { ENSName, toENSName } from './ENSName'
 import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
@@ -33,6 +33,7 @@ export {
     Multimap,
     AbortError,
     TimeoutError,
+    asAbortable,
     isENSName,
     keyToArrayIndex,
     randomString,

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -1,3 +1,4 @@
+import { AbortError } from './AbortError'
 import { Defer } from './Defer'
 import { ENSName, toENSName } from './ENSName'
 import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
@@ -21,7 +22,7 @@ import { toEthereumAddressOrENSName } from './toEthereumAddressOrENSName'
 import { BrandedString } from './types'
 import { wait } from './wait'
 import { waitForEvent } from './waitForEvent'
-import { AbortError, TimeoutError, withTimeout } from './withTimeout'
+import { TimeoutError, withTimeout } from './withTimeout'
 
 export {
     BrandedString,

--- a/packages/utils/src/wait.ts
+++ b/packages/utils/src/wait.ts
@@ -1,31 +1,19 @@
-import { AbortError } from './AbortError'
+import { asAbortable } from './asAbortable'
 
 /**
  * Wait for a specific time
  * @param ms time to wait for in milliseconds
- * @param abortController to control cancellation of any wait
+ * @param abortController to control abortion of any wait
  * @returns {Promise<void>} resolves when time has passed
  */
 export function wait(ms: number, abortController?: AbortController): Promise<void> {
-    if (abortController?.signal?.aborted === true) {
-        return Promise.reject(new AbortError())
-    }
     let timeoutRef: NodeJS.Timeout
-    let abortListener: () => void
-    return new Promise<void>((resolve, reject) => {
-        if (abortController !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-            abortListener = () => {
-                reject(new AbortError())
-            }
-            (abortController.signal as any).addEventListener('abort', abortListener)
-        }
-        timeoutRef = setTimeout(resolve, ms)
-    }).finally(() => {
+    return asAbortable(
+        new Promise<void>((resolve) => {
+            timeoutRef = setTimeout(resolve, ms)
+        }),
+        abortController
+    ).finally(() => {
         clearTimeout(timeoutRef)
-        if (abortListener !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-            (abortController!.signal as any).removeEventListener('abort', abortListener)
-        }
     })
 }

--- a/packages/utils/src/wait.ts
+++ b/packages/utils/src/wait.ts
@@ -1,6 +1,19 @@
+import { setTimeout } from 'timers/promises'
+import { AbortError } from './AbortError'
+
 /**
  * Wait for a specific time
  * @param ms time to wait for in milliseconds
+ * @param abortController to control cancellation of any wait
  * @returns {Promise<void>} resolves when time has passed
  */
-export const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+export const wait = (ms: number, abortController?: AbortController): Promise<void> => setTimeout(
+    ms,
+    undefined,
+    { signal: abortController?.signal }
+).catch((e) => {
+    if (e?.code === 'ABORT_ERR') {
+        throw new AbortError()
+    }
+    throw e
+})

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -1,4 +1,4 @@
-import { AbortError } from './AbortError'
+import { asAbortable } from './asAbortable'
 
 export class TimeoutError extends Error {
     readonly code = 'TimeoutError'
@@ -16,30 +16,19 @@ export const withTimeout = <T>(
     customErrorContext?: string,
     abortController?: AbortController
 ): Promise<T> => {
-    if (abortController?.signal?.aborted === true) {
-        return Promise.reject(new AbortError(customErrorContext))
-    }
     let timeoutRef: NodeJS.Timeout
-    let abortListener: () => void
-    return Promise.race([
-        task,
-        new Promise<T>((_resolve, reject) => {
-            timeoutRef = setTimeout(() => {
-                reject(new TimeoutError(timeoutInMs, customErrorContext))
-            }, timeoutInMs)
-            if (abortController !== undefined) {
-                // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-                abortListener = () => {
-                    reject(new AbortError(customErrorContext))
-                }
-                (abortController.signal as any).addEventListener('abort', abortListener)
-            }
-        })
-    ]).finally(() => {
-        clearTimeout(timeoutRef) // clear timeout if promise wins race
-        if (abortListener !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-            (abortController!.signal as any).removeEventListener('abort', abortListener)
-        }
+    return asAbortable(
+        Promise.race([
+            task,
+            new Promise<T>((_resolve, reject) => {
+                timeoutRef = setTimeout(() => {
+                    reject(new TimeoutError(timeoutInMs, customErrorContext))
+                }, timeoutInMs)
+            })
+        ]),
+        abortController,
+        customErrorContext
+    ).finally(() => {
+        clearTimeout(timeoutRef)
     })
 }

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -1,3 +1,5 @@
+import { AbortError } from './AbortError'
+
 export class TimeoutError extends Error {
     readonly code = 'TimeoutError'
     constructor(timeoutInMs: number, customErrorContext?: string) {
@@ -5,16 +7,6 @@ export class TimeoutError extends Error {
             ? `timed out after ${timeoutInMs} ms`
             : `${customErrorContext} (timed out after ${timeoutInMs} ms)`)
         Error.captureStackTrace(this, TimeoutError)
-    }
-}
-
-export class AbortError extends Error {
-    readonly code = 'AbortError'
-    constructor(customErrorContext?: string) {
-        super(customErrorContext === undefined
-            ? `aborted`
-            : `${customErrorContext} aborted`)
-        Error.captureStackTrace(this, AbortError)
     }
 }
 

--- a/packages/utils/test/asAbortable.test.ts
+++ b/packages/utils/test/asAbortable.test.ts
@@ -1,0 +1,58 @@
+import { AbortError, asAbortable } from '../src/asAbortable'
+
+const sleep = (ms: number) => new Promise<string>((resolve) => setTimeout(() => resolve('foobar'), ms))
+
+const TIME_UNIT = 10
+
+describe(asAbortable, () => {
+    it('works without abortController', async () => {
+        const actual = await asAbortable(
+            sleep(TIME_UNIT)
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('resolves if no abort controller signalled', async () => {
+        const actual = await asAbortable(
+            sleep(TIME_UNIT),
+            new AbortController()
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('rejects if abort controller signalled before given promise resolves', async () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, TIME_UNIT)
+        const actual = asAbortable(
+            sleep(2 * TIME_UNIT),
+            abortController,
+            'customError'
+        )
+        return expect(actual).rejects.toEqual(new AbortError('customError'))
+    })
+
+    it('resolves if abort controller signalled after given promise resolved', async () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, 2 * TIME_UNIT)
+        const actual = await asAbortable(
+            sleep(TIME_UNIT),
+            abortController
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('rejects if given pre-aborted controller', () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        const actual = asAbortable(
+            sleep(TIME_UNIT),
+            abortController,
+            'customError'
+        )
+        return expect(actual).rejects.toEqual(new AbortError('customError'))
+    })
+})

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -1,13 +1,28 @@
 import { wait } from '../src/wait'
+import { AbortError } from '../src/AbortError'
 
 describe(wait, () => {
     // https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate
     const JITTER_FACTOR = 4
 
-    it("waits at least the predetermined time", async () => {
+    it('waits at least the predetermined time', async () => {
         const start = Date.now()
         await wait(20)
         const end = Date.now()
         expect(end - start).toBeGreaterThanOrEqual(20 - JITTER_FACTOR)
+    })
+
+    it('rejects if aborted during wait', () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, 10)
+        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
+    })
+
+    it('rejects if initially aborted', () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
     })
 })

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -1,5 +1,5 @@
 import { wait } from '../src/wait'
-import { AbortError } from '../src/AbortError'
+import { AbortError } from '../src/asAbortable'
 
 describe(wait, () => {
     // https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -1,5 +1,5 @@
 import { TimeoutError, withTimeout } from '../src/withTimeout'
-import { AbortError } from '../src/AbortError'
+import { AbortError } from '../src/asAbortable'
 
 describe(withTimeout, () => {
     it('resolves if given promise resolves before timeout', () => {

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -1,4 +1,5 @@
-import { AbortError, TimeoutError, withTimeout } from '../src/withTimeout'
+import { TimeoutError, withTimeout } from '../src/withTimeout'
+import { AbortError } from '../src/AbortError'
 
 describe(withTimeout, () => {
     it('resolves if given promise resolves before timeout', () => {


### PR DESCRIPTION
## Summary

Add support for `AbortController` in function `wait`. This allows a user to prematurely cancel `wait` leading to promise rejection. Add new exported function `asAbortable` with which one can turn any Promise into one that can be aborted.

## Changes
- Add `AbortController` support to `wait` in similar style as was done with `withTimeout` before.
- Add new function `asAbortable` which can be used to wrap any Promise into one that can be aborted. Resource cleanup, however, is not handled automatically and needs to be implemented by user of said function.
- Implement both `wait` and `withTimeout` using `asAbortable` to avoid repetition.

## Limitations and future improvements
- The `setTimeout` implementation could be drastically simpler (see my 1st commit e9fc9b57da240e8d434012684ae6334d9584500d) by using [`timers/promises`](https://nodejs.org/api/timers.html#timerspromisessettimeoutdelay-value-options) introduced in Node.js v16. However, this is not supported by browsers.
- Add support for `customErrorContext` similar to `withTimeout`?

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
