### PR TITLE
chore: wrapper for flaky test NET-918

### DIFF
--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -27,7 +27,7 @@ async function retryFlakyTestNET918(
             await it(name, fn, timeout)
             break
         } catch (e) {
-            if (e instanceof RangeError && e.message.includes('The value of "offset" is out of range')) {
+            if (e.message?.includes('The value of "offset" is out of range')) {
                 logger.warn('Flaky test run (NET-918) detected! %d/%d', i, MAX_RUNS)
                 if (i === MAX_RUNS) {
                     throw e

--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -16,15 +16,15 @@ const MESSAGE_SIZE = 1e3 // 1k
 
 const logger = new Logger(module)
 
-function retryFlakyTestNET918(
+async function retryFlakyTestNET918(
     name: string,
     fn?: ((cb: (...args: any[]) => any) => void) | (() => Promise<unknown>),
     timeout?: number
-): void {
+): Promise<void> {
     const MAX_RUNS = 5
     for (let i = 1; i <= MAX_RUNS; ++i) {
         try {
-            it(name, fn, timeout)
+            await it(name, fn, timeout)
             break
         } catch (e) {
             if (e instanceof RangeError && e.message.includes('The value of "offset" is out of range')) {

--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -21,19 +21,22 @@ function retryFlakyTestNET918(
     fn?: ((cb: (...args: any[]) => any) => void) | (() => Promise<unknown>),
     timeout?: number
 ): void {
-    for (let i = 0; i < 4; ++i) {
+    const MAX_RUNS = 5
+    for (let i = 1; i <= MAX_RUNS; ++i) {
         try {
             it(name, fn, timeout)
             break
         } catch (e) {
             if (e instanceof RangeError && e.message.includes('The value of "offset" is out of range')) {
-                logger.warn('Flaky test run (NET-918) detected!')
+                logger.warn('Flaky test run (NET-918) detected! %d/%d', i, MAX_RUNS)
+                if (i === MAX_RUNS) {
+                    throw e
+                }
             } else {
                 throw e
             }
         }
     }
-    it(name, fn, timeout)
 }
 
 describe('Storage: lots of data', () => {


### PR DESCRIPTION
## Summary

Create a flaky test wrapper. Currently for NET-918. Let's not get into the habit of using regularly so not moving to test-utils for the moment. 

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
