### PR TITLE
refactor(protocol): `StreamMessage` enums

### DIFF
--- a/packages/broker/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/broker/test/integration/plugins/storage/Storage.test.ts
@@ -5,7 +5,7 @@ import toArray from 'stream-to-array'
 import { Storage } from '../../../../src/plugins/storage/Storage'
 import { startCassandraStorage } from '../../../../src/plugins/storage/Storage'
 import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
-import { toStreamID, StreamMessage, MessageID } from "streamr-client-protocol"
+import { toStreamID, StreamMessage, MessageID, EncryptionType } from "streamr-client-protocol"
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 
 const contactPoints = [STREAMR_DOCKER_DEV_HOST]
@@ -62,7 +62,7 @@ function buildEncryptedMsg({
     return new StreamMessage({
         messageId: new MessageID(toStreamID(streamId), streamPartition, timestamp, sequenceNumber, publisherId, msgChainId),
         content,
-        encryptionType: StreamMessage.ENCRYPTION_TYPES.AES,
+        encryptionType: EncryptionType.AES,
         signature: 'signature'
     })
 }

--- a/packages/client/src/StreamMessageValidator.ts
+++ b/packages/client/src/StreamMessageValidator.ts
@@ -6,7 +6,8 @@ import {
     StreamMessage,
     StreamMessageError,
     ValidationError,
-    createSignaturePayload
+    createSignaturePayload,
+    StreamMessageType
 } from "streamr-client-protocol"
 import { verify as verifyImpl } from './utils/signingUtils'
 
@@ -67,11 +68,11 @@ export default class StreamMessageValidator {
         await this.assertSignatureIsValid(streamMessage)
 
         switch (streamMessage.messageType) {
-            case StreamMessage.MESSAGE_TYPES.MESSAGE:
+            case StreamMessageType.MESSAGE:
                 return this.validateMessage(streamMessage)
-            case StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST:
+            case StreamMessageType.GROUP_KEY_REQUEST:
                 return this.validateGroupKeyRequest(streamMessage)
-            case StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE:
+            case StreamMessageType.GROUP_KEY_RESPONSE:
                 return this.validateGroupKeyResponse(streamMessage)
             default:
                 throw new StreamMessageError(`Unknown message type: ${streamMessage.messageType}!`, streamMessage)

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -1,6 +1,6 @@
 import crypto, { CipherKey } from 'crypto'
 import { arrayify, hexlify } from '@ethersproject/bytes'
-import { StreamMessage, StreamMessageError } from 'streamr-client-protocol'
+import { EncryptionType, StreamMessage, StreamMessageError } from 'streamr-client-protocol'
 import { GroupKey } from './GroupKey'
 
 export class DecryptError extends StreamMessageError {
@@ -60,17 +60,17 @@ export class EncryptionUtil {
     }
 
     static decryptStreamMessage(streamMessage: StreamMessage, groupKey: GroupKey): void | never {
-        if ((streamMessage.encryptionType !== StreamMessage.ENCRYPTION_TYPES.AES)) {
+        if ((streamMessage.encryptionType !== EncryptionType.AES)) {
             return
         }
 
         try {
-            streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
+            streamMessage.encryptionType = EncryptionType.NONE
             const serializedContent = this.decryptWithAES(streamMessage.getSerializedContent(), groupKey.data).toString()
             streamMessage.parsedContent = JSON.parse(serializedContent)
             streamMessage.serializedContent = serializedContent
         } catch (err) {
-            streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
+            streamMessage.encryptionType = EncryptionType.AES
             throw new DecryptError(streamMessage, err.stack)
         }
 
@@ -82,7 +82,7 @@ export class EncryptionUtil {
                 streamMessage.newGroupKey = groupKey.decryptNextGroupKey(newGroupKey)
             }
         } catch (err) {
-            streamMessage.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
+            streamMessage.encryptionType = EncryptionType.AES
             throw new DecryptError(streamMessage, 'Could not decrypt new group key: ' + err.stack)
         }
         /* eslint-enable no-param-reassign */

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -1,6 +1,7 @@
 import { without } from 'lodash'
 import {
     EncryptedGroupKey,
+    EncryptionType,
     GroupKeyRequest,
     GroupKeyResponse,
     GroupKeyResponseSerialized,
@@ -66,10 +67,10 @@ export class PublisherKeyExchange {
                         undefined) as GroupKey[]
                     if (keys.length > 0) {
                         const response = await this.createResponse(
-                            keys, 
+                            keys,
                             request.getStreamPartID(),
-                            rsaPublicKey, 
-                            request.getPublisherId(), 
+                            rsaPublicKey,
+                            request.getPublisherId(),
                             requestId)
                         const node = await this.networkNodeFacade.getNode()
                         node.publish(response)
@@ -111,7 +112,7 @@ export class PublisherKeyExchange {
             ),
             serializedContent: JSON.stringify(responseContent.toArray()),
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+            encryptionType: EncryptionType.RSA,
             authentication: this.authentication
         })
         return response

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -1,4 +1,5 @@
 import {
+    EncryptionType,
     GroupKeyRequest,
     GroupKeyRequestSerialized,
     GroupKeyResponse,
@@ -24,7 +25,7 @@ import { RSAKeyPair } from './RSAKeyPair'
 import { EthereumAddress, Logger } from '@streamr/utils'
 import { LoggerFactory } from '../utils/LoggerFactory'
 
-const MAX_PENDING_REQUEST_COUNT = 50000 // just some limit, we can tweak the number if needed 
+const MAX_PENDING_REQUEST_COUNT = 50000 // just some limit, we can tweak the number if needed
 
 /*
  * Sends group key requests and receives group key responses
@@ -41,7 +42,7 @@ export class SubscriberKeyExchange {
     private readonly pendingRequests: MaxSizedSet<string> = new MaxSizedSet(MAX_PENDING_REQUEST_COUNT)
     private readonly ensureStarted: () => Promise<void>
     requestGroupKey: (groupKeyId: GroupKeyId, publisherId: EthereumAddress, streamPartId: StreamPartID) => Promise<void>
-    
+
     constructor(
         networkNodeFacade: NetworkNodeFacade,
         store: GroupKeyStore,
@@ -61,7 +62,7 @@ export class SubscriberKeyExchange {
             node.addMessageListener((msg: StreamMessage) => this.onMessage(msg))
             this.logger.debug('started')
         })
-        this.requestGroupKey = withThrottling((groupKeyId: GroupKeyId, publisherId: EthereumAddress, streamPartId: StreamPartID) => { 
+        this.requestGroupKey = withThrottling((groupKeyId: GroupKeyId, publisherId: EthereumAddress, streamPartId: StreamPartID) => {
             return this.doRequestGroupKey(groupKeyId, publisherId, streamPartId)
         }, decryptionConfig.maxKeyRequestsPerSecond)
     }
@@ -105,7 +106,7 @@ export class SubscriberKeyExchange {
             ),
             serializedContent: JSON.stringify(requestContent),
             messageType: StreamMessageType.GROUP_KEY_REQUEST,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            encryptionType: EncryptionType.NONE,
             authentication: this.authentication
         })
     }

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -1,4 +1,4 @@
-import { StreamMessage } from 'streamr-client-protocol'
+import { EncryptionType, StreamMessage } from 'streamr-client-protocol'
 import { EncryptionUtil, DecryptError } from '../encryption/EncryptionUtil'
 import { StreamRegistryCached } from '../registry/StreamRegistryCached'
 import { DestroySignal } from '../DestroySignal'
@@ -39,7 +39,7 @@ export class Decrypt<T> {
             return streamMessage
         }
 
-        if (streamMessage.encryptionType !== StreamMessage.ENCRYPTION_TYPES.AES) {
+        if (streamMessage.encryptionType !== EncryptionType.AES) {
             return streamMessage
         }
 

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { StreamMessage, toStreamPartID } from 'streamr-client-protocol'
+import { StreamMessageType, toStreamPartID } from 'streamr-client-protocol'
 import { fastPrivateKey } from 'streamr-test-utils'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
@@ -158,7 +158,7 @@ describe('Group Key Persistence', () => {
             ])
 
             const groupKeyRequests = environment.getNetwork().getSentMessages({
-                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+                messageType: StreamMessageType.GROUP_KEY_REQUEST
             })
             expect(groupKeyRequests.length).toBe(1)
             expect(received.map((m) => m.signature)).toEqual(published.slice(0, 1).map((m) => m.signature))

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -52,9 +52,9 @@ describe('PublisherKeyExchange', () => {
                 streamPartition: StreamPartIDUtils.getStreamPartition(streamPartId),
                 publisherId: toEthereumAddress(publisherWallet.address),
             },
-            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE,
-            contentType: StreamMessage.CONTENT_TYPES.JSON,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+            messageType: StreamMessageType.GROUP_KEY_RESPONSE,
+            contentType: ContentTypes.JSON,
+            encryptionType: EncryptionType.RSA,
             signature: expect.any(String)
         })
         const encryptedGroupKeys = (GroupKeyResponse.fromStreamMessage(actualResponse) as GroupKeyResponse).encryptedGroupKeys
@@ -99,7 +99,7 @@ describe('PublisherKeyExchange', () => {
             await triggerGroupKeyRequest()
 
             const response = await environment.getNetwork().waitForSentMessage({
-                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE
+                messageType: StreamMessageType.GROUP_KEY_RESPONSE
             })
             await assertValidResponse(response!, key)
         })

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -3,8 +3,11 @@ import 'reflect-metadata'
 import { toEthereumAddress } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import {
+    ContentType,
+    EncryptionType,
     GroupKeyResponse,
     StreamMessage,
+    StreamMessageType,
     StreamPartID,
     StreamPartIDUtils
 } from 'streamr-client-protocol'
@@ -53,7 +56,7 @@ describe('PublisherKeyExchange', () => {
                 publisherId: toEthereumAddress(publisherWallet.address),
             },
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
-            contentType: ContentTypes.JSON,
+            contentType: ContentType.JSON,
             encryptionType: EncryptionType.RSA,
             signature: expect.any(String)
         })

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -52,9 +52,9 @@ describe('SubscriberKeyExchange', () => {
                 streamPartition:  StreamPartIDUtils.getStreamPartition(streamPartId),
                 publisherId: toEthereumAddress(subscriberWallet.address)
             },
-            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST,
-            contentType: StreamMessage.CONTENT_TYPES.JSON,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            messageType: StreamMessageType.GROUP_KEY_REQUEST,
+            contentType: ContentTypes.JSON,
+            encryptionType: EncryptionType.NONE,
             signature: expect.any(String)
         })
         expect(request!.getParsedContent()).toEqual([
@@ -102,7 +102,7 @@ describe('SubscriberKeyExchange', () => {
             await triggerGroupKeyRequest(groupKey, publisher)
 
             const request = await environment.getNetwork().waitForSentMessage({
-                messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+                messageType: StreamMessageType.GROUP_KEY_REQUEST
             })
             await assertGroupKeyRequest(request!, [groupKey.id])
             const keyStore = getGroupKeyStore(toEthereumAddress(subscriberWallet.address))

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -3,7 +3,10 @@ import 'reflect-metadata'
 import { toEthereumAddress } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import {
+    ContentType,
+    EncryptionType,
     StreamMessage,
+    StreamMessageType,
     StreamPartID,
     StreamPartIDUtils
 } from 'streamr-client-protocol'
@@ -53,7 +56,7 @@ describe('SubscriberKeyExchange', () => {
                 publisherId: toEthereumAddress(subscriberWallet.address)
             },
             messageType: StreamMessageType.GROUP_KEY_REQUEST,
-            contentType: ContentTypes.JSON,
+            contentType: ContentType.JSON,
             encryptionType: EncryptionType.NONE,
             signature: expect.any(String)
         })

--- a/packages/client/test/integration/parallel-key-exchange.test.ts
+++ b/packages/client/test/integration/parallel-key-exchange.test.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata'
 import { Wallet } from '@ethersproject/wallet'
 import { wait } from '@streamr/utils'
 import { range } from 'lodash'
-import { StreamMessage } from 'streamr-client-protocol'
+import { StreamMessageType } from 'streamr-client-protocol'
 import { fastWallet } from 'streamr-test-utils'
 import { createAuthentication } from '../../src/Authentication'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -86,7 +86,7 @@ describe('parallel key exchange', () => {
         expect(messages).toHaveLength(expectedMessageCount)
         expect(messages.filter((msg) => !((msg.content as any).foo === 'bar'))).toEqual([])
         expect(environment.getNetwork().getSentMessages({
-            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+            messageType: StreamMessageType.GROUP_KEY_REQUEST
         })).toHaveLength(PUBLISHER_COUNT)
     }, 30 * 1000)
 })

--- a/packages/client/test/integration/pre-agreed-encryption-key.test.ts
+++ b/packages/client/test/integration/pre-agreed-encryption-key.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { StreamMessage } from 'streamr-client-protocol'
+import { StreamMessageType } from 'streamr-client-protocol'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
 import { nextValue } from '../../src/utils/iterators'
@@ -32,7 +32,7 @@ describe('pre-agreed encryption key', () => {
 
         expect(receivedMessage?.streamMessage.groupKeyId).toBe(key.id)
         const groupKeyRequests = environment.getNetwork().getSentMessages({
-            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+            messageType: StreamMessageType.GROUP_KEY_REQUEST
         })
         expect(groupKeyRequests).toHaveLength(0)
     })

--- a/packages/client/test/integration/resend-and-subscribe.test.ts
+++ b/packages/client/test/integration/resend-and-subscribe.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { GroupKeyMessage, GroupKeyRequest, StreamMessage } from 'streamr-client-protocol'
+import { GroupKeyMessage, GroupKeyRequest, StreamMessageType } from 'streamr-client-protocol'
 import { fastWallet } from 'streamr-test-utils'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
@@ -92,7 +92,7 @@ describe('resend and subscribe', () => {
         })
         expect(receivedMessage2!.streamMessage.groupKeyId).toBe(groupKey.id)
         const groupKeyRequests = environment.getNetwork().getSentMessages({
-            messageType: StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST
+            messageType: StreamMessageType.GROUP_KEY_REQUEST
         })
         expect(groupKeyRequests.length).toBe(1)
         expect((GroupKeyMessage.fromStreamMessage(groupKeyRequests[0]) as GroupKeyRequest).groupKeyIds).toEqual([groupKey.id])

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import {
     EncryptedGroupKey,
-    StreamMessage,
+    EncryptionType,
     StreamPartIDUtils,
     toStreamID,
     toStreamPartID
@@ -53,7 +53,7 @@ describe('EncryptionUtil', () => {
         })
         EncryptionUtil.decryptStreamMessage(streamMessage, key)
         expect(streamMessage.getSerializedContent()).toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(StreamMessage.ENCRYPTION_TYPES.NONE)
+        expect(streamMessage.encryptionType).toStrictEqual(EncryptionType.NONE)
         expect(streamMessage.groupKeyId).toBe(key.id)
         expect(streamMessage.newGroupKey).toEqual(nextKey)
     })

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -61,12 +61,12 @@ describe('MessageFactory', () => {
                 timestamp: TIMESTAMP
             },
             prevMsgRef: null,
-            messageType: StreamMessage.MESSAGE_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.AES,
+            messageType: StreamMessageType.MESSAGE,
+            encryptionType: EncryptionType.AES,
             groupKeyId: GROUP_KEY.id,
             newGroupKey: null,
             signature: expect.stringMatching(/^0x[0-9a-f]+$/),
-            contentType: StreamMessage.CONTENT_TYPES.JSON,
+            contentType: ContentTypes.JSON,
             serializedContent: expect.stringMatching(/^[0-9a-f]+$/)
         })
     })
@@ -79,7 +79,7 @@ describe('MessageFactory', () => {
         })
         const msg = await createMessage({}, messageFactory)
         expect(msg).toMatchObject({
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            encryptionType: EncryptionType.NONE,
             groupKeyId: null,
             serializedContent: JSON.stringify(CONTENT)
         })

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -1,6 +1,6 @@
 import { keyToArrayIndex, toEthereumAddress } from '@streamr/utils'
 import { random } from 'lodash'
-import { MAX_PARTITION_COUNT, StreamMessage, toStreamID } from 'streamr-client-protocol'
+import { ContentType, EncryptionType, MAX_PARTITION_COUNT, StreamMessage, StreamMessageType, toStreamID } from 'streamr-client-protocol'
 import { fastWallet } from 'streamr-test-utils'
 import { createAuthentication } from '../../src/Authentication'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -66,7 +66,7 @@ describe('MessageFactory', () => {
             groupKeyId: GROUP_KEY.id,
             newGroupKey: null,
             signature: expect.stringMatching(/^0x[0-9a-f]+$/),
-            contentType: ContentTypes.JSON,
+            contentType: ContentType.JSON,
             serializedContent: expect.stringMatching(/^[0-9a-f]+$/)
         })
     })

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -9,6 +9,7 @@ import {
     StatusAckMessage,
     StatusMessage,
     StreamMessage,
+    StreamMessageType,
     StreamPartIDUtils,
     toStreamID
 } from 'streamr-client-protocol'

--- a/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
+++ b/packages/network/test/integration/delivery-of-messages-protocol-layer.test.ts
@@ -124,7 +124,7 @@ describe('delivery of messages in protocol layer', () => {
             content: {
                 hello: 'world'
             },
-            messageType: StreamMessage.MESSAGE_TYPES.MESSAGE,
+            messageType: StreamMessageType.MESSAGE,
             signature: 'signature',
         })
         const messagePromise = waitForEvent(nodeToNode1, NodeToNodeEvent.DATA_RECEIVED)
@@ -211,7 +211,7 @@ describe('delivery of messages in protocol layer', () => {
 
         })
         trackerServer.send('node1', sentMessage)
-        
+
         const [msg, source] = await messagePromise
 
         expect(msg).toBeInstanceOf(RelayMessage)
@@ -318,5 +318,5 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.subType).toEqual('rtcConnect')
         expect(msg.data).toEqual({})
     })
-    
+
 })

--- a/packages/network/test/integration/proxy-groupkey-exchange.test.ts
+++ b/packages/network/test/integration/proxy-groupkey-exchange.test.ts
@@ -95,7 +95,7 @@ describe('GroupKey exchange via proxy connections', () => {
                 '0'
             ),
             messageType: StreamMessageType.GROUP_KEY_REQUEST,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            encryptionType: EncryptionType.NONE,
             content: requestContent,
             signature: 'signature'
         })
@@ -126,7 +126,7 @@ describe('GroupKey exchange via proxy connections', () => {
                 '0'
             ),
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+            encryptionType: EncryptionType.RSA,
             content: responseContent,
             signature: 'signature'
         })

--- a/packages/network/test/integration/proxy-groupkey-exchange.test.ts
+++ b/packages/network/test/integration/proxy-groupkey-exchange.test.ts
@@ -2,6 +2,7 @@ import { NetworkNode } from '../../src/logic/NetworkNode'
 import { startTracker, Tracker } from '@streamr/network-tracker'
 import { createNetworkNode } from '../../src/createNetworkNode'
 import {
+    EncryptionType,
     GroupKeyRequest,
     GroupKeyResponse,
     MessageID,

--- a/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
@@ -20,7 +20,7 @@ export default class GroupKeyRequest extends GroupKeyMessage {
     groupKeyIds: string[]
 
     constructor({ requestId, recipient, rsaPublicKey, groupKeyIds }: Options) {
-        super(recipient, StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST)
+        super(recipient, StreamMessageType.GROUP_KEY_REQUEST)
 
         validateIsString('requestId', requestId)
         this.requestId = requestId

--- a/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
@@ -1,7 +1,7 @@
 import { validateIsArray, validateIsString } from '../../utils/validations'
 import ValidationError from '../../errors/ValidationError'
 
-import StreamMessage from './StreamMessage'
+import StreamMessage, { StreamMessageType } from './StreamMessage'
 import GroupKeyMessage from './GroupKeyMessage'
 import EncryptedGroupKey, { EncryptedGroupKeySerialized } from './EncryptedGroupKey'
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
@@ -20,7 +20,7 @@ export default class GroupKeyResponse extends GroupKeyMessage {
     encryptedGroupKeys: EncryptedGroupKey[]
 
     constructor({ requestId, recipient, encryptedGroupKeys }: Options) {
-        super(recipient, StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE)
+        super(recipient, StreamMessageType.GROUP_KEY_RESPONSE)
 
         validateIsString('requestId', requestId)
         this.requestId = requestId
@@ -52,8 +52,8 @@ export default class GroupKeyResponse extends GroupKeyMessage {
     }
 
     static is(streamMessage: StreamMessage): streamMessage is StreamMessage<GroupKeyResponseSerialized> {
-        return streamMessage.messageType === StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE
+        return streamMessage.messageType === StreamMessageType.GROUP_KEY_RESPONSE
     }
 }
 
-GroupKeyMessage.classByMessageType[StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE] = GroupKeyResponse
+GroupKeyMessage.classByMessageType[StreamMessageType.GROUP_KEY_RESPONSE] = GroupKeyResponse

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -76,9 +76,9 @@ export type StreamMessageUnencrypted<T> = StreamMessage<T> & {
 export default class StreamMessage<T = unknown> {
     static LATEST_VERSION = LATEST_VERSION
 
-    static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessageType))
-    static VALID_CONTENT_TYPES = new Set(Object.values(ContentType))
-    static VALID_ENCRYPTIONS = new Set(Object.values(EncryptionType))
+    private static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessageType))
+    private static VALID_CONTENT_TYPES = new Set(Object.values(ContentType))
+    private static VALID_ENCRYPTIONS = new Set(Object.values(EncryptionType))
 
     messageId: MessageID
     prevMsgRef: MessageRef | null

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -104,7 +104,7 @@ export default class StreamMessage<T = unknown> {
      * Create a new StreamMessage identical to the passed-in streamMessage.
      */
     clone(): StreamMessage<T> {
-        const content = this.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE
+        const content = this.encryptionType === EncryptionType.NONE
             ? this.getParsedContent()
             : this.getSerializedContent()
 
@@ -125,9 +125,9 @@ export default class StreamMessage<T = unknown> {
         messageId,
         prevMsgRef = null,
         content,
-        messageType = StreamMessage.MESSAGE_TYPES.MESSAGE,
-        contentType = StreamMessage.CONTENT_TYPES.JSON,
-        encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE,
+        messageType = StreamMessageType.MESSAGE,
+        contentType = ContentType.JSON,
+        encryptionType = EncryptionType.NONE,
         groupKeyId = null,
         newGroupKey = null,
         signature,
@@ -219,12 +219,12 @@ export default class StreamMessage<T = unknown> {
     getParsedContent(): T {
         if (this.parsedContent == null) {
             // Don't try to parse encrypted messages
-            if (this.messageType === StreamMessage.MESSAGE_TYPES.MESSAGE && this.encryptionType !== StreamMessage.ENCRYPTION_TYPES.NONE) {
+            if (this.messageType === StreamMessageType.MESSAGE && this.encryptionType !== EncryptionType.NONE) {
                 // @ts-expect-error need type narrowing for encrypted vs unencrypted
                 return this.serializedContent
             }
 
-            if (this.contentType === StreamMessage.CONTENT_TYPES.JSON) {
+            if (this.contentType === ContentType.JSON) {
                 try {
                     this.parsedContent = JSON.parse(this.serializedContent!)
                 } catch (err: any) {
@@ -371,7 +371,7 @@ export default class StreamMessage<T = unknown> {
             contentType: this.contentType,
             encryptionType: this.encryptionType,
             groupKeyId: this.groupKeyId,
-            content: (this.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE ? this.getParsedContent() : this.getSerializedContent()),
+            content: (this.encryptionType === EncryptionType.NONE ? this.getParsedContent() : this.getSerializedContent()),
             signature: this.signature,
         }
     }

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -43,7 +43,7 @@ export interface StreamMessageOptions<T> {
     signature: string
 }
 
-export interface ObjectType<T> { 
+export interface ObjectType<T> {
     streamId: string
     streamPartition: number
     timestamp: number
@@ -76,18 +76,9 @@ export type StreamMessageUnencrypted<T> = StreamMessage<T> & {
 export default class StreamMessage<T = unknown> {
     static LATEST_VERSION = LATEST_VERSION
 
-    // TODO can we remove these static field and use the enum object directly?
-    static MESSAGE_TYPES = StreamMessageType
-
-    static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessage.MESSAGE_TYPES))
-
-    static CONTENT_TYPES = ContentType
-
-    static VALID_CONTENT_TYPES = new Set(Object.values(StreamMessage.CONTENT_TYPES))
-
-    static ENCRYPTION_TYPES = EncryptionType
-
-    static VALID_ENCRYPTIONS = new Set(Object.values(StreamMessage.ENCRYPTION_TYPES))
+    static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessageType))
+    static VALID_CONTENT_TYPES = new Set(Object.values(ContentType))
+    static VALID_ENCRYPTIONS = new Set(Object.values(EncryptionType))
 
     messageId: MessageID
     prevMsgRef: MessageRef | null

--- a/packages/protocol/test/unit/protocol/control_layer/BroadcastMessageSerializerV2.test.ts
+++ b/packages/protocol/test/unit/protocol/control_layer/BroadcastMessageSerializerV2.test.ts
@@ -5,7 +5,8 @@ import {
     BroadcastMessage,
     ControlMessage,
     ContentType,
-    EncryptionType
+    EncryptionType,
+    StreamMessageType
 } from '../../../../src/index'
 import { toEthereumAddress } from '@streamr/utils'
 import { SIGNATURE_TYPE_ETH } from '../../../../src/protocol/message_layer/StreamMessageSerializerV32'
@@ -13,7 +14,7 @@ import { SIGNATURE_TYPE_ETH } from '../../../../src/protocol/message_layer/Strea
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
 const streamMessage = StreamMessage.deserialize([32, ['streamId', 0, 1529549961116, 0, PUBLISHER_ID, 'msg-chain-id'],
-    [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE,
+    [1529549961000, 0], StreamMessageType.MESSAGE,
     ContentType.JSON, EncryptionType.NONE, null, '{"valid": "json"}', null, SIGNATURE_TYPE_ETH, 'signature'])
 
 const VERSION = 2

--- a/packages/protocol/test/unit/protocol/message_layer/GroupKeyRequest.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/GroupKeyRequest.test.ts
@@ -1,8 +1,8 @@
 import assert from 'assert'
 
 import {
-    StreamMessage,
-    GroupKeyRequest
+    GroupKeyRequest,
+    StreamMessageType
 } from '../../../../src/index'
 import GroupKeyMessage from '../../../../src/protocol/message_layer/GroupKeyMessage'
 import { toEthereumAddress } from '@streamr/utils'
@@ -21,7 +21,7 @@ const serializedMessage = JSON.stringify(['requestId', recipient, 'rsaPublicKey'
 describe('GroupKeyRequest', () => {
     describe('deserialize', () => {
         it('correctly parses messages', () => {
-            assert.deepStrictEqual(GroupKeyMessage.deserialize(serializedMessage, StreamMessage.MESSAGE_TYPES.GROUP_KEY_REQUEST), message)
+            assert.deepStrictEqual(GroupKeyMessage.deserialize(serializedMessage, StreamMessageType.GROUP_KEY_REQUEST), message)
         })
     })
     describe('serialize', () => {

--- a/packages/protocol/test/unit/protocol/message_layer/GroupKeyResponse.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/GroupKeyResponse.test.ts
@@ -1,8 +1,8 @@
 import assert from 'assert'
 
 import {
-    StreamMessage,
-    GroupKeyResponse
+    GroupKeyResponse,
+    StreamMessageType
 } from '../../../../src/index'
 import EncryptedGroupKey from '../../../../src/protocol/message_layer/EncryptedGroupKey'
 import GroupKeyMessage from '../../../../src/protocol/message_layer/GroupKeyMessage'
@@ -25,7 +25,7 @@ const serializedMessage = JSON.stringify(['requestId', recipient, [['groupKeyId1
 describe('GroupKeyResponse', () => {
     describe('deserialize', () => {
         it('correctly parses messages', () => {
-            assert.deepStrictEqual(GroupKeyMessage.deserialize(serializedMessage, StreamMessage.MESSAGE_TYPES.GROUP_KEY_RESPONSE), message)
+            assert.deepStrictEqual(GroupKeyMessage.deserialize(serializedMessage, StreamMessageType.GROUP_KEY_RESPONSE), message)
         })
     })
     describe('serialize', () => {

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -12,7 +12,7 @@ import {
 import ValidationError from '../../../../src/errors/ValidationError'
 import UnsupportedVersionError from '../../../../src/errors/UnsupportedVersionError'
 import { Serializer } from '../../../../src/Serializer'
-import StreamMessage from '../../../../src/protocol/message_layer/StreamMessage'
+import StreamMessage, { ContentType, EncryptionType, StreamMessageType } from '../../../../src/protocol/message_layer/StreamMessage'
 import { toEthereumAddress } from '@streamr/utils'
 
 const content = {
@@ -26,8 +26,8 @@ const msg = ({ timestamp = 1564046332168, sequenceNumber = 10, ...overrides } = 
         messageId: new MessageID(toStreamID('streamId'), 0, timestamp, sequenceNumber, PUBLISHER_ID, 'msgChainId'),
         prevMsgRef: new MessageRef(timestamp, 5),
         content: JSON.stringify(content),
-        messageType: StreamMessage.MESSAGE_TYPES.MESSAGE,
-        encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        messageType: StreamMessageType.MESSAGE,
+        encryptionType: EncryptionType.NONE,
         signature: 'signature',
         newGroupKey,
         ...overrides
@@ -47,9 +47,9 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
             assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
             assert.deepStrictEqual(streamMessage.prevMsgRef, new MessageRef(1564046332168, 5))
-            assert.strictEqual(streamMessage.messageType, StreamMessage.MESSAGE_TYPES.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, StreamMessage.CONTENT_TYPES.JSON)
-            assert.strictEqual(streamMessage.encryptionType, StreamMessage.ENCRYPTION_TYPES.NONE)
+            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
+            assert.strictEqual(streamMessage.contentType, ContentType.JSON)
+            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
             assert.strictEqual(streamMessage.groupKeyId, null)
             assert.deepStrictEqual(streamMessage.getContent(), content)
             assert.strictEqual(streamMessage.getSerializedContent(), JSON.stringify(content))
@@ -71,9 +71,9 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
             assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
             assert.deepStrictEqual(streamMessage.prevMsgRef, null)
-            assert.strictEqual(streamMessage.messageType, StreamMessage.MESSAGE_TYPES.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, StreamMessage.CONTENT_TYPES.JSON)
-            assert.strictEqual(streamMessage.encryptionType, StreamMessage.ENCRYPTION_TYPES.NONE)
+            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
+            assert.strictEqual(streamMessage.contentType, ContentType.JSON)
+            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
             assert.strictEqual(streamMessage.groupKeyId, null)
             assert.deepStrictEqual(streamMessage.getContent(), content)
             assert.strictEqual(streamMessage.getSerializedContent(), JSON.stringify(content))
@@ -103,7 +103,7 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: JSON.stringify(content),
                 signature: 'something',
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+                encryptionType: EncryptionType.RSA,
             })
 
             expect(StreamMessage.isEncrypted(encryptedMessage)).toBe(true)
@@ -128,7 +128,7 @@ describe('StreamMessage', () => {
             assert.doesNotThrow(() => msg({
                 // @ts-expect-error TODO
                 content: 'encrypted content',
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.AES,
+                encryptionType: EncryptionType.AES,
             }))
         })
 
@@ -236,15 +236,15 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: JSON.stringify(content),
                 signature: 'something',
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.RSA,
+                encryptionType: EncryptionType.RSA,
                 prevMsgRef: new MessageRef(1564046332168, 5),
             })
             const streamMessageClone = encryptedMessage.clone()
             expect(streamMessageClone).not.toBe(encryptedMessage)
             expect(streamMessageClone.messageId).not.toBe(encryptedMessage.messageId)
             expect(streamMessageClone.prevMsgRef).not.toBe(encryptedMessage.prevMsgRef)
-            expect(encryptedMessage.encryptionType).toEqual(StreamMessage.ENCRYPTION_TYPES.RSA)
-            expect(streamMessageClone.encryptionType).toEqual(StreamMessage.ENCRYPTION_TYPES.RSA)
+            expect(encryptedMessage.encryptionType).toEqual(EncryptionType.RSA)
+            expect(streamMessageClone.encryptionType).toEqual(EncryptionType.RSA)
             expect(streamMessageClone.encryptionType).toEqual(encryptedMessage.encryptionType)
             expect(streamMessageClone.toObject()).toEqual(encryptedMessage.toObject())
             expect(streamMessageClone.serialize()).toEqual(encryptedMessage.serialize())

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessageSerializerV32.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessageSerializerV32.test.ts
@@ -6,7 +6,10 @@ import {
     MessageID,
     EncryptedGroupKey,
     toStreamID,
-    ValidationError
+    ValidationError,
+    StreamMessageType,
+    ContentType,
+    EncryptionType
 } from '../../../../src/index'
 import { toEthereumAddress } from '@streamr/utils'
 import { SIGNATURE_TYPE_ETH } from '../../../../src/protocol/message_layer/StreamMessageSerializerV32'
@@ -20,10 +23,10 @@ const message = new StreamMessage({
     messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
     prevMsgRef: new MessageRef(1564046132168, 5),
     content: 'encrypted-content',
-    messageType: StreamMessage.MESSAGE_TYPES.MESSAGE,
-    contentType: StreamMessage.CONTENT_TYPES.JSON,
+    messageType: StreamMessageType.MESSAGE,
+    contentType: ContentType.JSON,
     groupKeyId: 'groupKeyId',
-    encryptionType: StreamMessage.ENCRYPTION_TYPES.AES,
+    encryptionType: EncryptionType.AES,
     newGroupKey: new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex', '["groupKeyId","encryptedGroupKeyHex"]'),
     signature: 'signature',
 })
@@ -31,9 +34,9 @@ const serializedMessage = JSON.stringify([
     VERSION,
     ['streamId', 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'],
     [1564046132168, 5],
-    StreamMessage.MESSAGE_TYPES.MESSAGE,
-    StreamMessage.CONTENT_TYPES.JSON,
-    StreamMessage.ENCRYPTION_TYPES.AES,
+    StreamMessageType.MESSAGE,
+    ContentType.JSON,
+    EncryptionType.AES,
     'groupKeyId',
     'encrypted-content',
     '["groupKeyId","encryptedGroupKeyHex"]',
@@ -44,7 +47,7 @@ const serializedMessage = JSON.stringify([
 describe('StreamMessageSerializerV32', () => {
 
     describe('deserialize', () => {
-    
+
         it('correctly parses messages', () => {
             assert.deepStrictEqual(StreamMessage.deserialize(serializedMessage), message)
         })
@@ -54,9 +57,9 @@ describe('StreamMessageSerializerV32', () => {
                 VERSION,
                 ['streamId', 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'],
                 [1564046132168, 5],
-                StreamMessage.MESSAGE_TYPES.MESSAGE,
-                StreamMessage.CONTENT_TYPES.JSON,
-                StreamMessage.ENCRYPTION_TYPES.AES,
+                StreamMessageType.MESSAGE,
+                ContentType.JSON,
+                EncryptionType.AES,
                 'groupKeyId',
                 'encrypted-content',
                 '["groupKeyId","encryptedGroupKeyHex"]',


### PR DESCRIPTION
Use `StreamMessageType`, `ContentType` and `EncryptionType` enums directly instead of accessing `StreamMessage` static field. The `StreamMessage` class contained static fields (`StreamMessage.MESSAGE_TYPES`, `StreamMessage.CONTENT_TYPES`, `StreamMessage.ENCRYPTION_TYPES`) which were just aliases to those enums.

Removed the alias fields. Also changed the visibility of static `VALID_*` fields to private.