### PR TITLE
fix: add checks for Error.captureStackTrace

### DIFF
--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -24,7 +24,9 @@ class WebRtcError extends Error {
     constructor(msg: string) {
         super(msg)
         // exclude this constructor from stack trace
-        Error.captureStackTrace(this, WebRtcError)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, WebRtcError)
+        }
     }
 }
 

--- a/packages/network/src/connection/ws/AbstractWsEndpoint.ts
+++ b/packages/network/src/connection/ws/AbstractWsEndpoint.ts
@@ -35,7 +35,9 @@ export class UnknownPeerError extends Error {
 
     constructor(msg: string) {
         super(msg)
-        Error.captureStackTrace(this, UnknownPeerError)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, UnknownPeerError)
+        }
     }
 }
 

--- a/packages/network/src/logic/DuplicateMessageDetector.ts
+++ b/packages/network/src/logic/DuplicateMessageDetector.ts
@@ -49,7 +49,9 @@ export class InvalidNumberingError extends Error {
     constructor() {
         super('pre-condition: previousNumber < number')
         // exclude this constructor from stack trace
-        Error.captureStackTrace(this, InvalidNumberingError)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, InvalidNumberingError)
+        }
     }
 }
 
@@ -57,7 +59,9 @@ export class GapMisMatchError extends Error {
     constructor(state: string, previousNumber: NumberPair, number: NumberPair) {
         super('pre-condition: gap overlap in given numbers:'
             + ` previousNumber=${previousNumber}, number=${number}, state=${state}`)
-        Error.captureStackTrace(this, GapMisMatchError) // exclude this constructor from stack trace
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, GapMisMatchError) // exclude this constructor from stack trace
+        }
     }
 }
 

--- a/packages/utils/src/asAbortable.ts
+++ b/packages/utils/src/asAbortable.ts
@@ -4,7 +4,9 @@ export class AbortError extends Error {
         super(customErrorContext === undefined
             ? `aborted`
             : `${customErrorContext} aborted`)
-        Error.captureStackTrace(this, AbortError)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, AbortError)
+        }
     }
 }
 

--- a/packages/utils/src/withTimeout.ts
+++ b/packages/utils/src/withTimeout.ts
@@ -6,7 +6,9 @@ export class TimeoutError extends Error {
         super(customErrorContext === undefined
             ? `timed out after ${timeoutInMs} ms`
             : `${customErrorContext} (timed out after ${timeoutInMs} ms)`)
-        Error.captureStackTrace(this, TimeoutError)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, TimeoutError)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Method `Error#captureStackTrace` not available in browser. Add an `if` check before each call in code.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
