### PR TITLE
feat(broker): Ethereum authentication

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -13,7 +13,8 @@
     "tracker": "bin/tracker.js",
     "delete-expired-data": "bin/delete-expired-data.js"
   },
-  "main": "bin/broker.js",
+  "main": "./dist/src/exports.js",
+  "types": "./dist/src/exports.d.ts",
   "scripts": {
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -1,6 +1,5 @@
 import { Logger, toEthereumAddress } from '@streamr/utils'
 import StreamrClient, { validateConfig as validateClientConfig, NetworkNodeStub } from 'streamr-client'
-import { Wallet } from 'ethers'
 import { Server as HttpServer } from 'http'
 import { Server as HttpsServer } from 'https'
 import { createPlugin } from './pluginRegistry'
@@ -24,9 +23,6 @@ export interface Broker {
 export const createBroker = async (config: Config): Promise<Broker> => {
     validateConfig(config, BROKER_CONFIG_SCHEMA)
     validateClientConfig(config.client)
-
-    const wallet = new Wallet(config.client.auth!.privateKey!)
-    const brokerAddress = wallet.address
 
     const streamrClient = new StreamrClient(config.client)
     const apiAuthenticator = createApiAuthenticator(config)
@@ -62,6 +58,7 @@ export const createBroker = async (config: Config): Promise<Broker> => {
             }
 
             const nodeId = (await streamrClient.getNode()).getNodeId()
+            const brokerAddress = await streamrClient.getAddress()
             const mnemonic = generateMnemonicFromAddress(toEthereumAddress(brokerAddress))
 
             logger.info(`Welcome to the Streamr Network. Your node's generated name is ${mnemonic}.`)

--- a/packages/broker/src/config/config.schema.json
+++ b/packages/broker/src/config/config.schema.json
@@ -19,14 +19,27 @@
             "additionalProperties": true,
             "properties": {
                 "auth": {
-                    "type": "object",
-                    "properties": {
-                        "privateKey": {
-                            "type": "string",
-                            "pattern": "^(0x)?[a-fA-F0-9]{64}$"
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "privateKey": {
+                                    "type": "string",
+                                    "pattern": "^(0x)?[a-fA-F0-9]{64}$"
+                                }
+                            },
+                            "required": ["privateKey"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "ethereum": {
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["ethereum"]
                         }
-                    },
-                    "required": ["privateKey"]
+                    ]
                 }
             },
             "required": ["auth"]

--- a/packages/broker/src/exports.ts
+++ b/packages/broker/src/exports.ts
@@ -1,0 +1,3 @@
+export { createBroker, Broker } from './broker'
+export { Config, HttpServerConfig, ApiAuthenticationConfig } from './config/config'
+export { StreamrClientConfig } from 'streamr-client'

--- a/packages/broker/test/unit/authentication.test.ts
+++ b/packages/broker/test/unit/authentication.test.ts
@@ -1,0 +1,61 @@
+import { fastWallet } from '@streamr/test-utils'
+import { ExternalProvider } from 'streamr-client'
+import { Broker, createBroker } from '../../src/broker'
+
+const formConfig = (auth: any) => {
+    return {
+        client: {
+            auth,
+            network: {
+                trackers: []
+            }
+        },
+        httpServer: {
+            port: 7171,
+            privateKeyFileName: null,
+            certFileName: null
+        },
+        apiAuthentication: null,
+        plugins: {},
+        $schema: 'dummy'
+    }
+}
+
+const getAddress = async (broker: Broker) => {
+    return (await broker.getNode()).getNodeId().split('#')[0]
+}
+
+const createExternalProvider = (address: string): ExternalProvider => {
+    return {
+        request: async (request: { method: string }): Promise<any> => {
+            if (request.method === 'eth_requestAccounts') {
+                return [address]
+            } else {
+                throw new Error(`unknown method: ${request.method}`)
+            }
+        }
+    }
+}
+
+describe('authentication', () => {
+
+    const wallet = fastWallet()
+
+    it('private key', async () => {
+        const broker = await createBroker(formConfig({
+            privateKey: wallet.privateKey
+        }))
+        await broker.start()
+        expect(await getAddress(broker)).toEqualCaseInsensitive(wallet.address)
+        await broker.stop()
+    })
+
+    it('ethereum', async () => {
+        const broker = await createBroker(formConfig({
+            ethereum: createExternalProvider(wallet.address)
+        }))
+        await broker.start()
+        expect(await getAddress(broker)).toEqualCaseInsensitive(wallet.address)
+        await broker.stop()
+    })
+})


### PR DESCRIPTION
Added support for `ethereum` authentication. 

Modified `package.json` to export `createBroker` method instead of `bin/broker.js` so that it is possible to start Broker instance programatically. 

## Future improvements

Currently createBroker needs a complex config object as an argument. We should simplify that so that it is easier to use the method programatically:
```
createBroker({
    client: {
        auth: {
            privateKey
        }
    },
    httpServer: {
        port: 7171,
        privateKeyFileName: null,
        certFileName: null
    },
    apiAuthentication: null,
    plugins: { },
    $schema: 'dummy'
})
```

Could be just:
```
createBroker({
    client: {
        auth: {
            privateKey
        }
    },
    plugins: {}
})
```

- all `null` values could be just optional parameters (in Broker and in plugins)
- we should make a automatic migration which transforms current configuration files to not to use `null` values
- `$schema `should be removed from `Config` interface, it is actually a property of a config file not the config itself