### PR TITLE
test(client): Break from message iteration loop

### DIFF
--- a/packages/client/test/integration/message-iteration.test.ts
+++ b/packages/client/test/integration/message-iteration.test.ts
@@ -1,0 +1,43 @@
+import 'reflect-metadata'
+import { range } from 'lodash'
+import { StreamPermission } from './../../src/permission'
+import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
+import { createTestStream } from './../test-utils/utils'
+
+const MESSAGE_COUNT = 10
+
+describe('message iteration', () => {
+
+    it('async iterator breaks out of loop', async () => {
+        const environment = new FakeEnvironment()
+        const publisher = environment.createClient()
+        const subscriber = environment.createClient()
+        const stream = await createTestStream(publisher, module)
+        stream.grantPermissions({
+            public: true,
+            permissions: [StreamPermission.SUBSCRIBE]
+        })
+        const sub = await subscriber.subscribe(stream.id)
+        setImmediate(() => {
+            range(MESSAGE_COUNT).map(() => publisher.publish(stream.id, {}))
+        })
+        let receivedMessageCount = 0
+        // eslint-disable-next-line no-underscore-dangle
+        for await (const _msg of sub) {
+            receivedMessageCount++
+            if (receivedMessageCount === (MESSAGE_COUNT / 2)) {
+                break
+            }
+        }
+        // - the break statement triggers iterator's return method to be called (standard JS behavior)
+        // - the iterator is a Pipeline
+        //   - in Pipeline#return we call this.iterator.return(v)
+        // - this.iterator is a wrapped iterator (iteratorFinally), created in Pipeline constructor
+        //   - it has a onFinally callback which calls Pipeline#cleanup
+        // - in Pipeline#cleanup we call this.onBeforeFinally.trigger() to signal an event to listeners
+        // - the event listener was initialized in SubscriptionSession#add
+        //   - in the event listener we call SubscriptionSession#remove
+        //   - there we remove the subscription by calling this.subscriptions.delete()
+        expect(await subscriber.getSubscriptions(stream.id)).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
## Summary

Added test case which demonstrates how subscription is automatically unsubscribed if user iterates it and breaks out of loop. It is not clear whether this is a good functionality? Or should we keep the subscription active unless use explicitly unsubscribes that? (Do we support e.g. multiple iterations from a single subscription, or should we support?)

This auto-close is maybe done in other scenarios, e.g. if we call internal `collect(n)`. 

Most this doesn't apply to situations where we'd iterate all messages from an iterator? 
- All iterators for realtime subscription are infinite so we most likely can't automatically close it by iterating it to the end (as it doesn't end).
- Resends are not (yet) subscriptions. But if change the semantics in that way, could check whether iterating all messages would auto-`return()` the iterable.