### PR TITLE
test(client): Divide `MessageStream` test

### DIFF
--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -1,15 +1,12 @@
-import { toEthereumAddress, wait } from '@streamr/utils'
-import { counterId, instanceId } from '../../src/utils/utils'
-import { createRandomAuthentication } from '../test-utils/utils'
-import { Msg } from '../test-utils/publish'
-import { LeaksDetector } from '../test-utils/LeaksDetector'
-import { MessageStream, MessageListener } from '../../src/subscribe/MessageStream'
-import { StreamMessage, MessageID, toStreamID } from 'streamr-client-protocol'
+import { toEthereumAddress } from '@streamr/utils'
 import { Readable } from 'stream'
+import { MessageID, toStreamID } from 'streamr-client-protocol'
 import { waitForCondition } from 'streamr-test-utils'
-import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { Authentication } from '../../src/Authentication'
-import { collect } from '../../src/utils/iterators'
+import { createSignedMessage } from '../../src/publish/MessageFactory'
+import { MessageListener, MessageStream } from '../../src/subscribe/MessageStream'
+import { Msg } from '../test-utils/publish'
+import { createRandomAuthentication } from '../test-utils/utils'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
@@ -35,8 +32,8 @@ const waitForCalls = async (onMessage: jest.Mock<any>, n: number) => {
 }
 
 describe('MessageStream', () => {
+
     const streamId = toStreamID('streamId')
-    let leaksDetector: LeaksDetector
     let authentication: Authentication
 
     const createMockMessage = async () => {
@@ -48,204 +45,7 @@ describe('MessageStream', () => {
     }
 
     beforeEach(async () => {
-        leaksDetector = new LeaksDetector()
         authentication = createRandomAuthentication()
-    })
-
-    afterEach(async () => {
-        await leaksDetector.checkNoLeaks()
-    })
-
-    it('works', async () => {
-        const s = new MessageStream()
-        leaksDetector.add(instanceId(s), s)
-        const testMessage = Msg()
-        leaksDetector.add('testMessage', testMessage)
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        s.push(streamMessage)
-        const received = []
-        for await (const msg of s) {
-            leaksDetector.add('receivedMessage', msg)
-            received.push(msg)
-            break
-        }
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('handles errors', async () => {
-        const testMessage = Msg()
-        const err = new Error(counterId('expected error'))
-        leaksDetector.add('err', err)
-        leaksDetector.add('testMessage', testMessage)
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add(instanceId(s), s)
-        const received: StreamMessage<typeof testMessage>[] = []
-        s.pull((async function* g() {
-            yield streamMessage
-
-            throw err
-        }()))
-
-        await expect(async () => {
-            for await (const msg of s) {
-                leaksDetector.add('receivedMessage', msg)
-                received.push(msg)
-            }
-        }).rejects.toThrow(err)
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('handles immediate errors in pull', async () => {
-        const testMessage = Msg()
-        const err = new Error(counterId('expected error'))
-        leaksDetector.add('err', err)
-        leaksDetector.add('testMessage', testMessage)
-        const streamMessage = createSignedMessage({
-            messageId: new MessageID(streamId, 0, 1, 0, PUBLISHER_ID, 'msgChainId'),
-            serializedContent: JSON.stringify(testMessage),
-            authentication
-        })
-        leaksDetector.add('streamMessage', streamMessage)
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add(instanceId(s), s)
-        const received: StreamMessage<typeof testMessage>[] = []
-        s.onError.listen((error) => {
-            throw error
-        })
-        // eslint-disable-next-line require-yield
-        s.pull((async function* g() {
-            throw err
-        }()))
-
-        await expect(async () => {
-            for await (const msg of s) {
-                leaksDetector.add('receivedMessage', msg)
-                received.push(msg)
-            }
-        }).rejects.toThrow(err)
-
-        expect(received).toEqual([])
-    })
-
-    it('handles error during iteration', async () => {
-        const testMessage = Msg()
-        leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add(instanceId(s), s)
-        const err = new Error(counterId('expected error'))
-        const streamMessage = await createMockMessage()
-        s.push(streamMessage)
-        leaksDetector.add('streamMessage', streamMessage)
-        const received: StreamMessage<typeof testMessage>[] = []
-        await expect(async () => {
-            for await (const msg of s) {
-                leaksDetector.add('receivedMessage', msg)
-                received.push(msg)
-                throw err
-            }
-        }).rejects.toThrow(err)
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('emits errors', async () => {
-        const testMessage = Msg()
-        leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add(instanceId(s), s)
-        const err = new Error(counterId('expected error'))
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        s.push(streamMessage)
-        const received: StreamMessage<typeof testMessage>[] = []
-        await expect(async () => {
-            for await (const msg of s) {
-                leaksDetector.add('receivedMessage', msg)
-                received.push(msg)
-                setTimeout(() => {
-                    s.throw(err).catch(() => {})
-                })
-            }
-        }).rejects.toThrow(err)
-        await wait(10)
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('processes buffer before handling errors with endWrite', async () => {
-        const testMessage = Msg()
-        leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add(instanceId(s), s)
-        const err = new Error(counterId('expected error'))
-
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        s.push(streamMessage)
-        s.endWrite(err)
-        const received: StreamMessage<typeof testMessage>[] = []
-        await expect(async () => {
-            for await (const msg of s) {
-                leaksDetector.add('receivedMessage', msg)
-                received.push(msg)
-            }
-        }).rejects.toThrow(err)
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('can collect', async () => {
-        const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
-
-        const streamMessage = await createMockMessage()
-        s.push(streamMessage)
-        const received = await collect(s, 1)
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('can cancel collect with return', async () => {
-        const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
-        leaksDetector.add('testMessage', testMessage)
-        leaksDetector.add(instanceId(s), s)
-
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        s.push(streamMessage)
-        const collectTask = collect(s)
-        await wait(10)
-        await s.return()
-        const received = await collectTask
-
-        expect(received).toEqual([streamMessage])
-    })
-
-    it('can cancel collect with throw', async () => {
-        const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
-        const err = new Error(counterId('expected error'))
-        leaksDetector.add('testMessage', testMessage)
-        leaksDetector.add(instanceId(s), s)
-        leaksDetector.add('err', err)
-
-        const streamMessage = await createMockMessage()
-        leaksDetector.add('streamMessage', streamMessage)
-        s.push(streamMessage)
-        const collectTask = collect(s)
-        await wait(10)
-        await expect(async () => {
-            await s.throw(err)
-        }).rejects.toThrow(err)
-        await expect(async () => {
-            await collectTask
-        }).rejects.toThrow(err)
     })
 
     describe('onMessage', () => {

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -1,29 +1,13 @@
 import { toEthereumAddress } from '@streamr/utils'
-import { Readable } from 'stream'
 import { MessageID, toStreamID } from 'streamr-client-protocol'
 import { waitForCondition } from 'streamr-test-utils'
 import { Authentication } from '../../src/Authentication'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
-import { MessageListener, MessageStream } from '../../src/subscribe/MessageStream'
+import { MessageStream } from '../../src/subscribe/MessageStream'
 import { Msg } from '../test-utils/publish'
 import { createRandomAuthentication } from '../test-utils/utils'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-
-const fromReadable = async (readable: Readable, onMessage?: MessageListener<any>) => {
-    const result = new MessageStream<any>()
-    if (onMessage !== undefined) {
-        result.useLegacyOnMessageHandler(onMessage)
-    }
-    result.pull((async function* readStream() {
-        try {
-            yield* readable
-        } finally {
-            readable.destroy()
-        }
-    }()))
-    return result
-}
 
 const waitForCalls = async (onMessage: jest.Mock<any>, n: number) => {
     await waitForCondition(() => onMessage.mock.calls.length >= n, 1000, 100, () => {
@@ -48,28 +32,16 @@ describe('MessageStream', () => {
         authentication = createRandomAuthentication()
     })
 
-    describe('onMessage', () => {
-
-        it('push', async () => {
-            const stream = new MessageStream<any>()
-            const onMessage = jest.fn()
-            stream.useLegacyOnMessageHandler(onMessage)
-            const msg = await createMockMessage()
-            stream.push(msg)
-            await waitForCalls(onMessage, 1)
-            expect(onMessage).toBeCalledTimes(1)
-            expect(onMessage).toHaveBeenNthCalledWith(1, msg.getParsedContent(), msg)
-        })
-
-        it('from readable', async () => {
-            const msg1 = await createMockMessage()
-            const msg2 = await createMockMessage()
-            const readable = Readable.from([msg1, msg2], { objectMode: true })
-            const onMessage = jest.fn()
-            fromReadable(readable, onMessage)
-            await waitForCalls(onMessage, 2)
-            expect(onMessage).toHaveBeenNthCalledWith(1, msg1.getParsedContent(), msg1)
-            expect(onMessage).toHaveBeenNthCalledWith(2, msg2.getParsedContent(), msg2)
-        })
+    it('onMessage', async () => {
+        const stream = new MessageStream<any>()
+        const onMessage = jest.fn()
+        stream.useLegacyOnMessageHandler(onMessage)
+        const msg1 = await createMockMessage()
+        const msg2 = await createMockMessage()
+        stream.push(msg1)
+        stream.push(msg2)
+        await waitForCalls(onMessage, 2)
+        expect(onMessage).toHaveBeenNthCalledWith(1, msg1.getParsedContent(), msg1)
+        expect(onMessage).toHaveBeenNthCalledWith(2, msg2.getParsedContent(), msg2)
     })
 })

--- a/packages/client/test/unit/PushPipeline.test.ts
+++ b/packages/client/test/unit/PushPipeline.test.ts
@@ -3,11 +3,11 @@ import { counterId, instanceId } from '../../src/utils/utils'
 import { createRandomAuthentication } from '../test-utils/utils'
 import { Msg } from '../test-utils/publish'
 import { LeaksDetector } from '../test-utils/LeaksDetector'
-import { MessageStream } from '../../src/subscribe/MessageStream'
 import { StreamMessage, MessageID, toStreamID } from 'streamr-client-protocol'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { Authentication } from '../../src/Authentication'
 import { collect } from '../../src/utils/iterators'
+import { PushPipeline } from '../../src/utils/PushPipeline'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
@@ -35,7 +35,7 @@ describe('PushPipeline', () => {
     })
 
     it('works', async () => {
-        const s = new MessageStream()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const testMessage = Msg()
         leaksDetector.add('testMessage', testMessage)
@@ -59,7 +59,7 @@ describe('PushPipeline', () => {
         leaksDetector.add('testMessage', testMessage)
         const streamMessage = await createMockMessage()
         leaksDetector.add('streamMessage', streamMessage)
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const received: StreamMessage<typeof testMessage>[] = []
         s.pull((async function* g() {
@@ -89,7 +89,7 @@ describe('PushPipeline', () => {
             authentication
         })
         leaksDetector.add('streamMessage', streamMessage)
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const received: StreamMessage<typeof testMessage>[] = []
         s.onError.listen((error) => {
@@ -113,7 +113,7 @@ describe('PushPipeline', () => {
     it('handles error during iteration', async () => {
         const testMessage = Msg()
         leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const err = new Error(counterId('expected error'))
         const streamMessage = await createMockMessage()
@@ -134,7 +134,7 @@ describe('PushPipeline', () => {
     it('emits errors', async () => {
         const testMessage = Msg()
         leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const err = new Error(counterId('expected error'))
         const streamMessage = await createMockMessage()
@@ -158,7 +158,7 @@ describe('PushPipeline', () => {
     it('processes buffer before handling errors with endWrite', async () => {
         const testMessage = Msg()
         leaksDetector.add('testMessage', testMessage)
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
         const err = new Error(counterId('expected error'))
 
@@ -178,8 +178,7 @@ describe('PushPipeline', () => {
     })
 
     it('can collect', async () => {
-        const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
 
         const streamMessage = await createMockMessage()
         s.push(streamMessage)
@@ -190,7 +189,7 @@ describe('PushPipeline', () => {
 
     it('can cancel collect with return', async () => {
         const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         leaksDetector.add('testMessage', testMessage)
         leaksDetector.add(instanceId(s), s)
 
@@ -207,7 +206,7 @@ describe('PushPipeline', () => {
 
     it('can cancel collect with throw', async () => {
         const testMessage = Msg()
-        const s = new MessageStream<typeof testMessage>()
+        const s = new PushPipeline<StreamMessage>()
         const err = new Error(counterId('expected error'))
         leaksDetector.add('testMessage', testMessage)
         leaksDetector.add(instanceId(s), s)

--- a/packages/client/test/unit/PushPipeline.test.ts
+++ b/packages/client/test/unit/PushPipeline.test.ts
@@ -1,0 +1,228 @@
+import { toEthereumAddress, wait } from '@streamr/utils'
+import { counterId, instanceId } from '../../src/utils/utils'
+import { createRandomAuthentication } from '../test-utils/utils'
+import { Msg } from '../test-utils/publish'
+import { LeaksDetector } from '../test-utils/LeaksDetector'
+import { MessageStream } from '../../src/subscribe/MessageStream'
+import { StreamMessage, MessageID, toStreamID } from 'streamr-client-protocol'
+import { createSignedMessage } from '../../src/publish/MessageFactory'
+import { Authentication } from '../../src/Authentication'
+import { collect } from '../../src/utils/iterators'
+
+const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+
+describe('PushPipeline', () => {
+
+    const streamId = toStreamID('streamId')
+    let leaksDetector: LeaksDetector
+    let authentication: Authentication
+
+    const createMockMessage = async () => {
+        return await createSignedMessage({
+            messageId: new MessageID(streamId, 0, 0, 0, PUBLISHER_ID, 'msgChainId'),
+            serializedContent: JSON.stringify(Msg()),
+            authentication
+        })
+    }
+
+    beforeEach(async () => {
+        leaksDetector = new LeaksDetector()
+        authentication = createRandomAuthentication()
+    })
+
+    afterEach(async () => {
+        await leaksDetector.checkNoLeaks()
+    })
+
+    it('works', async () => {
+        const s = new MessageStream()
+        leaksDetector.add(instanceId(s), s)
+        const testMessage = Msg()
+        leaksDetector.add('testMessage', testMessage)
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        s.push(streamMessage)
+        const received = []
+        for await (const msg of s) {
+            leaksDetector.add('receivedMessage', msg)
+            received.push(msg)
+            break
+        }
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('handles errors', async () => {
+        const testMessage = Msg()
+        const err = new Error(counterId('expected error'))
+        leaksDetector.add('err', err)
+        leaksDetector.add('testMessage', testMessage)
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add(instanceId(s), s)
+        const received: StreamMessage<typeof testMessage>[] = []
+        s.pull((async function* g() {
+            yield streamMessage
+
+            throw err
+        }()))
+
+        await expect(async () => {
+            for await (const msg of s) {
+                leaksDetector.add('receivedMessage', msg)
+                received.push(msg)
+            }
+        }).rejects.toThrow(err)
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('handles immediate errors in pull', async () => {
+        const testMessage = Msg()
+        const err = new Error(counterId('expected error'))
+        leaksDetector.add('err', err)
+        leaksDetector.add('testMessage', testMessage)
+        const streamMessage = createSignedMessage({
+            messageId: new MessageID(streamId, 0, 1, 0, PUBLISHER_ID, 'msgChainId'),
+            serializedContent: JSON.stringify(testMessage),
+            authentication
+        })
+        leaksDetector.add('streamMessage', streamMessage)
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add(instanceId(s), s)
+        const received: StreamMessage<typeof testMessage>[] = []
+        s.onError.listen((error) => {
+            throw error
+        })
+        // eslint-disable-next-line require-yield
+        s.pull((async function* g() {
+            throw err
+        }()))
+
+        await expect(async () => {
+            for await (const msg of s) {
+                leaksDetector.add('receivedMessage', msg)
+                received.push(msg)
+            }
+        }).rejects.toThrow(err)
+
+        expect(received).toEqual([])
+    })
+
+    it('handles error during iteration', async () => {
+        const testMessage = Msg()
+        leaksDetector.add('testMessage', testMessage)
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add(instanceId(s), s)
+        const err = new Error(counterId('expected error'))
+        const streamMessage = await createMockMessage()
+        s.push(streamMessage)
+        leaksDetector.add('streamMessage', streamMessage)
+        const received: StreamMessage<typeof testMessage>[] = []
+        await expect(async () => {
+            for await (const msg of s) {
+                leaksDetector.add('receivedMessage', msg)
+                received.push(msg)
+                throw err
+            }
+        }).rejects.toThrow(err)
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('emits errors', async () => {
+        const testMessage = Msg()
+        leaksDetector.add('testMessage', testMessage)
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add(instanceId(s), s)
+        const err = new Error(counterId('expected error'))
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        s.push(streamMessage)
+        const received: StreamMessage<typeof testMessage>[] = []
+        await expect(async () => {
+            for await (const msg of s) {
+                leaksDetector.add('receivedMessage', msg)
+                received.push(msg)
+                setTimeout(() => {
+                    s.throw(err).catch(() => {})
+                })
+            }
+        }).rejects.toThrow(err)
+        await wait(10)
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('processes buffer before handling errors with endWrite', async () => {
+        const testMessage = Msg()
+        leaksDetector.add('testMessage', testMessage)
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add(instanceId(s), s)
+        const err = new Error(counterId('expected error'))
+
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        s.push(streamMessage)
+        s.endWrite(err)
+        const received: StreamMessage<typeof testMessage>[] = []
+        await expect(async () => {
+            for await (const msg of s) {
+                leaksDetector.add('receivedMessage', msg)
+                received.push(msg)
+            }
+        }).rejects.toThrow(err)
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('can collect', async () => {
+        const testMessage = Msg()
+        const s = new MessageStream<typeof testMessage>()
+
+        const streamMessage = await createMockMessage()
+        s.push(streamMessage)
+        const received = await collect(s, 1)
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('can cancel collect with return', async () => {
+        const testMessage = Msg()
+        const s = new MessageStream<typeof testMessage>()
+        leaksDetector.add('testMessage', testMessage)
+        leaksDetector.add(instanceId(s), s)
+
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        s.push(streamMessage)
+        const collectTask = collect(s)
+        await wait(10)
+        await s.return()
+        const received = await collectTask
+
+        expect(received).toEqual([streamMessage])
+    })
+
+    it('can cancel collect with throw', async () => {
+        const testMessage = Msg()
+        const s = new MessageStream<typeof testMessage>()
+        const err = new Error(counterId('expected error'))
+        leaksDetector.add('testMessage', testMessage)
+        leaksDetector.add(instanceId(s), s)
+        leaksDetector.add('err', err)
+
+        const streamMessage = await createMockMessage()
+        leaksDetector.add('streamMessage', streamMessage)
+        s.push(streamMessage)
+        const collectTask = collect(s)
+        await wait(10)
+        await expect(async () => {
+            await s.throw(err)
+        }).rejects.toThrow(err)
+        await expect(async () => {
+            await collectTask
+        }).rejects.toThrow(err)
+    })
+})


### PR DESCRIPTION
Moved most of the test cases of `MessageStream.test.ts` to new `PushPipeline.test.ts`. The test case weren't modified: only changed pipelines to be created with `new PushPipeline()` instead of `new MessageStream()`.

Also simplified `onMessage` test case in `MessageStream.test.ts` as the listener logic is same for all data output styles.