### PR TITLE
refactor: prefer AbortSignals where applicable

### DIFF
--- a/packages/broker/src/Plugin.ts
+++ b/packages/broker/src/Plugin.ts
@@ -10,6 +10,7 @@ export interface PluginOptions {
     streamrClient: StreamrClient
     apiAuthenticator: ApiAuthenticator
     brokerConfig: Config
+    abortSignal: AbortSignal
 }
 
 export abstract class Plugin<T> {
@@ -19,6 +20,7 @@ export abstract class Plugin<T> {
     readonly apiAuthenticator: ApiAuthenticator
     readonly brokerConfig: Config
     readonly pluginConfig: T
+    readonly abortSignal: AbortSignal
     private readonly httpServerRouters: express.Router[] = []
 
     constructor(options: PluginOptions) {
@@ -27,6 +29,7 @@ export abstract class Plugin<T> {
         this.apiAuthenticator = options.apiAuthenticator
         this.brokerConfig = options.brokerConfig
         this.pluginConfig = options.brokerConfig.plugins[this.name]
+        this.abortSignal = options.abortSignal
         const configSchema = this.getConfigSchema()
         if (configSchema !== undefined) {
             validateConfig(this.pluginConfig, configSchema, `${this.name} plugin`)

--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -15,22 +15,19 @@ export interface ConsoleMetricsPluginConfig {
 }
 
 export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
-    private producer?: { stop: () => void }
-
     async start(): Promise<void> {
         const metricsContext = (await (this.streamrClient!.getNode())).getMetricsContext()
-        this.producer = metricsContext.createReportProducer((report: MetricsReport) => {
+        metricsContext.createReportProducer((report: MetricsReport) => {
             // omit timestamp info as that is printed by the logger
             const data = omit(report, 'period')
             // remove quote chars to improve readability
             const output = JSON.stringify(data, undefined, 4).replace(/"/g, '')
             logger.info(`Report\n${output}`)
-        }, this.pluginConfig.interval * 1000, formatNumber)
+        }, this.pluginConfig.interval * 1000, formatNumber, this.abortSignal)
     }
     
-    async stop(): Promise<void> {
-        this.producer?.stop()
-    }
+    // eslint-disable-next-line class-methods-use-this
+    async stop(): Promise<void> {}
 
     // eslint-disable-next-line class-methods-use-this
     override getConfigSchema(): Schema {

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -26,7 +26,6 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         return this.server.start()
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async stop(): Promise<void> {
         await this.server!.stop()
     }

--- a/packages/broker/src/plugins/storage/StorageConfig.ts
+++ b/packages/broker/src/plugins/storage/StorageConfig.ts
@@ -63,16 +63,15 @@ export class StorageConfig {
         })
     }
 
-    async start(): Promise<void> {
+    async start(abortSignal: AbortSignal): Promise<void> {
         await Promise.all([
-            this.storagePoller.start(),
+            this.storagePoller.start(abortSignal),
             this.storageEventListener.start()
         ])
     }
 
-    async destroy(): Promise<void> {
-        this.storagePoller.destroy()
-        await this.storageEventListener.destroy()
+    destroy(): void {
+        this.storageEventListener.destroy()
     }
 
     hasStreamPart(streamPart: StreamPartID): boolean {

--- a/packages/broker/src/plugins/storage/StorageEventListener.ts
+++ b/packages/broker/src/plugins/storage/StorageEventListener.ts
@@ -44,7 +44,7 @@ export class StorageEventListener {
         this.streamrClient.on('removeFromStorageNode', this.onRemoveFromStorageNode)
     }
 
-    async destroy(): Promise<void> {
+    destroy(): void {
         this.streamrClient.off('addToStorageNode', this.onAddToStorageNode)
         this.streamrClient.off('removeFromStorageNode', this.onRemoveFromStorageNode)
     }

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -64,10 +64,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
         this.storageConfig!.getStreamParts().forEach((streamPart) => {
             node.unsubscribe(streamPart)
         })
-        await Promise.all([
-            this.cassandra!.close(),
-            this.storageConfig!.destroy()
-        ])
+        await this.storageConfig!.destroy()
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -84,7 +81,8 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
             password: this.pluginConfig.cassandra.password,
             opts: {
                 useTtl: false
-            }
+            },
+            abortSignal: this.abortSignal
         })
         cassandraStorage.enableMetrics(metricsContext)
         return cassandraStorage
@@ -119,7 +117,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
                 }
             }
         )
-        await storageConfig.start()
+        await storageConfig.start(this.abortSignal)
         return storageConfig
     }
 }

--- a/packages/broker/test/integration/plugins/storage/BucketManager.test.ts
+++ b/packages/broker/test/integration/plugins/storage/BucketManager.test.ts
@@ -9,9 +9,10 @@ const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 
 describe('BucketManager', () => {
+    let cassandraClient: Client
+    let abortController: AbortController
     let bucketManager: BucketManager
     let streamId: string
-    let cassandraClient: Client
     let streamIdx = 1
 
     const insertBuckets = async (startTimestamp: Date) => {
@@ -35,9 +36,9 @@ describe('BucketManager', () => {
             localDataCenter,
             keyspace,
         })
-
         await cassandraClient.connect()
-        bucketManager = new BucketManager(cassandraClient, {
+        abortController = new AbortController()
+        bucketManager = new BucketManager(cassandraClient, abortController.signal, {
             checkFullBucketsTimeout: 1000,
             storeBucketsTimeout: 1000,
             maxBucketSize: 10 * 300,
@@ -50,7 +51,7 @@ describe('BucketManager', () => {
     })
 
     afterEach(async () => {
-        bucketManager.stop()
+        abortController.abort()
         await cassandraClient.shutdown()
     })
 

--- a/packages/broker/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/broker/test/integration/plugins/storage/Storage.test.ts
@@ -92,6 +92,7 @@ async function storeMockMessages({
 }
 
 describe('Storage', () => {
+    let abortController: AbortController
     let storage: Storage
     let streamId: string
     let cassandraClient: Client
@@ -103,6 +104,7 @@ describe('Storage', () => {
             localDataCenter,
             keyspace,
         })
+        abortController = new AbortController()
         storage = await startCassandraStorage({
             contactPoints,
             localDataCenter,
@@ -112,15 +114,14 @@ describe('Storage', () => {
                 checkFullBucketsTimeout: 100,
                 storeBucketsTimeout: 100,
                 bucketKeepAliveSeconds: 1
-            }
+            },
+            abortSignal: abortController.signal
         })
     })
 
     afterAll(async () => {
-        await Promise.allSettled([
-            storage?.close(),
-            cassandraClient?.shutdown()
-        ])
+        abortController.abort()
+        await cassandraClient?.shutdown()
     })
 
     beforeEach(async () => {

--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -15,10 +15,12 @@ const NUM_MESSAGES = 1000
 const MESSAGE_SIZE = 1e3 // 1k
 
 describe('Storage: lots of data', () => {
+    let abortController: AbortController
     let storage: Storage
     let streamId: string
 
     beforeAll(async () => {
+        abortController = new AbortController()
         storage = await startCassandraStorage({
             contactPoints,
             localDataCenter,
@@ -28,13 +30,14 @@ describe('Storage: lots of data', () => {
                 checkFullBucketsTimeout: 100,
                 storeBucketsTimeout: 100,
                 bucketKeepAliveSeconds: 1
-            }
+            },
+            abortSignal: abortController.signal
         })
         streamId = getTestName(module) + Date.now()
     })
 
-    afterAll(async () => {
-        await storage.close()
+    afterAll(() => {
+        abortController.abort()
     })
 
     beforeAll(async () => {

--- a/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
+++ b/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
@@ -72,9 +72,11 @@ async function storeMockMessages({
 
 describe('CassandraNullPayloads', () => {
     let cassandraClient: Client
+    let abortController: AbortController
     let storage: Storage
 
     beforeAll(() => {
+        abortController = new AbortController()
         cassandraClient = new Client({
             contactPoints,
             localDataCenter,
@@ -83,6 +85,7 @@ describe('CassandraNullPayloads', () => {
     })
 
     afterAll(() => {
+        abortController.abort()
         cassandraClient.shutdown()
     })
 
@@ -95,12 +98,13 @@ describe('CassandraNullPayloads', () => {
                 checkFullBucketsTimeout: 100,
                 storeBucketsTimeout: 100,
                 bucketKeepAliveSeconds: 1
-            }
+            },
+            abortSignal: abortController.signal
         })
     })
 
-    afterEach(async () => {
-        await storage.close()
+    afterEach(() => {
+        abortController.abort()
     })
 
     test('insert a null payload and retrieve n-1 messages (null not included in return set)', async () => {

--- a/packages/client/src/DestroySignal.ts
+++ b/packages/client/src/DestroySignal.ts
@@ -15,10 +15,13 @@ import { StreamrClientError } from './StreamrClientError'
 export class DestroySignal {
     public readonly onDestroy = Signal.once()
     public readonly trigger = this.destroy
+    public readonly abortSignal: AbortSignal
 
     constructor() {
+        const controller = new AbortController()
+        this.abortSignal = controller.signal
         this.onDestroy.listen(() => {
-            // no-op, needed?
+            controller.abort()
         })
     }
 
@@ -34,14 +37,5 @@ export class DestroySignal {
 
     isDestroyed(): boolean {
         return this.onDestroy.triggerCount() > 0
-    }
-
-    createAbortController(): AbortController {
-        const controller = new AbortController()
-        if (this.isDestroyed()) {
-            controller.abort()
-        }
-        this.onDestroy.listen(async () => controller.abort())
-        return controller
     }
 }

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -15,7 +15,6 @@ export class MetricsPublisher {
     private eventEmitter: StreamrClientEventEmitter
     private destroySignal: DestroySignal
     private config: MetricsConfig
-    private producers: { stop: () => void }[] = []
 
     constructor(
         @inject(Publisher) publisher: Publisher,
@@ -33,16 +32,15 @@ export class MetricsPublisher {
             const node = await this.node.getNode()
             const metricsContext = node.getMetricsContext()
             const partitionKey = getEthereumAddressFromNodeId(node.getNodeId()).toLowerCase()
-            this.producers = this.config.periods.map((config) => {
+            this.config.periods.map((config) => {
                 return metricsContext.createReportProducer(async (report: MetricsReport) => {
                     await this.publish(report, config.streamId, partitionKey)
-                }, config.duration)
+                }, config.duration, undefined, this.destroySignal.abortSignal)
             })
         })
         if (this.config.periods.length > 0) {
             this.eventEmitter.on('publish', () => ensureStarted())
             this.eventEmitter.on('subscribe', () => ensureStarted())
-            this.destroySignal.onDestroy.listen(() => this.destroy())
         }
     }
 
@@ -56,9 +54,5 @@ export class MetricsPublisher {
         } catch (e: any) {
             console.warn(`Unable to publish metrics: ${e.message}`)
         }
-    }
-
-    private destroy(): void {
-        this.producers.forEach((producer) => producer.stop())
     }
 }

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -63,7 +63,7 @@ export class Decrypt<T> {
                         'addGroupKey',
                         this.decryptionConfig.keyRequestTimeout,
                         (storedGroupKey: GroupKey) => storedGroupKey.id === groupKeyId,
-                        this.destroySignal.createAbortController())
+                        this.destroySignal.abortSignal)
                     groupKey = groupKeys[0] as GroupKey
                 } catch (e: any) {
                     if (this.destroySignal.isDestroyed()) {

--- a/packages/utils/src/AbortError.ts
+++ b/packages/utils/src/AbortError.ts
@@ -1,0 +1,9 @@
+export class AbortError extends Error {
+    readonly code = 'AbortError'
+    constructor(customErrorContext?: string) {
+        super(customErrorContext === undefined
+            ? `aborted`
+            : `${customErrorContext} aborted`)
+        Error.captureStackTrace(this, AbortError)
+    }
+}

--- a/packages/utils/src/AbortError.ts
+++ b/packages/utils/src/AbortError.ts
@@ -1,9 +1,0 @@
-export class AbortError extends Error {
-    readonly code = 'AbortError'
-    constructor(customErrorContext?: string) {
-        super(customErrorContext === undefined
-            ? `aborted`
-            : `${customErrorContext} aborted`)
-        Error.captureStackTrace(this, AbortError)
-    }
-}

--- a/packages/utils/src/Metric.ts
+++ b/packages/utils/src/Metric.ts
@@ -209,8 +209,9 @@ export class MetricsContext {
     createReportProducer(
         onReport: (report: MetricsReport) => void, 
         interval: number,
-        formatNumber?: (value: number) => string
-    ): { stop: () => void } {
+        formatNumber?: (value: number) => string,
+        abortSignal?: AbortSignal
+    ): void {
         const ongoingSamples: Map<string, Sampler> = new Map()
         return scheduleAtFixedRate(async (now: number) => {
             if (ongoingSamples.size > 0) {
@@ -235,6 +236,6 @@ export class MetricsContext {
                 sample.start(now)
                 ongoingSamples.set(id, sample)
             })
-        }, interval)
+        }, interval, abortSignal)
     }
 }

--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -1,0 +1,39 @@
+/**
+ * setTimeout with AbortController support. Aborting will simply clear
+ * the timeout silently.
+ */
+export const setAbortableTimeout = createAbortableTimerFn(setTimeout, clearTimeout, true)
+
+/**
+ * setInterval with AbortController support. Aborting will simply clear
+ * the interval silently.
+ */
+export const setAbortableInterval = createAbortableTimerFn(setInterval, clearInterval, false)
+
+function createAbortableTimerFn(
+    setupTimerFn: (cb: () => void, ms?: number) => NodeJS.Timer,
+    clearFn: (ref: NodeJS.Timer) => void,
+    removeListenerAfterCb: boolean
+): (cb: () => void, ms?: number, abortSignal?: AbortSignal) => NodeJS.Timer {
+    return (callback, ms, abortSignal) => {
+        if (abortSignal?.aborted) {
+            return setTimeout(() => {})
+        }
+        let abortListener: () => void
+        if (abortSignal !== undefined) {
+            abortListener = () => {
+                clearFn(timeoutRef)
+            }
+            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+            (abortSignal as any).addEventListener('abort', abortListener)
+        }
+        const timeoutRef = setupTimerFn(() => {
+            if (abortListener !== undefined && removeListenerAfterCb) {
+                // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
+                (abortSignal as any).removeEventListener('abort', abortListener)
+            }
+            callback()
+        }, ms)
+        return timeoutRef
+    }
+}

--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -1,11 +1,11 @@
 /**
- * setTimeout with AbortController support. Aborting will simply clear
+ * setTimeout with AbortSignal support. Aborting will simply clear
  * the timeout silently.
  */
 export const setAbortableTimeout = createAbortableTimerFn(setTimeout, clearTimeout, true)
 
 /**
- * setInterval with AbortController support. Aborting will simply clear
+ * setInterval with AbortSignal support. Aborting will simply clear
  * the interval silently.
  */
 export const setAbortableInterval = createAbortableTimerFn(setInterval, clearInterval, false)

--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -23,6 +23,8 @@ function createAbortableTimerFn(
         if (abortSignal !== undefined) {
             abortListener = () => {
                 clearFn(timeoutRef)
+                // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+                ;(abortSignal as any).removeEventListener('abort', abortListener)
             }
             // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
             (abortSignal as any).addEventListener('abort', abortListener)

--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -13,7 +13,7 @@ export const setAbortableInterval = createAbortableTimerFn(setInterval, clearInt
 function createAbortableTimerFn(
     setupTimerFn: (cb: () => void, ms?: number) => NodeJS.Timer,
     clearFn: (ref: NodeJS.Timer) => void,
-    removeListenerAfterCb: boolean
+    removeListenerOnCb: boolean
 ): (cb: () => void, ms?: number, abortSignal?: AbortSignal) => NodeJS.Timer {
     return (callback, ms, abortSignal) => {
         if (abortSignal?.aborted) {
@@ -30,7 +30,7 @@ function createAbortableTimerFn(
             (abortSignal as any).addEventListener('abort', abortListener)
         }
         const timeoutRef = setupTimerFn(() => {
-            if (abortListener !== undefined && removeListenerAfterCb) {
+            if (abortListener !== undefined && removeListenerOnCb) {
                 // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
                 (abortSignal as any).removeEventListener('abort', abortListener)
             }

--- a/packages/utils/src/asAbortable.ts
+++ b/packages/utils/src/asAbortable.ts
@@ -9,7 +9,7 @@ export class AbortError extends Error {
 }
 
 /**
- * Wraps a Promise into one that can be aborted with `AbortController`.
+ * Wraps a Promise into one that can be aborted with `AbortSignal`.
  * Aborting causes the returned Promise to reject with `AbortError` unless
  * the underlying promise itself has already resolved or rejected.
  *
@@ -19,26 +19,26 @@ export class AbortError extends Error {
  */
 export function asAbortable<T>(
     promise: Promise<T>,
-    abortController?: AbortController,
+    abortSignal?: AbortSignal,
     customErrorContext?: string
 ): Promise<T> {
-    if (abortController?.signal.aborted === true) {
+    if (abortSignal?.aborted === true) {
         return Promise.reject(new AbortError(customErrorContext))
     }
     let abortListener: () => void
     return new Promise<T>((resolve, reject) => {
-        if (abortController?.signal !== undefined) {
+        if (abortSignal !== undefined) {
             abortListener = () => {
                 reject(new AbortError(customErrorContext))
             }
             // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-            (abortController.signal as any).addEventListener('abort', abortListener)
+            (abortSignal as any).addEventListener('abort', abortListener)
         }
         promise.then(resolve, reject)
     }).finally(() => {
         if (abortListener !== undefined) {
             // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-            (abortController!.signal as any).removeEventListener('abort', abortListener)
+            (abortSignal as any).removeEventListener('abort', abortListener)
         }
     })
 }

--- a/packages/utils/src/asAbortable.ts
+++ b/packages/utils/src/asAbortable.ts
@@ -1,0 +1,44 @@
+export class AbortError extends Error {
+    readonly code = 'AbortError'
+    constructor(customErrorContext?: string) {
+        super(customErrorContext === undefined
+            ? `aborted`
+            : `${customErrorContext} aborted`)
+        Error.captureStackTrace(this, AbortError)
+    }
+}
+
+/**
+ * Wraps a Promise into one that can be aborted with `AbortController`.
+ * Aborting causes the returned Promise to reject with `AbortError` unless
+ * the underlying promise itself has already resolved or rejected.
+ *
+ * Notice that it is the user's responsibility to implement any custom cleanup
+ * logic in a `finally` or `catch` block in case of resources that need to be
+ * freed up.
+ */
+export function asAbortable<T>(
+    promise: Promise<T>,
+    abortController?: AbortController,
+    customErrorContext?: string
+): Promise<T> {
+    if (abortController?.signal.aborted === true) {
+        return Promise.reject(new AbortError(customErrorContext))
+    }
+    let abortListener: () => void
+    return new Promise<T>((resolve, reject) => {
+        if (abortController?.signal !== undefined) {
+            abortListener = () => {
+                reject(new AbortError(customErrorContext))
+            }
+            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+            (abortController.signal as any).addEventListener('abort', abortListener)
+        }
+        promise.then(resolve, reject)
+    }).finally(() => {
+        if (abortListener !== undefined) {
+            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
+            (abortController!.signal as any).removeEventListener('abort', abortListener)
+        }
+    })
+}

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -5,6 +5,7 @@ import { ENSName, toENSName } from './ENSName'
 import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
 import { isENSName } from './isENSName'
 import { keyToArrayIndex } from './keyToArrayIndex'
+import { listenOnceForAbort } from './listenOnceForAbort'
 import { Logger } from './Logger'
 import {
     CountMetric,
@@ -37,6 +38,7 @@ export {
     asAbortable,
     isENSName,
     keyToArrayIndex,
+    listenOnceForAbort,
     randomString,
     scheduleAtFixedRate,
     scheduleAtInterval,

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -1,4 +1,4 @@
-import { AbortError } from './AbortError'
+import { AbortError, asAbortable } from './asAbortable'
 import { Defer } from './Defer'
 import { ENSName, toENSName } from './ENSName'
 import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
@@ -33,6 +33,7 @@ export {
     Multimap,
     AbortError,
     TimeoutError,
+    asAbortable,
     isENSName,
     keyToArrayIndex,
     randomString,

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -1,3 +1,4 @@
+import { setAbortableInterval, setAbortableTimeout } from './abortableTimers'
 import { AbortError, asAbortable } from './asAbortable'
 import { Defer } from './Defer'
 import { ENSName, toENSName } from './ENSName'
@@ -39,6 +40,8 @@ export {
     randomString,
     scheduleAtFixedRate,
     scheduleAtInterval,
+    setAbortableInterval,
+    setAbortableTimeout,
     toENSName,
     toEthereumAddress,
     toEthereumAddressOrENSName,

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -1,3 +1,4 @@
+import { AbortError } from './AbortError'
 import { Defer } from './Defer'
 import { ENSName, toENSName } from './ENSName'
 import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
@@ -21,7 +22,7 @@ import { toEthereumAddressOrENSName } from './toEthereumAddressOrENSName'
 import { BrandedString } from './types'
 import { wait } from './wait'
 import { waitForEvent } from './waitForEvent'
-import { AbortError, TimeoutError, withTimeout } from './withTimeout'
+import { TimeoutError, withTimeout } from './withTimeout'
 
 export {
     BrandedString,

--- a/packages/utils/src/listenOnceForAbort.ts
+++ b/packages/utils/src/listenOnceForAbort.ts
@@ -1,0 +1,34 @@
+import { AbortError } from './asAbortable'
+import { noop } from 'lodash'
+
+// TODO remove the type casting when type definition for abortController has been updated to include addEventListener
+/**
+ * A helper for attaching a listener to the abort event of an `AbortSignal`.
+ * Handles the special case in which the provided signal has already been
+ * "pre"-aborted.
+ *
+ * Returns an object with method `clear`, used to clear the listener from the
+ * `AbortSignal`. This should be invoked when
+ *      (a) the signal is a shared, long-lasting object, and
+ *      (b) the listener is no longer required, and
+ *      (c) the signal has not been aborted.
+ */
+export function listenOnceForAbort(
+    abortSignal: AbortSignal,
+    listener: () => void,
+    onPreAbortedSignal: 'throw' | 'triggerListener' = 'triggerListener',
+): { clear: () => void } | never {
+    if (!abortSignal.aborted) {
+        (abortSignal as any).addEventListener('abort', listener, { once: true })
+        return {
+            clear: () => (abortSignal as any).removeEventListener('abort', listener)
+        }
+    } else if (onPreAbortedSignal === 'triggerListener') {
+        listener()
+        return {
+            clear: noop
+        }
+    } else {
+        throw new AbortError()
+    }
+}

--- a/packages/utils/src/scheduleAtInterval.ts
+++ b/packages/utils/src/scheduleAtInterval.ts
@@ -2,19 +2,24 @@
  * @param {number} interval - number of milliseconds to wait after a task is completed
  */
 import { repeatScheduleTask } from './scheduleAtFixedRate'
+import { setAbortableTimeout } from './abortableTimers'
 
 export const scheduleAtInterval = async (
     task: () => Promise<void>,
     interval: number,
-    executeAtStart: boolean
-): Promise<{ stop: () => void }> => {
+    executeAtStart: boolean,
+    abortSignal?: AbortSignal
+): Promise<void> => {
+    if (abortSignal?.aborted) {
+        return
+    }
     if (executeAtStart) {
         await task()
     }
-    return repeatScheduleTask((doneCb) => {
-        return setTimeout(async () => {
+    repeatScheduleTask((doneCb) => {
+        setAbortableTimeout(async () => {
             await task()
             doneCb()
-        }, interval)
-    })
+        }, interval, abortSignal)
+    }, abortSignal)
 }

--- a/packages/utils/src/wait.ts
+++ b/packages/utils/src/wait.ts
@@ -1,31 +1,19 @@
-import { AbortError } from './AbortError'
+import { asAbortable } from './asAbortable'
 
 /**
  * Wait for a specific time
  * @param ms time to wait for in milliseconds
- * @param abortController to control cancellation of any wait
+ * @param abortController to control abortion of any wait
  * @returns {Promise<void>} resolves when time has passed
  */
 export function wait(ms: number, abortController?: AbortController): Promise<void> {
-    if (abortController?.signal?.aborted === true) {
-        return Promise.reject(new AbortError())
-    }
     let timeoutRef: NodeJS.Timeout
-    let abortListener: () => void
-    return new Promise<void>((resolve, reject) => {
-        if (abortController !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-            abortListener = () => {
-                reject(new AbortError())
-            }
-            (abortController.signal as any).addEventListener('abort', abortListener)
-        }
-        timeoutRef = setTimeout(resolve, ms)
-    }).finally(() => {
+    return asAbortable(
+        new Promise<void>((resolve) => {
+            timeoutRef = setTimeout(resolve, ms)
+        }),
+        abortController
+    ).finally(() => {
         clearTimeout(timeoutRef)
-        if (abortListener !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-            (abortController!.signal as any).removeEventListener('abort', abortListener)
-        }
     })
 }

--- a/packages/utils/src/wait.ts
+++ b/packages/utils/src/wait.ts
@@ -1,6 +1,19 @@
+import { setTimeout } from 'timers/promises'
+import { AbortError } from './AbortError'
+
 /**
  * Wait for a specific time
  * @param ms time to wait for in milliseconds
+ * @param abortController to control cancellation of any wait
  * @returns {Promise<void>} resolves when time has passed
  */
-export const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+export const wait = (ms: number, abortController?: AbortController): Promise<void> => setTimeout(
+    ms,
+    undefined,
+    { signal: abortController?.signal }
+).catch((e) => {
+    if (e?.code === 'ABORT_ERR') {
+        throw new AbortError()
+    }
+    throw e
+})

--- a/packages/utils/src/wait.ts
+++ b/packages/utils/src/wait.ts
@@ -3,16 +3,16 @@ import { asAbortable } from './asAbortable'
 /**
  * Wait for a specific time
  * @param ms time to wait for in milliseconds
- * @param abortController to control abortion of any wait
+ * @param abortSignal to control abortion of any wait
  * @returns {Promise<void>} resolves when time has passed
  */
-export function wait(ms: number, abortController?: AbortController): Promise<void> {
+export function wait(ms: number, abortSignal?: AbortSignal): Promise<void> {
     let timeoutRef: NodeJS.Timeout
     return asAbortable(
         new Promise<void>((resolve) => {
             timeoutRef = setTimeout(resolve, ms)
         }),
-        abortController
+        abortSignal
     ).finally(() => {
         clearTimeout(timeoutRef)
     })

--- a/packages/utils/src/waitForEvent.ts
+++ b/packages/utils/src/waitForEvent.ts
@@ -8,7 +8,7 @@ import { withTimeout } from './withTimeout'
  * @param eventName event to wait for
  * @param timeout amount of time in milliseconds to wait for
  * @param predicate function that gets passed the event arguments, should return true if event accepted
- * @param abortController
+ * @param abortSignal
  * @returns {Promise<unknown[]>} resolves with event arguments if event occurred within timeout else rejects
  */
 export async function waitForEvent(
@@ -16,7 +16,7 @@ export async function waitForEvent(
     eventName: string,
     timeout = 5000,
     predicate: (...eventArgs: any[]) => boolean = () => true,
-    abortController?: AbortController
+    abortSignal?: AbortSignal
 ): Promise<unknown[]> {
     let listener: (eventArgs: any[]) => void
     // eslint-disable-next-line no-async-promise-executor
@@ -32,7 +32,7 @@ export async function waitForEvent(
         task,
         timeout,
         'waitForEvent',
-        abortController
+        abortSignal
     ).finally(() => {
         emitter.off(eventName, listener)
     })

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -1,4 +1,4 @@
-import { AbortError } from './AbortError'
+import { asAbortable } from './asAbortable'
 
 export class TimeoutError extends Error {
     readonly code = 'TimeoutError'
@@ -16,30 +16,19 @@ export const withTimeout = <T>(
     customErrorContext?: string,
     abortController?: AbortController
 ): Promise<T> => {
-    if (abortController?.signal?.aborted === true) {
-        return Promise.reject(new AbortError(customErrorContext))
-    }
     let timeoutRef: NodeJS.Timeout
-    let abortListener: () => void
-    return Promise.race([
-        task,
-        new Promise<T>((_resolve, reject) => {
-            timeoutRef = setTimeout(() => {
-                reject(new TimeoutError(timeoutInMs, customErrorContext))
-            }, timeoutInMs)
-            if (abortController !== undefined) {
-                // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-                abortListener = () => {
-                    reject(new AbortError(customErrorContext))
-                }
-                (abortController.signal as any).addEventListener('abort', abortListener)
-            }
-        })
-    ]).finally(() => {
-        clearTimeout(timeoutRef) // clear timeout if promise wins race
-        if (abortListener !== undefined) {
-            // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-            (abortController!.signal as any).removeEventListener('abort', abortListener)
-        }
+    return asAbortable(
+        Promise.race([
+            task,
+            new Promise<T>((_resolve, reject) => {
+                timeoutRef = setTimeout(() => {
+                    reject(new TimeoutError(timeoutInMs, customErrorContext))
+                }, timeoutInMs)
+            })
+        ]),
+        abortController,
+        customErrorContext
+    ).finally(() => {
+        clearTimeout(timeoutRef)
     })
 }

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -1,3 +1,5 @@
+import { AbortError } from './AbortError'
+
 export class TimeoutError extends Error {
     readonly code = 'TimeoutError'
     constructor(timeoutInMs: number, customErrorContext?: string) {
@@ -5,16 +7,6 @@ export class TimeoutError extends Error {
             ? `timed out after ${timeoutInMs} ms`
             : `${customErrorContext} (timed out after ${timeoutInMs} ms)`)
         Error.captureStackTrace(this, TimeoutError)
-    }
-}
-
-export class AbortError extends Error {
-    readonly code = 'AbortError'
-    constructor(customErrorContext?: string) {
-        super(customErrorContext === undefined
-            ? `aborted`
-            : `${customErrorContext} aborted`)
-        Error.captureStackTrace(this, AbortError)
     }
 }
 

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -14,7 +14,7 @@ export const withTimeout = <T>(
     task: Promise<T>,
     timeoutInMs: number,
     customErrorContext?: string,
-    abortController?: AbortController
+    abortSignal?: AbortSignal
 ): Promise<T> => {
     let timeoutRef: NodeJS.Timeout
     return asAbortable(
@@ -26,7 +26,7 @@ export const withTimeout = <T>(
                 }, timeoutInMs)
             })
         ]),
-        abortController,
+        abortSignal,
         customErrorContext
     ).finally(() => {
         clearTimeout(timeoutRef)

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -11,7 +11,7 @@ describe('metrics', () => {
 
         let context: MetricsContext
         let reports: (MetricsReport & { generationTime: number })[]
-        let producer: { stop: () => void }
+        let abortController: AbortController
     
         const getReport = (timestamp: number) => {
             return reports.find((report) => (timestamp <= report.generationTime))
@@ -20,16 +20,17 @@ describe('metrics', () => {
         beforeEach(() => {
             context = new MetricsContext()
             reports = []
-            producer = context.createReportProducer((report) => {
+            abortController = new AbortController()
+            context.createReportProducer((report) => {
                 reports.push({
                     ...report,
                     generationTime: Date.now()
                 })
-            }, REPORT_INTERVAL)
+            }, REPORT_INTERVAL, undefined, abortController.signal)
         })
     
         afterEach(() => {
-            producer.stop()
+            abortController?.abort()
         })
     
         it('happy path', async () => {

--- a/packages/utils/test/abortableTimers.test.ts
+++ b/packages/utils/test/abortableTimers.test.ts
@@ -1,0 +1,72 @@
+import { setAbortableInterval, setAbortableTimeout } from '../src/abortableTimers'
+import { wait } from '../src/wait'
+
+const TIMEOUT_UNIT = 100
+const INTERVAL_UNIT = 50
+
+describe('setAbortableTimeout',  () => {
+    it('invokes callback once if not aborted', async () => {
+        const cb = jest.fn()
+        setAbortableTimeout(cb, TIMEOUT_UNIT)
+        await wait(TIMEOUT_UNIT / 2)
+        expect(cb).toHaveBeenCalledTimes(0)
+        await wait(TIMEOUT_UNIT)
+        expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not invoke callback if aborted', async () => {
+        const abortController = new AbortController()
+        const cb = jest.fn()
+        setAbortableTimeout(cb, TIMEOUT_UNIT, abortController.signal)
+        await wait(TIMEOUT_UNIT / 2)
+        abortController.abort()
+        await wait(TIMEOUT_UNIT + 20)
+        expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('does not invoke callback if initially aborted', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        const cb = jest.fn()
+        setAbortableTimeout(cb, TIMEOUT_UNIT, abortController.signal)
+        await wait(TIMEOUT_UNIT + 20)
+        expect(cb).not.toHaveBeenCalled()
+    })
+})
+
+describe('setAbortableInterval',  () => {
+    let ref: NodeJS.Timer
+
+    afterEach(() => {
+        clearTimeout(ref)
+    })
+
+    it('repeatedly invokes callback if not aborted', async () => {
+        const cb = jest.fn()
+        ref = setAbortableInterval(cb, INTERVAL_UNIT)
+        await wait(INTERVAL_UNIT / 4)
+        expect(cb).toHaveBeenCalledTimes(0)
+        await wait(INTERVAL_UNIT * 4 + INTERVAL_UNIT / 2)
+        expect(cb).toHaveBeenCalledTimes(4)
+    })
+
+    it('stops invoking callback if aborted', async () => {
+        const abortController = new AbortController()
+        const cb = jest.fn()
+        ref = setAbortableInterval(cb, INTERVAL_UNIT, abortController.signal)
+        await wait(INTERVAL_UNIT)
+        abortController.abort()
+        const callsBeforeAbort = cb.mock.calls.length
+        await wait(INTERVAL_UNIT * 4)
+        expect(cb.mock.calls.length).toEqual(callsBeforeAbort)
+    })
+
+    it('does not invoke callback if initially aborted', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        const cb = jest.fn()
+        ref = setAbortableInterval(cb, INTERVAL_UNIT, abortController.signal)
+        await wait(INTERVAL_UNIT * 4)
+        expect(cb).not.toHaveBeenCalled()
+    })
+})

--- a/packages/utils/test/abortableTimers.test.ts
+++ b/packages/utils/test/abortableTimers.test.ts
@@ -10,7 +10,7 @@ describe('setAbortableTimeout',  () => {
         setAbortableTimeout(cb, TIMEOUT_UNIT)
         await wait(TIMEOUT_UNIT / 2)
         expect(cb).toHaveBeenCalledTimes(0)
-        await wait(TIMEOUT_UNIT)
+        await wait(TIMEOUT_UNIT + 20)
         expect(cb).toHaveBeenCalledTimes(1)
     })
 
@@ -55,8 +55,8 @@ describe('setAbortableInterval',  () => {
         const cb = jest.fn()
         ref = setAbortableInterval(cb, INTERVAL_UNIT, abortController.signal)
         await wait(INTERVAL_UNIT)
-        abortController.abort()
         const callsBeforeAbort = cb.mock.calls.length
+        abortController.abort()
         await wait(INTERVAL_UNIT * 4)
         expect(cb.mock.calls.length).toEqual(callsBeforeAbort)
     })

--- a/packages/utils/test/asAbortable.test.ts
+++ b/packages/utils/test/asAbortable.test.ts
@@ -1,0 +1,58 @@
+import { AbortError, asAbortable } from '../src/asAbortable'
+
+const sleep = (ms: number) => new Promise<string>((resolve) => setTimeout(() => resolve('foobar'), ms))
+
+const TIME_UNIT = 10
+
+describe(asAbortable, () => {
+    it('works without abortController', async () => {
+        const actual = await asAbortable(
+            sleep(TIME_UNIT)
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('resolves if no abort controller signalled', async () => {
+        const actual = await asAbortable(
+            sleep(TIME_UNIT),
+            new AbortController()
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('rejects if abort controller signalled before given promise resolves', async () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, TIME_UNIT)
+        const actual = asAbortable(
+            sleep(2 * TIME_UNIT),
+            abortController,
+            'customError'
+        )
+        return expect(actual).rejects.toEqual(new AbortError('customError'))
+    })
+
+    it('resolves if abort controller signalled after given promise resolved', async () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, 2 * TIME_UNIT)
+        const actual = await asAbortable(
+            sleep(TIME_UNIT),
+            abortController
+        )
+        expect(actual).toEqual('foobar')
+    })
+
+    it('rejects if given pre-aborted controller', () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        const actual = asAbortable(
+            sleep(TIME_UNIT),
+            abortController,
+            'customError'
+        )
+        return expect(actual).rejects.toEqual(new AbortError('customError'))
+    })
+})

--- a/packages/utils/test/asAbortable.test.ts
+++ b/packages/utils/test/asAbortable.test.ts
@@ -15,7 +15,7 @@ describe(asAbortable, () => {
     it('resolves if no abort controller signalled', async () => {
         const actual = await asAbortable(
             sleep(TIME_UNIT),
-            new AbortController()
+            new AbortController().signal
         )
         expect(actual).toEqual('foobar')
     })
@@ -27,7 +27,7 @@ describe(asAbortable, () => {
         }, TIME_UNIT)
         const actual = asAbortable(
             sleep(2 * TIME_UNIT),
-            abortController,
+            abortController.signal,
             'customError'
         )
         return expect(actual).rejects.toEqual(new AbortError('customError'))
@@ -40,7 +40,7 @@ describe(asAbortable, () => {
         }, 2 * TIME_UNIT)
         const actual = await asAbortable(
             sleep(TIME_UNIT),
-            abortController
+            abortController.signal
         )
         expect(actual).toEqual('foobar')
     })
@@ -50,7 +50,7 @@ describe(asAbortable, () => {
         abortController.abort()
         const actual = asAbortable(
             sleep(TIME_UNIT),
-            abortController,
+            abortController.signal,
             'customError'
         )
         return expect(actual).rejects.toEqual(new AbortError('customError'))

--- a/packages/utils/test/listenOnceForAbort.test.ts
+++ b/packages/utils/test/listenOnceForAbort.test.ts
@@ -1,0 +1,49 @@
+import { listenOnceForAbort } from '../src/listenOnceForAbort'
+import { AbortError } from '../src/asAbortable'
+import { noop } from 'lodash'
+
+describe(listenOnceForAbort, () => {
+    it('triggers callback on abort signal', () => {
+        const controller = new AbortController()
+        const cb = jest.fn()
+        listenOnceForAbort(controller.signal, cb)
+        expect(cb).not.toHaveBeenCalled()
+        controller.abort()
+        expect(cb).toHaveBeenCalled()
+    })
+
+    it('does not trigger callback on abort signal if cleared', () => {
+        const controller = new AbortController()
+        const cb = jest.fn()
+        const { clear } = listenOnceForAbort(controller.signal, cb)
+        clear()
+        controller.abort()
+        expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('by default triggers callback given pre-aborted signal', () => {
+        const controller = new AbortController()
+        controller.abort()
+        const cb = jest.fn()
+        listenOnceForAbort(controller.signal, cb)
+        expect(cb).toHaveBeenCalled()
+    })
+
+    it('when given pre-aborted signal, returned clear is noop', () => {
+        const controller = new AbortController()
+        controller.abort()
+        const cb = jest.fn()
+        const { clear } = listenOnceForAbort(controller.signal, cb)
+        expect(clear).toBe(noop)
+    })
+
+    it('can be configured to throw instead given pre-aborted signal', () => {
+        const controller = new AbortController()
+        controller.abort()
+        const cb = jest.fn()
+        expect(() => listenOnceForAbort(controller.signal, cb, 'throw'))
+            .toThrowError(new AbortError())
+        expect(cb).not.toHaveBeenCalled()
+    })
+})
+

--- a/packages/utils/test/scheduleAtFixedRate.test.ts
+++ b/packages/utils/test/scheduleAtFixedRate.test.ts
@@ -5,20 +5,28 @@ const INTERVAL = 100
 
 describe(scheduleAtFixedRate, () => {
     let task: jest.Mock<Promise<void>, [number]>
-    let ref: { stop: () => void }
+    let abortController: AbortController
 
     beforeEach(() => {
         task = jest.fn()
+        abortController = new AbortController()
     })
 
     afterEach(() => {
-        ref.stop()
+        abortController?.abort()
     })
 
-    it('repeats every `interval`', async () => {
-        ref = scheduleAtFixedRate(task, INTERVAL)
+    it('repeats task every `interval`', async () => {
+        scheduleAtFixedRate(task, INTERVAL, abortController.signal)
         await wait(4 * INTERVAL)
         expect(task.mock.calls.length).toBeGreaterThanOrEqual(4)
         expect(task.mock.calls.every(([now]) => now % 100 === 0)).toEqual(true)
+    })
+
+    it('task never invoked if initially aborted', async () => {
+        abortController.abort()
+        scheduleAtFixedRate(task, INTERVAL, abortController.signal)
+        await wait(4 * INTERVAL)
+        expect(task).not.toHaveBeenCalled()
     })
 })

--- a/packages/utils/test/scheduleAtInterval.test.ts
+++ b/packages/utils/test/scheduleAtInterval.test.ts
@@ -6,36 +6,44 @@ const FIVE_REPEATS_TIME = INTERVAL * 5 + INTERVAL / 2
 
 describe(scheduleAtInterval, () => {
     let task: jest.Mock<Promise<void>, []>
-    let ref: { stop: () => void }
+    let abortController: AbortController
 
     beforeEach(() => {
         task = jest.fn()
+        abortController = new AbortController()
     })
 
     afterEach(() => {
-        ref.stop()
+        abortController?.abort()
     })
 
     it('execute at start enabled', async () => {
-        ref = await scheduleAtInterval(task, INTERVAL, true)
+        await scheduleAtInterval(task, INTERVAL, true, abortController.signal)
         expect(task).toHaveBeenCalledTimes(1)
     })
 
     it('execute at start disabled', async () => {
-        ref = await scheduleAtInterval(task, INTERVAL, false)
+        await scheduleAtInterval(task, INTERVAL, false, abortController.signal)
         expect(task).toHaveBeenCalledTimes(0)
     })
 
     it('repeats every `interval`', async () => {
-        ref = await scheduleAtInterval(task, INTERVAL, false)
+        await scheduleAtInterval(task, INTERVAL, false, abortController.signal)
         await wait(FIVE_REPEATS_TIME)
         expect(task.mock.calls.length).toEqual(5)
     })
 
     it('does not take into account the time for the promise to settle', async () => {
         task.mockImplementation(() => wait(INTERVAL))
-        ref = await scheduleAtInterval(task, INTERVAL, false)
+        await scheduleAtInterval(task, INTERVAL, false, abortController.signal)
         await wait(FIVE_REPEATS_TIME)
         expect(task.mock.calls.length).toBeLessThan(5)
+    })
+
+    it('task never invoked if initially aborted', async () => {
+        abortController.abort()
+        await scheduleAtInterval(task, INTERVAL, true, abortController.signal)
+        await wait(FIVE_REPEATS_TIME)
+        expect(task).not.toHaveBeenCalled()
     })
 })

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -17,12 +17,12 @@ describe(wait, () => {
         setTimeout(() => {
             abortController.abort()
         }, 10)
-        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
+        return expect(wait(20, abortController.signal)).rejects.toEqual(new AbortError())
     })
 
     it('rejects if initially aborted', () => {
         const abortController = new AbortController()
         abortController.abort()
-        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
+        return expect(wait(20, abortController.signal)).rejects.toEqual(new AbortError())
     })
 })

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -1,13 +1,28 @@
 import { wait } from '../src/wait'
+import { AbortError } from '../src/AbortError'
 
 describe(wait, () => {
     // https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate
     const JITTER_FACTOR = 4
 
-    it("waits at least the predetermined time", async () => {
+    it('waits at least the predetermined time', async () => {
         const start = Date.now()
         await wait(20)
         const end = Date.now()
         expect(end - start).toBeGreaterThanOrEqual(20 - JITTER_FACTOR)
+    })
+
+    it('rejects if aborted during wait', () => {
+        const abortController = new AbortController()
+        setTimeout(() => {
+            abortController.abort()
+        }, 10)
+        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
+    })
+
+    it('rejects if initially aborted', () => {
+        const abortController = new AbortController()
+        abortController.abort()
+        return expect(wait(20, abortController)).rejects.toEqual(new AbortError())
     })
 })

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -1,5 +1,5 @@
 import { wait } from '../src/wait'
-import { AbortError } from '../src/AbortError'
+import { AbortError } from '../src/asAbortable'
 
 describe(wait, () => {
     // https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -32,20 +32,20 @@ describe(withTimeout, () => {
         setTimeout(() => {
             abortController.abort()
         }, 10)
-        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController))
+        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController.signal))
             .rejects.toEqual(new AbortError('context'))
     })
 
     it('rejects if initially aborted', () => {
         const abortController = new AbortController()
         abortController.abort()
-        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController))
+        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController.signal))
             .rejects.toEqual(new AbortError('context'))
     })
 
     it('timeout if no abort controller signalled', () => {
         const abortController = new AbortController()
-        return expect(withTimeout(new Promise<unknown>(() => {}), 10, 'context', abortController))
+        return expect(withTimeout(new Promise<unknown>(() => {}), 10, 'context', abortController.signal))
             .rejects.toEqual(new TimeoutError(10, 'context'))
     })
 })

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -1,5 +1,5 @@
 import { TimeoutError, withTimeout } from '../src/withTimeout'
-import { AbortError } from '../src/AbortError'
+import { AbortError } from '../src/asAbortable'
 
 describe(withTimeout, () => {
     it('resolves if given promise resolves before timeout', () => {

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -1,4 +1,5 @@
-import { AbortError, TimeoutError, withTimeout } from '../src/withTimeout'
+import { TimeoutError, withTimeout } from '../src/withTimeout'
+import { AbortError } from '../src/AbortError'
 
 describe(withTimeout, () => {
     it('resolves if given promise resolves before timeout', () => {


### PR DESCRIPTION
## TODO
- [ ] Update PR description

## Summary
Based on #920 -> #919 -> #917.

Please provide a summary of the changes and a motivation if applicable.

## Changes
- utils: harmonize all exported functions and methods to use `AbortSignal`
  - Modify method `MetricsContext#createReportProducer` to take in `AbortSignal`.
  - Modify function `scheduleAtFixedRate`  to take in `AbortSignal`.
  - Modify function `scheduleAtInterval` to take in `AbortSignal`.
- client: update `MetricsPublisher` to use `AbortSignal` and remove `destroy` method.

## Limitations and future improvements

Provide a bullet list or description of known omissions or limitations of the
solution and/or any ideas for future improvement. Leave section ouf if
not applicable.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
