### PR TITLE
feat(utils): improve `waitForCondition`

### DIFF
--- a/packages/client/test/end-to-end/resend.test.ts
+++ b/packages/client/test/end-to-end/resend.test.ts
@@ -71,6 +71,7 @@ describe('resend', () => {
                 () => messages.length >= NUM_OF_MESSAGES,
                 TIMEOUT - 1000,
                 250,
+                undefined,
                 () => `messages array length was ${messages.length}`
             )
             expect(messages).toHaveLength(NUM_OF_MESSAGES)

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -76,7 +76,7 @@ export class FakeNetwork {
         await waitForCondition(() => {
             found = this.getSentMessages(opts)
             return found.length >= count
-        }, timeout, timeout / 100, () => {
+        }, timeout, timeout / 100, undefined, () => {
             return `waitForSentMessages timed out: ${JSON.stringify(opts)} matches ${found.length}/${count}`
         })
         return found.slice(0, count)

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -11,7 +11,7 @@ import { omit } from 'lodash'
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 
 const waitForCalls = async (onMessage: jest.Mock<any>, n: number) => {
-    await waitForCondition(() => onMessage.mock.calls.length >= n, 1000, 100, () => {
+    await waitForCondition(() => onMessage.mock.calls.length >= n, 1000, 100, undefined, () => {
         return `Timeout while waiting for calls: got ${onMessage.mock.calls.length} out of ${n}`
     })
 }

--- a/packages/network/test/unit/WebRtcEndpoint.test.ts
+++ b/packages/network/test/unit/WebRtcEndpoint.test.ts
@@ -388,7 +388,7 @@ describe('WebRtcEndpoint', () => {
             await onReconnect
             await waitForCondition(() => (
                 ep2NumOfReceivedMessages === 6
-            ), 30000, 500, () => `ep2NumOfReceivedMessages = ${ep2NumOfReceivedMessages}`)
+            ), 30000, 500, undefined, () => `ep2NumOfReceivedMessages = ${ep2NumOfReceivedMessages}`)
             // all send tasks completed
             await Promise.allSettled(sendTasks)
             await Promise.all(sendTasks)

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -113,6 +113,7 @@ export const runAndWaitForConditions = async (
         condition,
         timeout,
         retryInterval,
+        undefined,
         onTimeoutContext
     )))
     ops.forEach((op) => { op() })

--- a/packages/utils/src/waitForCondition.ts
+++ b/packages/utils/src/waitForCondition.ts
@@ -3,6 +3,15 @@ import { wait } from './wait'
 import { compact } from 'lodash'
 import { composeAbortSignals } from './composeAbortSignals'
 
+function throwError(userAborted: boolean, conditionFn: () => any, onTimeoutContext?: () => string): never {
+    const action = userAborted ? 'aborted' : 'timed out'
+    let msg = `waitForCondition: ${action} before "${conditionFn.toString()}" became true`
+    if (onTimeoutContext) {
+        msg += `\n${onTimeoutContext()}`
+    }
+    throw new Error(msg)
+}
+
 /**
  * Wait for a condition to become true by re-evaluating `conditionFn` every `retryInterval` milliseconds.
  *
@@ -10,7 +19,7 @@ import { composeAbortSignals } from './composeAbortSignals'
  * no side effects.
  * @param timeout amount of time in milliseconds to wait for
  * @param retryInterval how often, in milliseconds, to re-evaluate condition
- * @param userAbortSignal pass an abort signal to cancel waiting prematurely
+ * @param abortSignal pass an abort signal to cancel prematurely
  * @param onTimeoutContext evaluated only on timeout. Used to associate human-friendly textual context to error.
  * @returns {Promise<void>} resolves immediately if
  * conditionFn evaluates to true on a retry attempt within timeout. If timeout
@@ -20,32 +29,28 @@ export const waitForCondition = async (
     conditionFn: () => (boolean | Promise<boolean>),
     timeout = 5000,
     retryInterval = 100,
-    userAbortSignal?: AbortSignal,
+    abortSignal?: AbortSignal,
     onTimeoutContext?: () => string
 ): Promise<void> => {
-    let userAborted = userAbortSignal?.aborted ?? false
-    if (!userAborted) {
-        userAbortSignal?.addEventListener('abort', () => { userAborted = true }, { once: true })
+    let userAborted = abortSignal?.aborted ?? false
+    if (userAborted) {
+        throwError(userAborted, conditionFn, onTimeoutContext)
     }
-    const timeoutAbortSignal: AbortSignal = (AbortSignal as any).timeout(timeout)
-    const abortSignal = composeAbortSignals(...compact([timeoutAbortSignal, userAbortSignal]))
+    abortSignal?.addEventListener('abort', () => { userAborted = true }, { once: true })
+    const timeoutAbortSignal: AbortSignal = (AbortSignal as any).timeout(timeout) // TODO: remove `as any` cast when @types/node has support...
+    const composedSignal = composeAbortSignals(...compact([timeoutAbortSignal, abortSignal]))
     try {
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const result = await asAbortable(Promise.resolve(conditionFn()), abortSignal)
+            const result = await asAbortable(Promise.resolve(conditionFn()), composedSignal)
             if (result) {
                 return
             }
-            await wait(Math.max(retryInterval, 0), abortSignal)
+            await wait(retryInterval, composedSignal)
         }
     } catch (e) {
         if (e.code === 'AbortError') {
-            const action = userAborted ? 'aborted' : 'timed out'
-            let msg = `waitForCondition: ${action} before "${conditionFn.toString()}" became true`
-            if (onTimeoutContext) {
-                msg += `\n${onTimeoutContext()}`
-            }
-            throw new Error(msg)
+            throwError(userAborted, conditionFn, onTimeoutContext)
         }
         throw e
     }

--- a/packages/utils/test/waitForCondition.test.ts
+++ b/packages/utils/test/waitForCondition.test.ts
@@ -34,15 +34,6 @@ describe('waitForCondition', () => {
                 done()
             })
         })
-
-        it('rejects immediately if given pre-aborted signal', (done) => {
-            const abortController = new AbortController()
-            abortController.abort()
-            waitForCondition(() => true, 5000, 1, abortController.signal).catch((err) => {
-                expect(err.message).toEqual("waitForCondition: aborted before \"() => true\" became true")
-                done()
-            })
-        })
     })
 
     describe('given conditionFn that returns promisified booleans (i.e. Promise<boolean>)', () => {
@@ -97,14 +88,14 @@ describe('waitForCondition', () => {
                 done()
             })
         })
+    })
 
-        it('rejects immediately if given pre-aborted signal', (done) => {
-            const abortController = new AbortController()
-            abortController.abort()
-            waitForCondition(() => Promise.resolve(true), 5000, 1, abortController.signal).catch((err) => {
-                expect(err.message).toEqual("waitForCondition: aborted before \"() => Promise.resolve(true)\" became true")
-                done()
-            })
+    it('rejects immediately if given pre-aborted signal', (done) => {
+        const abortController = new AbortController()
+        abortController.abort()
+        waitForCondition(() => true, 5000, 1, abortController.signal).catch((err) => {
+            expect(err.message).toEqual("waitForCondition: aborted before \"() => true\" became true")
+            done()
         })
     })
 

--- a/packages/utils/test/waitForCondition.test.ts
+++ b/packages/utils/test/waitForCondition.test.ts
@@ -23,6 +23,26 @@ describe('waitForCondition', () => {
                 done()
             })
         })
+
+        it('rejects if conditionFn does not return true before abort signalled', (done) => {
+            const abortController = new AbortController()
+            setTimeout(() => {
+                abortController.abort()
+            }, 100)
+            waitForCondition(() => false, 5000, 10, abortController.signal).catch((err) => {
+                expect(err.message).toEqual("waitForCondition: aborted before \"() => false\" became true")
+                done()
+            })
+        })
+
+        it('rejects immediately if given pre-aborted signal', (done) => {
+            const abortController = new AbortController()
+            abortController.abort()
+            waitForCondition(() => true, 5000, 1, abortController.signal).catch((err) => {
+                expect(err.message).toEqual("waitForCondition: aborted before \"() => true\" became true")
+                done()
+            })
+        })
     })
 
     describe('given conditionFn that returns promisified booleans (i.e. Promise<boolean>)', () => {
@@ -56,11 +76,35 @@ describe('waitForCondition', () => {
             const fn = jest.fn()
                 .mockResolvedValueOnce(false)
                 .mockRejectedValueOnce(error)
-            await expect(waitForCondition(fn)).rejects.toThrow(error)
+            await expect(waitForCondition(fn))
+                .rejects
+                .toThrow(error)
         })
 
         it('rejects if conditionFn returns promise that does not settle within timeout', async () => {
-            await expect(waitForCondition(() => new Promise(() => {}), 100, 10)).rejects.toThrow()
+            await expect(waitForCondition(() => new Promise(() => {}), 100, 10))
+                .rejects
+                .toThrow('waitForCondition: timed out before "() => new Promise(() => { })" became true')
+        })
+
+        it('rejects if conditionFn does not return true before abort signalled', (done) => {
+            const abortController = new AbortController()
+            setTimeout(() => {
+                abortController.abort()
+            }, 100)
+            waitForCondition(() => Promise.resolve(false), 5000, 10, abortController.signal).catch((err) => {
+                expect(err.message).toEqual("waitForCondition: aborted before \"() => Promise.resolve(false)\" became true")
+                done()
+            })
+        })
+
+        it('rejects immediately if given pre-aborted signal', (done) => {
+            const abortController = new AbortController()
+            abortController.abort()
+            waitForCondition(() => Promise.resolve(true), 5000, 1, abortController.signal).catch((err) => {
+                expect(err.message).toEqual("waitForCondition: aborted before \"() => Promise.resolve(true)\" became true")
+                done()
+            })
         })
     })
 

--- a/packages/utils/test/waitForCondition.test.ts
+++ b/packages/utils/test/waitForCondition.test.ts
@@ -66,7 +66,7 @@ describe('waitForCondition', () => {
 
     it('can provide contextual information on rejection', (done) => {
         const pollCb = () => false
-        waitForCondition(pollCb, 50, 5, () => "a was 5, expected 10").catch((err) => {
+        waitForCondition(pollCb, 50, 5, undefined, () => "a was 5, expected 10").catch((err) => {
             expect(err.message).toEqual("waitForCondition: timed out before \"() => false\" became true" +
                 "\na was 5, expected 10")
             done()


### PR DESCRIPTION
## Summary

Improvements to `waitForCondition` utility.

## Changes

- Refactor the implementation to be while loop -based.
- Add `AbortSignal` support to allow for premature cancellation by user.
- <del>Will now fail after `timeout` regardless of whether `conditionFn` is being awaited on.</del> Apparently this was in place already.
- No longer the possibility of parallel `conditionFn` being awaited on when settling promises takes longer than `retryInterval`.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
