### PR TITLE
client(refactor): Remove `ensCacheChainAddress` config option

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove (non-functional) client configuration option `contracts.ensCacheChainAddress`
+
 ### Fixed
 
 ### Security

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -73,7 +73,6 @@ export interface StrictStreamrClientConfig {
         streamRegistryChainAddress: string
         streamStorageRegistryChainAddress: string
         storageNodeRegistryChainAddress: string
-        ensCacheChainAddress: string
         mainChainRPCs?: ChainConnectionInfo
         streamRegistryChainRPCs: ChainConnectionInfo
         // most of the above should go into ethereumNetworks configs once ETH-184 is ready
@@ -152,7 +151,6 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
         streamRegistryChainAddress: '0x0D483E10612F327FC11965Fc82E90dC19b141641',
         streamStorageRegistryChainAddress: '0xe8e2660CeDf2a59C917a5ED05B72df4146b58399',
         storageNodeRegistryChainAddress: '0x080F34fec2bc33928999Ea9e39ADc798bEF3E0d6',
-        ensCacheChainAddress: '0x870528c1aDe8f5eB4676AA2d15FC0B034E276A1A',
         mainChainRPCs: undefined, // Default to ethers.js default provider settings
         streamRegistryChainRPCs: {
             name: 'polygon',

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -253,10 +253,6 @@
                     "type": "string",
                     "format": "ethereum-address"
                 },
-                "ensCacheChainAddress": {
-                    "type": "string",
-                    "format": "ethereum-address"
-                },
                 "mainChainRPCs": {
                     "anyOf": [
                         {


### PR DESCRIPTION
Removed non-functional client configuration option `contracts.ensCacheChainAddress`. It was not used by client. 

It seems that the stream registry contract already knows the cache address (most likely `setEnsCache` contract method has been called by the contract admin). Therefore client doesn't need to know the address or pass it to the contract.