### PR TITLE
feat(client)!: Stream metadata public API

### DIFF
--- a/packages/broker/src/plugins/storage/DeleteExpiredCmd.ts
+++ b/packages/broker/src/plugins/storage/DeleteExpiredCmd.ts
@@ -116,7 +116,7 @@ export class DeleteExpiredCmd {
                     return {
                         streamId: stream.streamId,
                         partition: stream.partition,
-                        storageDays: streamFromChain.storageDays != null ? streamFromChain.storageDays : 365,
+                        storageDays: streamFromChain.getMetadata().storageDays ?? 365
                     }
                 } catch (err) { logger.error(err) }
             })

--- a/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageConfig.test.ts
@@ -17,11 +17,14 @@ const PARTITION_COUNT_LOOKUP: Record<string, number> = Object.freeze({
 })
 
 function makeStubStream(streamId: string): Stream {
+    const partitions = PARTITION_COUNT_LOOKUP[streamId]
     return {
         id: toStreamID(streamId),
-        partitions: PARTITION_COUNT_LOOKUP[streamId],
+        getMetadata: () => ({
+            partitions
+        }),
         getStreamParts(): StreamPartID[] { // TODO: duplicated code from client
-            return range(0, this.partitions).map((p) => toStreamPartID(this.id, p))
+            return range(0, partitions).map((p) => toStreamPartID(this.id, p))
         }
     } as Stream
 }

--- a/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
@@ -2,6 +2,12 @@ import { StorageEventListener } from '../../../../src/plugins/storage/StorageEve
 import { StorageNodeAssignmentEvent, Stream, StreamrClient, StreamrClientEvents } from 'streamr-client'
 import { EthereumAddress, toEthereumAddress, wait } from '@streamr/utils'
 
+const MOCK_STREAM = {
+    id: 'streamId',
+    getMetadata: () => ({
+        partitions: 3
+    })
+} as Stream
 const clusterId = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 const otherClusterId = toEthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
@@ -14,10 +20,7 @@ describe(StorageEventListener, () => {
     beforeEach(() => {
         stubClient = {
             async getStream() {
-                return {
-                    id: 'streamId',
-                    partitions: 3
-                } as Stream
+                return MOCK_STREAM
             },
             on(eventName: keyof StreamrClientEvents, listener: any) {
                 storageEventListeners.set(eventName, listener)
@@ -58,7 +61,7 @@ describe(StorageEventListener, () => {
         await wait(0)
         expect(onEvent).toHaveBeenCalledTimes(1)
         expect(onEvent).toHaveBeenCalledWith(
-            { id: 'streamId', partitions: 3 },
+            MOCK_STREAM,
             'added',
             1234
         )

--- a/packages/broker/test/unit/plugins/storage/StoragePoller.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StoragePoller.test.ts
@@ -6,8 +6,8 @@ const POLL_TIME = 5
 
 const POLL_RESULT = Object.freeze({
     streams: [
-        { id: 'stream-1', partitions: 1 },
-        { id: 'stream-2', partitions: 5 },
+        { id: 'stream-1', getMetadata: () => ({ partitions: 1 }) },
+        { id: 'stream-2', getMetadata: () => ({ partitions: 5 }) },
     ] as Stream[],
     blockNumber: 13
 })

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -3,7 +3,7 @@ import StreamrClient, {
     MaybeAsync,
     Stream,
     StreamPermission,
-    StreamProperties,
+    StreamMetadata,
     StreamrClientConfig
 } from 'streamr-client'
 import _ from 'lodash'
@@ -140,7 +140,7 @@ export const getTestName = (module: NodeModule): string => {
 export const createTestStream = async (
     streamrClient: StreamrClient,
     module: NodeModule,
-    props?: Partial<StreamProperties>
+    props?: Partial<StreamMetadata>
 ): Promise<Stream> => {
     const id = (await streamrClient.getAddress()) + '/test/' + getTestName(module) + '/' + Date.now()
     const stream = await streamrClient.createStream({

--- a/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
@@ -10,7 +10,7 @@ createClientCommand((async (client: StreamrClient, storageNodeAddress: string) =
         console.info(EasyTable.print(streams.map((stream) => {
             return {
                 id: stream.id,
-                partitions: stream.partitions
+                partitions: stream.getMetadata().partitions
             }
         })))
     }

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -12,7 +12,7 @@ createClientCommand(async (client: StreamrClient, streamIdOrPath: string, option
         partitions: options.partitions
     }
     const stream = await client.createStream(body)
-    console.info(JSON.stringify(stream.toObject(), null, 2))
+    console.info({ id: stream.id, ...stream.getMetadata() }, null, 2)
 })
     .arguments('<streamId>')
     .description('create a new stream')

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -6,7 +6,7 @@ import { getPermissionId } from '../src/permission'
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: any) => {
     const stream = await client.getStream(streamId)
-    const obj: any = stream.toObject()
+    const obj: any = { id: stream.id, ...stream.getMetadata() }
     if (options.includePermissions) {
         const assigments = await stream.getPermissions()
         obj.permissions = assigments.map((assignment) => {

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce concurrency limit for smart contract calls (per contract, configurable with `maxConcurrentContractCalls` config option)
 - Enforce presence of message signatures
   - all non-signed messages received by client are simply ignored
+- Stream metadata (e.g. `partitions`) is no longer stored as fields of `Stream` object
+  - query the data by calling `stream.getMetadata()`
 - Method `stream.update()` parameter `props` is no longer optional
 - Rename method `getStorageNodesOf()` to `getStorageNodes()`
 - Rename method `getStoredStreamsOf()` to `getStoredStreams()`
@@ -52,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - use `destroy()` instead
 - Remove method `unsubscribeAll()`
   - use `unsubscribe()` without arguments to same effect
+- Remove method `stream.toObject()`
+  - use `stream.getMetadata()` to get metadata (doesn't contain stream id)
 - Remove properties `subscription.onMessage`, `onStart`, and `onError`
   - use `subscription.on('error', cb)` to add an error listener
 - Remove configuration option `groupKeys`

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -54,8 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - use `destroy()` instead
 - Remove method `unsubscribeAll()`
   - use `unsubscribe()` without arguments to same effect
-- Remove method `stream.toObject()`
+- Remove method `stream.toObject()` and interface `StreamProperties`
   - use `stream.getMetadata()` to get metadata (doesn't contain stream id)
+  - use interface `StreamMetadata` instead
 - Remove properties `subscription.onMessage`, `onStart`, and `onError`
   - use `subscription.on('error', cb)` to add an error listener
 - Remove configuration option `groupKeys`

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce concurrency limit for smart contract calls (per contract, configurable with `maxConcurrentContractCalls` config option)
 - Enforce presence of message signatures
   - all non-signed messages received by client are simply ignored
-- Stream metadata (e.g. `partitions`) is no longer stored as fields of `Stream` object
-  - query the data by calling `stream.getMetadata()`
+- Stream metadata now accessed through `stream.getMetadata()`
+  - e.g. usages of `stream.partitions` has changed to `stream.getMetadata().partitions`
 - Method `stream.update()` parameter `props` is no longer optional
 - Rename method `getStorageNodesOf()` to `getStorageNodes()`
 - Rename method `getStoredStreamsOf()` to `getStoredStreams()`

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -505,7 +505,7 @@ const streamr = new StreamrClient({
 })
 ```
 
-        
+
 
 ### Stream partitioning
 
@@ -537,7 +537,7 @@ const stream = await streamr.createStream({
     id: `/foo/bar`,
     partitions: 10,
 })
-console.log(`Stream created: ${stream.id}. It has ${stream.partitions} partitions.`)
+console.log(`Stream created: ${stream.id}. It has ${stream.getMetadata().partitions} partitions.`)
 ```
 
 #### Publishing to partitioned streams

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -121,10 +121,7 @@ class StreamrStream {
             ...metadata
         }
         try {
-            await this._streamRegistry.updateStream({
-                ...merged,
-                id: this.id
-            })
+            await this._streamRegistry.updateStream(this.id, merged)
         } finally {
             this._streamRegistryCached.clearStream(this.id)
         }

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -228,11 +228,14 @@ class StreamrStream {
     }
 
     /** @internal */
-    static parsePropertiesFromMetadata(propsString: string): StreamMetadata & { id: string } {
+    static parseMetadata(metadata: string): StreamMetadata {
         try {
-            return JSON.parse(propsString)
+            // TODO we could pick the fields of StreamMetadata explicitly, so that this
+            // object can't contain extra fields and maybe check that partitions field
+            // is available
+            return JSON.parse(metadata)
         } catch (error) {
-            throw new Error(`Could not parse properties from onchain metadata: ${propsString}`)
+            throw new Error(`Could not parse properties from onchain metadata: ${metadata}`)
         }
     }
 

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -36,8 +36,6 @@ export interface StreamMetadata {
     inactivityThresholdHours?: number
 }
 
-export type StreamProperties = StreamMetadata & { id: string }
-
 export const VALID_FIELD_TYPES = ['number', 'string', 'boolean', 'list', 'map'] as const
 
 export interface Field {

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -225,7 +225,6 @@ class StreamrStream {
         const result = this._publisher.publish(this.id, content, metadata)
         this._eventEmitter.emit('publish', undefined)
         return result
-
     }
 
     /** @internal */

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -115,7 +115,7 @@ class StreamrStream {
     /**
      * Persist stream metadata updates.
      */
-    async update(metadata: StreamMetadata): Promise<void> {
+    async update(metadata: Partial<StreamMetadata>): Promise<void> {
         const merged = {
             ...this.getMetadata(),
             ...metadata

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -233,7 +233,7 @@ class StreamrStream {
     }
 
     /** @internal */
-    static parsePropertiesFromMetadata(propsString: string): StreamProperties {
+    static parsePropertiesFromMetadata(propsString: string): StreamMetadata & { id: string } {
         try {
             return JSON.parse(propsString)
         } catch (error) {

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -141,13 +141,6 @@ class StreamrStream {
         return this.metadata
     }
 
-    toObject(): StreamProperties {
-        return {
-            ...this.metadata,
-            id: this.id
-        }
-    }
-
     async delete(): Promise<void> {
         try {
             await this._streamRegistry.deleteStream(this.id)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -26,21 +26,17 @@ import { DEFAULT_PARTITION } from './StreamIDBuilder'
 import { Subscription } from './subscribe/Subscription'
 import { LoggerFactory } from './utils/LoggerFactory'
 
-export interface StreamProperties {
-    id: string
+export interface StreamMetadata {
+    partitions?: number
     description?: string
     config?: {
         fields: Field[]
     }
-    partitions?: number
     storageDays?: number
     inactivityThresholdHours?: number
 }
 
-/** @internal */
-export interface StreamrStreamConstructorOptions extends StreamProperties {
-    id: StreamID
-}
+export type StreamProperties = StreamMetadata & { id: string }
 
 export const VALID_FIELD_TYPES = ['number', 'string', 'boolean', 'list', 'map'] as const
 
@@ -93,7 +89,8 @@ class StreamrStream {
 
     /** @internal */
     constructor(
-        props: StreamrStreamConstructorOptions,
+        id: StreamID,
+        metadata: StreamMetadata,
         resends: Resends,
         publisher: Publisher,
         subscriber: Subscriber,
@@ -104,9 +101,9 @@ class StreamrStream {
         eventEmitter: StreamrClientEventEmitter,
         timeoutsConfig: TimeoutsConfig
     ) {
-        Object.assign(this, props)
-        this.id = props.id
-        this.partitions = props.partitions ? props.partitions : 1
+        Object.assign(this, metadata)
+        this.id = id
+        this.partitions = metadata.partitions ? metadata.partitions : 1
         this._resends = resends
         this._publisher = publisher
         this._subscriber = subscriber

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -20,7 +20,6 @@ import { waitForAssignmentsToPropagate } from './utils/waitForAssignmentsToPropa
 import { MessageMetadata } from '../src/publish/Publisher'
 import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
 import { toEthereumAddress, withTimeout } from '@streamr/utils'
-import { StreamMetadata } from './StreamMessageValidator'
 import { StreamrClientEventEmitter } from './events'
 import { collect } from './utils/iterators'
 import { DEFAULT_PARTITION } from './StreamIDBuilder'
@@ -73,7 +72,7 @@ function getFieldType(value: any): (Field['type'] | undefined) {
  * @category Important
  */
 /* eslint-disable no-underscore-dangle */
-class StreamrStream implements StreamMetadata {
+class StreamrStream {
     id: StreamID
     description?: string
     config: {

--- a/packages/client/src/StreamFactory.ts
+++ b/packages/client/src/StreamFactory.ts
@@ -46,7 +46,7 @@ export class StreamFactory {
         this.timeoutsConfig = timeoutsConfig
     }
 
-    createStream(id: StreamID, metadata: StreamMetadata): Stream {
+    createStream(id: StreamID, metadata: Partial<StreamMetadata>): Stream {
         return new Stream(
             id,
             metadata,

--- a/packages/client/src/StreamFactory.ts
+++ b/packages/client/src/StreamFactory.ts
@@ -1,11 +1,12 @@
 import { delay, inject, Lifecycle, scoped } from 'tsyringe'
+import { StreamID } from 'streamr-client-protocol'
 import { ConfigInjectionToken, TimeoutsConfig } from './Config'
 import { StreamrClientEventEmitter } from './events'
 import { Publisher } from './publish/Publisher'
 import { StreamRegistry } from './registry/StreamRegistry'
 import { StreamRegistryCached } from './registry/StreamRegistryCached'
 import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
-import { Stream, StreamrStreamConstructorOptions } from './Stream'
+import { Stream, StreamMetadata } from './Stream'
 import { Resends } from './subscribe/Resends'
 import { Subscriber } from './subscribe/Subscriber'
 import { LoggerFactory } from './utils/LoggerFactory'
@@ -45,9 +46,10 @@ export class StreamFactory {
         this.timeoutsConfig = timeoutsConfig
     }
 
-    createStream(props: StreamrStreamConstructorOptions): Stream {
+    createStream(id: StreamID, metadata: StreamMetadata): Stream {
         return new Stream(
-            props,
+            id,
+            metadata,
             this.resends,
             this.publisher,
             this.subscriber,

--- a/packages/client/src/StreamMessageValidator.ts
+++ b/packages/client/src/StreamMessageValidator.ts
@@ -10,12 +10,8 @@ import {
 } from "streamr-client-protocol"
 import { verify as verifyImpl } from './utils/signingUtils'
 
-export interface StreamMetadata {
-    partitions: number
-}
-
 export interface Options {
-    getStream: (streamId: StreamID) => Promise<StreamMetadata>
+    getPartitionCount: (streamId: StreamID) => Promise<number>
     isPublisher: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>
     isSubscriber: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>
     verify?: (address: EthereumAddress, payload: string, signature: string) => boolean
@@ -34,7 +30,7 @@ export interface Options {
  * TODO later: support for unsigned messages can be removed when deprecated system-wide.
  */
 export default class StreamMessageValidator {
-    readonly getStream: (streamId: StreamID) => Promise<StreamMetadata>
+    readonly getPartitionCount: (streamId: StreamID) => Promise<number>
     readonly isPublisher: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>
     readonly isSubscriber: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>
     readonly verify: (address: EthereumAddress, payload: string, signature: string) => boolean
@@ -47,8 +43,8 @@ export default class StreamMessageValidator {
      * @param verify function(address, payload, signature): returns true if the address and payload match the signature.
      * The default implementation uses the native secp256k1 library on node.js and falls back to the elliptic library on browsers.
      */
-    constructor({ getStream, isPublisher, isSubscriber, verify = verifyImpl }: Options) {
-        this.getStream = getStream
+    constructor({ getPartitionCount, isPublisher, isSubscriber, verify = verifyImpl }: Options) {
+        this.getPartitionCount = getPartitionCount
         this.isPublisher = isPublisher
         this.isSubscriber = isSubscriber
         this.verify = verify
@@ -97,7 +93,7 @@ export default class StreamMessageValidator {
             serializedContent: streamMessage.getSerializedContent(),
             prevMsgRef: streamMessage.prevMsgRef ?? undefined,
             newGroupKey: streamMessage.newGroupKey ?? undefined
-        }) 
+        })
         let success
         try {
             success = this.verify(streamMessage.getPublisherId(), payload, streamMessage.signature!)
@@ -110,11 +106,11 @@ export default class StreamMessageValidator {
     }
 
     private async validateMessage(streamMessage: StreamMessage): Promise<void> {
-        const stream = await this.getStream(streamMessage.getStreamId())
+        const partitionCount  = await this.getPartitionCount(streamMessage.getStreamId())
 
-        if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= stream.partitions) {
+        if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= partitionCount) {
             throw new StreamMessageError(
-                `Partition ${streamMessage.getStreamPartition()} is out of range (0..${stream.partitions - 1})`,
+                `Partition ${streamMessage.getStreamPartition()} is out of range (0..${partitionCount - 1})`,
                 streamMessage
             )
         }

--- a/packages/client/src/StreamMessageValidator.ts
+++ b/packages/client/src/StreamMessageValidator.ts
@@ -48,34 +48,10 @@ export default class StreamMessageValidator {
      * The default implementation uses the native secp256k1 library on node.js and falls back to the elliptic library on browsers.
      */
     constructor({ getStream, isPublisher, isSubscriber, verify = verifyImpl }: Options) {
-        StreamMessageValidator.checkInjectedFunctions(getStream, isPublisher, isSubscriber, verify)
         this.getStream = getStream
         this.isPublisher = isPublisher
         this.isSubscriber = isSubscriber
         this.verify = verify
-    }
-
-    static checkInjectedFunctions(
-        getStream: (streamId: StreamID) => Promise<StreamMetadata>,
-        isPublisher: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>,
-        isSubscriber: (address: EthereumAddress, streamId: StreamID) => Promise<boolean>,
-        verify: (address: EthereumAddress, payload: string, signature: string) => boolean
-    ): void | never {
-        if (typeof getStream !== 'function') {
-            throw new Error('getStream must be: async function(streamId): returns the validation metadata object for streamId')
-        }
-
-        if (typeof isPublisher !== 'function') {
-            throw new Error('isPublisher must be: async function(address, streamId): returns true if address is a permitted publisher on streamId')
-        }
-
-        if (typeof isSubscriber !== 'function') {
-            throw new Error('isSubscriber must be: async function(address, streamId): returns true if address is a permitted subscriber on streamId')
-        }
-
-        if (typeof verify !== 'function') {
-            throw new Error('verify must be: function(address, payload, signature): returns true if the address and payload match the signature')
-        }
     }
 
     /**

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -19,7 +19,7 @@ import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
 import { ProxyDirection, StreamMessage } from 'streamr-client-protocol'
 import { MessageStream, MessageListener } from './subscribe/MessageStream'
-import { Stream, StreamProperties } from './Stream'
+import { Stream, StreamMetadata } from './Stream'
 import { SearchStreamsPermissionFilter } from './registry/searchStreams'
 import { PermissionAssignment, PermissionQuery } from './permission'
 import { MetricsPublisher } from './MetricsPublisher'
@@ -205,7 +205,7 @@ export class StreamrClient {
     /**
      * @category Important
      */
-    createStream(propsOrStreamIdOrPath: StreamProperties | string): Promise<Stream> {
+    createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
         return this.streamRegistry.createStream(propsOrStreamIdOrPath)
     }
 
@@ -216,7 +216,7 @@ export class StreamrClient {
         return this.streamRegistry.getOrCreateStream(props)
     }
 
-    updateStream(props: StreamProperties): Promise<Stream> {
+    updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
         return this.streamRegistry.updateStream(props)
     }
 

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -209,9 +209,11 @@ export class StreamrClient {
      */
     async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
-        props.partitions ??= 1
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
-        return this.streamRegistry.createStream(streamId, omit(props, 'id'))
+        return this.streamRegistry.createStream(streamId, {
+            partitions: 1,
+            ...omit(props, 'id')
+        })
     }
 
     /**

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -205,7 +205,7 @@ export class StreamrClient {
     /**
      * @category Important
      */
-    createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
+    createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         return this.streamRegistry.createStream(propsOrStreamIdOrPath)
     }
 
@@ -216,7 +216,7 @@ export class StreamrClient {
         return this.streamRegistry.getOrCreateStream(props)
     }
 
-    updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
+    updateStream(props: Partial<StreamMetadata> & { id: string }): Promise<Stream> {
         return this.streamRegistry.updateStream(props)
     }
 

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -25,7 +25,7 @@ export class Validator extends StreamMessageValidator {
         super({
             getPartitionCount: async (streamId: StreamID) => {
                 const stream = await streamRegistryCached.getStream(streamId)
-                return stream.getMetadata().partitions!
+                return stream.getMetadata().partitions
             },
             isPublisher: (publisherId: EthereumAddress, streamId: StreamID) => {
                 return streamRegistryCached.isStreamPublisher(streamId, publisherId)

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -25,7 +25,7 @@ export class Validator extends StreamMessageValidator {
         super({
             getPartitionCount: async (streamId: StreamID) => {
                 const stream = await streamRegistryCached.getStream(streamId)
-                return stream.partitions
+                return stream.getMetadata().partitions!
             },
             isPublisher: (publisherId: EthereumAddress, streamId: StreamID) => {
                 return streamRegistryCached.isStreamPublisher(streamId, publisherId)

--- a/packages/client/src/Validator.ts
+++ b/packages/client/src/Validator.ts
@@ -23,8 +23,9 @@ export class Validator extends StreamMessageValidator {
         @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached
     ) {
         super({
-            getStream: (streamId: StreamID) => {
-                return streamRegistryCached.getStream(streamId)
+            getPartitionCount: async (streamId: StreamID) => {
+                const stream = await streamRegistryCached.getStream(streamId)
+                return stream.partitions
             },
             isPublisher: (publisherId: EthereumAddress, streamId: StreamID) => {
                 return streamRegistryCached.isStreamPublisher(streamId, publisherId)

--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -76,7 +76,7 @@ export class MessageFactory {
             throw new Error(`${publisherId} is not a publisher on stream ${this.streamId}`)
         }
 
-        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).partitions
+        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions!
         let partition
         if (explicitPartition !== undefined) {
             if ((explicitPartition < 0 || explicitPartition >= partitionCount)) {

--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -76,7 +76,7 @@ export class MessageFactory {
             throw new Error(`${publisherId} is not a publisher on stream ${this.streamId}`)
         }
 
-        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions!
+        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions
         let partition
         if (explicitPartition !== undefined) {
             if ((explicitPartition < 0 || explicitPartition >= partitionCount)) {

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -96,7 +96,7 @@ export class StreamRegistry {
 
     private parseStream(id: StreamID, metadata: string): Stream {
         const props: StreamProperties = Stream.parsePropertiesFromMetadata(metadata)
-        return this.streamFactory.createStream({ ...props, id })
+        return this.streamFactory.createStream(id, props)
     }
 
     private async connectToContract(): Promise<void> {
@@ -160,10 +160,7 @@ export class StreamRegistry {
             await this.ensureStreamIdInNamespaceOfAuthenticatedUser(domain, streamId)
             await waitForTx(this.streamRegistryContract!.createStream(path, metadata, ethersOverrides))
         }
-        return this.streamFactory.createStream({
-            ...props,
-            id: streamId
-        })
+        return this.streamFactory.createStream(streamId,  props)
     }
 
     private async ensureStreamIdInNamespaceOfAuthenticatedUser(address: EthereumAddress, streamId: StreamID): Promise<void> {
@@ -182,10 +179,7 @@ export class StreamRegistry {
             StreamRegistry.formMetadata(props),
             ethersOverrides
         ))
-        return this.streamFactory.createStream({
-            ...props,
-            id: streamId
-        })
+        return this.streamFactory.createStream(streamId, props)
     }
 
     async deleteStream(streamIdOrPath: string): Promise<void> {

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -94,7 +94,7 @@ export class StreamRegistry {
     }
 
     private parseStream(id: StreamID, metadata: string): Stream {
-        const props = Stream.parsePropertiesFromMetadata(metadata)
+        const props = Stream.parseMetadata(metadata)
         return this.streamFactory.createStream(id, props)
     }
 

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -7,7 +7,7 @@ import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { EthereumConfig, getAllStreamRegistryChainProviders, getStreamRegistryOverrides } from '../Ethereum'
 import { until } from '../utils/promises'
 import { ConfigInjectionToken, TimeoutsConfig } from '../Config'
-import { Stream, StreamProperties } from '../Stream'
+import { Stream, StreamMetadata } from '../Stream'
 import { ErrorCode, NotFoundError } from '../HttpUtil'
 import { StreamID, StreamIDUtils } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
@@ -95,7 +95,7 @@ export class StreamRegistry {
     }
 
     private parseStream(id: StreamID, metadata: string): Stream {
-        const props: StreamProperties = Stream.parsePropertiesFromMetadata(metadata)
+        const props = Stream.parsePropertiesFromMetadata(metadata)
         return this.streamFactory.createStream(id, props)
     }
 
@@ -122,7 +122,7 @@ export class StreamRegistry {
         }
     }
 
-    async createStream(propsOrStreamIdOrPath: StreamProperties | string): Promise<Stream> {
+    async createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
 
@@ -170,7 +170,7 @@ export class StreamRegistry {
         }
     }
 
-    async updateStream(props: StreamProperties): Promise<Stream> {
+    async updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         await this.connectToContract()
         const ethersOverrides = getStreamRegistryOverrides(this.ethereumConfig)
@@ -270,7 +270,7 @@ export class StreamRegistry {
         return JSON.stringify({ query })
     }
 
-    private static formMetadata(props: StreamProperties): string {
+    private static formMetadata(props: StreamMetadata & { id: string }): string {
         return JSON.stringify(omit(props, 'id'))
     }
 

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -152,7 +152,9 @@ export class StreamRegistry {
         }
     }
 
-    async updateStream(streamId: StreamID, metadata: StreamMetadata): Promise<Stream> {
+    // TODO maybe we should require metadata to be StreamMetadata instead of Partial<StreamMetadata>
+    // Most likely the contract doesn't make any merging (like we do in Stream#update)?
+    async updateStream(streamId: StreamID, metadata: Partial<StreamMetadata>): Promise<Stream> {
         await this.connectToContract()
         const ethersOverrides = getStreamRegistryOverrides(this.ethereumConfig)
         await waitForTx(this.streamRegistryContract!.updateStreamMetadata(

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -122,7 +122,7 @@ export class StreamRegistry {
         }
     }
 
-    async createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
+    async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
 
@@ -170,7 +170,7 @@ export class StreamRegistry {
         }
     }
 
-    async updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
+    async updateStream(props: Partial<StreamMetadata> & { id: string }): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         await this.connectToContract()
         const ethersOverrides = getStreamRegistryOverrides(this.ethereumConfig)
@@ -270,7 +270,7 @@ export class StreamRegistry {
         return JSON.stringify({ query })
     }
 
-    private static formMetadata(props: StreamMetadata & { id: string }): string {
+    private static formMetadata(props: Partial<StreamMetadata> & { id: string }): string {
         return JSON.stringify(omit(props, 'id'))
     }
 

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -150,7 +150,7 @@ export class StreamStorageRegistry {
         this.logger.debug('getting stored streams of node %s', nodeAddress)
         const res = await this.graphQLClient.sendQuery(query) as StorageNodeQueryResult
         const streams = res.node.storedStreams.map((stream) => {
-            const props = Stream.parsePropertiesFromMetadata(stream.metadata)
+            const props = Stream.parseMetadata(stream.metadata)
             return this.streamFactory.createStream(toStreamID(stream.id), props) // toStreamID() not strictly necessary
         })
         return {

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -151,7 +151,7 @@ export class StreamStorageRegistry {
         const res = await this.graphQLClient.sendQuery(query) as StorageNodeQueryResult
         const streams = res.node.storedStreams.map((stream) => {
             const props: StreamProperties = Stream.parsePropertiesFromMetadata(stream.metadata)
-            return this.streamFactory.createStream({ ...props, id: toStreamID(stream.id) }) // toStreamID() not strictly necessary
+            return this.streamFactory.createStream(toStreamID(stream.id), props) // toStreamID() not strictly necessary
         })
         return {
             streams,

--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -3,7 +3,7 @@ import StreamStorageRegistryArtifact from '../ethereumArtifacts/StreamStorageReg
 import { StreamQueryResult } from './StreamRegistry'
 import { scoped, Lifecycle, inject, delay } from 'tsyringe'
 import { ConfigInjectionToken } from '../Config'
-import { Stream, StreamProperties } from '../Stream'
+import { Stream } from '../Stream'
 import { EthereumConfig, getStreamRegistryChainProvider, getStreamRegistryOverrides } from '../Ethereum'
 import { StreamID, toStreamID } from 'streamr-client-protocol'
 import { StreamIDBuilder } from '../StreamIDBuilder'
@@ -150,7 +150,7 @@ export class StreamStorageRegistry {
         this.logger.debug('getting stored streams of node %s', nodeAddress)
         const res = await this.graphQLClient.sendQuery(query) as StorageNodeQueryResult
         const streams = res.node.storedStreams.map((stream) => {
-            const props: StreamProperties = Stream.parsePropertiesFromMetadata(stream.metadata)
+            const props = Stream.parsePropertiesFromMetadata(stream.metadata)
             return this.streamFactory.createStream(toStreamID(stream.id), props) // toStreamID() not strictly necessary
         })
         return {

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -226,14 +226,14 @@ describe('StreamRegistry', () => {
             })
             await until(async () => {
                 try {
-                    return (await client.getStream(createdStream.id)).description === createdStream.description
+                    return (await client.getStream(createdStream.id)).getMetadata().description === createdStream.getMetadata().description
                 } catch (err) {
                     return false
                 }
             }, 100000, 1000)
             // check that other fields not overwritten
             const updatedStream = await client.getStream(createdStream.id)
-            expect(updatedStream.partitions).toBe(PARTITION_COUNT)
+            expect(updatedStream.getMetadata().partitions).toBe(PARTITION_COUNT)
         })
     })
 

--- a/packages/client/test/integration/Stream.test.ts
+++ b/packages/client/test/integration/Stream.test.ts
@@ -98,9 +98,9 @@ describe('Stream', () => {
                     type: 'string',
                 },
             ]
-            expect(stream.config.fields).toEqual(expectedFields)
+            expect(stream.getMetadata().config?.fields).toEqual(expectedFields)
             const loadedStream = await client.getStream(stream.id)
-            expect(loadedStream.config.fields).toEqual(expectedFields)
+            expect(loadedStream.getMetadata().config?.fields).toEqual(expectedFields)
         })
 
         it('skips unsupported types', async () => {
@@ -126,9 +126,9 @@ describe('Stream', () => {
                     type: 'map',
                 },
             ]
-            expect(stream.config.fields).toEqual(expectedFields)
+            expect(stream.getMetadata().config?.fields).toEqual(expectedFields)
             const loadedStream = await client.getStream(stream.id)
-            expect(loadedStream.config.fields).toEqual(expectedFields)
+            expect(loadedStream.getMetadata().config?.fields).toEqual(expectedFields)
         })
     })
 })

--- a/packages/client/test/test-utils/fake/FakeChain.ts
+++ b/packages/client/test/test-utils/fake/FakeChain.ts
@@ -1,5 +1,5 @@
 import { StreamID } from 'streamr-client-protocol'
-import { StreamProperties } from '../../../src/Stream'
+import { StreamMetadata } from '../../../src/Stream'
 import { StreamPermission } from '../../../src/permission'
 import { EthereumAddress, Multimap } from '@streamr/utils'
 import { StorageNodeMetadata } from '../../../src/registry/StorageNodeRegistry'
@@ -8,7 +8,7 @@ export type PublicPermissionTarget = 'public'
 export const PUBLIC_PERMISSION_TARGET: PublicPermissionTarget = 'public'
 
 export interface StreamRegistryItem {
-    metadata: Omit<StreamProperties, 'id'>
+    metadata: StreamMetadata
     permissions: Multimap<EthereumAddress | PublicPermissionTarget, StreamPermission>
 }
 

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -52,7 +52,9 @@ export class FakeStorageNode extends FakeNetworkNode {
         const storageNodeAssignmentStreamPermissions = new Multimap<EthereumAddress, StreamPermission>()
         storageNodeAssignmentStreamPermissions.add(address, StreamPermission.PUBLISH)
         this.chain.streams.set(formStorageNodeAssignmentStreamId(address), {
-            metadata: {},
+            metadata: {
+                partitions: 1
+            },
             permissions: storageNodeAssignmentStreamPermissions
         })
     }

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -41,7 +41,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         this.streamRegistryCached = streamRegistryCached
     }
 
-    async createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
+    async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
@@ -69,7 +69,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
+    async updateStream(props: Partial<StreamMetadata> & { id: string }): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         const registryItem = this.chain.streams.get(streamId)
         if (registryItem === undefined) {

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -12,7 +12,7 @@ import {
 import { SearchStreamsPermissionFilter } from '../../../src/registry/searchStreams'
 import { StreamRegistry } from '../../../src/registry/StreamRegistry'
 import { StreamRegistryCached } from '../../../src/registry/StreamRegistryCached'
-import { Stream, StreamProperties } from '../../../src/Stream'
+import { Stream, StreamMetadata } from '../../../src/Stream'
 import { StreamFactory } from '../../../src/StreamFactory'
 import { StreamIDBuilder } from '../../../src/StreamIDBuilder'
 import { Methods } from '../types'
@@ -41,7 +41,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         this.streamRegistryCached = streamRegistryCached
     }
 
-    async createStream(propsOrStreamIdOrPath: StreamProperties | string): Promise<Stream> {
+    async createStream(propsOrStreamIdOrPath: StreamMetadata & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         props.partitions ??= 1
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
@@ -69,7 +69,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async updateStream(props: StreamProperties): Promise<Stream> {
+    async updateStream(props: StreamMetadata & { id: string }): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
         const registryItem = this.chain.streams.get(streamId)
         if (registryItem === undefined) {

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -56,16 +56,13 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
             permissions
         }
         this.chain.streams.set(streamId, registryItem)
-        return this.streamFactory.createStream({
-            ...props,
-            id: streamId
-        })
+        return this.streamFactory.createStream(streamId, props)
     }
 
     async getStream(id: StreamID): Promise<Stream> {
         const registryItem = this.chain.streams.get(id)
         if (registryItem !== undefined) {
-            return this.streamFactory.createStream({ ...registryItem.metadata, id })
+            return this.streamFactory.createStream(id, registryItem.metadata)
         } else {
             throw new NotFoundError('Stream not found: id=' + id)
         }
@@ -80,10 +77,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         } else {
             registryItem.metadata = props
         }
-        return this.streamFactory.createStream({
-            ...props,
-            id: streamId
-        })
+        return this.streamFactory.createStream(streamId, props)
     }
 
     async hasPermission(query: PermissionQuery): Promise<boolean> {

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -149,11 +149,11 @@ export const createStreamRegistryCached = (opts: {
     isStreamSubscriber?: boolean
 }): StreamRegistryCached => {
     return {
-        getStream: async () => {
-            return {
+        getStream: async () => ({
+            getMetadata: () => ({
                 partitions: opts?.partitionCount ?? 1
-            } as any
-        },
+            })
+        }),
         isPublic: async () => {
             return opts.isPublicStream ?? false
         },

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -6,7 +6,7 @@ import { Wallet } from 'ethers'
 import { StreamMessage, StreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } from 'streamr-client-protocol'
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
-import { Stream, StreamProperties } from '../../src/Stream'
+import { Stream, StreamMetadata } from '../../src/Stream'
 import { ConfigTest } from '../../src/ConfigTest'
 import { STREAM_CLIENT_DEFAULTS, StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -42,7 +42,7 @@ export const createRelativeTestStreamId = (module: NodeModule, suffix?: string):
     return counterId(`/test/${randomTestRunId}/${getTestName(module)}${(suffix !== undefined) ? '-' + suffix : ''}`, '-')
 }
 
-export const createTestStream = async (streamrClient: StreamrClient, module: NodeModule, props?: Partial<StreamProperties>): Promise<Stream> => {
+export const createTestStream = async (streamrClient: StreamrClient, module: NodeModule, props?: Partial<StreamMetadata>): Promise<Stream> => {
     const stream = await streamrClient.createStream({
         id: createRelativeTestStreamId(module),
         ...props

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -17,7 +17,7 @@ describe('Stream', () => {
         expect(stream.getMetadata().config?.fields).toEqual([])
     })
 
-    it('toObject', () => {
+    it('getMetadata', () => {
         const mockContainer = rootContainer.createChildContainer()
         initContainer(createStrictConfig({}), mockContainer)
         const factory = mockContainer.resolve(StreamFactory)
@@ -25,8 +25,7 @@ describe('Stream', () => {
             partitions: 10,
             storageDays: 20
         })
-        expect(stream.toObject()).toEqual({
-            id: 'mock-id',
+        expect(stream.getMetadata()).toEqual({
             partitions: 10,
             storageDays: 20,
             // currently we get also this field, which was not set by the user

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -13,9 +13,7 @@ describe('Stream', () => {
         const mockContainer = rootContainer.createChildContainer()
         initContainer(createStrictConfig({}), mockContainer)
         const factory = mockContainer.resolve(StreamFactory)
-        const stream = factory.createStream({
-            id: toStreamID('mock-id')
-        })
+        const stream = factory.createStream(toStreamID('mock-id'), {})
         expect(stream.config.fields).toEqual([])
     })
 
@@ -23,8 +21,7 @@ describe('Stream', () => {
         const mockContainer = rootContainer.createChildContainer()
         initContainer(createStrictConfig({}), mockContainer)
         const factory = mockContainer.resolve(StreamFactory)
-        const stream = factory.createStream({
-            id: toStreamID('mock-id'),
+        const stream = factory.createStream(toStreamID('mock-id'), {
             partitions: 10,
             storageDays: 20
         })
@@ -49,8 +46,7 @@ describe('Stream', () => {
                 updateStream: jest.fn().mockRejectedValue(new Error('mock-error'))
             } as any)
             const factory = mockContainer.resolve(StreamFactory)
-            const stream = factory.createStream({
-                id: toStreamID('mock-id'),
+            const stream = factory.createStream(toStreamID('mock-id'), {
                 description: 'original-description'
             })
 

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -14,7 +14,7 @@ describe('Stream', () => {
         initContainer(createStrictConfig({}), mockContainer)
         const factory = mockContainer.resolve(StreamFactory)
         const stream = factory.createStream(toStreamID('mock-id'), {})
-        expect(stream.config.fields).toEqual([])
+        expect(stream.getMetadata().config?.fields).toEqual([])
     })
 
     it('toObject', () => {
@@ -55,7 +55,7 @@ describe('Stream', () => {
                     description: 'updated-description'
                 })
             }).rejects.toThrow('mock-error')
-            expect(stream.description).toBe('original-description')
+            expect(stream.getMetadata().description).toBe('original-description')
         })
     })
 })

--- a/packages/client/test/unit/StreamMessageValidator.test.ts
+++ b/packages/client/test/unit/StreamMessageValidator.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'streamr-client-protocol'
 import { Authentication } from '../../src/Authentication'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
-import StreamMessageValidator, { StreamMetadata } from '../../src/StreamMessageValidator'
+import StreamMessageValidator from '../../src/StreamMessageValidator'
 import { createRandomAuthentication } from '../test-utils/utils'
 import { EthereumAddress } from '@streamr/utils'
 
@@ -36,7 +36,7 @@ const publisherAuthentication = createRandomAuthentication()
 const subscriberAuthentication = createRandomAuthentication()
 
 describe('StreamMessageValidator', () => {
-    let getStream: (streamId: string) => Promise<StreamMetadata>
+    let getPartitionCount: (streamId: string) => Promise<number>
     let isPublisher: (address: EthereumAddress, streamId: string) => Promise<boolean>
     let isSubscriber: (address: EthereumAddress, streamId: string) => Promise<boolean>
     let verify: ((address: EthereumAddress, payload: string, signature: string) => boolean) | undefined
@@ -46,16 +46,12 @@ describe('StreamMessageValidator', () => {
     let groupKeyRequest: StreamMessage
     let groupKeyResponse: StreamMessage
 
-    const defaultGetStreamResponse = {
-        partitions: 10
-    }
-
     const getValidator = (customConfig?: any) => {
         if (customConfig) {
             return new StreamMessageValidator(customConfig)
         } else {
             return new StreamMessageValidator({
-                getStream, isPublisher, isSubscriber, verify
+                getPartitionCount, isPublisher, isSubscriber, verify
             })
         }
     }
@@ -64,7 +60,7 @@ describe('StreamMessageValidator', () => {
         const publisher = await publisherAuthentication.getAddress()
         const subscriber = await subscriberAuthentication.getAddress()
         // Default stubs
-        getStream = jest.fn().mockResolvedValue(defaultGetStreamResponse)
+        getPartitionCount = jest.fn().mockResolvedValue(10)
         isPublisher = async (address: EthereumAddress, streamId: string) => {
             return address === publisher && streamId === 'streamId'
         }
@@ -174,7 +170,7 @@ describe('StreamMessageValidator', () => {
 
         it('rejects if getStream rejects', async () => {
             const testError = new Error('test error')
-            getStream = jest.fn().mockRejectedValue(testError)
+            getPartitionCount = jest.fn().mockRejectedValue(testError)
 
             await assert.rejects(getValidator().validate(msg), (err: Error) => {
                 assert(err === testError)

--- a/packages/client/test/unit/StreamMessageValidator.test.ts
+++ b/packages/client/test/unit/StreamMessageValidator.test.ts
@@ -46,15 +46,7 @@ describe('StreamMessageValidator', () => {
     let groupKeyRequest: StreamMessage
     let groupKeyResponse: StreamMessage
 
-    const getValidator = (customConfig?: any) => {
-        if (customConfig) {
-            return new StreamMessageValidator(customConfig)
-        } else {
-            return new StreamMessageValidator({
-                getPartitionCount, isPublisher, isSubscriber, verify
-            })
-        }
-    }
+    const getValidator = () => new StreamMessageValidator({ getPartitionCount, isPublisher, isSubscriber, verify })
 
     beforeEach(async () => {
         const publisher = await publisherAuthentication.getAddress()

--- a/packages/client/test/unit/Validator.test.ts
+++ b/packages/client/test/unit/Validator.test.ts
@@ -15,11 +15,11 @@ const PARTITION_COUNT = 3
 
 const createMockValidator = () => {
     const streamRegistry: Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'> = {
-        getStream: async (): Promise<Stream> => {
-            return {
+        getStream: async (): Promise<Stream> => ({
+            getMetadata: () => ({
                 partitions: PARTITION_COUNT
-            } as any
-        },
+            })
+        } as any),
         isStreamPublisher: async (_streamIdOrPath: string, userAddress: EthereumAddress) => {
             return userAddress === toEthereumAddress(publisherWallet.address)
         }
@@ -52,7 +52,7 @@ const validate = async (messageOptions: MessageOptions) => {
 }
 
 describe('Validator', () => {
-    
+
     describe('StreamMessage', () => {
 
         it('happy path', async () => {
@@ -64,7 +64,7 @@ describe('Validator', () => {
                 partition: PARTITION_COUNT
             })).rejects.toThrow(`Partition ${PARTITION_COUNT} is out of range`)
         })
-    
+
         it('invalid signature', async () => {
             await expect(() => validate({
                 signature: 'invalid-signature'

--- a/packages/client/test/unit/searchStreams.test.ts
+++ b/packages/client/test/unit/searchStreams.test.ts
@@ -51,7 +51,7 @@ describe('searchStreams', () => {
             return {
                 id,
                 getMetadata: () => ({
-                    partitions: props.partitions!
+                    partitions: props.partitions
                 })
             } as any
         }

--- a/packages/client/test/unit/searchStreams.test.ts
+++ b/packages/client/test/unit/searchStreams.test.ts
@@ -47,7 +47,7 @@ describe('searchStreams', () => {
             createMockResultItem(stream3, JSON.stringify({ partitions: 33 }))
         ])
         const parseStream = (id: StreamID, metadata: string): Stream => {
-            const props = Stream.parsePropertiesFromMetadata(metadata)
+            const props = Stream.parseMetadata(metadata)
             return {
                 id,
                 getMetadata: () => ({

--- a/packages/client/test/unit/searchStreams.test.ts
+++ b/packages/client/test/unit/searchStreams.test.ts
@@ -46,26 +46,28 @@ describe('searchStreams', () => {
             createMockResultItem(stream2, 'invalid-json'),
             createMockResultItem(stream3, JSON.stringify({ partitions: 33 }))
         ])
-        const parseStream = (id: StreamID, metadata: string): Pick<Stream, 'id' | 'partitions'> => {
+        const parseStream = (id: StreamID, metadata: string): Stream => {
             const props = Stream.parsePropertiesFromMetadata(metadata)
             return {
                 id,
-                partitions: props.partitions!
-            }
+                getMetadata: () => ({
+                    partitions: props.partitions!
+                })
+            } as any
         }
 
         const streams = await collect(searchStreams(
             '/',
             undefined,
             graphQLClient as any,
-            parseStream as any,
+            parseStream,
             mockLoggerFactory().createLogger(module)
         ))
 
         expect(streams).toHaveLength(2)
         expect(streams[0].id).toBe(stream1)
-        expect(streams[0].partitions).toBe(11)
+        expect(streams[0].getMetadata().partitions).toBe(11)
         expect(streams[1].id).toBe(stream3)
-        expect(streams[1].partitions).toBe(33)
+        expect(streams[1].getMetadata().partitions).toBe(33)
     })
 })

--- a/packages/client/test/unit/subscribePipeline.test.ts
+++ b/packages/client/test/unit/subscribePipeline.test.ts
@@ -53,8 +53,8 @@ describe('subscribePipeline', () => {
         streamPartId = StreamPartIDUtils.parse(`${randomEthereumAddress()}/path#0`)
         publisher = fastWallet()
         const stream = new Stream(
+            toStreamID(streamPartId),
             {
-                id: toStreamID(streamPartId),
                 partitions: 1,
             },
             undefined as any,


### PR DESCRIPTION
## Summary

This is a breaking change.

Stream metadata is no longer stored as fields of `Stream` object. Therefore e.g. partition could and other metadata is now be queried via new  `stream.getMetadata()` method. Previously it was possible to access metadata directly.

```
const description = stream.getMetadata().description
// was: const description = stream.description
```

## Related changes

Removed `Stream#toObject` method. The new `stream.getMetadata()` implements almost the same logig:
- the `Stream#toObject` contained also the stream
- it used reflection to collect fields from `Stream` object

## Partitions

As partition count is also part of stream metadata, it is queried via the same method. We could have a separate method for this if needed. But it is quite straightforward to access it via `stream.getMetadata().partitions`.

The partitions property of `StreamMetadata` is a a required property. In StreamProperties object it was optional, but in `Stream` an it was initialized to `1` if no value was provided.

## Refactoring

- Modified `StreamRegistry#createStream` and `StreamRegistry#updateStream` to operate on `StreamID` and `StreamMetadata` instead of a raw object. Now The parsing is done in `StreamrClient`. Also moved `getOrCreateStream` from `StreamRegistry` to `StreamrClient` as it operates on raw objects.
- `StreamMessageValidator` used an interface called `StreamMetadata`, but now it uses just a simple method which returns the stream partition count.
- Renamed `Stream#parsePropertiesFromMetadata` to `Stream#parseMetadata` and inlined `StreamRegistry#formMetadata` (internal methods)

## Future improvements

Added several TODOs, which we should implement either in this PR or later:

- Currently we collect all properties from contract's metadata JSON to Stream metadata. There is no picking, e.g. currently the metadata object can have also other values than those listed in `StreamMetadata` interface.

- Currently we don't validate the metadata properties in any way. We should maybe check that all required parameters are available and have valid values: in practice we'd validate that the metadata contains `partitions` field, and it has value between `0` and `99`.

- In `StreamrClient#updateStream` we don't currently require any metadata fields. It is too easy to write invalid metadata (e.g. a JSON which doesn't contain the partition count) by calling that method. The method doesn't do any merging with the existing metadata field and most likely the contract doesn't do either. The logic of that method is different from e.g. `Stream#update` which does merge the current metadata with the existing metadata. It is also different from e.g. `createStream` which defaults partition count to `1` if none is set.
- Maybe it would make sense that we'd reimplement `StreamrClient#updateStream` just as a delegate to `Stream#update`? (or that `Stream#update` would delegate `StreamrClient#updateStream`)
- If we do that we could also change the signature so that the methods gets two parameters: `streamId` and `metadata`

- Config field of metadata is currently defaulted to empty array in `Stream` constructor. Therefore if is kind of "required property". It is a property used in frontend, but not part of e.g. the Streamr protocol. Maybe we should not set that to default value and frontend could just fallback to empty array if there is no config definition available in the metadata. (Alternatively we could annotate the config property as required parameter, but that is maybe not an optimal solution.)