### PR TITLE
refactor(utils): remove "as any" casts and undefined checks

### DIFF
--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -16,23 +16,16 @@ function createAbortableTimerFn(
     removeListenerOnCb: boolean
 ): (cb: () => void, ms: number, abortSignal: AbortSignal) => void {
     return (callback, ms, abortSignal): void => {
-        if (abortSignal?.aborted) {
+        if (abortSignal.aborted) {
             return
         }
-        let abortListener: () => void
-        if (abortSignal !== undefined) {
-            abortListener = () => {
-                clearFn(timeoutRef)
-                // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-                ;(abortSignal as any).removeEventListener('abort', abortListener)
-            }
-            // TODO remove the type casting when type definition for abortController has been updated to include addEventListener
-            (abortSignal as any).addEventListener('abort', abortListener)
+        const abortListener = () => {
+            clearFn(timeoutRef)
         }
+        abortSignal.addEventListener('abort', abortListener, { once: true })
         const timeoutRef = setupTimerFn(() => {
-            if (abortListener !== undefined && removeListenerOnCb) {
-                // TODO remove the type casting when type definition for abortController has been updated to include removeEventListener
-                (abortSignal as any).removeEventListener('abort', abortListener)
+            if (removeListenerOnCb) {
+                abortSignal.removeEventListener('abort', abortListener)
             }
             callback()
         }, ms)


### PR DESCRIPTION
## Changes

- With the new version of Node.js type definitions `@types/nodes` introduced in 074d31611c94bd69dfe4b5fecd072b80374cc69c,  interface `AbortSignal` now properly inherits from `EventTarget` removing the need for `as any` casts to add and remove event listeners.
- Remove undefined checks for parameter `abortSignal` in `setAbortableTimeout` and `setAbortableInterval`. No need as the parameter is not optional.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
