### PR TITLE
refactor(client): Message listener assignment

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -23,6 +23,7 @@ import { toEthereumAddress, withTimeout } from '@streamr/utils'
 import { StreamMetadata } from './StreamMessageValidator'
 import { StreamrClientEventEmitter } from './events'
 import { collect } from './utils/iterators'
+import { DEFAULT_PARTITION } from './StreamIDBuilder'
 
 export interface StreamProperties {
     id: string
@@ -154,10 +155,10 @@ class StreamrStream implements StreamMetadata {
 
     async detectFields(): Promise<void> {
         // Get last message of the stream to be used for field detecting
-        const sub = await this._resends.resend<any>(
-            this.id,
+        const sub = await this._resends.last<any>(
+            toStreamPartID(this.id, DEFAULT_PARTITION),
             {
-                last: 1,
+                count: 1,
             }
         )
 

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,7 +191,8 @@ class StreamrStream implements StreamMetadata {
         let assignmentSubscription
         const normalizedNodeAddress = toEthereumAddress(nodeAddress)
         try {
-            assignmentSubscription = await this._subscriber.subscribe(formStorageNodeAssignmentStreamId(normalizedNodeAddress))
+            const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
+            assignmentSubscription = await this._subscriber.add(streamPartId)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, this)
             await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -134,7 +134,7 @@ export class StreamrClient {
             const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
             result = await this.subscriber.add<T>(streamPartId)
         }
-        if (onMessage) {
+        if (onMessage !== undefined) {
             result.useLegacyOnMessageHandler(onMessage)
         }
         this.eventEmitter.emit('subscribe', undefined)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -181,12 +181,16 @@ export class StreamrClient {
      * Call last/from/range as appropriate based on arguments
      * @category Important
      */
-    resend<T>(
+    async resend<T>(
         streamDefinition: StreamDefinition,
         options: ResendOptions,
         onMessage?: MessageListener<T>
     ): Promise<MessageStream<T>> {
-        return this.resends.resend(streamDefinition, options, onMessage)
+        const messageStream = await this.resends.resend<T>(streamDefinition, options)
+        if (onMessage !== undefined) {
+            messageStream.useLegacyOnMessageHandler(onMessage)
+        }
+        return messageStream
     }
 
     waitForStorage(streamMessage: StreamMessage, options?: {

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -131,7 +131,11 @@ export class StreamrClient {
         if (options.resend !== undefined) {
             result = await this.resendSubscribe<T>(options, options.resend, onMessage)
         } else {
-            result = await this.subscriber.subscribe<T>(options, onMessage)
+            const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
+            result = await this.subscriber.add<T>(streamPartId)
+            if (onMessage) {
+                result.useLegacyOnMessageHandler(onMessage)
+            }
         }
         this.eventEmitter.emit('subscribe', undefined)
         return result

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -129,13 +129,13 @@ export class StreamrClient {
     ): Promise<Subscription<T>> {
         let result
         if (options.resend !== undefined) {
-            result = await this.resendSubscribe<T>(options, options.resend, onMessage)
+            result = await this.resendSubscribe<T>(options, options.resend)
         } else {
             const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
             result = await this.subscriber.add<T>(streamPartId)
-            if (onMessage) {
-                result.useLegacyOnMessageHandler(onMessage)
-            }
+        }
+        if (onMessage) {
+            result.useLegacyOnMessageHandler(onMessage)
         }
         this.eventEmitter.emit('subscribe', undefined)
         return result
@@ -143,8 +143,7 @@ export class StreamrClient {
 
     private async resendSubscribe<T>(
         streamDefinition: StreamDefinition,
-        resendOptions: ResendOptions,
-        onMessage?: MessageListener<T>
+        resendOptions: ResendOptions
     ): Promise<ResendSubscription<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
         const sub = new ResendSubscription<T>(
@@ -155,9 +154,6 @@ export class StreamrClient {
             this.loggerFactory,
             this.config
         )
-        if (onMessage) {
-            sub.useLegacyOnMessageHandler(onMessage)
-        }
         await this.subscriber.addSubscription<T>(sub)
         return sub
     }

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -186,7 +186,8 @@ export class StreamrClient {
         options: ResendOptions,
         onMessage?: MessageListener<T>
     ): Promise<MessageStream<T>> {
-        const messageStream = await this.resends.resend<T>(streamDefinition, options)
+        const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
+        const messageStream = await this.resends.resend<T>(streamPartId, options)
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }

--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -24,14 +24,12 @@ export class MessageStream<T = unknown> implements AsyncIterable<StreamMessage<T
      * onMessage is passed parsed content as first arument, and streamMessage as second argument.
      * @internal
      */
-    useLegacyOnMessageHandler(onMessage?: MessageListener<T>): this {
-        if (onMessage) {
-            this.pipeline.onMessage.listen(async (streamMessage) => {
-                if (streamMessage instanceof StreamMessage) {
-                    await onMessage(streamMessage.getParsedContent(), streamMessage)
-                }
-            })
-        }
+    useLegacyOnMessageHandler(onMessage: MessageListener<T>): this {
+        this.pipeline.onMessage.listen(async (streamMessage) => {
+            if (streamMessage instanceof StreamMessage) {
+                await onMessage(streamMessage.getParsedContent(), streamMessage)
+            }
+        })
         this.pipeline.flow()
 
         return this

--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -26,9 +26,7 @@ export class MessageStream<T = unknown> implements AsyncIterable<StreamMessage<T
      */
     useLegacyOnMessageHandler(onMessage: MessageListener<T>): this {
         this.pipeline.onMessage.listen(async (streamMessage) => {
-            if (streamMessage instanceof StreamMessage) {
-                await onMessage(streamMessage.getParsedContent(), streamMessage)
-            }
+            await onMessage(streamMessage.getParsedContent(), streamMessage)
         })
         this.pipeline.flow()
 

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -40,11 +40,7 @@ export class ResendSubscription<T> extends Subscription<T> {
     }
 
     private async getResent(): Promise<MessageStream<T>> {
-        const [id, partition] = StreamPartIDUtils.getStreamIDAndPartition(this.streamPartId)
-        const resentMsgs = await this.resends.resend<T>({
-            id,
-            partition,
-        }, this.resendOptions)
+        const resentMsgs = await this.resends.resend<T>(this.streamPartId, this.resendOptions)
 
         this.onBeforeFinally.listen(async () => {
             resentMsgs.end()

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -191,7 +191,7 @@ export class Resends {
         return messageStream
     }
 
-    private async last<T>(streamPartId: StreamPartID, { count }: { count: number }): Promise<MessageStream<T>> {
+    async last<T>(streamPartId: StreamPartID, { count }: { count: number }): Promise<MessageStream<T>> {
         if (count <= 0) {
             const emptyStream = new MessageStream<T>()
             emptyStream.endWrite()

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -4,7 +4,7 @@
 import { inject, Lifecycle, scoped, delay } from 'tsyringe'
 import { MessageRef, StreamPartID, StreamPartIDUtils, StreamMessage } from 'streamr-client-protocol'
 
-import { MessageStream, MessageListener } from './MessageStream'
+import { MessageStream } from './MessageStream'
 import { createSubscribePipeline } from './SubscribePipeline'
 
 import { StorageNodeRegistry } from '../registry/StorageNodeRegistry'
@@ -98,18 +98,10 @@ export class Resends {
 
     async resend<T>(
         streamDefinition: StreamDefinition,
-        options: ResendOptions,
-        onMessage?: MessageListener<T>
+        options: ResendOptions
     ): Promise<MessageStream<T>> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-
-        const sub = await this.resendMessages<T>(streamPartId, options)
-
-        if (onMessage) {
-            sub.useLegacyOnMessageHandler(onMessage)
-        }
-
-        return sub
+        return this.resendMessages<T>(streamPartId, options)
     }
 
     private resendMessages<T>(streamPartId: StreamPartID, options: ResendOptions): Promise<MessageStream<T>> {

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -2,7 +2,6 @@ import { inject, scoped, Lifecycle, delay } from 'tsyringe'
 import { allSettledValues } from '../utils/promises'
 import { SubscriptionSession } from './SubscriptionSession'
 import { Subscription } from './Subscription'
-import { MessageListener } from './MessageStream'
 import { StreamPartID } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
 import { StreamDefinition } from '../types'
@@ -61,22 +60,6 @@ export class Subscriber {
         this.logger = loggerFactory.createLogger(module)
     }
 
-    async subscribe<T>(
-        streamDefinition: StreamDefinition,
-        onMessage?: MessageListener<T>
-    ): Promise<Subscription<T>> {
-        const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        return this.subscribeTo(streamPartId, onMessage)
-    }
-
-    private async subscribeTo<T>(streamPartId: StreamPartID, onMessage?: MessageListener<T>): Promise<Subscription<T>> {
-        const sub: Subscription<T> = await this.add(streamPartId)
-        if (onMessage) {
-            sub.useLegacyOnMessageHandler(onMessage)
-        }
-        return sub
-    }
-
     getOrCreateSubscriptionSession<T>(streamPartId: StreamPartID): SubscriptionSession<T> {
         if (this.subSessions.has(streamPartId)) {
             return this.getSubscriptionSession<T>(streamPartId)!
@@ -118,7 +101,7 @@ export class Subscriber {
         return sub
     }
 
-    private async add<T>(streamPartId: StreamPartID): Promise<Subscription<T>> {
+    async add<T>(streamPartId: StreamPartID): Promise<Subscription<T>> {
         const sub = new Subscription<T>(streamPartId, this.loggerFactory)
         return this.addSubscription(sub)
     }


### PR DESCRIPTION
Small refactoring to the interaction between `StreamClient`, `Subscriber` and `Resends`:
- `onMessage` handler is assigned to a `MessageStream` in `StreamrClient`, not in `Subscriber` or `Resends` (internal components don't need to know about the message listener concept)
- `StreamrClient#subscribe` and `StreamrClient#resend` parse stream definition and pass `StreamPartID` to the internal components
  - also `Stream#detectFields` and `Stream#addToStorageNode` methods operate now on `StreamPartID` instead of `StreamDefinition`
  - removed some methods from `Subscriber` and `Resends` which are now obsolete

Also small refactoring to `MessageStream#useLegacyOnMessageHandler`:
- `onMessage` is now a required parameter
- we don't need to check `streamMessage instanceof StreamMessage` (we can be sure that every value is a `StreamMessage` because the objects are produces by our internal components)