### PR TITLE
refactor(client): Remove `SubscriptionSession` dependency from `Subscription`

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { container as rootContainer, DependencyContainer } from 'tsyringe'
+import { container as rootContainer } from 'tsyringe'
 import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
 import { pOnce } from './utils/promises'
 import { StreamrClientConfig, createStrictConfig, StrictStreamrClientConfig } from './Config'
@@ -40,7 +40,6 @@ export class StreamrClient {
 
     public readonly id: string
     private readonly config: StrictStreamrClientConfig
-    private readonly container: DependencyContainer
     private readonly node: NetworkNodeFacade
     private readonly authentication: Authentication
     private readonly resends: Resends
@@ -61,7 +60,6 @@ export class StreamrClient {
         const container = parentContainer.createChildContainer()
         initContainer(this.config, container)
 
-        this.container = container
         this.id = this.config.id
         this.node = container.resolve<NetworkNodeFacade>(NetworkNodeFacade)
         this.authentication = container.resolve<Authentication>(AuthenticationInjectionToken)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -141,8 +141,7 @@ export class StreamrClient {
         onMessage?: SubscriptionOnMessage<T>
     ): Promise<ResendSubscription<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const subSession = this.subscriber.getOrCreateSubscriptionSession<T>(streamPartId)
-        const sub = new ResendSubscription<T>(subSession, this.resends, resendOptions, this.container)
+        const sub = new ResendSubscription<T>(streamPartId, this.resends, resendOptions, this.container)
         if (onMessage) {
             sub.useLegacyOnMessageHandler(onMessage)
         }

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -1,4 +1,4 @@
-import { DependencyContainer } from 'tsyringe'
+import { inject } from 'tsyringe'
 import { Subscription } from './Subscription'
 import { StreamMessage, StreamPartID, StreamPartIDUtils } from 'streamr-client-protocol'
 import { ConfigInjectionToken } from '../Config'
@@ -6,6 +6,7 @@ import { OrderMessages } from './OrderMessages'
 import { ResendOptions, Resends } from './Resends'
 import { DestroySignal } from '../DestroySignal'
 import { LoggerFactory } from '../utils/LoggerFactory'
+import { SubscribeConfig } from './../Config'
 
 export class ResendSubscription<T> extends Subscription<T> {
     private orderMessages: OrderMessages<T>
@@ -13,24 +14,25 @@ export class ResendSubscription<T> extends Subscription<T> {
     /** @internal */
     constructor(
         streamPartId: StreamPartID,
-        private resends: Resends,
         private resendOptions: ResendOptions,
-        container: DependencyContainer
+        private resends: Resends,
+        destroySignal: DestroySignal,
+        loggerFactory: LoggerFactory,
+        @inject(ConfigInjectionToken.Subscribe) subscibreConfig: SubscribeConfig
     ) {
-        super(streamPartId, container.resolve(LoggerFactory))
+        super(streamPartId, loggerFactory)
         this.resendThenRealtime = this.resendThenRealtime.bind(this)
         this.orderMessages = new OrderMessages<T>(
-            container.resolve(ConfigInjectionToken.Subscribe),
-            container.resolve(Resends),
+            subscibreConfig,
+            resends,
             streamPartId,
-            container.resolve(LoggerFactory)
+            loggerFactory
         )
         this.pipe(this.resendThenRealtime)
         this.pipe(this.orderMessages.transform())
         this.onBeforeFinally.listen(async () => {
             this.orderMessages.stop()
         })
-        const destroySignal = container.resolve(DestroySignal)
         destroySignal.onDestroy.listen(() => {
             this.eventEmitter.removeAllListeners()
         })

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -1,7 +1,6 @@
 import { DependencyContainer } from 'tsyringe'
-import { SubscriptionSession } from './SubscriptionSession'
 import { Subscription } from './Subscription'
-import { StreamMessage, StreamPartIDUtils } from 'streamr-client-protocol'
+import { StreamMessage, StreamPartID, StreamPartIDUtils } from 'streamr-client-protocol'
 import { ConfigInjectionToken } from '../Config'
 import { OrderMessages } from './OrderMessages'
 import { ResendOptions, Resends } from './Resends'
@@ -13,17 +12,17 @@ export class ResendSubscription<T> extends Subscription<T> {
 
     /** @internal */
     constructor(
-        subSession: SubscriptionSession<T>,
+        streamPartId: StreamPartID,
         private resends: Resends,
         private resendOptions: ResendOptions,
         container: DependencyContainer
     ) {
-        super(subSession, container.resolve(LoggerFactory))
+        super(streamPartId, container.resolve(LoggerFactory))
         this.resendThenRealtime = this.resendThenRealtime.bind(this)
         this.orderMessages = new OrderMessages<T>(
             container.resolve(ConfigInjectionToken.Subscribe),
             container.resolve(Resends),
-            subSession.streamPartId,
+            streamPartId,
             container.resolve(LoggerFactory)
         )
         this.pipe(this.resendThenRealtime)

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -118,10 +118,7 @@ export class Subscriber {
     }
 
     private async add<T>(streamPartId: StreamPartID): Promise<Subscription<T>> {
-        const subSession = this.getOrCreateSubscriptionSession<T>(streamPartId)
-
-        // create subscription
-        const sub = new Subscription<T>(subSession.streamPartId, this.loggerFactory)
+        const sub = new Subscription<T>(streamPartId, this.loggerFactory)
         return this.addSubscription(sub)
     }
 

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -92,7 +92,7 @@ export class Subscriber {
             this.loggerFactory,
             this.rootConfig
         )
-        
+
         this.subSessions.set(streamPartId, subSession as SubscriptionSession<unknown>)
         subSession.onRetired.listen(() => {
             this.subSessions.delete(streamPartId)
@@ -121,7 +121,7 @@ export class Subscriber {
         const subSession = this.getOrCreateSubscriptionSession<T>(streamPartId)
 
         // create subscription
-        const sub = new Subscription<T>(subSession, this.loggerFactory)
+        const sub = new Subscription<T>(subSession.streamPartId, this.loggerFactory)
         return this.addSubscription(sub)
     }
 

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -48,11 +48,6 @@ export class Subscription<T = unknown> extends MessageStream<T> {
         await this.return()
     }
 
-    /** @internal */
-    waitForNeighbours(numNeighbours?: number, timeout?: number): Promise<boolean> {
-        return this.subSession.waitForNeighbours(numNeighbours, timeout)
-    }
-
     on<E extends keyof SubscriptionEvents>(eventName: E, listener: SubscriptionEvents[E]): void {
         this.eventEmitter.on(eventName, listener as any)
     }

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -4,7 +4,6 @@
  */
 import { StreamPartID } from 'streamr-client-protocol'
 import { MessageStream, MessageStreamOnMessage } from './MessageStream'
-import { SubscriptionSession } from './SubscriptionSession'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
@@ -21,17 +20,14 @@ export interface SubscriptionEvents {
  */
 export class Subscription<T = unknown> extends MessageStream<T> {
     /** @internal */
-    private readonly subSession: SubscriptionSession<T>
-    /** @internal */
     private readonly logger: Logger
     readonly streamPartId: StreamPartID
     protected eventEmitter: EventEmitter<SubscriptionEvents>
 
     /** @internal */
-    constructor(subSession: SubscriptionSession<T>, loggerFactory: LoggerFactory) {
+    constructor(streamPartId: StreamPartID, loggerFactory: LoggerFactory) {
         super()
-        this.subSession = subSession
-        this.streamPartId = subSession.streamPartId
+        this.streamPartId = streamPartId
         this.eventEmitter = new EventEmitter<SubscriptionEvents>()
         this.logger = loggerFactory.createLogger(module)
         this.onMessage.listen((msg) => {

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -19,7 +19,6 @@ export interface SubscriptionEvents {
  * @category Important
  */
 export class Subscription<T = unknown> extends MessageStream<T> {
-    /** @internal */
     private readonly logger: Logger
     readonly streamPartId: StreamPartID
     protected eventEmitter: EventEmitter<SubscriptionEvents>

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -3,7 +3,6 @@ import { inject } from 'tsyringe'
 import { StreamMessage, StreamMessageType, StreamPartID } from 'streamr-client-protocol'
 
 import { Scaffold } from '../utils/Scaffold'
-import { until } from '../utils/promises'
 import { Signal } from '../utils/Signal'
 import { MessageStream } from './MessageStream'
 
@@ -163,15 +162,6 @@ export class SubscriptionSession<T> {
 
     has(sub: Subscription<T>): boolean {
         return this.subscriptions.has(sub)
-    }
-
-    async waitForNeighbours(numNeighbours = 1, timeout = 10000): Promise<boolean> {
-        return until(async () => {
-            if (!this.shouldBeSubscribed()) { return true } // abort
-            const node = await this.node.getNode()
-            if (!this.shouldBeSubscribed()) { return true } // abort
-            return node.getNeighborsForStreamPart(this.streamPartId).length >= numNeighbours
-        }, timeout)
     }
 
     /**

--- a/packages/client/src/utils/Pipeline.ts
+++ b/packages/client/src/utils/Pipeline.ts
@@ -216,7 +216,6 @@ export class Pipeline<InType, OutType = InType> implements IPipeline<InType, Out
         return this
     }
 
-    /** @internal */
     private async cleanup(error?: Error): Promise<void> {
         this.isCleaningUp = true
         try {

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -1,4 +1,4 @@
-import { StreamMessage } from 'streamr-client-protocol'
+import { StreamMessage, StreamPartID } from 'streamr-client-protocol'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamrClientConfig } from '../../src/Config'
 import { Stream } from '../../src/Stream'
@@ -12,10 +12,16 @@ import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
 
 const MAX_MESSAGES = 10
 
-function monkeypatchMessageHandler<T = any>(sub: Subscription<T>, fn: ((msg: StreamMessage<T>, count: number) => undefined | null)) {
+function monkeypatchMessageHandler<T = any>(
+    streamPartId: StreamPartID,
+    client: StreamrClient,
+    fn: ((msg: StreamMessage<T>, count: number) => undefined | null)
+) {
     let count = 0
     // @ts-expect-error private
-    sub.subSession.pipeline.pipeBefore(async function* DropMessages(src: AsyncGenerator<any>) {
+    const subSession = client.subscriber.getSubscriptionSession(streamPartId)!
+    // @ts-expect-error private
+    subSession.pipeline.pipeBefore(async function* DropMessages(src: AsyncGenerator<any>) {
         for await (const msg of src) {
             const result = fn(msg, count)
             count += 1
@@ -87,7 +93,7 @@ describe('GapFill', () => {
                 // @ts-expect-error private
                 const calledResend = jest.spyOn(client.resends, 'range')
                 const sub = await client.subscribe(stream.id)
-                monkeypatchMessageHandler(sub, (_msg, count) => {
+                monkeypatchMessageHandler(sub.streamPartId, client, (_msg, count) => {
                     if (count === 2) {
                         return null
                     }
@@ -114,7 +120,7 @@ describe('GapFill', () => {
 
             it('can fill gap of multiple messages', async () => {
                 const sub = await client.subscribe(stream.id)
-                monkeypatchMessageHandler(sub, (_msg, count) => {
+                monkeypatchMessageHandler(sub.streamPartId, client, (_msg, count) => {
                     if (count > 1 && count < 4) { return null }
                     return undefined
                 })
@@ -136,7 +142,7 @@ describe('GapFill', () => {
             it('can fill multiple gaps', async () => {
                 const sub = await client.subscribe(stream.id)
 
-                monkeypatchMessageHandler(sub, (_msg, count) => {
+                monkeypatchMessageHandler(sub.streamPartId, client, (_msg, count) => {
                     if (count === 3 || count === 4 || count === 7) { return null }
                     return undefined
                 })

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -6,8 +6,10 @@ import { StreamPermission } from '../../src/permission'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { fastPrivateKey } from 'streamr-test-utils'
-import { StreamMessage } from 'streamr-client-protocol'
+import { StreamMessage, toStreamPartID } from 'streamr-client-protocol'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
+import { until } from '../../src/utils/promises'
+import { DEFAULT_PARTITION } from './../../src/StreamIDBuilder'
 
 describe('Group Key Persistence', () => {
     let publisherPrivateKey: string
@@ -141,7 +143,10 @@ describe('Group Key Persistence', () => {
             const sub2 = await subscriber2.subscribe({
                 stream: stream.id,
             })
-            await sub2.waitForNeighbours()
+            const node2 = await subscriber2.getNode()
+            await until(async () => {
+                return node2.getNeighborsForStreamPart(toStreamPartID(stream.id, DEFAULT_PARTITION)).length >= 1
+            })
 
             await Promise.all([
                 sub2.collect(3),


### PR DESCRIPTION
## Summary

There was circular dependency between `Subscription` and `SubscriptionSession`. Removed `Subscriptions`'s dependency from `SubscriptionSession`. Removed also internal `Subscription#waitForNeighbours` method which was only used in one test.

## Other changes

- provided direct dependencies for `ResendSubscription` (earlier passed a `DependencyContainer` as an argument)
- removed `StreamrClient#container` private field, which is no longer needed
- removed `@internal` annotations from some private fields
