### PR TITLE
test(client): Test client error code

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     ...rootConfig,
     globalSetup: './jest.setup.js',
     globalTeardown: './jest.teardown.js',
+    setupFilesAfterEnv: rootConfig.setupFilesAfterEnv.concat('./test/test-utils/customMatchers.ts'),
     modulePathIgnorePatterns: [
         '<rootDir>/dist/package.json',
     ]

--- a/packages/client/src/DestroySignal.ts
+++ b/packages/client/src/DestroySignal.ts
@@ -28,7 +28,7 @@ export class DestroySignal {
 
     assertNotDestroyed(): void {
         if (this.isDestroyed()) {
-            throw new StreamrClientError('Client is destroyed. Create a new instance', 'CLIENT_IS_DESTROYED')
+            throw new StreamrClientError('Client is destroyed. Create a new instance', 'CLIENT_DESTROYED')
         }
     }
 

--- a/packages/client/src/StreamrClientError.ts
+++ b/packages/client/src/StreamrClientError.ts
@@ -1,4 +1,4 @@
-export type StreamrClientErrorCode = 'NO_STORAGE_NODES' | 'INVALID_ARGUMENT' | 'CLIENT_IS_DESTROYED' | 'PIPELINE_ERROR'
+export type StreamrClientErrorCode = 'NO_STORAGE_NODES' | 'INVALID_ARGUMENT' | 'CLIENT_DESTROYED' | 'PIPELINE_ERROR'
 
 export class StreamrClientError extends Error {
     constructor(message: string, public readonly code: StreamrClientErrorCode) {

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -150,9 +150,10 @@ export class Resends {
     ) {
         const loggerIdx = counterId('fetchStream')
         this.logger.debug('[%s] fetching resend %s for %s with options %o', loggerIdx, endpointSuffix, streamPartId, query)
-        const nodeAddresses = await this.streamStorageRegistry.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
+        const streamId = StreamPartIDUtils.getStreamID(streamPartId)
+        const nodeAddresses = await this.streamStorageRegistry.getStorageNodes(streamId)
         if (!nodeAddresses.length) {
-            throw new StreamrClientError(`no storage assigned: ${streamPartId}`, 'NO_STORAGE_NODES')
+            throw new StreamrClientError(`no storage assigned: ${streamId}`, 'NO_STORAGE_NODES')
         }
 
         const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -226,20 +226,6 @@ describe('GapFill', () => {
                 const expected = published.filter((_value: any, index: number) => index !== 2).map((m) => m.signature)
                 expect(received.map((m) => m.signature)).toEqual(expected)
             }, 20000)
-
-            it('rejects resend if no storage assigned', async () => {
-                // new stream, assign to storage node not called
-                stream = await createTestStream(client, module)
-
-                await expect(async () => {
-                    await client.resend(
-                        stream.id,
-                        {
-                            last: MAX_MESSAGES
-                        }
-                    )
-                }).rejects.toThrow('storage')
-            })
         })
     })
 

--- a/packages/client/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/client/test/integration/NetworkNodeFacade.test.ts
@@ -127,7 +127,7 @@ describe('NetworkNodeFacade', () => {
                 await client.destroy()
                 await expect(async () => {
                     await client.getNode()
-                }).rejects.toThrow('destroy')
+                }).rejects.toThrowStreamError({ code: 'CLIENT_DESTROYED' })
             })
 
             it('can call destroy multiple times', async () => {
@@ -139,14 +139,14 @@ describe('NetworkNodeFacade', () => {
                 await client.destroy()
                 await expect(async () => {
                     await client.getNode()
-                }).rejects.toThrow('destroy')
+                }).rejects.toThrowStreamError({ code: 'CLIENT_DESTROYED' })
             })
 
             it('can destroy before start', async () => {
                 await client.destroy()
                 await expect(async () => {
                     await client.getNode()
-                }).rejects.toThrow('destroy')
+                }).rejects.toThrowStreamError({ code: 'CLIENT_DESTROYED' })
             })
 
             it('can destroy during start', async () => {
@@ -157,7 +157,7 @@ describe('NetworkNodeFacade', () => {
                     ]
                     await Promise.allSettled(tasks)
                     await Promise.all(tasks)
-                }).rejects.toThrow('destroy')
+                }).rejects.toThrowStreamError({ code: 'CLIENT_DESTROYED' })
             })
         })
     })

--- a/packages/client/test/integration/Resends.test.ts
+++ b/packages/client/test/integration/Resends.test.ts
@@ -9,6 +9,7 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
 import { createRandomAuthentication, createRelativeTestStreamId } from '../test-utils/utils'
 import { toEthereumAddress } from '@streamr/utils'
+import { StreamrClientError } from '../../src/StreamrClientError'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
@@ -86,7 +87,7 @@ describe('Resends', () => {
                 messageMatchFn: () => {
                     return true
                 }
-            })).rejects.toThrow('no storage assigned')
+            })).rejects.toThrowStreamError(new StreamrClientError(`no storage assigned: ${stream.id}`, 'NO_STORAGE_NODES'))
         })
     })
 })

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -44,18 +44,6 @@ describe('Resends2', () => {
         await publisher?.destroy()
     })
 
-    it('throws error if bad stream id', async () => {
-        await expect(async () => {
-            await client.resend({
-                streamId: 'badstream',
-                partition: 0,
-            },
-            {
-                last: 5
-            })
-        }).rejects.toThrow('badstream')
-    })
-
     it('throws if no storage assigned', async () => {
         const notStoredStream = await createTestStream(client, module)
         await expect(async () => {

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -10,6 +10,7 @@ import { Stream } from '../../src/Stream'
 import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from './../test-utils/fake/FakeStorageNode'
 import { StreamPermission } from './../../src/permission'
+import { StreamrClientError } from '../../src/StreamrClientError'
 
 const MAX_MESSAGES = 5
 
@@ -64,7 +65,7 @@ describe('Resends2', () => {
             }, {
                 last: 5
             })
-        }).rejects.toThrow('storage')
+        }).rejects.toThrowStreamError(new StreamrClientError(`no storage assigned: ${notStoredStream.id}`, 'NO_STORAGE_NODES'))
     })
 
     it('throws error if bad partition', async () => {

--- a/packages/client/test/integration/client-destroy.test.ts
+++ b/packages/client/test/integration/client-destroy.test.ts
@@ -30,7 +30,7 @@ describe('client destroy', () => {
         await client.destroy()
         await expect(async () => {
             await client.subscribe(stream.id)
-        }).rejects.toThrow('Client is destroyed')
+        }).rejects.toThrowStreamError({ code: 'CLIENT_DESTROYED' })
     })
 
     it('unable to publish after destroy called', async () => {

--- a/packages/client/test/test-utils/customMatchers.ts
+++ b/packages/client/test/test-utils/customMatchers.ts
@@ -2,7 +2,7 @@ import { expect } from '@jest/globals'
 import type { MatcherState } from 'expect'
 import { printExpected, printReceived } from 'jest-matcher-utils'
 import { isFunction } from 'lodash'
-import { StreamrClientError } from './../../src/StreamrClientError'
+import { StreamrClientError, StreamrClientErrorCode } from './../../src/StreamrClientError'
 
 // we could ES2015 module syntax (https://jestjs.io/docs/expect#expectextendmatchers),
 // but the IDE doesn't find custom matchers if we do that
@@ -10,7 +10,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace jest {
         interface Matchers<R> {
-            toThrowStreamError(expectedError: Partial<StreamrClientError>): R
+            toThrowStreamError(expectedError: { code: StreamrClientErrorCode, message?: string }): R
         }
     }
 }
@@ -25,7 +25,7 @@ const formError = (description: string, expected: string, actual: string) => {
 const toThrowStreamError = function(
     this: MatcherState,
     actual: unknown, // should be (() => StreamrClientError) | StreamrClientError
-    expectedError: Partial<StreamrClientError>
+    expectedError: { code: StreamrClientErrorCode, message?: string }
 ) {
     let actualError
     if (isFunction(actual)) {
@@ -44,7 +44,7 @@ const toThrowStreamError = function(
     if (!(actualError instanceof StreamrClientError)) {
         return formError('Class name', 'StreamrClientError', (actualError as any).constructor.name)
     }
-    if ((expectedError.code !== undefined) && (actualError.code !== expectedError.code)) {
+    if (actualError.code !== expectedError.code) {
         return formError('StreamrClientError.code', expectedError.code, actualError.code)
     }
     if ((expectedError.message !== undefined) && (actualError.message !== expectedError.message)) {

--- a/packages/client/test/test-utils/customMatchers.ts
+++ b/packages/client/test/test-utils/customMatchers.ts
@@ -4,18 +4,28 @@ import { printExpected, printReceived } from 'jest-matcher-utils'
 import { isFunction } from 'lodash'
 import { StreamrClientError, StreamrClientErrorCode } from './../../src/StreamrClientError'
 
+interface ExpectationResult {
+    pass: boolean
+    message: () => string
+}
+
+interface PartialStreamrClientError {
+    code: StreamrClientErrorCode
+    message?: string
+}
+
 // we could ES2015 module syntax (https://jestjs.io/docs/expect#expectextendmatchers),
 // but the IDE doesn't find custom matchers if we do that
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace jest {
         interface Matchers<R> {
-            toThrowStreamError(expectedError: { code: StreamrClientErrorCode, message?: string }): R
+            toThrowStreamError(expectedError: PartialStreamrClientError): R
         }
     }
 }
 
-const formError = (description: string, expected: string, actual: string) => {
+const formError = (description: string, expected: string, actual: string): ExpectationResult => {
     return {
         pass: false,
         message: () => `${description}\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
@@ -25,8 +35,8 @@ const formError = (description: string, expected: string, actual: string) => {
 const toThrowStreamError = function(
     this: MatcherState,
     actual: unknown, // should be (() => StreamrClientError) | StreamrClientError
-    expectedError: { code: StreamrClientErrorCode, message?: string }
-) {
+    expectedError: PartialStreamrClientError
+): ExpectationResult {
     let actualError
     if (isFunction(actual)) {
         try {

--- a/packages/client/test/test-utils/customMatchers.ts
+++ b/packages/client/test/test-utils/customMatchers.ts
@@ -43,7 +43,7 @@ const toThrowStreamError = function(
             actual()
             return {
                 pass: false,
-                message: () => `Function didn't throw`
+                message: () => 'Function didn\'t throw'
             }
         } catch (e) {
             actualError = e
@@ -51,6 +51,7 @@ const toThrowStreamError = function(
     } else {
         actualError = actual
     }
+
     if (!(actualError instanceof StreamrClientError)) {
         return formError('Class name', 'StreamrClientError', (actualError as any).constructor.name)
     }

--- a/packages/client/test/test-utils/customMatchers.ts
+++ b/packages/client/test/test-utils/customMatchers.ts
@@ -1,0 +1,46 @@
+import { expect } from '@jest/globals'
+import type { MatcherState } from 'expect'
+import { printExpected, printReceived } from 'jest-matcher-utils'
+import { StreamrClientError } from './../../src/StreamrClientError'
+
+// we could ES2015 module syntax (https://jestjs.io/docs/expect#expectextendmatchers),
+// but the IDE doesn't find custom matchers if we do that
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        interface Matchers<R> {
+            toThrowStreamError(expectedError: Partial<StreamrClientError>): R
+        }
+    }
+}
+
+const formError = (description: string, expected: string, actual: string) => {
+    return {
+        pass: false,
+        message: () => `${description}\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
+    }
+}
+
+const toThrowStreamError = function(
+    this: MatcherState,
+    actualError: unknown,
+    expectedError: Partial<StreamrClientError>
+) {
+    if (!(actualError instanceof StreamrClientError)) {
+        return formError('Class name', 'StreamrClientError', (actualError as any).constructor.name)
+    }
+    if ((expectedError.code !== undefined) && (actualError.code !== expectedError.code)) {
+        return formError('StreamrClientError.code', expectedError.code, actualError.code)
+    }
+    if ((expectedError.message !== undefined) && (actualError.message !== expectedError.message)) {
+        return formError('StreamrClientError.message', expectedError.message, actualError.message)
+    }
+    return {
+        pass: true,
+        message: () => ''
+    }
+}
+
+expect.extend({
+    toThrowStreamError
+})

--- a/packages/client/test/test-utils/customMatchers.ts
+++ b/packages/client/test/test-utils/customMatchers.ts
@@ -52,7 +52,7 @@ const toThrowStreamError = function(
     }
     return {
         pass: true,
-        message: () => ''
+        message: () => `Expected not to throw ${printReceived('StreamrClientError')}`
     }
 }
 

--- a/packages/client/test/unit/PushBuffer.test.ts
+++ b/packages/client/test/unit/PushBuffer.test.ts
@@ -174,19 +174,19 @@ describe.skip('PushBuffer', () => {
         it('errors on bad buffer size', async () => {
             expect(() => {
                 new PushBuffer(0)
-            }).toThrow('bufferSize')
+            }).toThrowStreamError({ code: 'INVALID_ARGUMENT' })
             expect(() => {
                 new PushBuffer(-1)
-            }).toThrow('bufferSize')
+            }).toThrowStreamError({ code: 'INVALID_ARGUMENT' })
             expect(() => {
                 new PushBuffer(Number.MAX_SAFE_INTEGER + 10)
-            }).toThrow('bufferSize')
+            }).toThrowStreamError({ code: 'INVALID_ARGUMENT' })
             expect(() => {
                 new PushBuffer(1.5)
-            }).toThrow('bufferSize')
+            }).toThrowStreamError({ code: 'INVALID_ARGUMENT' })
             expect(() => {
                 new PushBuffer(0.5)
-            }).toThrow('bufferSize')
+            }).toThrowStreamError({ code: 'INVALID_ARGUMENT' })
         })
 
         it('can push inside pull', async () => {


### PR DESCRIPTION
## Summary

Added assertions about `StreamrClientError`. Now we always check the error code, and optionally also the error message.

Implemented custom Jest matcher `toThrowStreamError` so that we can easily check these multiple aspects of thrown error.

## Other changes

- Fixed error message for `NO_STORAGE_NODE` error: it uses `streamId` instead of `streamPartId` as assignments are stream specific.
- Renamed `CLIENT_IS_DESTROYED` code to `CLIENT_DESTROYED`. This is not a breaking changes as v6 didn't have any error codes (and we haven't documented the error codes in changelog or in readme).
- Removed invalid test in `Resends2.test.ts`, which seemed to check streamId validity but actually failed for `NO_STORAGE_NODE` (and therefore was a duplicate test).
- Removed duplicate test in `GapFill.test.ts` which tested that client.resend throws `NO_STORAGE_NODE` error (was already tested in `Resends2.test.ts`)

