### PR TITLE
chore(network): drastically downsize propagation buffer

### DIFF
--- a/packages/network/src/logic/propagation/Propagation.ts
+++ b/packages/network/src/logic/propagation/Propagation.ts
@@ -11,7 +11,7 @@ interface ConstructorOptions {
     maxMessages?: number
 }
 
-const DEFAULT_MAX_MESSAGES = 10000
+const DEFAULT_MAX_MESSAGES = 30
 const DEFAULT_TTL = 30 * 1000
 
 /**


### PR DESCRIPTION
## Summary

Reduce the default maximum active propagation tasks parameter in network node, i.e. `Propagation#DEFAULT_MAX_MESSAGES`, from 10000 to 30. Having the "propagation buffer" be too large can cause extremely busty behavior in large topologies leading to message delivery failure and high resource consumption.

## Limitations and Future improvements

- Temporarily had to adjust broker test `multiple-publisher-plugins.test.ts` to wait a bit after publishing 1st message (so that connections get opened). Otherwise it would publish 120 messages at once, leading to most of them dropping off the buffer. This should be addressed in NET-919.

- Consider adding a rate limit to how fast a buffer gets emptied. This could allow for a larger buffer whilst keeping the bursty-ness in check.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
