### PR TITLE
docs(client): Categorize API reference by group

### DIFF
--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -45,9 +45,6 @@ export interface EthereumNetworkConfig {
     gasPriceStrategy?: (estimatedGasPrice: BigNumber) => BigNumber
 }
 
-/**
- * @category Important
- */
 export interface StrictStreamrClientConfig {
     /** Custom human-readable debug id for client. Used in logging. */
     id: string
@@ -118,6 +115,9 @@ export interface StrictStreamrClientConfig {
     }
 }
 
+/**
+ * @category Important
+ */
 export type StreamrClientConfig = Partial<Omit<StrictStreamrClientConfig, 'network' | 'contracts' | 'decryption'> & {
     network: Partial<StrictStreamrClientConfig['network']>
     contracts: Partial<StrictStreamrClientConfig['contracts']>

--- a/packages/client/src/Message.ts
+++ b/packages/client/src/Message.ts
@@ -1,6 +1,9 @@
 import { EthereumAddress } from '@streamr/utils'
 import { StreamID, StreamMessage } from '@streamr/protocol'
 
+/**
+ * @category Important
+ */
 export interface Message {
     content: unknown
     streamId: StreamID

--- a/packages/client/typedoc.js
+++ b/packages/client/typedoc.js
@@ -9,5 +9,6 @@ module.exports = {
     excludeProtected: true,
     excludeInternal: true,
     includeVersion: true,
-    disableSources: true
+    disableSources: true,
+    categorizeByGroup: false
 }


### PR DESCRIPTION
Enable `categorizeByGroup` in TypeDoc config. This way all important classes are at the top of the API reference html page.

Also changed `@important` annotations:
- `Message` class is important
- `StreamrClientConfig` type is important, and `StrictStreamrClientConfig` is not important