### PR TITLE
refactor(client): NET-923 Client default config from schema

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Deprecate TypeScript interfaces `StrictStreamrClientConfig`
+- Deprecate `gasPriceStrategy` config option in `contracts.ethereumNetworks`, use `highGasPriceStrategy` instead
+
 ### Fixed
 
 ### Security

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -11,7 +11,7 @@ import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'
 import { LogLevel } from '@streamr/utils'
 
-import { NetworkNodeOptions, STREAMR_ICE_SERVERS } from '@streamr/network-node'
+import { NetworkNodeOptions } from '@streamr/network-node'
 import type { ConnectionInfo } from '@ethersproject/web'
 import { generateClientId } from './utils/utils'
 
@@ -140,7 +140,19 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
         trackers: {
             contractAddress: '0xab9BEb0e8B106078c953CcAB4D6bF9142BeF854d'
         },
-        acceptProxyConnections: false
+        acceptProxyConnections: false,
+        iceServers: [
+            {
+                url: 'stun:stun.streamr.network',
+                port: 5349
+            },
+            {
+                url: 'turn:turn.streamr.network',
+                port: 5349,
+                username: 'BrubeckTurn1',
+                password: 'MIlbgtMw4nhpmbgqRrht1Q=='
+            }
+        ]
     },
 
     // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider
@@ -218,11 +230,6 @@ export const createStrictConfig = (inputOptions: StreamrClientConfig = {}): Stri
         }
         // NOTE: sidechain and storageNode settings are not merged with the defaults
     }
-
-    if (options.network.iceServers === undefined) {
-        options.network.iceServers = STREAMR_ICE_SERVERS
-    }
-
     return options
 }
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -71,7 +71,7 @@ export interface StrictStreamrClientConfig {
         streamRegistryChainAddress: string
         streamStorageRegistryChainAddress: string
         storageNodeRegistryChainAddress: string
-        mainChainRPCs?: ChainConnectionInfo
+        mainChainRPCs: ChainConnectionInfo
         streamRegistryChainRPCs: ChainConnectionInfo
         // most of the above should go into ethereumNetworks configs once ETH-184 is ready
         ethereumNetworks: Record<string, EthereumNetworkConfig>

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -42,6 +42,8 @@ export interface ChainConnectionInfo {
 export interface EthereumNetworkConfig {
     chainId: number
     overrides?: Overrides
+    highGasPriceStrategy?: boolean
+    /** @deprecated */
     gasPriceStrategy?: (estimatedGasPrice: BigNumber) => BigNumber
 }
 
@@ -175,7 +177,7 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
         ethereumNetworks: {
             polygon: {
                 chainId: 137,
-                gasPriceStrategy: (estimatedGasPrice: BigNumber) => estimatedGasPrice.add('10000000000'),
+                highGasPriceStrategy: true
             }
         },
         theGraphUrl: 'https://api.thegraph.com/subgraphs/name/streamr-dev/streams',

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -2,12 +2,12 @@
  * Config and utilities for interating with identity & Ethereum chain.
  */
 import { Wallet } from '@ethersproject/wallet'
-import { getDefaultProvider, JsonRpcProvider } from '@ethersproject/providers'
+import { JsonRpcProvider } from '@ethersproject/providers'
 import type { Provider } from '@ethersproject/providers'
 import type { ConnectionInfo } from '@ethersproject/web'
 import type { Overrides } from '@ethersproject/contracts'
 import type { BigNumber } from '@ethersproject/bignumber'
-import { StrictStreamrClientConfig } from './Config'
+import { ChainConnectionInfo, StrictStreamrClientConfig } from './Config'
 
 export const generateEthereumAccount = (): { address: string, privateKey: string } => {
     const wallet = Wallet.createRandom()
@@ -17,14 +17,10 @@ export const generateEthereumAccount = (): { address: string, privateKey: string
     }
 }
 
+// TODO maybe we should use all providers?
 export const getMainnetProvider = (config: Pick<StrictStreamrClientConfig, 'contracts'>): Provider => {
-    return getAllMainnetProviders(config)[0]
-}
-
-const getAllMainnetProviders = (config: Pick<StrictStreamrClientConfig, 'contracts'>): Provider[] => {
-    return config.contracts.mainChainRPCs.rpcs.map((c: ConnectionInfo) => {
-        return new JsonRpcProvider(c)
-    })
+    const providers = getRpcProviders(config.contracts.mainChainRPCs)
+    return providers[0]
 }
 
 export const getStreamRegistryChainProvider = (config: Pick<StrictStreamrClientConfig, 'contracts'>): Provider => {
@@ -32,7 +28,11 @@ export const getStreamRegistryChainProvider = (config: Pick<StrictStreamrClientC
 }
 
 export const getAllStreamRegistryChainProviders = (config: Pick<StrictStreamrClientConfig, 'contracts'>): Provider[] => {
-    return config.contracts.streamRegistryChainRPCs.rpcs.map((c: ConnectionInfo) => {
+    return getRpcProviders(config.contracts.streamRegistryChainRPCs)
+}
+
+const getRpcProviders = (connectionInfo: ChainConnectionInfo): Provider[] => {
+    return connectionInfo.rpcs.map((c: ConnectionInfo) => {
         return new JsonRpcProvider(c)
     })
 }

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -22,9 +22,6 @@ export const getMainnetProvider = (config: Pick<StrictStreamrClientConfig, 'cont
 }
 
 const getAllMainnetProviders = (config: Pick<StrictStreamrClientConfig, 'contracts'>): Provider[] => {
-    if (config.contracts.mainChainRPCs === undefined) {
-        return [getDefaultProvider()]
-    }
     return config.contracts.mainChainRPCs.rpcs.map((c: ConnectionInfo) => {
         return new JsonRpcProvider(c)
     })

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -49,7 +49,7 @@ const getOverrides = (chainName: string, provider: Provider, config: Pick<Strict
     const chainConfig = config.contracts.ethereumNetworks[chainName]
     if (chainConfig === undefined) { return {} }
     const overrides = chainConfig.overrides ?? {}
-    const gasPriceStrategy = (chainConfig.highGasPriceStrategy)
+    const gasPriceStrategy = chainConfig.highGasPriceStrategy
         ? (estimatedGasPrice: BigNumber) => estimatedGasPrice.add('10000000000') 
         : chainConfig.gasPriceStrategy
     if (gasPriceStrategy !== undefined) {

--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -6,6 +6,7 @@ import { getDefaultProvider, JsonRpcProvider } from '@ethersproject/providers'
 import type { Provider } from '@ethersproject/providers'
 import type { ConnectionInfo } from '@ethersproject/web'
 import type { Overrides } from '@ethersproject/contracts'
+import type { BigNumber } from '@ethersproject/bignumber'
 import { StrictStreamrClientConfig } from './Config'
 
 export const generateEthereumAccount = (): { address: string, privateKey: string } => {
@@ -51,10 +52,13 @@ const getOverrides = (chainName: string, provider: Provider, config: Pick<Strict
     const chainConfig = config.contracts.ethereumNetworks[chainName]
     if (chainConfig === undefined) { return {} }
     const overrides = chainConfig.overrides ?? {}
-    if (chainConfig.gasPriceStrategy !== undefined) {
+    const gasPriceStrategy = (chainConfig.highGasPriceStrategy)
+        ? (estimatedGasPrice: BigNumber) => estimatedGasPrice.add('10000000000') 
+        : chainConfig.gasPriceStrategy
+    if (gasPriceStrategy !== undefined) {
         return {
             ...overrides,
-            gasPrice: provider.getGasPrice().then(chainConfig.gasPriceStrategy)
+            gasPrice: provider.getGasPrice().then(gasPriceStrategy)
         }
     }
     return overrides

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -196,15 +196,18 @@
             "properties": {
                 "streamRegistryChainAddress": {
                     "type": "string",
-                    "format": "ethereum-address"
+                    "format": "ethereum-address",
+                    "default": "0x0D483E10612F327FC11965Fc82E90dC19b141641"
                 },
                 "streamStorageRegistryChainAddress": {
                     "type": "string",
-                    "format": "ethereum-address"
+                    "format": "ethereum-address",
+                    "default": "0xe8e2660CeDf2a59C917a5ED05B72df4146b58399"
                 },
                 "storageNodeRegistryChainAddress": {
                     "type": "string",
-                    "format": "ethereum-address"
+                    "format": "ethereum-address",
+                    "default": "0x080F34fec2bc33928999Ea9e39ADc798bEF3E0d6"
                 },
                 "mainChainRPCs": {
                     "anyOf": [
@@ -218,7 +221,18 @@
                     ]
                 },
                 "streamRegistryChainRPCs": {
-                    "$ref": "#/definitions/chainConnectionInfoList"
+                    "$ref": "#/definitions/chainConnectionInfoList",
+                    "default": {
+                        "name": "polygon",
+                        "chainId": 137,
+                        "rpcs": [{
+                            "url": "https://polygon-rpc.com",
+                            "timeout": 120000
+                        }, {
+                            "url": "https://poly-rpc.gateway.pokt.network/",
+                            "timeout": 120000
+                        }]
+                    }
                 },
                 "ethereumNetworks": {
                     "type": "object",
@@ -231,10 +245,12 @@
                 },
                 "theGraphUrl": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "default": "https://api.thegraph.com/subgraphs/name/streamr-dev/streams"
                 },
                 "maxConcurrentCalls": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 10
                 }
             },
             "default": {}

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -311,8 +311,7 @@
                         }
                     }
                 }
-            ],
-            "default": true
+            ]
         },
         "cache": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -155,7 +155,19 @@
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "default": [
+                        {
+                            "url": "stun:stun.streamr.network",
+                            "port": 5349
+                        },
+                        {
+                            "url": "turn:turn.streamr.network",
+                            "port": 5349,
+                            "username": "BrubeckTurn1",
+                            "password": "MIlbgtMw4nhpmbgqRrht1Q=="
+                        }
+                    ]
                 },
                 "location": {
                     "type": "object",
@@ -175,7 +187,8 @@
                         }
                     }
                 }
-            }
+            },
+            "default": {}
         },
         "contracts": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -291,12 +291,15 @@
             "additionalProperties": false,
             "properties": {
                 "maxSize": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 10000
                 },
                 "maxAge": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 86400000
                 }
-            }
+            },
+            "default": {}
         },
         "_timeouts": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -264,12 +264,15 @@
             "additionalProperties": false,
             "properties": {
                 "keyRequestTimeout": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 30000
                 },
                 "maxKeyRequestsPerSecond": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 20
                 }
-            }
+            },
+            "default": {}
         },
         "metrics": {
             "anyOf": [

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -228,7 +228,25 @@
                             "type": "string",
                             "format": "uri"
                         }
-                    ]
+                    ],
+                    "default": {
+                        "name": "ethereum",
+                        "chainId": 1,
+                        "rpcs": [
+                            {
+                                "url": "https://eth-rpc.gateway.pokt.network",
+                                "timeout": 120000
+                            },
+                            {
+                                "url": "https://ethereum.publicnode.com",
+                                "timeout": 120000
+                            },
+                            {
+                                "url": "https://rpc.ankr.com/eth",
+                                "timeout": 120000
+                            }
+                        ]
+                    }
                 },
                 "streamRegistryChainRPCs": {
                     "$ref": "#/definitions/chainConnectionInfoList",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -18,7 +18,8 @@
                 "info",
                 "debug",
                 "trace"
-            ]
+            ],
+            "default": "info"
         },
         "auth": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -221,7 +221,13 @@
                     "$ref": "#/definitions/chainConnectionInfoList"
                 },
                 "ethereumNetworks": {
-                    "type": "object"
+                    "type": "object",
+                    "default": {
+                        "polygon": {
+                            "chainId": 137,
+                            "highGasPriceStrategy": true
+                        }
+                    }
                 },
                 "theGraphUrl": {
                     "type": "string",
@@ -230,7 +236,8 @@
                 "maxConcurrentCalls": {
                     "type": "number"
                 }
-            }
+            },
+            "default": {}
         },
         "decryption": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -38,19 +38,24 @@
             }
         },
         "orderMessages": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
         },
         "gapFill": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
         },
         "maxGapRequests": {
-            "type": "number"
+            "type": "number",
+            "default": 5
         },
         "retryResendAfter": {
-            "type": "number"
+            "type": "number",
+            "default": 5000
         },
         "gapFillTimeout": {
-            "type": "number"
+            "type": "number",
+            "default": 5000
         },
         "network": {
             "type": "object",

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -60,7 +60,8 @@
                     "type": "string"
                 },
                 "acceptProxyConnections": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": false
                 },
                 "trackers": {
                     "anyOf": [
@@ -103,7 +104,10 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "default": {
+                        "contractAddress": "0xab9BEb0e8B106078c953CcAB4D6bF9142BeF854d"
+                    }
                 },
                 "trackerPingInterval": {
                     "type": "number"

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -307,41 +307,52 @@
                     "additionalProperties": false,
                     "properties": {
                         "timeout": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 60000
                         },
                         "retryInterval": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 1000
                         }
-                    }
+                    },
+                    "default": {}
                 },
                 "storageNode": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "timeout": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 30000
                         },
                         "retryInterval": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 1000
                         }
-                    }
+                    },
+                    "default": {}
                 },
                 "jsonRpc": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "timeout": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 30000
                         },
                         "retryInterval": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 1000
                         }
-                    }
+                    },
+                    "default": {}
                 },
                 "httpFetchTimeout": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 30000
                 }
-            }
+            },
+            "default": {}
         }
     },
     "definitions": {

--- a/packages/client/src/index-exports.ts
+++ b/packages/client/src/index-exports.ts
@@ -21,9 +21,12 @@ export {
 export { StorageNodeAssignmentEvent } from './registry/StreamStorageRegistry'
 export { StorageNodeMetadata } from './registry/StorageNodeRegistry'
 export { SearchStreamsPermissionFilter } from './registry/searchStreams'
+import { StrictStreamrClientConfig as _StrictStreamrClientConfig } from './Config'
+/** @deprecated */
+type StrictStreamrClientConfig = _StrictStreamrClientConfig
+export { StrictStreamrClientConfig }
 export {
     StreamrClientConfig,
-    StrictStreamrClientConfig,
     TrackerRegistryContract,
     ChainConnectionInfo,
     EthereumNetworkConfig,

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -2,7 +2,6 @@ import { TrackerRegistryRecord } from '@streamr/protocol'
 import { createStrictConfig, STREAM_CLIENT_DEFAULTS } from '../../src/Config'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
-import { STREAMR_ICE_SERVERS } from '@streamr/network-node'
 import { StreamrClient } from '../../src/StreamrClient'
 
 describe('Config', () => {
@@ -94,11 +93,6 @@ describe('Config', () => {
                 }).toThrow('/auth/privateKey must match format "ethereum-private-key"')
             })
         })
-    })
-
-    it('uses PRODUCTION_STUN_URLS by default', () => {
-        const clientDefaults = createStrictConfig()
-        expect(clientDefaults.network.iceServers).toEqual(STREAMR_ICE_SERVERS)
     })
 
     describe('ignorable properties', () => {

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -118,7 +118,9 @@ describe('Config', () => {
                 network: {}
             })
             expect(clientOverrides.network).toEqual(clientDefaults.network)
-            expect(clientOverrides.network.trackers).toEqual(STREAM_CLIENT_DEFAULTS.network.trackers)
+            expect(clientOverrides.network.trackers).toEqual({
+                contractAddress: '0xab9BEb0e8B106078c953CcAB4D6bF9142BeF854d'
+            })
         })
 
         it('can override trackers', () => {

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,19 +1,10 @@
 import { TrackerRegistryRecord } from '@streamr/protocol'
-import { createStrictConfig, STREAM_CLIENT_DEFAULTS } from '../../src/Config'
+import { createStrictConfig } from '../../src/Config'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
 import { StreamrClient } from '../../src/StreamrClient'
 
 describe('Config', () => {
-
-    it('defaults', () => { // TODO temporary test, do not merge to main 
-        const strictConfig = createStrictConfig({} as any)
-        expect(strictConfig.id).toBeString()
-        expect(strictConfig.contracts.mainChainRPCs).toBeUndefined()
-        delete (strictConfig as any).id
-        strictConfig.contracts.mainChainRPCs = undefined
-        expect(strictConfig).toEqual(STREAM_CLIENT_DEFAULTS)
-    })
 
     describe('validate', () => {
         it('additional property', () => {

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -6,6 +6,16 @@ import { STREAMR_ICE_SERVERS } from '@streamr/network-node'
 import { StreamrClient } from '../../src/StreamrClient'
 
 describe('Config', () => {
+
+    it('defaults', () => { // TODO temporary test, do not merge to main 
+        const strictConfig = createStrictConfig({} as any)
+        expect(strictConfig.id).toBeString()
+        expect(strictConfig.contracts.mainChainRPCs).toBeUndefined()
+        delete (strictConfig as any).id
+        strictConfig.contracts.mainChainRPCs = undefined
+        expect(strictConfig).toEqual(STREAM_CLIENT_DEFAULTS)
+    })
+
     describe('validate', () => {
         it('additional property', () => {
             expect(() => {

--- a/packages/network/src/browser.ts
+++ b/packages/network/src/browser.ts
@@ -1,5 +1,4 @@
 import 'setimmediate'
-export { STREAMR_ICE_SERVERS } from './constants'
 export { IceServer } from './connection/webrtc/WebRtcConnection'
 export { NameDirectory } from './NameDirectory'
 export { Logger, MetricsContext } from '@streamr/utils'

--- a/packages/network/src/composition.ts
+++ b/packages/network/src/composition.ts
@@ -11,8 +11,7 @@ export {
 } from './identifiers'
 export {
     COUNTER_UNSUBSCRIBE,
-    DEFAULT_MAX_NEIGHBOR_COUNT,
-    STREAMR_ICE_SERVERS
+    DEFAULT_MAX_NEIGHBOR_COUNT
 } from './constants'
 export { IceServer } from './connection/webrtc/WebRtcConnection'
 export { NetworkNode } from './logic/NetworkNode'

--- a/packages/network/src/constants.ts
+++ b/packages/network/src/constants.ts
@@ -7,16 +7,3 @@ export const GOOGLE_STUN_SERVER: IceServer = {
     url: 'stun:stun.l.google.com',
     port: 19302
 }
-
-export const STREAMR_ICE_SERVERS: ReadonlyArray<IceServer> = Object.freeze([
-    {
-        url: 'stun:stun.streamr.network',
-        port: 5349
-    },
-    {
-        url: 'turn:turn.streamr.network',
-        port: 5349,
-        username: 'BrubeckTurn1',
-        password: 'MIlbgtMw4nhpmbgqRrht1Q=='
-    }
-])


### PR DESCRIPTION
Client defaults are defined in JSON schema and applied using Ajv. Similar process was already used in Broker. 

Also marked `StrictStreamrClientConfig` as deprecated as it is just an internal type annotation.

## Related changes

- Removed `STREAMR_ICE_SERVERS` constant from network package. The value is inlined in `config.schema.json` (and `STREAM_CLIENT_DEFAULTS` which has been deprecated in an earlier PR)
- Deprecated `gasPriceStrategy` and introduced new `highGasPriceStrategy` config option so that gas price strategy can be configured from schema.
 
## Future improvements

- In `createStrictConfig` we have been cloning user's config options. That is a good practice because when Ajv applies the defaults, it modifies the objects instead of making clones. But as config options can contain references to (global) objects like `auth.ethereum`, it is not ideal to clone those objects. E.g. the strict config should just reference to `auth.ethereum` and not clone that object. Is it possible to analyze which objects we should deep clone (e.g. simple objects like `_timeouts`) and which we should just use as a reference? This functionality has not changed in this PR, and therefore it seems that e.g. `ethereum` authentication works ok event when we do the cloning.
- Currenty the public `StreamrClientConfig` interface is based on `StrictStreamrClientConfig`. As `StrictStreamrClientConfig` is now deprecated we should define `StreamrClientConfig` independently from `StrictStreamrClientConfig`. Or we should derive `StrictStreamrClientConfig` from `StreamrClientConfig` (i.e. do the opposite type derivation to what we currently do).
- In the future we could get type definition for `StrictStreamrClientConfig` automatically from Ajv's `JTDDataType`. Currently we don't use it, because it doesn't yet support the `useDefaults` config option.
  - Also some type definitions are not very straightforward, e.g. `boolean` values are shown as `JTDDataDef<{ readonly type: "boolean" }, Record<string, never>>`
