### PR TITLE
test(client): Fix `no storage assigned` resend test

### DIFF
--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -196,11 +196,8 @@ describe('Resends2', () => {
                     }
                 })
 
-                sub.onError.listen((err: any) => {
-                    if (err.code === 'NO_STORAGE_NODES') { return }
-
-                    throw err
-                })
+                const onError = jest.fn()
+                sub.onError.listen(onError)
 
                 const publishedMessages = await publishTestMessages(3, nonStoredStream.id)
 
@@ -209,7 +206,6 @@ describe('Resends2', () => {
                 const onResent = jest.fn(() => {
                     expect(receivedMsgs).toEqual([])
                 })
-
                 sub.once('resendComplete', onResent)
 
                 for await (const msg of sub) {
@@ -221,6 +217,7 @@ describe('Resends2', () => {
 
                 expect(receivedMsgs).toHaveLength(publishedMessages.length)
                 expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedMessages.map((m) => m.signature))
+                expect(onError).toHaveBeenCalledTimes(0)
                 expect(onResent).toHaveBeenCalledTimes(1)
                 expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
             })

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -524,32 +524,6 @@ describe('Resends2', () => {
                 expect(msgs.map((m) => m.signature)).toEqual(published.slice(0, END_AFTER).map((m) => m.signature))
                 expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
-
-            it('no storage assigned', async () => {
-                const nonStoredStream = await createTestStream(client, module)
-                await nonStoredStream.grantPermissions({
-                    user: publisherWallet.address,
-                    permissions: [StreamPermission.PUBLISH]
-                })
-                const sub = await client.subscribe({
-                    streamId: nonStoredStream.id,
-                    resend: {
-                        last: 5
-                    }
-                })
-                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(1)
-
-                const onResent = jest.fn()
-                sub.once('resendComplete', onResent)
-
-                const publishedMessages = await publishTestMessages(2, nonStoredStream.id)
-
-                const receivedMsgs = await sub.collect(publishedMessages.length)
-                expect(receivedMsgs).toHaveLength(publishedMessages.length)
-                expect(onResent).toHaveBeenCalledTimes(1)
-                expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedMessages.map((m) => m.signature))
-                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
-            })
         })
     })
 

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -183,8 +183,14 @@ describe('Resends2', () => {
             })
 
             it('no storage assigned', async () => {
+                const nonStoredStream = await createTestStream(client, module)
+                await nonStoredStream.grantPermissions({
+                    user: publisherWallet.address,
+                    permissions: [StreamPermission.PUBLISH]
+                })
+
                 const sub = await client.subscribe({
-                    streamId: stream.id,
+                    streamId: nonStoredStream.id,
                     resend: {
                         last: 100
                     }
@@ -196,7 +202,7 @@ describe('Resends2', () => {
                     throw err
                 })
 
-                const publishedStream2 = await publishTestMessages(3)
+                const publishedMessages = await publishTestMessages(3, nonStoredStream.id)
 
                 const receivedMsgs: any[] = []
 
@@ -208,15 +214,15 @@ describe('Resends2', () => {
 
                 for await (const msg of sub) {
                     receivedMsgs.push(msg)
-                    if (receivedMsgs.length === publishedStream2.length) {
+                    if (receivedMsgs.length === publishedMessages.length) {
                         break
                     }
                 }
 
-                expect(receivedMsgs).toHaveLength(publishedStream2.length)
-                expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedStream2.map((m) => m.signature))
+                expect(receivedMsgs).toHaveLength(publishedMessages.length)
+                expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedMessages.map((m) => m.signature))
                 expect(onResent).toHaveBeenCalledTimes(1)
-                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
+                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
             })
         })
     })

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -78,8 +78,9 @@ describe('Resends2', () => {
         }).rejects.toThrow('streamPartition')
     })
 
-    describe('no data', () => {
-        it('handles nothing to resend', async () => {
+    describe('no historical messages available', () => {
+
+        it('happy path', async () => {
             const sub = await client.resend({
                 streamId: stream.id,
                 partition: 0,
@@ -92,7 +93,7 @@ describe('Resends2', () => {
         })
 
         describe('resendSubscribe', () => {
-            it('sees realtime when no resend', async () => {
+            it('happy path', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -175,7 +176,7 @@ describe('Resends2', () => {
                 expect(onSubError).toHaveBeenCalledTimes(1)
             })
 
-            it('sees realtime when no storage assigned', async () => {
+            it('no storage assigned', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -214,7 +215,7 @@ describe('Resends2', () => {
         })
     })
 
-    describe('with resend data', () => {
+    describe('historical messages available', () => {
         let published: StreamMessage[]
 
         beforeEach(async () => {
@@ -351,7 +352,7 @@ describe('Resends2', () => {
         })
 
         describe('resendSubscribe', () => {
-            it('sees resends and realtime', async () => {
+            it('happy path', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -385,7 +386,7 @@ describe('Resends2', () => {
                 expect(received.map((m) => m.signature)).toEqual(published.slice(-2).map((m) => m.signature))
             })
 
-            it('sees resends when no realtime', async () => {
+            it('receives historical messages when no realtime messages available', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -515,7 +516,7 @@ describe('Resends2', () => {
                 expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
-            it('does not error if no storage assigned', async () => {
+            it('no storage assigned', async () => {
                 const nonStoredStream = await createTestStream(client, module)
                 const sub = await client.subscribe({
                     streamId: nonStoredStream.id,


### PR DESCRIPTION
## Summary

Fixed `"no historical messages available / resendSubscribe / no storage assigned"` test cases which was earlier refactored in this PR: https://github.com/streamr-dev/network-monorepo/pull/795. In that refactoring the test was incorrectly modified to use a stream which has a storage node assigned. Now that test cases creates a separate stream (and doesn't assign it to a storage node).

Added also assertion that `onError` is not called.

## Open questions

Why we have a special handling for `resendSubscribe` (`client.subscribe({..., resend: {}})`) to not to throw if there is no storage node assigned? (`ResendSubscription:60`). Maybe it would make more sense that it would throw, similarly as `client.resend` does?
- if we want to unify the behavior we could remove the `"no historical messages available / resendSubscribe / no storage assigned"` test case altogether

## Other changes

- Improved test naming
- Removed a test case from `"historical messages available"` section. The test case simulated a situation where storage node was not assigned. That didn't didn't make any sense: if there is no storage node, there can't be "historical messages available".
- Added local `publishTestMessages` utility method so that it can publish to a non-default stream.

## Limitations and future improvements

It is not clear whether we should assert subscription count at the end of each test case. The subscription count is 0 because we iterate the received messages (e.g. by `collect` or by `for await` loop). That triggers the unsubscribe. Therefore those subscription counts asserts our test logic instead of production functionality. Related PR: https://github.com/streamr-dev/network-monorepo/pull/924.

