### PR TITLE
fix(client): Error code field name

### DIFF
--- a/packages/client/src/StreamrClientError.ts
+++ b/packages/client/src/StreamrClientError.ts
@@ -1,7 +1,7 @@
 export type StreamrClientErrorCode = 'NO_STORAGE_NODES' | 'INVALID_ARGUMENT' | 'CLIENT_IS_DESTROYED' | 'PIPELINE_ERROR'
 
 export class StreamrClientError extends Error {
-    constructor(message: string, public readonly errorCode: StreamrClientErrorCode) {
+    constructor(message: string, public readonly code: StreamrClientErrorCode) {
         super(message)
         this.name = this.constructor.name
     }

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -196,11 +196,8 @@ describe('Resends2', () => {
                     }
                 })
 
-                sub.onError.listen((err: any) => {
-                    if (err.code === 'NO_STORAGE_NODES') { return }
-
-                    throw err
-                })
+                const onError = jest.fn()
+                sub.onError.listen(onError)
 
                 const publishedMessages = await publishTestMessages(3, nonStoredStream.id)
 
@@ -209,7 +206,6 @@ describe('Resends2', () => {
                 const onResent = jest.fn(() => {
                     expect(receivedMsgs).toEqual([])
                 })
-
                 sub.once('resendComplete', onResent)
 
                 for await (const msg of sub) {
@@ -221,6 +217,7 @@ describe('Resends2', () => {
 
                 expect(receivedMsgs).toHaveLength(publishedMessages.length)
                 expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedMessages.map((m) => m.signature))
+                expect(onError).toHaveBeenCalledTimes(0)
                 expect(onResent).toHaveBeenCalledTimes(1)
                 expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
             })

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -183,8 +183,14 @@ describe('Resends2', () => {
             })
 
             it('no storage assigned', async () => {
+                const nonStoredStream = await createTestStream(client, module)
+                await nonStoredStream.grantPermissions({
+                    user: publisherWallet.address,
+                    permissions: [StreamPermission.PUBLISH]
+                })
+
                 const sub = await client.subscribe({
-                    streamId: stream.id,
+                    streamId: nonStoredStream.id,
                     resend: {
                         last: 100
                     }
@@ -196,7 +202,7 @@ describe('Resends2', () => {
                     throw err
                 })
 
-                const publishedStream2 = await publishTestMessages(3)
+                const publishedMessages = await publishTestMessages(3, nonStoredStream.id)
 
                 const receivedMsgs: any[] = []
 
@@ -208,15 +214,15 @@ describe('Resends2', () => {
 
                 for await (const msg of sub) {
                     receivedMsgs.push(msg)
-                    if (receivedMsgs.length === publishedStream2.length) {
+                    if (receivedMsgs.length === publishedMessages.length) {
                         break
                     }
                 }
 
-                expect(receivedMsgs).toHaveLength(publishedStream2.length)
-                expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedStream2.map((m) => m.signature))
+                expect(receivedMsgs).toHaveLength(publishedMessages.length)
+                expect(receivedMsgs.map((m) => m.signature)).toEqual(publishedMessages.map((m) => m.signature))
                 expect(onResent).toHaveBeenCalledTimes(1)
-                expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
+                expect(await client.getSubscriptions(nonStoredStream.id)).toHaveLength(0)
             })
         })
     })

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -78,8 +78,9 @@ describe('Resends2', () => {
         }).rejects.toThrow('streamPartition')
     })
 
-    describe('no data', () => {
-        it('handles nothing to resend', async () => {
+    describe('no historical messages available', () => {
+
+        it('happy path', async () => {
             const sub = await client.resend({
                 streamId: stream.id,
                 partition: 0,
@@ -92,7 +93,7 @@ describe('Resends2', () => {
         })
 
         describe('resendSubscribe', () => {
-            it('sees realtime when no resend', async () => {
+            it('happy path', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -175,7 +176,7 @@ describe('Resends2', () => {
                 expect(onSubError).toHaveBeenCalledTimes(1)
             })
 
-            it('sees realtime when no storage assigned', async () => {
+            it('no storage assigned', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -214,7 +215,7 @@ describe('Resends2', () => {
         })
     })
 
-    describe('with resend data', () => {
+    describe('historical messages available', () => {
         let published: StreamMessage[]
 
         beforeEach(async () => {
@@ -351,7 +352,7 @@ describe('Resends2', () => {
         })
 
         describe('resendSubscribe', () => {
-            it('sees resends and realtime', async () => {
+            it('happy path', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -385,7 +386,7 @@ describe('Resends2', () => {
                 expect(received.map((m) => m.signature)).toEqual(published.slice(-2).map((m) => m.signature))
             })
 
-            it('sees resends when no realtime', async () => {
+            it('receives historical messages when no realtime messages available', async () => {
                 const sub = await client.subscribe({
                     streamId: stream.id,
                     resend: {
@@ -515,7 +516,7 @@ describe('Resends2', () => {
                 expect(await client.getSubscriptions(stream.id)).toHaveLength(0)
             })
 
-            it('does not error if no storage assigned', async () => {
+            it('no storage assigned', async () => {
                 const nonStoredStream = await createTestStream(client, module)
                 const sub = await client.subscribe({
                     streamId: nonStoredStream.id,


### PR DESCRIPTION
## Summary

Rename `StreamrClientError` error code field name to `code` (was `errorCode`). Before this https://github.com/streamr-dev/network-monorepo/pull/881  we used `code`, at least for `NO_STORAGE_NODES` (which was set explicitly). The code is the same field name as used in Node:
- https://nodejs.org/api/errors.html#errorcode
- usages:
  - https://github.com/streamr-dev/network-monorepo/blob/72fcada9ec4fbfb5f733a77761a365f86600d2a4/packages/client/src/subscribe/ResendSubscription.ts#L60
 - https://github.com/streamr-dev/network-monorepo/blob/72fcada9ec4fbfb5f733a77761a365f86600d2a4/packages/client/src/subscribe/OrderMessages.ts#L97
 
 We don't document the code field in API docs or in readme. Therefore it is ok to you either one.
 
 Other generic errors are not checked internally. In `HttpError` we use both `code` and `errorCode`:
- https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/src/HttpUtil.ts#L25