### PR TITLE
refactor(client): Simplify `RSAKeyPair`

### DIFF
--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -42,8 +42,8 @@ async function exportCryptoKey(key: CryptoKey, { isPrivate = false } = {}): Prom
 
 export class RSAKeyPair {
     // the keys are in PEM format
-    public privateKey: string
-    public publicKey: string
+    private readonly privateKey: string
+    private readonly publicKey: string
 
     private constructor(privateKey: string, publicKey: string) {
         this.privateKey = privateKey

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -62,12 +62,12 @@ export class RSAKeyPair {
     public publicKey: string | undefined
     private _generateKeyPairPromise: Promise<void> | undefined
 
-    async onReady(): Promise<void> {
+    private async onReady(): Promise<void> {
         if (this.isReady()) { return undefined }
         return this.generateKeyPair()
     }
 
-    isReady(this: RSAKeyPair): this is InitializedRSAKeyPair {
+    private isReady(this: RSAKeyPair): this is InitializedRSAKeyPair {
         return (this.privateKey !== undefined && this.publicKey !== undefined)
     }
 

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -60,11 +60,11 @@ export class RSAKeyPair {
 
     static async create(): Promise<RSAKeyPair> {
         return (typeof window !== 'undefined')
-            ? RSAKeyPair.keyPairBrowser()
-            : RSAKeyPair.keyPairServer()
+            ? RSAKeyPair.create_browserEnvironment()
+            : RSAKeyPair.create_serverEnvironment()
     }
 
-    private static async keyPairServer(): Promise<RSAKeyPair> {
+    private static async create_serverEnvironment(): Promise<RSAKeyPair> {
         // promisify here to work around browser/server packaging
         const generateKeyPair = promisify(crypto.generateKeyPair)
         const { publicKey, privateKey } = await generateKeyPair('rsa', {
@@ -82,7 +82,7 @@ export class RSAKeyPair {
         return new RSAKeyPair(privateKey, publicKey)
     }
 
-    private static async keyPairBrowser(): Promise<RSAKeyPair> {
+    private static async create_browserEnvironment(): Promise<RSAKeyPair> {
         const { publicKey, privateKey } = await getSubtle().generateKey({
             name: 'RSA-OAEP',
             modulusLength: 4096,

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -41,6 +41,7 @@ async function exportCryptoKey(key: CryptoKey, { isPrivate = false } = {}): Prom
 }
 
 export class RSAKeyPair {
+    // the keys are in PEM format
     public privateKey: string
     public publicKey: string
 
@@ -49,12 +50,10 @@ export class RSAKeyPair {
         this.publicKey = publicKey
     }
 
-    // Returns a String (base64 encoding)
     getPublicKey(): string {
         return this.publicKey
     }
 
-    // Returns a String (base64 encoding)
     getPrivateKey(): string {
         return this.privateKey
     }

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util'
 
 const { webcrypto } = crypto
 
-function getSubtle(): any {
+function getSubtle(): SubtleCrypto {
     const subtle = typeof window !== 'undefined' ? window?.crypto?.subtle : webcrypto.subtle
     if (!subtle) {
         const url = 'https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto'
@@ -89,10 +89,6 @@ export class RSAKeyPair {
             publicExponent: new Uint8Array([1, 0, 1]), // 65537
             hash: 'SHA-256'
         }, true, ['encrypt', 'decrypt'])
-        if (!(publicKey && privateKey)) {
-            // TS says this is possible.
-            throw new Error('could not generate keys')
-        }
 
         const [exportedPrivate, exportedPublic] = await Promise.all([
             exportCryptoKey(privateKey, {

--- a/packages/client/src/encryption/RSAKeyPair.ts
+++ b/packages/client/src/encryption/RSAKeyPair.ts
@@ -49,12 +49,6 @@ export class RSAKeyPair {
         this.publicKey = publicKey
     }
 
-    static async create(): Promise<RSAKeyPair> {
-        return (typeof window !== 'undefined')
-            ? RSAKeyPair.keyPairBrowser()
-            : RSAKeyPair.keyPairServer()
-    }
-
     // Returns a String (base64 encoding)
     getPublicKey(): string {
         return this.publicKey
@@ -63,6 +57,12 @@ export class RSAKeyPair {
     // Returns a String (base64 encoding)
     getPrivateKey(): string {
         return this.privateKey
+    }
+
+    static async create(): Promise<RSAKeyPair> {
+        return (typeof window !== 'undefined')
+            ? RSAKeyPair.keyPairBrowser()
+            : RSAKeyPair.keyPairServer()
     }
 
     private static async keyPairServer(): Promise<RSAKeyPair> {


### PR DESCRIPTION
Simplified internal object creation logic in `RSAKeyPair`.

All components which used `RSAKeyPair` created it by calling `RSAKeyPair.create()`. In this PR we annotated the constructor as private to enforce that logic. After that enforcement we can be sure that any `RsaKeyPair` instance is always "ready"  when it is given to the caller component. Therefore:
- we don't need a separate `InitializedRSAKeyPair` type 
- we don't need `isReady` method, and calls to that method
- `publicKey` and `privateKey` fields can't be undefined as we set the during the initialization

Refactored the factory methods `keyPairServer` and `keyPairBrowser` to return `RSAKeyPair` instances instead of modifying an existing instance. Also renamed the methods to make it clear that those are environment-specific variants of the same functionality. 

Removed caching of the factory promise `(_generateKeyPairPromise`). No need to have caching as the factory is called only once for each instance.

Annotated `publicKey` and `privateKey` fields private as those are always accessed via the accessors.

Annotated return type of `getSubtle()` and removed an unnecessary null check related to that.

## Future improvements

- After this PR the only place where we use `ts-toolbelt` library is used only for MaybeAsync helper type. The dependency could be dropped if we inline/remove `MaybeAsync`.