### PR TITLE
Drop faulty Polygon RPC with CORS errors

### DIFF
--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -162,9 +162,6 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
             }, {
                 url: 'https://poly-rpc.gateway.pokt.network/',
                 timeout: 120 * 1000
-            }, {
-                url: 'https://rpc-mainnet.matic.network',
-                timeout: 120 * 1000
             }]
         },
         ethereumNetworks: {


### PR DESCRIPTION
Drop the public Polygon RPC `https://rpc-mainnet.matic.network/` from the default, as it produces CORS errors when used in the browser.
