### PR TITLE
fix(client): Add `ensCacheChainAddress` to config schema

### DIFF
--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -285,6 +285,10 @@
             "type": "string",
             "format": "ethereum-address"
         },
+        "ensCacheChainAddress": {
+            "type": "string",
+            "format": "ethereum-address"
+        },
         "metrics": {
             "anyOf": [
                 {


### PR DESCRIPTION
There was no `ensCacheChainAddress` config option in config schema. Therefore users weren't able to define that property.

- bug was introduced here: https://github.com/streamr-dev/network/pull/297 (the initial PR which included the feature)
- error throw: `Error: must NOT have additional properties: ensCacheChainAddress` when a `StreamrClient` instance is created