### PR TITLE
NET-846: fix hanging integration tests

### DIFF
--- a/packages/dht/src/connection/WebRTC/WebRtcConnector.ts
+++ b/packages/dht/src/connection/WebRTC/WebRtcConnector.ts
@@ -99,7 +99,7 @@ export class WebRtcConnector extends EventEmitter<ManagedConnectionSourceEvent> 
             const managedConnection = new ManagedWebRtcConnection(this.ownPeerDescriptor!, this.config.protocolVersion, connection)
             managedConnection.setPeerDescriptor(remotePeer)
             this.ongoingConnectAttempts.set(peerKey, managedConnection)
-            this.bindListenersAndStartConnection(remotePeer, connection)
+            this.bindListenersAndStartConnection(remotePeer, connection, false)
 
             this.emit('newConnection', managedConnection)
         }

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -18,8 +18,8 @@
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",
     "test-unit": "jest test/unit",
-    "test-integration": "jest --forceExit test/integration",
-    "test-e2e": "jest --forceExit --runInBand test/end-to-end"
+    "test-integration": "jest test/integration",
+    "test-e2e": "jest --runInBand test/end-to-end"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.8.0",

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test-unit": "jest test/unit",
     "test-integration": "jest test/integration",
-    "test-e2e": "jest --runInBand test/end-to-end"
+    "test-e2e": "jest --runInBand --forceExit test/end-to-end"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.8.0",

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -110,6 +110,12 @@ describe('random graph with real connections', () => {
             randomGraphNode3.stop(),
             randomGraphNode4.stop(),
             randomGraphNode5.stop(),
+            (epDhtNode.getTransport() as ConnectionManager).stop(),
+            (dhtNode1.getTransport() as ConnectionManager).stop(),
+            (dhtNode2.getTransport() as ConnectionManager).stop(),
+            (dhtNode3.getTransport() as ConnectionManager).stop(),
+            (dhtNode4.getTransport() as ConnectionManager).stop(),
+
         ])
     })
 

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -83,10 +83,10 @@ describe('Full node network with WebRTC connections', () => {
         await Promise.all([
             epStreamrNode.destroy(),
             ...streamrNodes.map((streamrNode) => streamrNode.destroy()),
+            layer0Ep.stop(),
+            ...layer0DhtNodes.map((dhtNode) => dhtNode.stop()),
             epConnectionManager.stop(),
             ...connectionManagers.map((cm) => cm.stop()),
-            layer0Ep.stop(),
-            ...layer0DhtNodes.map((dhtNode) => dhtNode.stop())
         ])
     })
 

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -24,12 +24,16 @@ describe('Full node network with WebRTC connections', () => {
     let connectionManagers: ConnectionManager[]
     let streamrNodes: StreamrNode[]
 
+    let layer0Ep: DhtNode
+    let layer0DhtNodes: DhtNode[]
+
     beforeEach(async () => {
 
         streamrNodes = []
         connectionManagers = []
+        layer0DhtNodes = []
 
-        const layer0Ep = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 4, routeMessageTimeout: 10000 })
+        layer0Ep = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 4, routeMessageTimeout: 10000 })
 
         await layer0Ep.start()
         await layer0Ep.joinDht(epPeerDescriptor)
@@ -58,6 +62,8 @@ describe('Full node network with WebRTC connections', () => {
                     entryPoints: [epPeerDescriptor]
                 })
 
+                layer0DhtNodes.push(layer0)
+
                 await layer0.start()
                 await layer0.joinDht(epPeerDescriptor)
 
@@ -78,7 +84,9 @@ describe('Full node network with WebRTC connections', () => {
             epStreamrNode.destroy(),
             ...streamrNodes.map((streamrNode) => streamrNode.destroy()),
             epConnectionManager.stop(),
-            ...connectionManagers.map((cm) => cm.stop())
+            ...connectionManagers.map((cm) => cm.stop()),
+            layer0Ep.stop(),
+            ...layer0DhtNodes.map((dhtNode) => dhtNode.stop())
         ])
     })
 

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -22,12 +22,16 @@ describe('Full node network with WebSocket connections only', () => {
     let connectionManagers: ConnectionManager[]
     let streamrNodes: StreamrNode[]
 
+    let layer0Ep: DhtNode
+    let layer0DhtNodes: DhtNode[]
+
     beforeEach(async () => {
 
         streamrNodes = []
         connectionManagers = []
+        layer0DhtNodes = []
 
-        const layer0Ep = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 4, routeMessageTimeout: 10000 })
+        layer0Ep = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 4, routeMessageTimeout: 10000 })
         await layer0Ep.start()
         await layer0Ep.joinDht(epPeerDescriptor)
 
@@ -48,6 +52,8 @@ describe('Full node network with WebSocket connections only', () => {
                     peerIdString: `${i}`,
                     numberOfNodesPerKBucket: 4
                 })
+
+                layer0DhtNodes.push(layer0)
 
                 await layer0.start()
                 await layer0.joinDht(epPeerDescriptor)
@@ -70,7 +76,9 @@ describe('Full node network with WebSocket connections only', () => {
             epStreamrNode.destroy(),
             ...streamrNodes.map((streamrNode) => streamrNode.destroy()),
             epConnectionManager.stop(),
-            ...connectionManagers.map((cm) => cm.stop())
+            ...connectionManagers.map((cm) => cm.stop()),
+            layer0Ep.stop(),
+            ...layer0DhtNodes.map((dhtNode) => dhtNode.stop())
         ])
     })
 


### PR DESCRIPTION
## Summary

integration tests no longer hang, e2e tests still hang in CI, the cause is likely incomplete webrtc clean up.
## Changes

Provide a bullet list of individual changes. Leave this section out if change
set is small and obvious from summary.

## Limitations and future improvements

Provide a bullet list or description of known omissions or limitations of the
solution and/or any ideas for future improvement. Leave section ouf if
not applicable.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
