### PR TITLE
Add governance voting to CLI tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,6 +2237,11 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/@ensdomains/eth-ens-namehash": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+            "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -5286,6 +5291,28 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
             "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "node_modules/@snapshot-labs/snapshot.js": {
+            "version": "0.4.43",
+            "resolved": "https://registry.npmjs.org/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.43.tgz",
+            "integrity": "sha512-H279y596WTUOaRbirgnDAGSqVsIhCuDfB9Obt2hmVmnFVgUSmGzXHY83a3i2B8osSvdFKV0VxozikWlvu/V/mw==",
+            "dependencies": {
+                "@ensdomains/eth-ens-namehash": "^2.0.15",
+                "@ethersproject/abi": "^5.6.4",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/contracts": "^5.6.2",
+                "@ethersproject/hash": "^5.6.1",
+                "@ethersproject/providers": "^5.6.8",
+                "@ethersproject/wallet": "^5.6.2",
+                "ajv": "^8.11.0",
+                "ajv-formats": "^2.1.1",
+                "cross-fetch": "^3.1.5",
+                "json-to-graphql-query": "^2.2.4",
+                "lodash.set": "^4.3.2"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@streamr/cli-tools": {
             "resolved": "packages/cli-tools",
@@ -9172,6 +9199,14 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
+        },
+        "node_modules/cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "dependencies": {
+                "node-fetch": "2.6.7"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -16379,6 +16414,11 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
+        "node_modules/json-to-graphql-query": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.2.4.tgz",
+            "integrity": "sha512-vNvsOKDSlEqYCzejI1xHS9Hm738dSnG4Upy09LUGqyybZXSIIb7NydDphB/6WxW2EEVpPU4JeU/Yo63Nw9dEJg=="
+        },
         "node_modules/json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -18869,6 +18909,11 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "node_modules/lodash.set": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+            "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
         },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
@@ -29336,6 +29381,8 @@
             "version": "7.0.0-beta.0",
             "license": "AGPL-3.0",
             "dependencies": {
+                "@ethersproject/wallet": "^5.7.0",
+                "@snapshot-labs/snapshot.js": "^0.4.43",
                 "@streamr/utils": "^1.0.0",
                 "commander": "^8.3.0",
                 "easy-table": "^1.1.1",
@@ -31438,6 +31485,11 @@
                     "dev": true
                 }
             }
+        },
+        "@ensdomains/eth-ens-namehash": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+            "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
         },
         "@eslint/eslintrc": {
             "version": "1.3.0",
@@ -33728,9 +33780,30 @@
                 }
             }
         },
+        "@snapshot-labs/snapshot.js": {
+            "version": "0.4.43",
+            "resolved": "https://registry.npmjs.org/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.43.tgz",
+            "integrity": "sha512-H279y596WTUOaRbirgnDAGSqVsIhCuDfB9Obt2hmVmnFVgUSmGzXHY83a3i2B8osSvdFKV0VxozikWlvu/V/mw==",
+            "requires": {
+                "@ensdomains/eth-ens-namehash": "^2.0.15",
+                "@ethersproject/abi": "^5.6.4",
+                "@ethersproject/bytes": "^5.6.1",
+                "@ethersproject/contracts": "^5.6.2",
+                "@ethersproject/hash": "^5.6.1",
+                "@ethersproject/providers": "^5.6.8",
+                "@ethersproject/wallet": "^5.6.2",
+                "ajv": "^8.11.0",
+                "ajv-formats": "^2.1.1",
+                "cross-fetch": "^3.1.5",
+                "json-to-graphql-query": "^2.2.4",
+                "lodash.set": "^4.3.2"
+            }
+        },
         "@streamr/cli-tools": {
             "version": "file:packages/cli-tools",
             "requires": {
+                "@ethersproject/wallet": "*",
+                "@snapshot-labs/snapshot.js": "^0.4.43",
                 "@streamr/utils": "^1.0.0",
                 "@types/easy-table": "0.0.32",
                 "@types/event-stream": "^3.3.34",
@@ -37026,6 +37099,14 @@
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
+        },
+        "cross-fetch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+            "requires": {
+                "node-fetch": "2.6.7"
+            }
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -42638,6 +42719,11 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
+        "json-to-graphql-query": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.2.4.tgz",
+            "integrity": "sha512-vNvsOKDSlEqYCzejI1xHS9Hm738dSnG4Upy09LUGqyybZXSIIb7NydDphB/6WxW2EEVpPU4JeU/Yo63Nw9dEJg=="
+        },
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -44741,6 +44827,11 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "lodash.set": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+            "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
         },
         "lodash.sortby": {
             "version": "4.7.0",

--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added command `governance vote` for casting votes on Streamr governance proposals
+
 ### Changed
 
 - Replace command `storage-node list-stream-parts` with `storage-node list-streams` and change the output format

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -151,6 +151,23 @@ To fetch data between two date-times
 streamr stream resend range 2019-05-10T17:00:00 2019-05-11T21:00:00 <streamId> --private-key <key>
 ```
 
+### Vote
+
+The CLI tool can be used to vote on Streamr governance proposals as an alternative to doing it manually in the [voting UI](https://vote.streamr.network). This is useful if you have tokens in a large number of wallets (for example due to staking) and you therefore prefer to cast your votes programmatically.
+
+```
+streamr governance vote <proposalId> <choiceId>
+```
+
+The easiest way to find the `proposalId` is to click on a proposal in the [voting UI](https://vote.streamr.network) and then look at the browser URL. The URL has the form `https://vote.streamr.network/#/proposal/<proposalId>`, i.e. the last part of the URL is the `proposalId`. It starts with `0x...`.
+
+The `choiceId` is just a sequence number. You can again use the UI to check what the choices are. The first option from the top is `1`, the next one is `2`, and so on. For example:
+
+```
+streamr governance vote 0x2109759e060ba5a37d70be00522e00da77397f838c01c12f74c8d834ad4f4b0c 1 --private-key <key>
+```
+
+
 #### Configuration
 
 User can specify environment and authentication details with the following command line arguments:

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -156,7 +156,7 @@ streamr stream resend range 2019-05-10T17:00:00 2019-05-11T21:00:00 <streamId> -
 The CLI tool can be used to vote on Streamr governance proposals as an alternative to doing it manually in the [voting UI](https://vote.streamr.network). This is useful if you have tokens in a large number of wallets (for example due to staking) and you therefore prefer to cast your votes programmatically.
 
 ```
-streamr governance vote <proposalId> <choiceId>
+streamr governance vote <proposalId> <choiceId> --private-key <key>
 ```
 
 The easiest way to find the `proposalId` is to click on a proposal in the [voting UI](https://vote.streamr.network) and then look at the browser URL. The URL has the form `https://vote.streamr.network/#/proposal/<proposalId>`, i.e. the last part of the URL is the `proposalId`. It starts with `0x...`.
@@ -167,6 +167,7 @@ The `choiceId` is just a sequence number. You can again use the UI to check what
 streamr governance vote 0x2109759e060ba5a37d70be00522e00da77397f838c01c12f74c8d834ad4f4b0c 1 --private-key <key>
 ```
 
+You must pass either the `--private-key` or `--config` option.
 
 #### Configuration
 

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import pkg from '../package.json'
 import { createCommand } from '../src/command'
 import { getClientConfig } from '../src/client'
 import snapshot from '@snapshot-labs/snapshot.js'

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -21,6 +21,7 @@ const vote = async (privateKey: string, proposal: string, choice: number) => {
         console.log(`Wallet ${wallet.address} successfully voted for choice ${choice} on proposal ${proposal}`)
     } catch (err) {
         console.error(err)
+        process.exit(1)
     }
 }
 

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -18,7 +18,7 @@ const vote = async (privateKey: string, proposal: string, choice: number) => {
             choice,
             app: 'cli-tool'
         })
-        console.log(`Successfully voted for choice ${choice} on proposal ${proposal}`)
+        console.log(`Wallet ${wallet.address} successfully voted for choice ${choice} on proposal ${proposal}`)
     } catch (err) {
         console.error(err)
     }

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -8,7 +8,7 @@ import { Wallet } from '@ethersproject/wallet'
 const hub = 'https://hub.snapshot.org'
 const snapshotClient = new snapshot.Client712(hub)
 
-const vote = async (privateKey: string, proposal: string, choice: number) => {
+const vote = async (privateKey: string, proposal: string, choice: string) => {
     const wallet = new Wallet(privateKey)
     try {
         await snapshotClient.vote(wallet, wallet.address, {
@@ -35,9 +35,9 @@ createCommand()
         if (!config.auth || !config.auth.privateKey) {
             console.error('You must pass a private key either via --private-key or via a config file using --config')
             command.help()
-        } else {
-            await vote(config.auth.privateKey, proposalId, parseInt(choiceId))
-        }
+            process.exit(1)
+        } 
+
+        await vote(config.auth.privateKey, proposalId, choiceId)
     })
-    .version(pkg.version)
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import pkg from '../package.json'
+import { createCommand } from '../src/command'
+import { getClientConfig } from '../src/client'
+import snapshot from '@snapshot-labs/snapshot.js'
+import { Wallet } from '@ethersproject/wallet'
+
+const hub = 'https://hub.snapshot.org'
+const snapshotClient = new snapshot.Client712(hub)
+
+const vote = async (privateKey: string, proposal: string, choice: number) => {
+    const wallet = new Wallet(privateKey)
+    try {
+        await snapshotClient.vote(wallet, wallet.address, {
+            space: 'streamr.eth',
+            proposal,
+            type: 'single-choice', // support only this type for now
+            choice,
+            app: 'cli-tool'
+        })
+        console.log(`Successfully voted for choice ${choice} on proposal ${proposal}`)
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+// The StreamrClient is not really used here, but we want to support the same
+// --private-key and --config args as the commands that actually use the client
+createCommand()
+    .description('vote on a Streamr governance proposal')
+    .arguments('<proposalId> <choiceId>')
+    .option('--private-key <key>', 'use an Ethereum private key to authenticate')
+    .option('--config <file>', 'read connection and authentication settings from a config file')
+    .action(async (proposalId: string, choiceId: string, options, command) => {
+        const config = getClientConfig(options)
+        if (!config.auth || !config.auth.privateKey) {
+            console.error('You must pass a private key either via --private-key or via a config file using --config')
+            command.help()
+        } else {
+            await vote(config.auth.privateKey, proposalId, parseInt(choiceId))
+        }
+    })
+    .version(pkg.version)
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-governance-vote.ts
+++ b/packages/cli-tools/bin/streamr-governance-vote.ts
@@ -24,8 +24,6 @@ const vote = async (privateKey: string, proposal: string, choice: number) => {
     }
 }
 
-// The StreamrClient is not really used here, but we want to support the same
-// --private-key and --config args as the commands that actually use the client
 createCommand()
     .description('vote on a Streamr governance proposal')
     .arguments('<proposalId> <choiceId>')

--- a/packages/cli-tools/bin/streamr-governance.ts
+++ b/packages/cli-tools/bin/streamr-governance.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { program } from 'commander'
+import pkg from '../package.json'
+
+program
+    .version(pkg.version)
+    .usage('<command> [<args>]')
+    .description('governance subcommands')
+    .command('vote', 'votes on a governance proposal')
+    .parse()

--- a/packages/cli-tools/bin/streamr.ts
+++ b/packages/cli-tools/bin/streamr.ts
@@ -10,4 +10,5 @@ program
     .command('storage-node', 'storage node subcommands')
     .command('mock-data', 'mock data subcommands')
     .command('wallet', 'wallet subcommands')
+    .command('governance', 'governance subcommands')
     .parse()

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/streamr-dev/cli-tools#readme",
   "dependencies": {
-    "@ethersproject/wallet": "^5.7.0",
+    "@ethersproject/wallet": "^5.5.0",
     "@snapshot-labs/snapshot.js": "^0.4.43",
     "@streamr/utils": "^1.0.0",
     "commander": "^8.3.0",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -30,6 +30,8 @@
   },
   "homepage": "https://github.com/streamr-dev/cli-tools#readme",
   "dependencies": {
+    "@ethersproject/wallet": "^5.7.0",
+    "@snapshot-labs/snapshot.js": "^0.4.43",
     "@streamr/utils": "^1.0.0",
     "commander": "^8.3.0",
     "easy-table": "^1.1.1",

--- a/packages/cli-tools/src/client.ts
+++ b/packages/cli-tools/src/client.ts
@@ -3,7 +3,7 @@ import { StreamrClientConfig, StreamrClient, ConfigTest } from 'streamr-client'
 import { GlobalCommandLineArgs } from './common'
 import { getConfig } from './config'
 
-const getClientConfig = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig) => {
+export const getClientConfig = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
     const environmentOptions = (commandLineArgs.dev !== undefined) ? omit(ConfigTest, 'auth') : undefined
     const configFileJson = getConfig(commandLineArgs.config)?.client
     const authenticationOptions = (commandLineArgs.privateKey !== undefined) ? { auth: { privateKey: commandLineArgs.privateKey } } : undefined


### PR DESCRIPTION
## Summary

Adds a new command to the CLI tool for casting governance votes:

```
streamr governance vote <proposalId> <choiceId>
```

Supports the `--private-key` and `--config` command line options. One of them must be provided, and if `--config` is used, there must be a private key in the config file (in `client.auth.privateKey` as usual).

Tested manually after creating a dummy proposal on Snapshot:

```
streamr governance vote 0x38f5117518171ee2d9575c369aa3235fda4a63f08cd7c8882579f6daeca68e9b 1 --private-key <key>
```

Success output:

```
Wallet 0xD4081fCd7b3d4006515f9Daf7C7B6Cc13935df12 successfully voted for choice 1 on proposal 0x38f5117518171ee2d9575c369aa3235fda4a63f08cd7c8882579f6daeca68e9b
```

Vote was cast, verified in the UI:
<img width="628" alt="Screenshot 2022-10-26 at 22 27 43" src="https://user-images.githubusercontent.com/1263120/198130320-d3d3e882-74e0-44de-8f78-ea39bc26d1a2.png">

If any error happens while casting the vote, the error object is simply printed to `console.error` (this example is from trying to vote on an already closed proposal):

```
{ error: 'unauthorized', error_description: 'not in voting window' }
```

## Limitations and future improvements

Only implements the `vote` command for casting votes. There's no functionality for e.g. listing proposals

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [X] Read through code myself one more time.
- [X] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage? (there are no tests for the CLI tool)
- [X] Updated changelog if applicable.
- [X] Updated documentation if applicable.
