### PR TITLE
refactor(client): Rename message listener

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change storage node assignment event handlers
   - replace method `registerStorageEventListeners(listener)` with `on('addToStorageNode', listener)` and `on('removeFromStorageNode', listener)`
   - replace method `unRegisterStorageEventListeners()` with `off('addToStorageNode', listener)` and `off('removeFromStorageNode', listener)`
-- Rename message listener interface `SubscriptionOnMessage`/`MessageStreamOnMessage` to `MessageListener`
+- Rename interface `SubscriptionOnMessage`/`MessageStreamOnMessage` to `MessageListener`
 - Rename classes `GroupKey` and `GroupKeyId` to `EncryptionKey` and `EncryptionKeyId`
 
 ### Deprecated

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change storage node assignment event handlers
   - replace method `registerStorageEventListeners(listener)` with `on('addToStorageNode', listener)` and `on('removeFromStorageNode', listener)`
   - replace method `unRegisterStorageEventListeners()` with `off('addToStorageNode', listener)` and `off('removeFromStorageNode', listener)`
+- Rename message listener interface `SubscriptionOnMessage`/`MessageStreamOnMessage` to `MessageListener`
 - Rename classes `GroupKey` and `GroupKeyId` to `EncryptionKey` and `EncryptionKeyId`
 
 ### Deprecated

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -14,11 +14,11 @@ import { GroupKeyStore, UpdateEncryptionKeyOptions } from './encryption/GroupKey
 import { StorageNodeMetadata, StorageNodeRegistry } from './registry/StorageNodeRegistry'
 import { StreamRegistry } from './registry/StreamRegistry'
 import { StreamDefinition } from './types'
-import { Subscription, SubscriptionOnMessage } from './subscribe/Subscription'
+import { Subscription } from './subscribe/Subscription'
 import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
 import { ProxyDirection, StreamMessage } from 'streamr-client-protocol'
-import { MessageStream, MessageStreamOnMessage } from './subscribe/MessageStream'
+import { MessageStream, MessageListener } from './subscribe/MessageStream'
 import { Stream, StreamProperties } from './Stream'
 import { SearchStreamsPermissionFilter } from './registry/searchStreams'
 import { PermissionAssignment, PermissionQuery } from './permission'
@@ -125,13 +125,13 @@ export class StreamrClient {
      */
     async subscribe<T>(
         options: StreamDefinition & { resend?: ResendOptions },
-        onMessage?: SubscriptionOnMessage<T>
+        onMessage?: MessageListener<T>
     ): Promise<Subscription<T>> {
         let result
         if (options.resend !== undefined) {
-            result = await this.resendSubscribe(options, options.resend, onMessage)
+            result = await this.resendSubscribe<T>(options, options.resend, onMessage)
         } else {
-            result = await this.subscriber.subscribe(options, onMessage)
+            result = await this.subscriber.subscribe<T>(options, onMessage)
         }
         this.eventEmitter.emit('subscribe', undefined)
         return result
@@ -140,7 +140,7 @@ export class StreamrClient {
     private async resendSubscribe<T>(
         streamDefinition: StreamDefinition,
         resendOptions: ResendOptions,
-        onMessage?: SubscriptionOnMessage<T>
+        onMessage?: MessageListener<T>
     ): Promise<ResendSubscription<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
         const sub = new ResendSubscription<T>(
@@ -184,7 +184,7 @@ export class StreamrClient {
     resend<T>(
         streamDefinition: StreamDefinition,
         options: ResendOptions,
-        onMessage?: MessageStreamOnMessage<T>
+        onMessage?: MessageListener<T>
     ): Promise<MessageStream<T>> {
         return this.resends.resend(streamDefinition, options, onMessage)
     }

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -6,9 +6,8 @@ export * from './Stream'
 export { DecryptError } from './encryption/EncryptionUtil'
 export { StreamrClientEvents } from './events'
 export { MessageMetadata } from './publish/Publisher'
-export { Subscription, SubscriptionEvents, SubscriptionOnMessage } from './subscribe/Subscription'
-export { MessageStreamOnMessage } from './subscribe/MessageStream'
-export type { MessageStream } from './subscribe/MessageStream'
+export { Subscription, SubscriptionEvents, } from './subscribe/Subscription'
+export type { MessageStream, MessageListener } from './subscribe/MessageStream'
 export { ResendOptions, ResendLastOptions, ResendFromOptions, ResendRangeOptions, ResendRef } from './subscribe/Resends'
 export {
     StreamPermission,

--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -8,7 +8,7 @@ import { PushPipeline } from '../utils/PushPipeline'
 import { StreamMessage } from 'streamr-client-protocol'
 import * as G from '../utils/GeneratorUtils'
 
-export type MessageStreamOnMessage<T, R = unknown> = (msg: T, streamMessage: StreamMessage<T>) => R | Promise<R>
+export type MessageListener<T, R = unknown> = (msg: T, streamMessage: StreamMessage<T>) => R | Promise<R>
 
 export class MessageStream<
     T = unknown,
@@ -20,7 +20,7 @@ export class MessageStream<
      * onMessage is passed parsed content as first arument, and streamMessage as second argument.
      * @internal
      */
-    useLegacyOnMessageHandler(onMessage?: MessageStreamOnMessage<T>): this {
+    useLegacyOnMessageHandler(onMessage?: MessageListener<T>): this {
         if (onMessage) {
             this.onMessage.listen(async (streamMessage) => {
                 if (streamMessage instanceof StreamMessage) {

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -4,7 +4,7 @@
 import { inject, Lifecycle, scoped, delay } from 'tsyringe'
 import { MessageRef, StreamPartID, StreamPartIDUtils, StreamMessage } from 'streamr-client-protocol'
 
-import { MessageStream, MessageStreamOnMessage } from './MessageStream'
+import { MessageStream, MessageListener } from './MessageStream'
 import { createSubscribePipeline } from './SubscribePipeline'
 
 import { StorageNodeRegistry } from '../registry/StorageNodeRegistry'
@@ -98,7 +98,7 @@ export class Resends {
     async resend<T>(
         streamDefinition: StreamDefinition,
         options: ResendOptions,
-        onMessage?: MessageStreamOnMessage<T>
+        onMessage?: MessageListener<T>
     ): Promise<MessageStream<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
 

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -1,7 +1,8 @@
 import { inject, scoped, Lifecycle, delay } from 'tsyringe'
 import { allSettledValues } from '../utils/promises'
 import { SubscriptionSession } from './SubscriptionSession'
-import { Subscription, SubscriptionOnMessage } from './Subscription'
+import { Subscription } from './Subscription'
+import { MessageListener } from './MessageStream'
 import { StreamPartID } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
@@ -62,13 +63,13 @@ export class Subscriber {
 
     async subscribe<T>(
         streamDefinition: StreamDefinition,
-        onMessage?: SubscriptionOnMessage<T>
+        onMessage?: MessageListener<T>
     ): Promise<Subscription<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
         return this.subscribeTo(streamPartId, onMessage)
     }
 
-    private async subscribeTo<T>(streamPartId: StreamPartID, onMessage?: SubscriptionOnMessage<T>): Promise<Subscription<T>> {
+    private async subscribeTo<T>(streamPartId: StreamPartID, onMessage?: MessageListener<T>): Promise<Subscription<T>> {
         const sub: Subscription<T> = await this.add(streamPartId)
         if (onMessage) {
             sub.useLegacyOnMessageHandler(onMessage)

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -3,12 +3,10 @@
  * Primary interface for consuming StreamMessages.
  */
 import { StreamPartID } from 'streamr-client-protocol'
-import { MessageStream, MessageStreamOnMessage } from './MessageStream'
+import { MessageStream } from './MessageStream'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
-
-export { MessageStreamOnMessage as SubscriptionOnMessage }
 
 export interface SubscriptionEvents {
     error: (err: Error) => void

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -3,7 +3,7 @@ import { counterId, instanceId } from '../../src/utils/utils'
 import { createRandomAuthentication } from '../test-utils/utils'
 import { Msg } from '../test-utils/publish'
 import { LeaksDetector } from '../test-utils/LeaksDetector'
-import { MessageStream, MessageStreamOnMessage } from '../../src/subscribe/MessageStream'
+import { MessageStream, MessageListener } from '../../src/subscribe/MessageStream'
 import { StreamMessage, MessageID, toStreamID } from 'streamr-client-protocol'
 import { Readable } from 'stream'
 import { waitForCondition } from 'streamr-test-utils'
@@ -12,7 +12,7 @@ import { Authentication } from '../../src/Authentication'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
-const fromReadable = async (readable: Readable, onMessage?: MessageStreamOnMessage<any>) => {
+const fromReadable = async (readable: Readable, onMessage?: MessageListener<any>) => {
     const result = new MessageStream<any>()
     if (onMessage !== undefined) {
         result.useLegacyOnMessageHandler(onMessage)


### PR DESCRIPTION
Renamed message listener interface `SubscriptionOnMessage`/`MessageStreamOnMessage` to `MessageListener`. This is a change to the public API as the type was exported in `SubscriptionOnMessage` in `index-exports.ts` and documented in API docs. But in typically end-users don't specify the the type of the listener, and therefore this doesn't affect many use case.