### PR TITLE
test(utils): Browser tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,10 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: utils
+      command: |
+        npm run test
+        sudo apt-get install xvfb
+        xvfb-run --auto-servernum npm run test-browser
   protocol:
     needs: build
     uses: ./.github/workflows/test-setup.yml

--- a/packages/utils/dummy-stdout.js
+++ b/packages/utils/dummy-stdout.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/utils/karma-setup.js
+++ b/packages/utils/karma-setup.js
@@ -1,0 +1,59 @@
+// Add important parts of Jest to the Karma/Jasmine browser-test runtime's global scope
+// the jest.fn() API
+
+import * as jestMock from 'jest-mock'
+
+// The following lines need to use the require syntax to fix 
+// process.stdout dependency in expect v. 28+ 
+process.stdout = require('./dummy-stdout')
+const expect = require ('expect').default
+
+import { ModernFakeTimers } from '@jest/fake-timers'
+
+// importing jest-extended directly relies on global.expect to be set
+// importing the matchers and calling expect.extend manually
+// prevents tests failing due to global.expect not being set
+import jestExtendedMatchers from 'jest-extended/dist/matchers'
+
+let jest = jestMock
+const timers = new ModernFakeTimers({global: window, config: null })
+
+// prevent navigation
+// without this karma fails the suite with "Some of your tests did a full page reload!"
+// not clear what is causing the reload.
+window.onbeforeunload = () => 'unload prevented'
+
+jest.advanceTimersByTime = timers.advanceTimersByTime
+jest.advanceTimersToNextTimer = timers.advanceTimersToNextTimer
+jest.clearAllTimers = timers.clearAllTimers
+jest.dispose = timers.dispose
+jest.getRealSystemTime = timers.getRealSystemTime
+jest.getTimerCount = timers.getTimerCount
+jest.reset = timers.reset
+jest.runAllTicks = timers.runAllTicks
+jest.runAllTimers = timers.runAllTimers
+jest.runOnlyPendingTimers = timers.runOnlyPendingTimers
+jest.setSystemTime = timers.setSystemTime
+jest.useFakeTimers = timers.useFakeTimers
+jest.useRealTimers = timers.useRealTimers
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000
+// eslint-disable-next-line no-underscore-dangle
+jest._checkFakeTimers = timers._checkFakeTimers
+
+Object.assign(jest, timers)
+
+expect.extend(jestExtendedMatchers)
+
+// Add missing Jest functions
+window.test = window.it
+window.test.each = (inputs) => (testName, test) =>
+    inputs.forEach((args) => window.it(testName, () => test(...args)))
+window.test.todo = function () {
+    return undefined
+}
+
+window.expect = expect
+window.setImmediate = setTimeout
+window.clearImmediate = clearTimeout
+window.jest = jestMock
+

--- a/packages/utils/karma-setup.js
+++ b/packages/utils/karma-setup.js
@@ -13,7 +13,7 @@ import { ModernFakeTimers } from '@jest/fake-timers'
 // importing jest-extended directly relies on global.expect to be set
 // importing the matchers and calling expect.extend manually
 // prevents tests failing due to global.expect not being set
-import jestExtendedMatchers from 'jest-extended/dist/matchers'
+import * as jestExtendedMatchers from 'jest-extended'
 
 let jest = jestMock
 const timers = new ModernFakeTimers({global: window, config: null })

--- a/packages/utils/karma.config.js
+++ b/packages/utils/karma.config.js
@@ -1,0 +1,57 @@
+const webpackConfig = require('./webpack.config')
+
+module.exports = function (config) {
+    config.set({
+        plugins: [
+            'karma-electron',
+            'karma-webpack',
+            'karma-jasmine',
+            'karma-spec-reporter',
+            'karma-sourcemap-loader'
+        ],
+        basePath: '.',
+        frameworks: ['jasmine'],
+        reporters: ['spec'],
+        files: [
+            './karma-setup.js',
+            './test/end-to-end/**/!(webrtc*|websocket*)',
+            './test/integration/**',
+            './test/unit/**',
+           {
+                pattern: '**/*.js.map',
+                included: false
+            }
+           
+        ],
+        preprocessors: {
+            './karma-setup.js': ['webpack'],
+            './test/**/*.ts': ['webpack','sourcemap'],
+        },
+        customLaunchers: {
+            CustomElectron: {
+                base: 'Electron',
+                browserWindowOptions: {
+                    webPreferences: {
+                        contextIsolation: false,
+                        preload: __dirname + '/preload.js',
+                        webSecurity: false,
+                        sandbox: false
+                    },
+                    show: false // set to true to show the electron window
+                }
+            }
+        },
+        browserDisconnectTimeout: 30000,
+        browserNoActivityTimeout: 400000,
+        browsers: ['CustomElectron'],
+        client: {
+            clearContext: false, // leave Jasmine Spec Runner output visible in browser
+            useIframe: false,
+        },
+        singleRun: true,   //set to false to leave electron window open
+        webpack: {
+            ...webpackConfig('test'),
+            entry: {}
+        }
+    })
+}

--- a/packages/utils/karma.config.js
+++ b/packages/utils/karma.config.js
@@ -14,18 +14,11 @@ module.exports = function (config) {
         reporters: ['spec'],
         files: [
             './karma-setup.js',
-            './test/end-to-end/**/!(webrtc*|websocket*)',
-            './test/integration/**',
-            './test/unit/**',
-           {
-                pattern: '**/*.js.map',
-                included: false
-            }
-           
+            './test/*.ts'
         ],
         preprocessors: {
             './karma-setup.js': ['webpack'],
-            './test/**/*.ts': ['webpack','sourcemap'],
+            './test/*.ts': ['webpack', 'sourcemap'],
         },
         customLaunchers: {
             CustomElectron: {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -45,7 +45,6 @@
     "karma-chrome-launcher": "^3.1.1",
     "karma-electron": "^7.3.0",
     "karma-jasmine": "^5.1.0",
-    "karma-jest": "^1.0.0-beta.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-spec-reporter": "^0.0.34",
     "karma-webpack": "^5.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,6 +8,7 @@
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "test": "jest",
     "test-unit": "npm run test",
+    "test-browser": "webpack --mode=development --progress && karma start karma.config.js",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepare": "npm run build",
     "build": "tsc --build tsconfig.node.json",
@@ -36,6 +37,22 @@
   "devDependencies": {
     "@types/lodash": "^4.14.175",
     "@types/pino": "^6.3.8",
-    "@types/pino-pretty": "^4.7.0"
+    "@types/pino-pretty": "^4.7.0",
+    "electron": "^20.0.3",
+    "electron-rebuild": "^3.2.9",
+    "express": "^4.17.1",
+    "karma": "^6.4.0",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-electron": "^7.3.0",
+    "karma-jasmine": "^5.1.0",
+    "karma-jest": "^1.0.0-beta.0",
+    "karma-sourcemap-loader": "^0.3.8",
+    "karma-spec-reporter": "^0.0.34",
+    "karma-webpack": "^5.0.0",
+    "node-module-polyfill": "^1.0.1",
+    "node-polyfill-webpack-plugin": "^1.1.4",
+    "typescript": "^4.5.2",
+    "webpack": "^5.64.1",
+    "webpack-cli": "^4.9.1"
   }
 }

--- a/packages/utils/preload.js
+++ b/packages/utils/preload.js
@@ -6,6 +6,4 @@ process.once("loaded", () => {
     window.HTTP = require('http')
     window.HTTPS = require('https')
     window.NodeJsBuffer = Buffer
-    // maybe we can set this karma-setup
-    window._streamr_electron_test = true
 })

--- a/packages/utils/preload.js
+++ b/packages/utils/preload.js
@@ -1,0 +1,9 @@
+// Loads non-browser compatible components to Electron's NodeJS sandbox during tests
+
+process.once("loaded", () => {
+    window.NodeJsWsServer = require('websocket').server
+    window.Express = require('express')
+    window.HTTP = require('http')
+    window.HTTPS = require('https')
+    window.NodeJsBuffer = Buffer
+})

--- a/packages/utils/preload.js
+++ b/packages/utils/preload.js
@@ -6,4 +6,6 @@ process.once("loaded", () => {
     window.HTTP = require('http')
     window.HTTPS = require('https')
     window.NodeJsBuffer = Buffer
+    // maybe we can set this karma-setup
+    window._streamr_electron_test = true
 })

--- a/packages/utils/test/Defer.test.ts
+++ b/packages/utils/test/Defer.test.ts
@@ -1,6 +1,6 @@
 import { Defer } from '../src/Defer'
 
-describe(Defer, () => {
+describe('Defer', () => {
     it('can be constructed', () => {
         expect(() => new Defer()).not.toThrow()
     })

--- a/packages/utils/test/ENSName.test.ts
+++ b/packages/utils/test/ENSName.test.ts
@@ -1,6 +1,6 @@
 import { toENSName } from '../src/exports'
 
-describe(toENSName, () => {
+describe('toENSName', () => {
     it.each(['noperiod', '.domain'])('throws on invalid ENS name "%s"', (str) => {
         expect(() => toENSName(str)).toThrowError()
     })

--- a/packages/utils/test/EthereumAddress.test.ts
+++ b/packages/utils/test/EthereumAddress.test.ts
@@ -1,6 +1,6 @@
 import { toEthereumAddress } from '../src/EthereumAddress'
 
-describe(toEthereumAddress, () => {
+describe('toEthereumAddress', () => {
     it('invalid addresses', () => {
         expect(() => toEthereumAddress('')).toThrowError()
         expect(() => toEthereumAddress('0x')).toThrowError()

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -5,7 +5,7 @@ import Mock = jest.Mock
 // eslint-disable-next-line no-underscore-dangle
 declare let _streamr_electron_test: any
 
-describe(Logger, () => {
+describe('Logger', () => {
     let logger: Logger
     let fatalFn: Mock
     let errorFn: Mock

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -2,9 +2,6 @@ import path from 'path'
 import { Logger } from '../src/Logger'
 import Mock = jest.Mock
 
-// eslint-disable-next-line no-underscore-dangle
-declare let _streamr_electron_test: any
-
 describe('Logger', () => {
     let logger: Logger
     let fatalFn: Mock
@@ -88,10 +85,6 @@ describe('Logger', () => {
         // is not used as the default: When something, e.g a process manager,
         // has monkey-patched process.stdout.write." This is the case
         // in our browser tests.
-
-        if (typeof _streamr_electron_test !== 'undefined') {
-            return
-        }
 
         let lines: string[]
         const logger = new Logger(module, '', undefined, {

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -2,6 +2,9 @@ import path from 'path'
 import { Logger } from '../src/Logger'
 import Mock = jest.Mock
 
+// eslint-disable-next-line no-underscore-dangle
+declare let _streamr_electron_test: any
+
 describe('Logger', () => {
     let logger: Logger
     let fatalFn: Mock
@@ -85,6 +88,10 @@ describe('Logger', () => {
         // is not used as the default: When something, e.g a process manager,
         // has monkey-patched process.stdout.write." This is the case
         // in our browser tests.
+
+        if (typeof _streamr_electron_test !== 'undefined') {
+            return
+        }
 
         let lines: string[]
         const logger = new Logger(module, '', undefined, {

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -1,6 +1,49 @@
-import { waitForCondition } from 'streamr-test-utils'
 import { wait } from '../src/wait'
 import { AverageMetric, CountMetric, LevelMetric, MetricsContext, MetricsReport, RateMetric } from '../src/Metric'
+
+// TODO import this from streamr-test-utils if possible
+// in browser tests we get error: "Can't resolve '@streamr/utils' in '/Users/teogeb/workspace/streamr/network-monorepo/packages/test-utils/dist/src'"
+const waitForCondition = async (
+    conditionFn: () => (boolean | Promise<boolean>),
+    timeout = 5000,
+    retryInterval = 100,
+    onTimeoutContext?: () => string
+): Promise<void> => {
+    // create error beforehand to capture more usable stack
+    const err = new Error(`waitForCondition: timed out before "${conditionFn.toString()}" became true`)
+    return new Promise((resolve, reject) => {
+        let poller: NodeJS.Timeout | undefined = undefined
+        const clearPoller = () => {
+            if (poller !== undefined) {
+                clearInterval(poller)
+            }
+        }
+        const maxTime = Date.now() + timeout
+        const poll = async () => {
+            if (Date.now() < maxTime) {
+                let result
+                try {
+                    result = await conditionFn()
+                } catch (err) {
+                    clearPoller()
+                    reject(err)
+                }
+                if (result) {
+                    clearPoller()
+                    resolve()
+                }
+            } else {
+                clearPoller()
+                if (onTimeoutContext) {
+                    err.message += `\n${onTimeoutContext()}`
+                }
+                reject(err)
+            }
+        }
+        setTimeout(poll, 0)
+        poller = setInterval(poll, retryInterval)
+    })
+}
 
 const REPORT_INTERVAL = 100
 const ONE_SECOND = 1000

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -1,8 +1,9 @@
 import { wait } from '../src/wait'
 import { AverageMetric, CountMetric, LevelMetric, MetricsContext, MetricsReport, RateMetric } from '../src/Metric'
 
-// TODO import this from streamr-test-utils if possible
-// in browser tests we get error: "Can't resolve '@streamr/utils' in '/Users/teogeb/workspace/streamr/network-monorepo/packages/test-utils/dist/src'"
+// this is inlined version of stream-test-utils as we get this error if we'd import this from the library:
+// "Can't resolve '@streamr/utils' in '/Users/teogeb/workspace/streamr/network-monorepo/packages/test-utils/dist/src'"
+// will be fixed in NET-920
 const waitForCondition = async (
     conditionFn: () => (boolean | Promise<boolean>),
     timeout = 5000,

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -1,5 +1,5 @@
 import { waitForCondition } from 'streamr-test-utils'
-import { wait } from '@streamr/utils'
+import { wait } from '../src/wait'
 import { AverageMetric, CountMetric, LevelMetric, MetricsContext, MetricsReport, RateMetric } from '../src/Metric'
 
 const REPORT_INTERVAL = 100
@@ -12,11 +12,11 @@ describe('metrics', () => {
         let context: MetricsContext
         let reports: (MetricsReport & { generationTime: number })[]
         let producer: { stop: () => void }
-    
+
         const getReport = (timestamp: number) => {
             return reports.find((report) => (timestamp <= report.generationTime))
         }
-    
+
         beforeEach(() => {
             context = new MetricsContext()
             reports = []
@@ -27,11 +27,11 @@ describe('metrics', () => {
                 })
             }, REPORT_INTERVAL)
         })
-    
+
         afterEach(() => {
             producer.stop()
         })
-    
+
         it('happy path', async () => {
             const metricOne = {
                 count: new CountMetric(),
@@ -45,7 +45,7 @@ describe('metrics', () => {
             }
             context.addMetrics('metricThree', metricThree)
             metricThree.level.record(30)
-    
+
             // wait until the initial values have been seen by the producer
             await wait(REPORT_INTERVAL)
             const inputTime1 = Date.now()
@@ -57,7 +57,7 @@ describe('metrics', () => {
             metricThree.level.record(35)
             metricThree.rate.record(2000)
             metricThree.rate.record(4000)
-    
+
             await waitForCondition(() => getReport(inputTime1) !== undefined)
             expect(getReport(inputTime1)).toMatchObject({
                 metricOne: {
@@ -73,12 +73,12 @@ describe('metrics', () => {
                     end: expect.anything()
                 }
             })
-    
+
             const inputTime2 = Date.now()
             metricOne.count.record(3)
             metricThree.level.record(39)
             metricThree.rate.record(1000)
-    
+
             await waitForCondition(() => getReport(inputTime2) !== undefined)
             expect(getReport(inputTime2)).toMatchObject({
                 metricOne: {
@@ -94,7 +94,7 @@ describe('metrics', () => {
                 }
             })
         })
-    
+
         it('no data', async () => {
             context.addMetrics('foo', {
                 bar: new CountMetric()
@@ -138,7 +138,7 @@ describe('metrics', () => {
                 sampler.stop(Date.now())
                 expect(sampler.getAggregatedValue()).toBe(8)
             })
-            
+
             it('no data', () => {
                 const metric = new AverageMetric()
                 const sampler = metric.createSampler()
@@ -159,7 +159,7 @@ describe('metrics', () => {
                 sampler.stop(Date.now())
                 expect(sampler.getAggregatedValue()).toBe(11)
             })
-    
+
             it('include latest before start', () => {
                 const metric = new LevelMetric()
                 const sampler = metric.createSampler()
@@ -191,7 +191,7 @@ describe('metrics', () => {
                 sampler.stop(14000)
                 expect(sampler.getAggregatedValue()).toBe(25)
             })
-            
+
             it('no data', () => {
                 const metric = new RateMetric()
                 const sampler = metric.createSampler()

--- a/packages/utils/test/asAbortable.test.ts
+++ b/packages/utils/test/asAbortable.test.ts
@@ -4,7 +4,7 @@ const sleep = (ms: number) => new Promise<string>((resolve) => setTimeout(() => 
 
 const TIME_UNIT = 10
 
-describe(asAbortable, () => {
+describe('asAbortable', () => {
     it('works without abortController', async () => {
         const actual = await asAbortable(
             sleep(TIME_UNIT)

--- a/packages/utils/test/keyToArrayIndex.test.ts
+++ b/packages/utils/test/keyToArrayIndex.test.ts
@@ -1,6 +1,6 @@
 import { keyToArrayIndex } from '../src/keyToArrayIndex'
 
-describe(keyToArrayIndex, () => {
+describe('keyToArrayIndex', () => {
     it('always returns 0 if there is only one item', () => {
         expect(keyToArrayIndex(1, 'foo')).toBe(0)
         expect(keyToArrayIndex(1, 'bar')).toBe(0)

--- a/packages/utils/test/randomString.test.ts
+++ b/packages/utils/test/randomString.test.ts
@@ -6,7 +6,7 @@ function assertStringConsistsOfCharset(actual: string, expectedCharset: string):
     })
 }
 
-describe(randomString, () => {
+describe('randomString', () => {
     it('generates a random string of given length', () => {
         const str = randomString(61)
         expect(str).toHaveLength(61)

--- a/packages/utils/test/scheduleAtFixedRate.test.ts
+++ b/packages/utils/test/scheduleAtFixedRate.test.ts
@@ -3,7 +3,7 @@ import { wait } from '../src/wait'
 
 const INTERVAL = 100
 
-describe(scheduleAtFixedRate, () => {
+describe('scheduleAtFixedRate', () => {
     let task: jest.Mock<Promise<void>, [number]>
     let ref: { stop: () => void }
 

--- a/packages/utils/test/scheduleAtInterval.test.ts
+++ b/packages/utils/test/scheduleAtInterval.test.ts
@@ -4,7 +4,7 @@ import { wait } from '../src/wait'
 const INTERVAL = 40
 const FIVE_REPEATS_TIME = INTERVAL * 5 + INTERVAL / 2
 
-describe(scheduleAtInterval, () => {
+describe('scheduleAtInterval', () => {
     let task: jest.Mock<Promise<void>, []>
     let ref: { stop: () => void }
 

--- a/packages/utils/test/toEthereumAddressOrENSName.test.ts
+++ b/packages/utils/test/toEthereumAddressOrENSName.test.ts
@@ -1,6 +1,6 @@
 import { toEthereumAddressOrENSName } from '../src/toEthereumAddressOrENSName'
 
-describe(toEthereumAddressOrENSName, () => {
+describe('toEthereumAddressOrENSName', () => {
     it('returns ethereum address (lowercased) given ethereum address', () => {
         expect(toEthereumAddressOrENSName('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'))
             .toEqual('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')

--- a/packages/utils/test/wait.test.ts
+++ b/packages/utils/test/wait.test.ts
@@ -1,7 +1,7 @@
 import { wait } from '../src/wait'
 import { AbortError } from '../src/asAbortable'
 
-describe(wait, () => {
+describe('wait', () => {
     // https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate
     const JITTER_FACTOR = 4
 

--- a/packages/utils/test/waitForEvent.test.ts
+++ b/packages/utils/test/waitForEvent.test.ts
@@ -2,7 +2,7 @@ import { waitForEvent } from '../src/waitForEvent'
 import { EventEmitter } from 'events'
 import { TimeoutError } from '../src/withTimeout'
 
-describe(waitForEvent, () => {
+describe('waitForEvent', () => {
     it("waits for correct event and records the arguments of invocation", async () => {
         const emitter = new EventEmitter()
         setTimeout(() => {

--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -1,7 +1,7 @@
 import { TimeoutError, withTimeout } from '../src/withTimeout'
 import { AbortError } from '../src/asAbortable'
 
-describe(withTimeout, () => {
+describe('withTimeout', () => {
     it('resolves if given promise resolves before timeout', () => {
         return expect(withTimeout(new Promise((resolve) => setTimeout(() => resolve(123), 10)), 20))
             .resolves.toEqual(123)

--- a/packages/utils/tsconfig.browser.json
+++ b/packages/utils/tsconfig.browser.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.browser.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDirs": ["src", "test"],
+    "noImplicitOverride": false
+  },
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}

--- a/packages/utils/webpack.config.js
+++ b/packages/utils/webpack.config.js
@@ -1,0 +1,99 @@
+const path = require('path')
+const webpack = require('webpack')
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
+
+const pkg = require('./package.json')
+const libraryName = pkg.name
+
+const externals = (env) => {
+    const externals = {
+        'node-datachannel': 'commonjs node-datachannel',
+        'http': 'HTTP',
+        'https': 'HTTPS',
+        'express': 'Express',
+        'process': 'process'
+    }
+    return externals
+}
+
+const fallbacks = (env) => {
+    const fallbacks = {
+        'fs': require.resolve('browserify-fs'),
+        'module': false,
+        'net': false
+    }
+    if (env === 'production') {
+        return Object.assign(fallbacks, {
+            'http': false,
+            'https': false,
+            'express': false,
+            'websocket': false,
+        })
+    }
+    return fallbacks
+}
+
+const aliases = (env) => {
+    const aliases = {
+        'process': 'process/browser',
+        [path.resolve(__dirname, '../dht/src/connection/WebRTC/NodeWebRtcConnection.ts')]:
+            path.resolve(__dirname, '../dht/src/connection/WebRTC/BrowserWebRtcConnection.ts'),
+        '@streamr/dht': path.resolve('../dht/src/exports.ts'),
+        '@streamr/proto-rpc': path.resolve('../proto-rpc/src/exports.ts'),
+    }
+    return aliases
+}
+
+module.exports = (env, argv) => {
+    let environment = 'development'
+
+    if (env === 'test' || argv.mode === 'test' || process.env.node_env === 'test') {
+        environment = 'test'
+    }
+    const isProduction = environment === 'production'
+
+    const config = {
+        cache: {
+            type: 'filesystem',
+        },
+        mode: isProduction ? 'production' : 'development',
+        entry: './src/exports.ts',
+        devtool: "source-map",
+        module: {
+            rules: [
+                {
+                    test: /\.ts?$/,
+                    exclude: /(node_modules|simulation)/,
+                    use: [{
+                        loader: 'ts-loader',
+                        options: { configFile: 'tsconfig.browser.json' },
+                    }]
+                }
+            ],
+        },
+        plugins: [
+            new NodePolyfillPlugin({
+                includeAliases: ['process']
+            }),
+            new webpack.ProvidePlugin({
+                process: 'process/browser'
+            })
+        ],
+        resolve: {
+            extensions: ['.tsx', '.ts', '.js'],
+            alias: aliases(environment),
+            fallback: fallbacks(environment)
+        },
+        output: {
+            filename: `${libraryName}.js`,
+            sourceMapFilename: `[name].[contenthash].js.map`,
+            chunkFilename: '[id].[contenthash].js',
+            path: path.resolve(__dirname, 'dist'),
+            library: 'TrackerlessNetwork',
+            libraryTarget: 'umd2',
+            umdNamedDefine: true,
+        },
+        externals: externals(environment)
+    }
+    return config
+}

--- a/packages/utils/webpack.config.js
+++ b/packages/utils/webpack.config.js
@@ -35,11 +35,7 @@ const fallbacks = (env) => {
 
 const aliases = (env) => {
     const aliases = {
-        'process': 'process/browser',
-        [path.resolve(__dirname, '../dht/src/connection/WebRTC/NodeWebRtcConnection.ts')]:
-            path.resolve(__dirname, '../dht/src/connection/WebRTC/BrowserWebRtcConnection.ts'),
-        '@streamr/dht': path.resolve('../dht/src/exports.ts'),
-        '@streamr/proto-rpc': path.resolve('../proto-rpc/src/exports.ts'),
+        'process': 'process/browser'
     }
     return aliases
 }
@@ -89,7 +85,7 @@ module.exports = (env, argv) => {
             sourceMapFilename: `[name].[contenthash].js.map`,
             chunkFilename: '[id].[contenthash].js',
             path: path.resolve(__dirname, 'dist'),
-            library: 'TrackerlessNetwork',
+            library: 'utils',
             libraryTarget: 'umd2',
             umdNamedDefine: true,
         },


### PR DESCRIPTION
## Summary

Run all tests in `utils` package also in a browser environment.

## Related changes

- Fixed import of wait in `Metric.test.ts` (it imported it from the `@streamr/utils` package)
- Changed test names to be strings instead of class references. When class references were used, the test name was not shown in karma output (it printed the test name as `null`)

## Browser test warnings

There are this kind of warning messages in karma output log:
```
WARNING in ../../node_modules/jest-util/build/requireOrImportModule.js 53:27-44
Critical dependency: the request of a dependency is an expression
 @ ../../node_modules/jest-util/build/index.js 162:2-36
 @ ../../node_modules/expect/build/asymmetricMatchers.js 27:16-36
 @ ../../node_modules/expect/build/index.js 18:26-57
 @ ./karma-setup.js 9:15-41
```

It is not clear what is the root cause of those warnings. All tests seem to run ok anyway. Similar warnings are also shown when browser tests are run for the  `network` package.

## Future improvements

- One of the test cases in `Logger.test.ts` is disabled when it is run in browser environment. If possible, we should enable that test case? 
  - The test case has a comment which tells why it has been disabled. 
  - It was most likely disabled already when `Logger` class was in the network package. 
- NET-920: The `waitForCondition` test utility method is temporarily inlined. If we import it from `streamr-test-utils` there seem to be some dependency error related to the fact that `streamr-test-utils` depends on this utils package. The error message is: `"Can't resolve '@streamr/utils' in '/Users/teogeb/workspace/streamr/network-monorepo/packages/test-utils/dist/src'"`
- Maybe part of NET-921: If we don't need to use features from Node environment, we could maybe use headless Chrome browser instead of Electron.