### PR TITLE
fix(network): fix MessageQueue size

### DIFF
--- a/packages/network/src/connection/MessageQueue.ts
+++ b/packages/network/src/connection/MessageQueue.ts
@@ -64,7 +64,7 @@ export class MessageQueue<M> {
     private readonly logger: Logger
     private readonly maxSize: number
 
-    constructor(maxSize = 5000) {
+    constructor(maxSize = 500) {
         this.heap = new Heap<QueueItem<M>>((a, b) => a.no - b.no)
         this.logger = new Logger(module)
         this.maxSize = maxSize

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -165,7 +165,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         routerId: string,
         deferredConnectionAttempt: DeferredConnectionAttempt | null
     ) {
-        const messageQueue = this.messageQueues[targetPeerId] = this.messageQueues[targetPeerId] || new MessageQueue(this.maxMessageSize)
+        const messageQueue = this.messageQueues[targetPeerId] = this.messageQueues[targetPeerId] || new MessageQueue()
         const connectionOptions: ConstructorOptions = {
             selfId: this.peerInfo.peerId,
             targetPeerId,


### PR DESCRIPTION
## Summary

- Fix bug(?) in which MessageQueue default buffer size was huge (potentially `1048576` passed from `WebRtcEndpoint.ts`).
- Reduce default MessageQueue buffer size from 5000 to 500. 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
