### PR TITLE
refactor(client ): Deprecate config defaults

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- Deprecate `STREAM_CLIENT_DEFAULTS` constant
+
 ### Removed
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecate `STREAM_CLIENT_DEFAULTS` constant
+- Deprecate `ConfigTest` constant, use `CONFIG_TEST` instead
 
 ### Removed
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -128,9 +128,7 @@ export type StreamrClientConfig = Partial<Omit<StrictStreamrClientConfig, 'netwo
 
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
-/**
- * @category Important
- */
+/** @deprecated */
 export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'auth'> = {
     logLevel: 'info',
 

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -17,7 +17,7 @@ const sideChainConfig = {
 /**
  * Streamr client constructor options that work in the test environment
  */
-export const ConfigTest: StreamrClientConfig = {
+export const CONFIG_TEST: StreamrClientConfig = {
     network: {
         trackers: [
             {
@@ -69,5 +69,8 @@ export const ConfigTest: StreamrClientConfig = {
     },
     metrics: false
 }
+
+/** @deprecated Use CONFIG_TEST */
+export const ConfigTest = CONFIG_TEST
 
 export const DOCKER_DEV_STORAGE_NODE = toEthereumAddress('0xde1112f631486CfC759A50196853011528bC5FA0')

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -36,7 +36,7 @@ export {
 export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/GroupKeyStore'
 
-export { ConfigTest } from './ConfigTest'
+export { CONFIG_TEST, ConfigTest } from './ConfigTest'
 export { NetworkNodeStub } from './NetworkNodeFacade'
 export { StreamDefinition } from './types'
 export { formStorageNodeAssignmentStreamId } from './utils/utils'

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -9,7 +9,7 @@ import { container as rootContainer, DependencyContainer } from 'tsyringe'
 import { writeHeapSnapshot } from 'v8'
 import { Subscription } from '../../src/subscribe/Subscription'
 import { counterId, instanceId } from '../../src/utils/utils'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { createStrictConfig, StrictStreamrClientConfig } from '../../src/Config'
 import { ethers } from 'ethers'
 import { NetworkNodeFacade } from '../../src/NetworkNodeFacade'
@@ -73,7 +73,7 @@ describe('MemoryLeaks', () => {
                 childContainer: DependencyContainer
             }> => {
                 const config = createStrictConfig({
-                    ...ConfigTest,
+                    ...CONFIG_TEST,
                     auth: {
                         privateKey: await fetchPrivateKeyWithGas(),
                     },
@@ -113,7 +113,7 @@ describe('MemoryLeaks', () => {
         beforeAll(() => {
             createClient = async (opts: any = {}) => {
                 const c = new StreamrClient({
-                    ...ConfigTest,
+                    ...CONFIG_TEST,
                     auth: {
                         privateKey: await fetchPrivateKeyWithGas(),
                     },

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -1,7 +1,7 @@
 import { Wallet } from 'ethers'
 
 import { createRelativeTestStreamId } from '../test-utils/utils'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
@@ -20,7 +20,7 @@ describe('Stream permissions', () => {
         const wallet = new Wallet(await fetchPrivateKeyWithGas())
         otherUser = fastWallet()
         client = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: wallet.privateKey,
             }
@@ -212,7 +212,7 @@ describe('Stream permissions', () => {
 
     it('granting publish permission enables publishing (invalidates isStreamPublisher cache)', async () => {
         const otherUserClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: otherUser.privateKey,
             }

--- a/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
+++ b/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
@@ -2,7 +2,7 @@ import { createTestStream, getCreateClient } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { wait } from '@streamr/utils'
 import { ProxyDirection, toStreamPartID } from '@streamr/protocol'
@@ -41,7 +41,7 @@ describe('PubSub with proxy connections', () => {
             },
             network: {
                 acceptProxyConnections: true,
-                trackers: ConfigTest.network!.trackers
+                trackers: CONFIG_TEST.network!.trackers
             }
         })
         proxyClient2 = await createClient({
@@ -51,7 +51,7 @@ describe('PubSub with proxy connections', () => {
             },
             network: {
                 acceptProxyConnections: true,
-                trackers: ConfigTest.network!.trackers
+                trackers: CONFIG_TEST.network!.trackers
             }
         })
     }, 10000)

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import { Wallet } from 'ethers'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
-import { ConfigTest, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { until } from '../../src/utils/promises'
@@ -20,13 +20,13 @@ describe('StorageNodeRegistry', () => {
         creatorWallet = new Wallet(await fetchPrivateKeyWithGas())
         listenerWallet = new Wallet(await fetchPrivateKeyWithGas())
         creatorClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: creatorWallet.privateKey,
             },
         })
         listenerClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: listenerWallet.privateKey,
             },
@@ -70,12 +70,12 @@ describe('StorageNodeRegistry', () => {
     it('no assignments', async () => {
         const storageNodeWallet = new Wallet(await fetchPrivateKeyWithGas())
         const storageNodeManager = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: storageNodeWallet.privateKey
             },
             network: {
-                ...ConfigTest.network,
+                ...CONFIG_TEST.network,
                 id: storageNodeWallet.address
             }
         })

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -1,7 +1,7 @@
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
-import { ConfigTest, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { createTestStream } from '../test-utils/utils'
@@ -20,14 +20,14 @@ describe('StorageNodeRegistry2', () => {
 
     beforeAll(async () => {
         client = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: await fetchPrivateKeyWithGas()
             }
         })
         const storageNodeWallet = new Wallet(await fetchPrivateKeyWithGas())
         storageNodeClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: storageNodeWallet.privateKey
             }

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -4,7 +4,7 @@ import { until } from '../../src/utils/promises'
 import { NotFoundError } from '../../src/HttpUtil'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { toStreamID } from '@streamr/protocol'
 import { collect } from '../../src/utils/iterators'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
@@ -15,7 +15,7 @@ const PARTITION_COUNT = 3
 
 const TIMEOUT_CONFIG = {
     // eslint-disable-next-line no-underscore-dangle
-    ...ConfigTest._timeouts!,
+    ...CONFIG_TEST._timeouts!,
     jsonRpc: {
         timeout: 5000,
         retryInterval: 200
@@ -36,7 +36,7 @@ describe('StreamRegistry', () => {
         wallet = new Wallet(await fetchPrivateKeyWithGas())
         publicAddress = toEthereumAddress(wallet.address)
         client = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: wallet.privateKey,
             },
@@ -88,7 +88,7 @@ describe('StreamRegistry', () => {
             it('domain owned by user', async () => {
                 const streamId = 'testdomain1.eth/foobar/' + Date.now()
                 const ensOwnerClient = new StreamrClient({
-                    ...ConfigTest,
+                    ...CONFIG_TEST,
                     auth: {
                         // In dev environment the testdomain1.eth is owned by 0x4178baBE9E5148c6D5fd431cD72884B07Ad855a0.
                         // The ownership is preloaded by docker-dev-chain-init (https://github.com/streamr-dev/network-contracts)

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { StreamID, toStreamPartID } from '@streamr/protocol'
 import { createNetworkNode } from '@streamr/network-node'
 import { fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { PermissionAssignment, StreamPermission } from '../../src/permission'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -18,7 +18,7 @@ const ENCRYPTED_MESSSAGE_FORMAT = /^[0-9A-Fa-f]+$/
 async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID): Promise<unknown[]> {
     const networkNode = await createNetworkNode({
         // TODO better typing for ConfigTest.network.trackers?
-        ...ConfigTest.network as any,
+        ...CONFIG_TEST.network as any,
         id: 'networkNode',
     })
     try {
@@ -39,7 +39,7 @@ async function createStreamWithPermissions(
     ...assignments: PermissionAssignment[]
 ): Promise<Stream> {
     const creatorClient = new StreamrClient({
-        ...ConfigTest,
+        ...CONFIG_TEST,
         auth: {
             privateKey
         }
@@ -66,13 +66,13 @@ describe('publish-subscribe', () => {
 
     beforeEach(async () => {
         publisherClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: publisherPk
             }
         })
         subscriberClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: subscriberWallet.privateKey
             }

--- a/packages/client/test/end-to-end/resend.test.ts
+++ b/packages/client/test/end-to-end/resend.test.ts
@@ -1,7 +1,7 @@
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { createTestStream } from '../test-utils/utils'
 import { range } from 'lodash'
-import { ConfigTest, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { wait, waitForCondition } from '@streamr/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'
@@ -17,13 +17,13 @@ describe('resend', () => {
 
     beforeEach(async () => {
         publisherClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: await fetchPrivateKeyWithGas()
             }
         })
         resendClient = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: fastPrivateKey()
             }

--- a/packages/client/test/end-to-end/searchStreams.test.ts
+++ b/packages/client/test/end-to-end/searchStreams.test.ts
@@ -2,7 +2,7 @@ import { fastWallet, fetchPrivateKeyWithGas, randomEthereumAddress } from '@stre
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { PermissionAssignment, StreamPermission } from '../../src/permission'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { SearchStreamsPermissionFilter } from '../../src/registry/searchStreams'
 import { collect } from '../../src/utils/iterators'
 
@@ -41,7 +41,7 @@ describe('searchStreams', () => {
 
     beforeAll(async () => {
         client = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: await fetchPrivateKeyWithGas(),
             }

--- a/packages/client/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/client/test/integration/NetworkNodeFacade.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 
 import { fastPrivateKey, fastWallet } from '@streamr/test-utils'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 
@@ -58,7 +58,7 @@ describe('NetworkNodeFacade', () => {
                     privateKey: wallet.privateKey
                 },
                 network: {
-                    ...ConfigTest.network,
+                    ...CONFIG_TEST.network,
                     id: nodeId,
                 }
             })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -8,7 +8,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
 import { Stream, StreamMetadata } from '../../src/Stream'
 import { ConfigTest } from '../../src/ConfigTest'
-import { STREAM_CLIENT_DEFAULTS, StreamrClientConfig } from '../../src/Config'
+import { StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { addAfterFn } from './jest-utils'
 import { GroupKeyStore } from '../../src/encryption/GroupKeyStore'
@@ -24,7 +24,7 @@ const logger = new Logger(module)
 export function mockLoggerFactory(clientId?: string): LoggerFactory {
     return new LoggerFactory({
         id: clientId ?? counterId('TestCtx'),
-        logLevel: STREAM_CLIENT_DEFAULTS.logLevel
+        logLevel: 'info'
     })
 }
 

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -7,7 +7,7 @@ import { StreamMessage, StreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } f
 import { StreamrClient } from '../../src/StreamrClient'
 import { counterId } from '../../src/utils/utils'
 import { Stream, StreamMetadata } from '../../src/Stream'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { StreamrClientConfig } from '../../src/Config'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { addAfterFn } from './jest-utils'
@@ -64,7 +64,7 @@ export const getCreateClient = (
             key = await fetchPrivateKeyWithGas()
         }
         const client = new StreamrClient({
-            ...ConfigTest,
+            ...CONFIG_TEST,
             auth: {
                 privateKey: key,
             },

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,7 +1,7 @@
 import { TrackerRegistryRecord } from '@streamr/protocol'
 import { fastPrivateKey } from '@streamr/test-utils'
 import { createStrictConfig, STREAM_CLIENT_DEFAULTS } from '../../src/Config'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
 import { STREAMR_ICE_SERVERS } from '@streamr/network-node'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -108,9 +108,9 @@ describe('Config', () => {
 
         it('can override network.trackers arrays', () => {
             const clientDefaults = createStrictConfig()
-            const clientOverrides = createStrictConfig(ConfigTest)
+            const clientOverrides = createStrictConfig(CONFIG_TEST)
             expect(clientOverrides.network.trackers).not.toEqual(clientDefaults.network.trackers)
-            expect(clientOverrides.network.trackers).toEqual(ConfigTest.network!.trackers)
+            expect(clientOverrides.network.trackers).toEqual(CONFIG_TEST.network!.trackers)
         })
 
         it('network can be empty', () => {

--- a/packages/client/test/unit/StreamrClient.test.ts
+++ b/packages/client/test/unit/StreamrClient.test.ts
@@ -3,14 +3,14 @@ import 'reflect-metadata'
 import { merge } from 'lodash'
 import { container } from 'tsyringe'
 import { StreamrClientConfig } from '../../src/Config'
-import { ConfigTest } from '../../src/ConfigTest'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamrClient } from '../../src/StreamrClient'
 
 const createClient = (opts: StreamrClientConfig = {}) => {
     return new StreamrClient(merge(
         {},
-        ConfigTest,
+        CONFIG_TEST,
         {
             network: {
                 trackers: [] // without this setting NetworkNodeFacade would query the tracker addresses from the contract


### PR DESCRIPTION
Deprecated `STREAM_CLIENT_DEFAULTS` constant. No need to expose to end-users.

Deprecated `ConfigTest` constant as it is now renamed to `CONFIG_TEST`. Currently we need to export this so that it is easy to define that a client uses the test environment.

## Future improvements

The file `ConfigTest.ts` could have better name?