### PR TITLE
fix(broker): Remove tracker bin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27399,8 +27399,7 @@
             "bin": {
                 "network": "bin/network.js",
                 "publisher": "bin/publisher.js",
-                "subscriber": "bin/subscriber.js",
-                "tracker": "bin/tracker.js"
+                "subscriber": "bin/subscriber.js"
             },
             "optionalDependencies": {
                 "bufferutil": "^4.0.5",
@@ -29271,7 +29270,7 @@
         },
         "packages/broker": {
             "name": "streamr-broker",
-            "version": "32.0.0-beta.1",
+            "version": "32.0.0-beta.2",
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
@@ -29304,8 +29303,7 @@
             "bin": {
                 "delete-expired-data": "bin/delete-expired-data.js",
                 "streamr-broker": "bin/broker.js",
-                "streamr-broker-init": "bin/config-wizard.js",
-                "tracker": "bin/tracker.js"
+                "streamr-broker-init": "bin/config-wizard.js"
             },
             "devDependencies": {
                 "@streamr/test-utils": "7.0.1",

--- a/packages/broker/.eslintignore
+++ b/packages/broker/.eslintignore
@@ -2,5 +2,3 @@ dist/**
 node_modules/**
 stress-test/**
 coverage/**
-# symbolic link to bin/tracker.js
-/tracker.js

--- a/packages/broker/bin/kill-all.sh
+++ b/packages/broker/bin/kill-all.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-pkill -f ./tracker.js
 pkill -f ./broker.js

--- a/packages/broker/bin/run-all.js
+++ b/packages/broker/bin/run-all.js
@@ -100,11 +100,14 @@ const forkProcess = (processName, filePath, args, color) => {
     })
 }
 
+// TODO better way to access the tracker.js?
+const trackerBin = '../../network-tracker/bin/tracker.js'
 /* eslint-disable max-len */
-forkProcess('T1', './tracker.js', ['0xe5abc5ee43b8830e7b0f98d03efff5d6cae574d52a43204528eab7b52cd6408d', 'T1', '--port=30301'], chalk.hex('#66CC66')) // 0xb9e7cEBF7b03AE26458E32a059488386b05798e8
-forkProcess('T2', './tracker.js', ['0x96de9d06f9e409119a2cd9b57dfc326f66d953a0418f3937b92c8930f930893c', 'T2', '--port=30302'], chalk.hex('#00FF66')) // 0x0540A3e144cdD81F402e7772C76a5808B71d2d30
-forkProcess('T3', './tracker.js', ['0x6117b7a7cb8f3c8d40e3b7e87823c11af7f401515bc4fdf2bfdda70f1b833027', 'T3', '--port=30303'], chalk.hex('#66FFAA')) // 0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2
+forkProcess('T1', trackerBin, ['0xe5abc5ee43b8830e7b0f98d03efff5d6cae574d52a43204528eab7b52cd6408d', 'T1', '--port=30301'], chalk.hex('#66CC66')) // 0xb9e7cEBF7b03AE26458E32a059488386b05798e8
+forkProcess('T2', trackerBin, ['0x96de9d06f9e409119a2cd9b57dfc326f66d953a0418f3937b92c8930f930893c', 'T2', '--port=30302'], chalk.hex('#00FF66')) // 0x0540A3e144cdD81F402e7772C76a5808B71d2d30
+forkProcess('T3', trackerBin, ['0x6117b7a7cb8f3c8d40e3b7e87823c11af7f401515bc4fdf2bfdda70f1b833027', 'T3', '--port=30303'], chalk.hex('#66FFAA')) // 0xf2C195bE194a2C91e93Eacb1d6d55a00552a85E2
 
-forkProcess('S1', './broker.js', ['../configs/development-1.env.json'], chalk.hex('#8888FF')) // 0xde1112f631486CfC759A50196853011528bC5FA0
-forkProcess('B1', './broker.js', ['../configs/development-2.env.json'], chalk.hex('#0088FF')) // 0xde222E8603FCf641F928E5F66a0CBf4de70d5352
-forkProcess('B2', './broker.js', ['../configs/development-3.env.json'], chalk.hex('#88CCFF')) // 0xde3331cA6B8B636E0b82Bf08E941F727B8927442
+const brokerBin = './broker.js' 
+forkProcess('S1', brokerBin, ['../configs/development-1.env.json'], chalk.hex('#8888FF')) // 0xde1112f631486CfC759A50196853011528bC5FA0
+forkProcess('B1', brokerBin, ['../configs/development-2.env.json'], chalk.hex('#0088FF')) // 0xde222E8603FCf641F928E5F66a0CBf4de70d5352
+forkProcess('B2', brokerBin, ['../configs/development-3.env.json'], chalk.hex('#88CCFF')) // 0xde3331cA6B8B636E0b82Bf08E941F727B8927442

--- a/packages/broker/bin/tracker.js
+++ b/packages/broker/bin/tracker.js
@@ -1,1 +1,0 @@
-../../network-tracker/bin/tracker.js

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -10,7 +10,6 @@
   "bin": {
     "streamr-broker": "bin/broker.js",
     "streamr-broker-init": "bin/config-wizard.js",
-    "tracker": "bin/tracker.js",
     "delete-expired-data": "bin/delete-expired-data.js"
   },
   "main": "./dist/src/exports.js",


### PR DESCRIPTION
Removed "tracker" bin script which used a `tracker.js` file via a symbolic link to `network-tracker` package. 

The `tracker.js` file was not included in the `npm` packaging (and should not, as it is in a separate package), and therefore `npm` installs for `streamr-broker` fail with error:

```
ENOENT: no such file or directory, chmod '/foo/bar/node_modules/streamr-broker/bin/tracker.js'
```

## Future improvements

Currently `run-all.js` access `tracker.js` using relative path to `network-tracker` package. That is maybe ok as it is in same monorepo. But it would be better if we could access that e.g. via `network-tracker`'s bin script? Maybe we should move this script to `monorepo` root, e.g. to new `scripts` directory there?