### PR TITLE
refactor(broker): Null values in config

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -58,7 +58,6 @@
     "httpServer": {
         "port": 8891
     },
-    "apiAuthentication": null,
     "plugins": {
         "storage": {
             "cassandra": {

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -58,6 +58,5 @@
     "httpServer": {
         "port": 8791
     },
-    "apiAuthentication": null,
     "plugins": {}
 }

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -58,6 +58,5 @@
     "httpServer": {
         "port": 8691
     },
-    "apiAuthentication": null,
     "plugins": {}
 }

--- a/packages/broker/configs/development-prod-resend.env.json
+++ b/packages/broker/configs/development-prod-resend.env.json
@@ -20,6 +20,5 @@
     "httpServer": {
         "port": 8791
     },
-    "apiAuthentication": null,
     "plugins": {}
 }

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -44,7 +44,6 @@
     "httpServer": {
         "port": 8891
     },
-    "apiAuthentication": null,
     "plugins": {
         "consoleMetrics": {
             "interval": 30

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -44,7 +44,6 @@
     "httpServer": {
         "port": 8791
     },
-    "apiAuthentication": null,
     "plugins": {
         "consoleMetrics": {
             "interval": 30

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -44,7 +44,6 @@
     "httpServer": {
         "port": 8691
     },
-    "apiAuthentication": null,
     "plugins": {
         "consoleMetrics": {
             "interval": 30

--- a/packages/broker/src/apiAuthenticator.ts
+++ b/packages/broker/src/apiAuthenticator.ts
@@ -5,7 +5,7 @@ export interface ApiAuthenticator {
 }
 
 export const createApiAuthenticator = (config: Config): ApiAuthenticator => {
-    if (config.apiAuthentication !== null) {
+    if (config.apiAuthentication !== undefined) {
         return {
             isValidAuthentication: (apiKey?: string) => {
                 if (apiKey === undefined) {

--- a/packages/broker/src/config/config.schema.json
+++ b/packages/broker/src/config/config.schema.json
@@ -63,30 +63,18 @@
                     "default": 7171
                 },
                 "certFileName": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Path of certificate file to use for SSL",
-                    "default": null
+                    "type": "string",
+                    "description": "Path of certificate file to use for SSL"
                 },
                 "privateKeyFileName": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Path of private key file to use for SSL",
-                    "default": null
+                    "type": "string",
+                    "description": "Path of private key file to use for SSL"
                 }
             }
         },
         "apiAuthentication": {
-            "type": [
-                "object",
-                "null"
-            ],
+            "type": "object",
             "description": "Plugins should restrict the API access: if an endpoint requires authentication, the user must provide one of the API keys e.g. in a request header",
-            "default": null,
             "required": [
                 "keys"
             ],

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -4,18 +4,18 @@ import * as os from 'os'
 
 export interface HttpServerConfig {
     port: number
-    privateKeyFileName: string | null
-    certFileName: string | null
+    privateKeyFileName?: string
+    certFileName?: string
 }
 
-export type ApiAuthenticationConfig = { keys: string[] } | null
+export type ApiAuthenticationConfig = { keys: string[] }
 
 export interface Config {
     $schema: string
     client: StreamrClientConfig
     httpServer: HttpServerConfig
     plugins: Record<string, any>
-    apiAuthentication: ApiAuthenticationConfig
+    apiAuthentication?: ApiAuthenticationConfig
 }
 
 export const getDefaultFile = (): string => {

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -8,7 +8,9 @@ export interface HttpServerConfig {
     certFileName?: string
 }
 
-export type ApiAuthenticationConfig = { keys: string[] }
+export interface ApiAuthenticationConfig { 
+    keys: string[]
+}
 
 export interface Config {
     $schema: string

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -152,6 +152,30 @@ const convertV1ToV2 = (source: any): Config => {
         target.plugins.http = source.plugins.publishHttp
         delete target.plugins.publishHttp
     }
+    const deleteNullProperties = (obj: any, excludeKeys: string[] = []) => {
+        const keys = Object.keys(obj)
+        for (const key of keys) {
+            if ((obj[key] === null) && (!excludeKeys.includes(key))) {
+                delete obj[key]
+            }
+        }
+    }
+    deleteNullProperties(target)
+    if (target.httpServer !== undefined) {
+        deleteNullProperties(target.httpServer)
+    }
+    if (target.plugins.brubeckMiner !== undefined) {
+        deleteNullProperties(target.plugins.brubeckMiner, ['stunServerHost'])
+    }
+    if (target.plugins.mqtt !== undefined) {
+        deleteNullProperties(target.plugins.mqtt)
+    }
+    if (target.plugins.storage !== undefined) {
+        deleteNullProperties(target.plugins.storage.cluster)
+    }
+    if (target.plugins.websocket !== undefined) {
+        deleteNullProperties(target.plugins.websocket)
+    }
     return target as Config
 }
 

--- a/packages/broker/src/httpServer.ts
+++ b/packages/broker/src/httpServer.ts
@@ -47,7 +47,7 @@ export const startServer = async (
     app.use(createAuthenticatorMiddleware(apiAuthenticator))
     routers.forEach((router) => app.use(router))
     let serverFactory: { listen: (port: number) => HttpServer | HttpsServer }
-    if (config.privateKeyFileName && config.certFileName) {
+    if ((config.privateKeyFileName !== undefined) && (config.certFileName !== undefined)) {
         serverFactory = https.createServer({
             cert: fs.readFileSync(config.certFileName),
             key: fs.readFileSync(config.privateKeyFileName)

--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -24,7 +24,7 @@ export interface BrubeckMinerPluginConfig {
     claimServerUrl: string
     maxClaimDelay: number
     stunServerHost: string | null
-    beneficiaryAddress: string | null
+    beneficiaryAddress?: string
 }
 
 interface Peer {
@@ -125,7 +125,7 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
             clientServerLatency: this.latestLatency,
             waitTime: delay,
             natType: this.natType,
-            beneficiaryAddress: this.pluginConfig.beneficiaryAddress,
+            beneficiaryAddress: this.pluginConfig.beneficiaryAddress ?? null,
             peers
         }
         try {

--- a/packages/broker/src/plugins/brubeckMiner/config.schema.json
+++ b/packages/broker/src/plugins/brubeckMiner/config.schema.json
@@ -39,11 +39,7 @@
             "default": "stun.sipgate.net"
         },
         "beneficiaryAddress": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "default": null
+            "type": "string"
         }
     }
 }

--- a/packages/broker/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/broker/src/plugins/mqtt/MqttPlugin.ts
@@ -7,7 +7,7 @@ import { Schema } from 'ajv'
 
 export interface MqttPluginConfig {
     port: number
-    streamIdDomain: string | null
+    streamIdDomain?: string
     payloadMetadata: boolean
 }
 
@@ -20,7 +20,7 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
             this.streamrClient!, 
             this.server, 
             getPayloadFormat(this.pluginConfig.payloadMetadata),
-            this.pluginConfig.streamIdDomain ?? undefined
+            this.pluginConfig.streamIdDomain
         )
         this.server.setListener(bridge)
         return this.server.start()

--- a/packages/broker/src/plugins/mqtt/config.schema.json
+++ b/packages/broker/src/plugins/mqtt/config.schema.json
@@ -11,12 +11,8 @@
             "default": 1883
         },
         "streamIdDomain": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "All topics are mapped to streamIds by prepending the domain to the topic: streamIdDomain + '/' + topic",
-            "default": null
+            "type": "string",
+            "description": "All topics are mapped to streamIds by prepending the domain to the topic: streamIdDomain + '/' + topic"
         },
         "payloadMetadata": {
             "type": "boolean",

--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -24,8 +24,8 @@ export interface StoragePluginConfig {
         refreshInterval: number
     }
     cluster: {
-        // If clusterAddress is null, the broker's address will be used
-        clusterAddress: EthereumAddress | null
+        // If clusterAddress is undefined, the broker's address will be used
+        clusterAddress?: EthereumAddress
         clusterSize: number
         myIndexInCluster: number
     }
@@ -41,7 +41,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
     private messageListener?: (msg: StreamMessage) => void
 
     async start(): Promise<void> {
-        const clusterId = this.pluginConfig.cluster.clusterAddress || await this.streamrClient.getAddress()
+        const clusterId = this.pluginConfig.cluster.clusterAddress ?? await this.streamrClient.getAddress()
         const assignmentStream = await this.streamrClient.getStream(formStorageNodeAssignmentStreamId(clusterId))
         const metricsContext = (await (this.streamrClient!.getNode())).getMetricsContext()
         this.cassandra = await this.startCassandraStorage(metricsContext)

--- a/packages/broker/src/plugins/storage/config.schema.json
+++ b/packages/broker/src/plugins/storage/config.schema.json
@@ -61,14 +61,13 @@
             "type": "object",
             "description": "Storage node cluster config",
             "required": [
-                "clusterAddress",
                 "clusterSize",
                 "myIndexInCluster"
             ],
             "additionalProperties": false,
             "properties": {
                 "clusterAddress": {
-                    "type": ["string", "null"]
+                    "type": "string"
                 },
                 "clusterSize": {
                     "type": "number"
@@ -78,7 +77,6 @@
                 }
             },
             "default": {
-                "clusterAddress": null,
                 "clusterSize": 1,
                 "myIndexInCluster": 0
             }

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -12,7 +12,7 @@ export interface SslCertificateConfig {
 export interface WebsocketPluginConfig {
     port: number
     payloadMetadata: boolean
-    sslCertificate: SslCertificateConfig | null
+    sslCertificate?: SslCertificateConfig
 }
 
 export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
@@ -24,7 +24,7 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
             this.pluginConfig.port, 
             getPayloadFormat(this.pluginConfig.payloadMetadata),
             this.apiAuthenticator, 
-            this.pluginConfig.sslCertificate ?? undefined
+            this.pluginConfig.sslCertificate
         )
     }
 

--- a/packages/broker/src/plugins/websocket/config.schema.json
+++ b/packages/broker/src/plugins/websocket/config.schema.json
@@ -17,11 +17,7 @@
         },
         "sslCertificate": {
             "description": "Files to use for SSL",
-            "type": [
-                "object",
-                "null"
-            ],
-            "default": null,
+            "type": "object",
             "required": [
                 "certFileName",
                 "privateKeyFileName"

--- a/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
@@ -112,6 +112,7 @@ describe('BrubeckMinerPlugin', () => {
         expect(claimServer.claimRequestBody.waitTime).toBeGreaterThanOrEqual(0)
         // will have broker as peer
         expect(claimServer.claimRequestBody.peers).toHaveLength(1)
+        expect(claimServer.claimRequestBody.beneficiaryAddress).toBeNull()
     })
 
     it('tracker is supplied metadata about broker version and nat type', async () => {

--- a/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/WebsocketPlugin.test.ts
@@ -30,8 +30,5 @@ createMessagingPluginTest('websocket',
         plugin: WEBSOCKET_PORT,
         tracker: TRACKER_PORT
     },
-    module,
-    {
-        sslCertificate: null
-    }
+    module
 )

--- a/packages/broker/test/unit/authentication.test.ts
+++ b/packages/broker/test/unit/authentication.test.ts
@@ -1,8 +1,9 @@
 import { fastWallet } from '@streamr/test-utils'
-import { ExternalProvider } from 'streamr-client'
+import { ExternalProvider, StreamrClientConfig } from 'streamr-client'
 import { Broker, createBroker } from '../../src/broker'
+import { Config } from '../../src/config/config'
 
-const formConfig = (auth: any) => {
+const formConfig = (auth: StreamrClientConfig['auth']): Config => {
     return {
         client: {
             auth,
@@ -11,11 +12,8 @@ const formConfig = (auth: any) => {
             }
         },
         httpServer: {
-            port: 7171,
-            privateKeyFileName: null,
-            certFileName: null
+            port: 7171
         },
-        apiAuthentication: null,
         plugins: {},
         $schema: 'dummy'
     }

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -292,6 +292,83 @@ describe('Config migration', () => {
                 }
             })
             expect(createMigratedConfig(v1)).toEqual(v2)
+            validateTargetConfig(v2)
+        })
+
+        it('null values', () => {
+            const v1 = createConfig(1, {
+                client: {},
+                httpServer: {
+                    port: 1111,
+                    privateKeyFileName: null,
+                    certFileName: null
+                },
+                apiAuthentication: null,
+                plugins: {
+                    brubeckMiner: {
+                        rewardStreamIds: ['mock-id'],
+                        stunServerHost: null,
+                        beneficiaryAddress: null
+                    },
+                    mqtt: {
+                        port: 2222,
+                        streamIdDomain: null
+                    },
+                    storage: {
+                        cassandra: {
+                            hosts: ['mock-host'],
+                            username: '',
+                            password: '',
+                            keyspace: '',
+                            datacenter: ''
+                        },
+                        cluster: {
+                            clusterAddress: null,
+                            clusterSize: 123,
+                            myIndexInCluster: 0
+                        }
+                    },
+                    websocket: {
+                        port: 3333,
+                        sslCertificate: null
+                    }
+                }
+            })
+            const v2 = createConfig(2, {
+                client: {
+                    metrics: false
+                },
+                httpServer: {
+                    port: 1111
+                },
+                plugins: {
+                    brubeckMiner: {
+                        rewardStreamIds: ['mock-id'],
+                        stunServerHost: null
+                    },
+                    mqtt: {
+                        port: 2222
+                    },
+                    storage: {
+                        cassandra: {
+                            hosts: ['mock-host'],
+                            username: '',
+                            password: '',
+                            keyspace: '',
+                            datacenter: ''
+                        },
+                        cluster: {
+                            clusterSize: 123,
+                            myIndexInCluster: 0
+                        }
+                    },
+                    websocket: {
+                        port: 3333
+                    }
+                }
+            })
+            expect(createMigratedConfig(v1)).toEqual(v2)
+            validateTargetConfig(v2)
         })
 
         it('metrics: default', () => {

--- a/packages/broker/test/unit/httpServer.test.ts
+++ b/packages/broker/test/unit/httpServer.test.ts
@@ -13,9 +13,7 @@ const startTestServer = (apiConfig: { keys: string[] } | null) => {
         res.send('FOO')
     })
     return startServer([router], {
-        port: PORT,
-        privateKeyFileName: null,
-        certFileName: null
+        port: PORT
     }, createApiAuthenticator({
         apiAuthentication: apiConfig
     } as any))

--- a/packages/broker/test/unit/httpServer.test.ts
+++ b/packages/broker/test/unit/httpServer.test.ts
@@ -7,7 +7,7 @@ import { createApiAuthenticator } from '../../src/apiAuthenticator'
 const MOCK_API_KEY = 'mock-api-key'
 const PORT = 18888
 
-const startTestServer = (apiConfig: { keys: string[] } | null) => {
+const startTestServer = (apiConfig?: { keys: string[] }) => {
     const router = express.Router()
     router.get('/foo', (_req: Request, res: Response) => {
         res.send('FOO')
@@ -39,7 +39,7 @@ describe('HttpServer', () => {
     describe('ApiAuthenticator', () => {
         
         it('no authentication required', async () => {
-            server = await startTestServer(null)
+            server = await startTestServer()
             const response = await createRequest()
             const body = await response.text()
             expect(body).toBe('FOO')

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -23,8 +23,6 @@ interface TestConfig {
     extraPlugins?: Record<string, unknown>
     apiAuthentication?: ApiAuthenticationConfig
     enableCassandra?: boolean
-    privateKeyFileName?: null | string
-    certFileName?: null | string
     storageConfigRefreshInterval?: number
 }
 
@@ -81,9 +79,7 @@ export const formConfig = ({
             }
         },
         httpServer: {
-            port: httpPort ? httpPort : 7171,
-            privateKeyFileName: null,
-            certFileName: null
+            port: httpPort ? httpPort : 7171
         },
         apiAuthentication,
         plugins

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -31,7 +31,7 @@ export const formConfig = ({
     privateKey,
     httpPort = null,
     extraPlugins = {},
-    apiAuthentication = null,
+    apiAuthentication,
     enableCassandra = false,
     storageConfigRefreshInterval = 0,
 }: TestConfig): Config => {

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -19,7 +19,7 @@ export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '1
 interface TestConfig {
     trackerPort: number
     privateKey: string
-    httpPort?: null | number
+    httpPort?: number
     extraPlugins?: Record<string, unknown>
     apiAuthentication?: ApiAuthenticationConfig
     enableCassandra?: boolean
@@ -29,7 +29,7 @@ interface TestConfig {
 export const formConfig = ({
     trackerPort,
     privateKey,
-    httpPort = null,
+    httpPort,
     extraPlugins = {},
     apiAuthentication,
     enableCassandra = false,


### PR DESCRIPTION
## Summary

Broker configurations use `undefined` instead of `null` where there is no value for some config option.

## Changes

Changed these fields:
- `apiAuthentication`
- `httpServer.certFileName` and `httpServer.privateKeyFileName`
- `brubeckMiner` plugin: `beneficiaryAddress`
- `mqtt` plugin: `streamIdDomain`
- `storage` plugin: `cluster.clusterAddress`
- `websocket` plugin: `sslCertificate`

In `brubeckMiner` plugin the `stunServerHost` can still have a `null` value. There it means that we don't use the default stunServerHost.
