### PR TITLE
refactor(client): Config normalization

### DIFF
--- a/packages/client/src/Authentication.ts
+++ b/packages/client/src/Authentication.ts
@@ -59,7 +59,7 @@ export const createAuthentication = (config: Pick<StrictStreamrClientConfig, 'au
                 return sig
             }, 1),
             getStreamRegistryChainSigner: async () => {
-                if (!config.contracts.streamRegistryChainRPCs || config.contracts.streamRegistryChainRPCs.chainId === undefined) {
+                if (config.contracts.streamRegistryChainRPCs.chainId === undefined) {
                     throw new Error('Streamr streamRegistryChainRPC not configured (with chainId) in the StreamrClient options!')
                 }
                 const { chainId } = await metamaskProvider.getNetwork()

--- a/packages/client/src/Authentication.ts
+++ b/packages/client/src/Authentication.ts
@@ -30,7 +30,11 @@ export const createPrivateKeyAuthentication = (key: string, config: Pick<StrictS
 
 export const createAuthentication = (config: Pick<StrictStreamrClientConfig, 'auth' | 'contracts'>): Authentication => {
     if ((config.auth as PrivateKeyAuthConfig)?.privateKey !== undefined) {
-        return createPrivateKeyAuthentication((config.auth as PrivateKeyAuthConfig).privateKey, config)
+        const privateKey = (config.auth as PrivateKeyAuthConfig).privateKey
+        const normalizedPrivateKey = !privateKey.startsWith('0x')
+            ? `0x${privateKey}`
+            : privateKey
+        return createPrivateKeyAuthentication(normalizedPrivateKey, config)
     } else if ((config.auth as ProviderAuthConfig)?.ethereum !== undefined) {
         const ethereum = (config.auth as ProviderAuthConfig)?.ethereum
         const metamaskProvider = new Web3Provider(ethereum)

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -224,13 +224,6 @@ export const createStrictConfig = (inputOptions: StreamrClientConfig = {}): Stri
         // NOTE: sidechain and storageNode settings are not merged with the defaults
     }
 
-    const privateKey = (options.auth as PrivateKeyAuthConfig)?.privateKey
-    if (privateKey !== undefined) {
-        if (typeof privateKey === 'string' && !privateKey.startsWith('0x')) {
-            (options.auth as PrivateKeyAuthConfig).privateKey = `0x${privateKey}`
-        }
-    }
-
     if (options.network.iceServers === undefined) {
         options.network.iceServers = STREAMR_ICE_SERVERS
     }

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -88,11 +88,6 @@ export interface StrictStreamrClientConfig {
         maxKeyRequestsPerSecond: number
     }
 
-    cache: {
-        maxSize: number
-        maxAge: number
-    }
-
     metrics?: {
         periods?: {
             streamId: string
@@ -100,6 +95,11 @@ export interface StrictStreamrClientConfig {
         }[]
         maxPublishDelay?: number
     } | boolean
+
+    cache: {
+        maxSize: number
+        maxAge: number
+    }
 
     /** @internal */
     _timeouts: {
@@ -134,10 +134,10 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
     logLevel: 'info',
 
     orderMessages: true,
-    retryResendAfter: 5000,
-    gapFillTimeout: 5000,
     gapFill: true,
     maxGapRequests: 5,
+    retryResendAfter: 5000,
+    gapFillTimeout: 5000,
     
     network: {
         trackers: {
@@ -181,10 +181,12 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
         keyRequestTimeout: 30 * 1000,
         maxKeyRequestsPerSecond: 20
     },
+
     cache: {
         maxSize: 10000,
         maxAge: 24 * 60 * 60 * 1000, // 24 hours
     },
+
     _timeouts: {
         theGraph: {
             timeout: 60 * 1000,

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -3,9 +3,51 @@ import { StreamrClientEventEmitter } from './events'
 import { DestroySignal } from './DestroySignal'
 import { NetworkNodeFacade, getEthereumAddressFromNodeId } from './NetworkNodeFacade'
 import { Publisher } from './publish/Publisher'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from './Config'
+import { ConfigInjectionToken, StreamrClientConfig, ProviderAuthConfig } from './Config'
 import { pOnce } from './utils/promises'
 import { MetricsReport, wait } from '@streamr/utils'
+
+type NormalizedConfig = NonNullable<Required<Exclude<StreamrClientConfig['metrics'], boolean>>>
+
+export const DEFAULTS = {
+    periods: [
+        {
+            duration: 60000,
+            streamId: 'streamr.eth/metrics/nodes/firehose/min'
+        },
+        {
+            duration: 3600000,
+            streamId: 'streamr.eth/metrics/nodes/firehose/hour'
+        },
+        {
+            duration: 86400000,
+            streamId: 'streamr.eth/metrics/nodes/firehose/day'
+        }
+    ],
+    maxPublishDelay: 30000
+}
+
+const getNormalizedConfig = (config: Pick<StreamrClientConfig, 'metrics' | 'auth'>): NormalizedConfig  => {
+    if (config.metrics === true) {
+        return DEFAULTS
+    } else if (config.metrics === false) {
+        return {
+            ...DEFAULTS,
+            periods: []
+        }
+    } else if (config.metrics !== undefined) {
+        return {
+            ...DEFAULTS,
+            ...config.metrics
+        }
+    } else {
+        const isEthereumAuth = ((config.auth as ProviderAuthConfig)?.ethereum !== undefined)
+        return {
+            ...DEFAULTS,
+            periods: isEthereumAuth ? [] : DEFAULTS.periods
+        }
+    }
+}
 
 @scoped(Lifecycle.ContainerScoped)
 export class MetricsPublisher {
@@ -14,38 +56,38 @@ export class MetricsPublisher {
     private node: NetworkNodeFacade
     private eventEmitter: StreamrClientEventEmitter
     private destroySignal: DestroySignal
-    private config: Pick<StrictStreamrClientConfig, 'metrics'>
+    private config: NormalizedConfig
 
     constructor(
         @inject(Publisher) publisher: Publisher,
         @inject(NetworkNodeFacade) node: NetworkNodeFacade,
         @inject(StreamrClientEventEmitter) eventEmitter: StreamrClientEventEmitter,
         @inject(DestroySignal) destroySignal: DestroySignal,
-        @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'metrics'>
+        @inject(ConfigInjectionToken) config: Pick<StreamrClientConfig, 'metrics' | 'auth'>
     ) {
         this.publisher = publisher
         this.node = node
         this.eventEmitter = eventEmitter
         this.destroySignal = destroySignal
-        this.config = config
+        this.config = getNormalizedConfig(config)
         const ensureStarted = pOnce(async () => {
             const node = await this.node.getNode()
             const metricsContext = node.getMetricsContext()
             const partitionKey = getEthereumAddressFromNodeId(node.getNodeId()).toLowerCase()
-            this.config.metrics.periods.map((config) => {
+            this.config.periods.map((config) => {
                 return metricsContext.createReportProducer(async (report: MetricsReport) => {
                     await this.publish(report, config.streamId, partitionKey)
                 }, config.duration, this.destroySignal.abortSignal)
             })
         })
-        if (this.config.metrics.periods.length > 0) {
+        if (this.config.periods.length > 0) {
             this.eventEmitter.on('publish', () => ensureStarted())
             this.eventEmitter.on('subscribe', () => ensureStarted())
         }
     }
 
     private async publish(report: MetricsReport, streamId: string, partitionKey: string): Promise<void> {
-        await wait(Math.random() * this.config.metrics.maxPublishDelay)
+        await wait(Math.random() * this.config.maxPublishDelay)
         try {
             await this.publisher.publish(streamId, report, {
                 timestamp: report.period.end,

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -37,63 +37,6 @@
                 }
             }
         },
-        "cache": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSize": {
-                    "type": "number"
-                },
-                "maxAge": {
-                    "type": "number"
-                }
-            }
-        },
-        "_timeouts": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "theGraph": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "timeout": {
-                            "type": "number"
-                        },
-                        "retryInterval": {
-                            "type": "number"
-                        }
-                    }
-                },
-                "storageNode": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "timeout": {
-                            "type": "number"
-                        },
-                        "retryInterval": {
-                            "type": "number"
-                        }
-                    }
-                },
-                "jsonRpc": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "timeout": {
-                            "type": "number"
-                        },
-                        "retryInterval": {
-                            "type": "number"
-                        }
-                    }
-                },
-                "httpFetchTimeout": {
-                    "type": "number"
-                }
-            }
-        },
         "orderMessages": {
             "type": "boolean"
         },
@@ -119,26 +62,8 @@
                 "id": {
                     "type": "string"
                 },
-                "location": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "latitude": {
-                            "type": "number"
-                        },
-                        "longitude": {
-                            "type": "number"
-                        },
-                        "country": {
-                            "type": "string"
-                        },
-                        "city": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "trackerPingInterval": {
-                    "type": "number"
+                "acceptProxyConnections": {
+                    "type": "boolean"
                 },
                 "trackers": {
                     "anyOf": [
@@ -183,11 +108,14 @@
                         }
                     ]
                 },
-                "disconnectionWaitTime": {
+                "trackerPingInterval": {
                     "type": "number"
                 },
-                "peerPingInterval": {
+                "trackerConnectionMaintenanceInterval": {
                     "type": "number"
+                },
+                "webrtcDisallowPrivateAddresses": {
+                    "type": "boolean"
                 },
                 "newWebrtcConnectionTimeout": {
                     "type": "number"
@@ -196,6 +124,15 @@
                     "type": "number"
                 },
                 "webrtcDatachannelBufferThresholdHigh": {
+                    "type": "number"
+                },
+                "disconnectionWaitTime": {
+                    "type": "number"
+                },
+                "peerPingInterval": {
+                    "type": "number"
+                },
+                "rttUpdateTimeout": {
                     "type": "number"
                 },
                 "iceServers": {
@@ -223,17 +160,23 @@
                         }
                     }
                 },
-                "rttUpdateTimeout": {
-                    "type": "number"
-                },
-                "trackerConnectionMaintenanceInterval": {
-                    "type": "number"
-                },
-                "webrtcDisallowPrivateAddresses": {
-                    "type": "boolean"
-                },
-                "acceptProxyConnections": {
-                    "type": "boolean"
+                "location": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "latitude": {
+                            "type": "number"
+                        },
+                        "longitude": {
+                            "type": "number"
+                        },
+                        "country": {
+                            "type": "string"
+                        },
+                        "city": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -329,6 +272,63 @@
                 }
             ],
             "default": true
+        },
+        "cache": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSize": {
+                    "type": "number"
+                },
+                "maxAge": {
+                    "type": "number"
+                }
+            }
+        },
+        "_timeouts": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "theGraph": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeout": {
+                            "type": "number"
+                        },
+                        "retryInterval": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "storageNode": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeout": {
+                            "type": "number"
+                        },
+                        "retryInterval": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "jsonRpc": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeout": {
+                            "type": "number"
+                        },
+                        "retryInterval": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "httpFetchTimeout": {
+                    "type": "number"
+                }
+            }
         }
     },
     "definitions": {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -1,7 +1,7 @@
 {
     "$id": "config.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Broker configuration format",
+    "description": "Client configuration format",
     "type": "object",
     "additionalProperties": false,
     "properties": {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -52,9 +52,6 @@
         "gapFillTimeout": {
             "type": "number"
         },
-        "encryptionKeys": {
-            "type": "object"
-        },
         "network": {
             "type": "object",
             "additionalProperties": false,

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -43,8 +43,8 @@ export class OrderMessages<T> {
         this.onOrdered = this.onOrdered.bind(this)
         this.onGap = this.onGap.bind(this)
         this.maybeClose = this.maybeClose.bind(this)
-        const { gapFillTimeout, retryResendAfter, maxGapRequests, orderMessages = true, gapFill = true } = this.config
-        this.enabled = !!(gapFill && maxGapRequests)
+        const { gapFillTimeout, retryResendAfter, maxGapRequests, orderMessages, gapFill } = this.config
+        this.enabled = gapFill && (maxGapRequests > 0)
         this.orderMessages = orderMessages
         this.orderingUtil = new OrderingUtil(
             this.onOrdered,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -67,7 +67,7 @@ export class Resends {
     private readonly subscriberKeyExchange: SubscriberKeyExchange
     private readonly streamrClientEventEmitter: StreamrClientEventEmitter
     private readonly destroySignal: DestroySignal
-    private readonly rootConfig: StrictStreamrClientConfig
+    private readonly config: StrictStreamrClientConfig
     private readonly loggerFactory: LoggerFactory
     private readonly logger: Logger
 
@@ -80,14 +80,14 @@ export class Resends {
         subscriberKeyExchange: SubscriberKeyExchange,
         streamrClientEventEmitter: StreamrClientEventEmitter,
         destroySignal: DestroySignal,
-        @inject(ConfigInjectionToken) rootConfig: StrictStreamrClientConfig,
+        @inject(ConfigInjectionToken) config: StrictStreamrClientConfig,
         @inject(LoggerFactory) loggerFactory: LoggerFactory
     ) {
         this.groupKeyStore = groupKeyStore
         this.subscriberKeyExchange = subscriberKeyExchange
         this.streamrClientEventEmitter = streamrClientEventEmitter
         this.destroySignal = destroySignal
-        this.rootConfig = rootConfig
+        this.config = config
         this.loggerFactory = loggerFactory
         this.logger = loggerFactory.createLogger(module)
     }
@@ -148,7 +148,7 @@ export class Resends {
             streamRegistryCached: this.streamRegistryCached,
             streamrClientEventEmitter: this.streamrClientEventEmitter,
             destroySignal: this.destroySignal,
-            config: this.rootConfig,
+            config: this.config,
             loggerFactory: this.loggerFactory
         })
 
@@ -214,9 +214,9 @@ export class Resends {
 
     async waitForStorage(message: Message, {
         // eslint-disable-next-line no-underscore-dangle
-        interval = this.rootConfig._timeouts.storageNode.retryInterval,
+        interval = this.config._timeouts.storageNode.retryInterval,
         // eslint-disable-next-line no-underscore-dangle
-        timeout = this.rootConfig._timeouts.storageNode.timeout,
+        timeout = this.config._timeouts.storageNode.timeout,
         count = 100,
         messageMatchFn = (msgTarget: Message, msgGot: Message) => {
             return msgTarget.signature === msgGot.signature

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -27,7 +27,7 @@ export class Subscriber {
     private readonly node: NetworkNodeFacade
     private readonly streamrClientEventEmitter: StreamrClientEventEmitter
     private readonly destroySignal: DestroySignal
-    private readonly rootConfig: StrictStreamrClientConfig
+    private readonly config: StrictStreamrClientConfig
     private readonly loggerFactory: LoggerFactory
     private readonly logger: Logger
 
@@ -40,7 +40,7 @@ export class Subscriber {
         node: NetworkNodeFacade,
         streamrClientEventEmitter: StreamrClientEventEmitter,
         destroySignal: DestroySignal,
-        @inject(ConfigInjectionToken) rootConfig: StrictStreamrClientConfig,
+        @inject(ConfigInjectionToken) config: StrictStreamrClientConfig,
         @inject(LoggerFactory) loggerFactory: LoggerFactory,
     ) {
         this.streamIdBuilder = streamIdBuilder
@@ -51,7 +51,7 @@ export class Subscriber {
         this.node = node
         this.streamrClientEventEmitter = streamrClientEventEmitter
         this.destroySignal = destroySignal
-        this.rootConfig = rootConfig
+        this.config = config
         this.loggerFactory = loggerFactory
         this.logger = loggerFactory.createLogger(module)
     }
@@ -70,7 +70,7 @@ export class Subscriber {
             this.streamrClientEventEmitter,
             this.destroySignal,
             this.loggerFactory,
-            this.rootConfig
+            this.config
         )
 
         this.subSessions.set(streamPartId, subSession as SubscriptionSession<unknown>)

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -43,7 +43,7 @@ export class SubscriptionSession<T> {
         streamrClientEventEmitter: StreamrClientEventEmitter,
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory,
-        @inject(ConfigInjectionToken) rootConfig: StrictStreamrClientConfig
+        @inject(ConfigInjectionToken) config: StrictStreamrClientConfig
     ) {
         this.streamPartId = streamPartId
         this.distributeMessage = this.distributeMessage.bind(this)
@@ -58,7 +58,7 @@ export class SubscriptionSession<T> {
             streamrClientEventEmitter,
             loggerFactory,
             destroySignal,
-            config: rootConfig
+            config: config
         })
         this.pipeline.onError.listen(this.onError)
         this.pipeline

--- a/packages/client/src/utils/LoggerFactory.ts
+++ b/packages/client/src/utils/LoggerFactory.ts
@@ -5,10 +5,10 @@ import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 @scoped(Lifecycle.ContainerScoped)
 export class LoggerFactory {
     constructor(
-        @inject(ConfigInjectionToken) private readonly rootConfig: Pick<StrictStreamrClientConfig, 'id' | 'logLevel'>
+        @inject(ConfigInjectionToken) private readonly config: Pick<StrictStreamrClientConfig, 'id' | 'logLevel'>
     ) {}
 
     createLogger(module: NodeJS.Module): Logger {
-        return new Logger(module, this.rootConfig.id, this.rootConfig.logLevel)
+        return new Logger(module, this.config.id, this.config.logLevel)
     }
 }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -8,7 +8,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
 import { Stream, StreamMetadata } from '../../src/Stream'
 import { ConfigTest } from '../../src/ConfigTest'
-import { STREAM_CLIENT_DEFAULTS, StreamrClientConfig } from '../../src/Config'
+import { StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { addAfterFn } from './jest-utils'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
@@ -18,13 +18,14 @@ import { Authentication, createPrivateKeyAuthentication } from '../../src/Authen
 import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
 import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
 import { LoggerFactory } from '../../src/utils/LoggerFactory'
+import { waitForCondition } from '@streamr/utils'
 
 const logger = new Logger(module)
 
 export function mockLoggerFactory(clientId?: string): LoggerFactory {
     return new LoggerFactory({
         id: clientId ?? counterId('TestCtx'),
-        logLevel: STREAM_CLIENT_DEFAULTS.logLevel
+        logLevel: 'info'
     })
 }
 
@@ -171,4 +172,10 @@ export const createGroupKeyQueue = async (current?: GroupKey, next?: GroupKey): 
         await queue.rotate(next)
     }
     return queue
+}
+
+export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Promise<void> => {
+    await waitForCondition(() => mockFunction.mock.calls.length >= n, 1000, 10, undefined, () => {
+        return `Timeout while waiting for calls: got ${mockFunction.mock.calls.length} out of ${n}`
+    })
 }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -8,7 +8,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
 import { Stream, StreamMetadata } from '../../src/Stream'
 import { ConfigTest } from '../../src/ConfigTest'
-import { StreamrClientConfig } from '../../src/Config'
+import { STREAM_CLIENT_DEFAULTS, StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { addAfterFn } from './jest-utils'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
@@ -25,7 +25,7 @@ const logger = new Logger(module)
 export function mockLoggerFactory(clientId?: string): LoggerFactory {
     return new LoggerFactory({
         id: clientId ?? counterId('TestCtx'),
-        logLevel: 'info'
+        logLevel: STREAM_CLIENT_DEFAULTS.logLevel
     })
 }
 

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,5 +1,4 @@
 import { TrackerRegistryRecord } from '@streamr/protocol'
-import { fastPrivateKey } from '@streamr/test-utils'
 import { createStrictConfig, STREAM_CLIENT_DEFAULTS } from '../../src/Config'
 import { ConfigTest } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
@@ -138,66 +137,6 @@ describe('Config', () => {
             expect(clientOverrides.network.trackers).toEqual(trackers)
             expect(clientOverrides.network.trackers).not.toBe(trackers)
             expect((clientOverrides.network.trackers as TrackerRegistryRecord[])[0]).not.toBe(trackers[0])
-        })
-
-        describe('metrics', () => {
-            describe('default', () => {
-                it('private key auth', () => {
-                    const config = createStrictConfig({
-                        auth: {
-                            privateKey: fastPrivateKey()
-                        }
-                    })
-                    expect(config.metrics.periods).toEqual(STREAM_CLIENT_DEFAULTS.metrics.periods)
-                    expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-                })
-                it('ethereum auth', () => {
-                    const config = createStrictConfig({
-                        auth: {
-                            ethereum: {}
-                        }
-                    })
-                    expect(config.metrics.periods).toEqual([])
-                    expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-                })
-                it('unauthenticated', () => {
-                    const config = createStrictConfig({})
-                    expect(config.metrics.periods).toEqual(STREAM_CLIENT_DEFAULTS.metrics.periods)
-                    expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-                })
-            })
-            it('periods overrided', () => {
-                const config = createStrictConfig({
-                    metrics: {
-                        periods: [{ duration: 10, streamId: 'foo' }]
-                    }
-                })
-                expect(config.metrics.periods).toEqual([{ duration: 10, streamId: 'foo' }])
-                expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-            })
-            it('maxPublishDelay overrided', () => {
-                const config = createStrictConfig({
-                    metrics: {
-                        maxPublishDelay: 123
-                    }
-                })
-                expect(config.metrics.periods).toEqual(STREAM_CLIENT_DEFAULTS.metrics.periods)
-                expect(config.metrics.maxPublishDelay).toEqual(123)
-            })
-            it('enabled', () => {
-                const config = createStrictConfig({
-                    metrics: true
-                })
-                expect(config.metrics.periods).toEqual(STREAM_CLIENT_DEFAULTS.metrics.periods)
-                expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-            })
-            it('disabled', () => {
-                const config = createStrictConfig({
-                    metrics: false
-                })
-                expect(config.metrics.periods).toEqual([])
-                expect(config.metrics.maxPublishDelay).toEqual(STREAM_CLIENT_DEFAULTS.metrics.maxPublishDelay)
-            })
         })
     })
 })

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -1,20 +1,14 @@
-import { toEthereumAddress, waitForCondition } from '@streamr/utils'
+import { toEthereumAddress } from '@streamr/utils'
 import { MessageID, toStreamID } from '@streamr/protocol'
 import { Authentication } from '../../src/Authentication'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { MessageStream } from '../../src/subscribe/MessageStream'
 import { Msg } from '../test-utils/publish'
-import { createRandomAuthentication } from '../test-utils/utils'
+import { createRandomAuthentication, waitForCalls } from '../test-utils/utils'
 import { convertStreamMessageToMessage } from './../../src/Message'
 import { omit } from 'lodash'
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-
-const waitForCalls = async (onMessage: jest.Mock<any>, n: number) => {
-    await waitForCondition(() => onMessage.mock.calls.length >= n, 1000, 100, undefined, () => {
-        return `Timeout while waiting for calls: got ${onMessage.mock.calls.length} out of ${n}`
-    })
-}
 
 describe('MessageStream', () => {
 

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -1,0 +1,151 @@
+import 'reflect-metadata'
+
+import { randomEthereumAddress } from '@streamr/test-utils'
+import { LevelMetric, MetricsContext, wait } from '@streamr/utils'
+import { StreamrClientConfig } from '../../src/Config'
+import { DestroySignal } from '../../src/DestroySignal'
+import { StreamrClientEventEmitter } from '../../src/events'
+import { MetricsPublisher, DEFAULTS } from '../../src/MetricsPublisher'
+import { NetworkNodeFacade } from '../../src/NetworkNodeFacade'
+import { Publisher } from '../../src/publish/Publisher'
+import { waitForCalls } from '../test-utils/utils'
+
+const nodeAddress = randomEthereumAddress()
+const DEFAULT_DURATIONS = DEFAULTS.periods.map((p) => p.duration)
+
+describe('MetricsPublisher', () => {
+
+    let publishReportMessage: jest.Mock
+    let metricsContext: MetricsContext
+    let destroySignal: DestroySignal
+
+    const startMetricsPublisher = (config: Pick<StreamrClientConfig, 'metrics' | 'auth'>) => {
+        const publisher: Pick<Publisher, 'publish'> = {
+            publish: publishReportMessage
+        }
+        const node: Pick<NetworkNodeFacade, 'getNode'> = {
+            getNode: async () => ({
+                getMetricsContext: () => metricsContext,
+                getNodeId: () => nodeAddress + '#mock-session-id'
+            }) as any
+        }
+        const eventEmitter = new StreamrClientEventEmitter()
+        new MetricsPublisher(
+            publisher as any,
+            node as any,
+            eventEmitter,
+            destroySignal,
+            config
+        )
+
+        eventEmitter.emit('subscribe', undefined)
+    }
+
+    const assertPublisherEnabled = async (
+        config: Pick<StreamrClientConfig, 'metrics' | 'auth'>,
+        expectedDurations: number[]
+    ) => {
+        startMetricsPublisher(config)
+        const createReportProducer = metricsContext.createReportProducer as jest.Mock
+        await waitForCalls(createReportProducer, 1)
+        const durations = createReportProducer.mock.calls.map((c) => c[1])
+        expect(durations).toEqual(expectedDurations)
+    }
+
+    const assertPublisherDisabled = async (config: Pick<StreamrClientConfig, 'metrics' | 'auth'>) => {
+        startMetricsPublisher(config)
+        await wait(10)
+        expect(metricsContext.createReportProducer).not.toBeCalled()
+    }
+    
+    beforeEach(() => {
+        publishReportMessage = jest.fn()
+        metricsContext = new MetricsContext()
+        jest.spyOn(metricsContext, 'createReportProducer')
+        const metrics = {
+            'level': new LevelMetric()
+        }
+        metricsContext.addMetrics('mockNamespace', metrics)
+        metrics.level.record(123)
+        destroySignal = new DestroySignal()
+    })
+
+    afterEach(() => {
+        destroySignal?.destroy()
+    })
+
+    it('happy path', async () => {
+        const PERIOD_DURATION = 50
+        const config: Pick<StreamrClientConfig, 'metrics' | 'auth'> = {
+            metrics: {
+                periods: [{
+                    streamId: 'mock-stream-id',
+                    duration: PERIOD_DURATION
+                }],
+                maxPublishDelay: 1
+            }
+        }
+        startMetricsPublisher(config)
+        
+        await waitForCalls(publishReportMessage, 1)
+
+        const [ streamId, reportContent, publishMetadata ] = publishReportMessage.mock.calls[0]
+        expect(streamId).toBe('mock-stream-id')
+        expect(reportContent).toMatchObject({
+            mockNamespace: {
+                level: 123
+            },
+            period: {
+                start: expect.toBeNumber(),
+                end: expect.toBeNumber()
+            }
+        })
+        expect(publishMetadata).toMatchObject({
+            partitionKey: nodeAddress,
+            timestamp: expect.toBeNumber()
+        })
+    })
+
+    describe('config', () => {
+
+        it('default', async () => {
+            await assertPublisherEnabled({}, DEFAULT_DURATIONS)
+        })
+
+        it('ethereum authentication', async () => {
+            await assertPublisherDisabled({
+                auth: {
+                    ethereum: {}
+                }
+            })
+        })
+
+        it('explictly enabled', async () => {
+            await assertPublisherEnabled({ metrics: true }, DEFAULT_DURATIONS)
+        })
+
+        it('explictly disabled', async () => {
+            await assertPublisherDisabled({ metrics: false })
+        })
+
+        it('custom periods', async () => {
+            await assertPublisherEnabled({
+                metrics: {
+                    periods: [
+                        { duration: 1234, streamId: '' },
+                        { duration: 5678, streamId: '' }
+                    ], 
+                    maxPublishDelay: 1 
+                }
+            }, [1234, 5678])
+        })
+
+        it('custom maxPublishDelay', async () => {
+            await assertPublisherEnabled({
+                metrics: {
+                    maxPublishDelay: 1 
+                }
+            }, DEFAULT_DURATIONS)
+        })
+    })
+})

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -38,7 +38,7 @@ describe('MetricsPublisher', () => {
             config
         )
 
-        // trigger publisher to start
+        // trigger metric publisher to start
         eventEmitter.emit('subscribe', undefined)
     }
 
@@ -90,7 +90,7 @@ describe('MetricsPublisher', () => {
         
         await waitForCalls(publishReportMessage, 1)
 
-        const [ streamId, reportContent, publishMetadata ] = publishReportMessage.mock.calls[0]
+        const [streamId, reportContent, publishMetadata] = publishReportMessage.mock.calls[0]
         expect(streamId).toBe('mock-stream-id')
         expect(reportContent).toMatchObject({
             mockNamespace: {

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -38,6 +38,7 @@ describe('MetricsPublisher', () => {
             config
         )
 
+        // trigger publisher to start
         eventEmitter.emit('subscribe', undefined)
     }
 


### PR DESCRIPTION
Refactored config handling. Metrics and private key configs are now normalized locally (in `MetricPublisher` and in `Authentication`, i.e. in the components which need the normalized structure).
  - added also a unit test for `MetricsPublisher`

## Other config-related changes

- fixed schema description
- removed `encryptionKeys` config option from schema
   - should have removed it already in https://github.com/streamr-dev/network/pull/839
- reorder configs so that the options are in same order in all definitions: `StrictStreamrClientConfig`, `STREAM_CLIENT_DEFAULTS` and in schema
- remove unnecessary check for non-nullable `streamRegistryChainRPCs` field
- remove gap fill defaults from `OrderingUtils` as there are always values for those config options (either given by user or client defaults)
  - Simplified also `boolean` evaluation