### PR TITLE
fix(client): Query stored streams for non-existent storage node

### DIFF
--- a/packages/client/src/registry/StreamStorageRegistry.ts
+++ b/packages/client/src/registry/StreamStorageRegistry.ts
@@ -159,7 +159,7 @@ export class StreamStorageRegistry {
             (response: any) => {
                 // eslint-disable-next-line no-underscore-dangle
                 blockNumbers.push(response._meta.block.number)
-                return response.node.storedStreams
+                return (response.node !== null) ? response.node.storedStreams : []
             }
         ))
         const streams = res.map((stream: any) => {

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -60,6 +60,34 @@ describe('StorageNodeRegistry', () => {
         stored.streams.forEach((s) => expect(s).toBeInstanceOf(Stream))
     }, TEST_TIMEOUT)
 
+    it('no storage node', async () => {
+        stream = await createTestStream(creatorClient, module)
+        const id = randomEthereumAddress()
+        const stored = await creatorClient.getStoredStreams(id)
+        expect(stored.streams).toEqual([])
+        expect(stored.blockNumber).toBeNumber()
+    }, TEST_TIMEOUT)
+
+    it('no assignments', async () => {
+        const storageNodeWallet = new Wallet(await fetchPrivateKeyWithGas())
+        const storageNodeManager = new StreamrClient({
+            ...ConfigTest,
+            auth: {
+                privateKey: storageNodeWallet.privateKey
+            },
+            network: {
+                ...ConfigTest.network,
+                id: storageNodeWallet.address
+            }
+        })
+        await storageNodeManager.setStorageNodeMetadata({ http: 'mock-url' })
+        stream = await createTestStream(creatorClient, module)
+        const stored = await creatorClient.getStoredStreams(storageNodeWallet.address)
+        expect(stored.streams).toEqual([])
+        expect(stored.blockNumber).toBeNumber()
+        await storageNodeManager.destroy()
+    }, TEST_TIMEOUT)
+
     it('event listener: picks up add and remove events', async () => {
         stream = await createTestStream(creatorClient, module)
 

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -61,7 +61,6 @@ describe('StorageNodeRegistry', () => {
     }, TEST_TIMEOUT)
 
     it('no storage node', async () => {
-        stream = await createTestStream(creatorClient, module)
         const id = randomEthereumAddress()
         const stored = await creatorClient.getStoredStreams(id)
         expect(stored.streams).toEqual([])
@@ -81,7 +80,6 @@ describe('StorageNodeRegistry', () => {
             }
         })
         await storageNodeManager.setStorageNodeMetadata({ http: 'mock-url' })
-        stream = await createTestStream(creatorClient, module)
         const stored = await creatorClient.getStoredStreams(storageNodeWallet.address)
         expect(stored.streams).toEqual([])
         expect(stored.blockNumber).toBeNumber()

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import { Wallet } from 'ethers'
-import { fetchPrivateKeyWithGas } from 'streamr-test-utils'
+import { fetchPrivateKeyWithGas, randomEthereumAddress } from 'streamr-test-utils'
 import { ConfigTest, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -56,6 +56,8 @@ describe('StorageNodeRegistry', () => {
         expect(storageNodes).toHaveLength(0)
         stored = await creatorClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
         expect(stored.streams.some((s) => s.id === stream.id)).toBe(false)
+        expect(stored.streams.length).toBeGreaterThanOrEqual(0)
+        stored.streams.forEach((s) => expect(s).toBeInstanceOf(Stream))
     }, TEST_TIMEOUT)
 
     it('event listener: picks up add and remove events', async () => {
@@ -88,12 +90,5 @@ describe('StorageNodeRegistry', () => {
             nodeAddress: DOCKER_DEV_STORAGE_NODE,
             streamId: stream.id,
         })
-    }, TEST_TIMEOUT)
-
-    it('getStoredStreams', async () => {
-        const result = await listenerClient.getStoredStreams(DOCKER_DEV_STORAGE_NODE)
-        expect(result.blockNumber).toBeGreaterThanOrEqual(0)
-        expect(result.streams.length).toBeGreaterThanOrEqual(0)
-        result.streams.forEach((s) => expect(s).toBeInstanceOf(Stream))
     }, TEST_TIMEOUT)
 })


### PR DESCRIPTION
If `StreamrClient#getStoredStreams` was called for a non-existent storage node it threw an exception. Fixed the bug by adding a `null` check.

- bug was introduced here: https://github.com/streamr-dev/network/pull/965
- error: `TypeError: Cannot read properties of null (reading 'storedStreams')`
- GraphQL response: `{ node: null, _meta: { block: { number: ... } } }`

Improved also test coverage:
- added two test cases
- merged one test to another