### PR TITLE
fix(broker): Default metrics periods in migration

### DIFF
--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -123,10 +123,6 @@ const convertV1ToV2 = (source: any): Config => {
             target.client.metrics = {
                 periods: [
                     {
-                        duration: 5000,
-                        streamId: `${streamIdPrefix}/sec`
-                    },
-                    {
                         duration: 60000,
                         streamId: `${streamIdPrefix}/min`
                     },

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -335,10 +335,6 @@ describe('Config migration', () => {
                     metrics: {
                         periods: [
                             {
-                                duration: 5000,
-                                streamId: 'mock-prefix/sec'
-                            },
-                            {
                                 duration: 60000,
                                 streamId: 'mock-prefix/min'
                             },


### PR DESCRIPTION
Removed 5s from the default metrics periods which are written to config file when if v1 broker configuration used explicit `streamIdPrefix` config option.  

Before the PR the automatic migration created 5s/1h/1m/1d periods if `streamIdPrefix` config option was used.  As we dropped 5s period in https://github.com/streamr-dev/network/pull/903, it makes sense to drop it here, too. If `streamIdPrefix` was not used, Broker already automatically used client default periods. Therefore the periods were different  for no reason.