### PR TITLE
chore(client): remove extraneous generics

### DIFF
--- a/packages/broker/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/broker/test/integration/multiple-publisher-plugins.test.ts
@@ -144,9 +144,9 @@ describe('multiple publisher plugins', () => {
 
     it('subscribe by StreamrClient', async () => {
 
-        const receivedMessages: Queue<object> = new Queue()
+        const receivedMessages: Queue<unknown> = new Queue()
         const subscriber = await createClient(tracker, fastPrivateKey())
-        await subscriber.subscribe(streamId, (message: object) => {
+        await subscriber.subscribe(streamId, (message: unknown) => {
             receivedMessages.push(message)
         })
 

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -80,10 +80,10 @@ export class HttpUtil {
         this.logger = loggerFactory.createLogger(module)
     }
 
-    async* fetchHttpStream<T>(
+    async* fetchHttpStream(
         url: string,
         abortController = new AbortController()
-    ): AsyncIterable<StreamMessage<T>> {
+    ): AsyncIterable<StreamMessage> {
         const response = await fetchResponse(url, this.logger, {
             signal: abortController.signal
         })

--- a/packages/client/src/Message.ts
+++ b/packages/client/src/Message.ts
@@ -53,7 +53,7 @@ export interface Message {
 
 export type MessageMetadata = Omit<Message, 'content'>
 
-export const convertStreamMessageToMessage = (msg: StreamMessage<any>): Message => {
+export const convertStreamMessageToMessage = (msg: StreamMessage): Message => {
     return {
         content: msg.getParsedContent(),
         streamId: msg.getStreamId(),

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -188,7 +188,7 @@ export class Stream {
      */
     async detectFields(): Promise<void> {
         // Get last message of the stream to be used for field detecting
-        const sub = await this._resends.last<any>(
+        const sub = await this._resends.last(
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 count: 1,
@@ -232,7 +232,7 @@ export class Stream {
         const normalizedNodeAddress = toEthereumAddress(storageNodeAddress)
         try {
             const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
-            assignmentSubscription = new Subscription<any>(streamPartId, this._loggerFactory)
+            assignmentSubscription = new Subscription(streamPartId, this._loggerFactory)
             await this._subscriber.add(assignmentSubscription)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
                 id: this.id,
@@ -274,7 +274,7 @@ export class Stream {
      *
      * @category Important
      */
-    async publish<T>(content: T, metadata?: PublishMetadata): Promise<Message> {
+    async publish(content: unknown, metadata?: PublishMetadata): Promise<Message> {
         const result = await this._publisher.publish(this.id, content, metadata)
         this._eventEmitter.emit('publish', undefined)
         return convertStreamMessageToMessage(result)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -102,7 +102,7 @@ export class StreamrClient {
      * @category Important
      *
      * @param streamDefinition - the stream or stream partition to publish the message to
-     * @param content - the content (the payload) of the message (usually an JSON serializable object)
+     * @param content - the content (the payload) of the message (must be JSON serializable)
      * @param metadata - provide additional metadata to be included in the message or to control the publishing process
      * @returns the published message (note: the field {@link Message.content} is encrypted if the stream is private)
      */

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -102,13 +102,13 @@ export class StreamrClient {
      * @category Important
      *
      * @param streamDefinition - the stream or stream partition to publish the message to
-     * @param content - the content (the payload) of the message
+     * @param content - the content (the payload) of the message (usually an JSON serializable object)
      * @param metadata - provide additional metadata to be included in the message or to control the publishing process
      * @returns the published message (note: the field {@link Message.content} is encrypted if the stream is private)
      */
-    async publish<T>(
+    async publish(
         streamDefinition: StreamDefinition,
-        content: T,
+        content: unknown,
         metadata?: PublishMetadata
     ): Promise<Message> {
         const result = await this.publisher.publish(streamDefinition, content, metadata)
@@ -159,21 +159,21 @@ export class StreamrClient {
      * @param onMessage - callback will be invoked for each message received in subscription
      * @returns a {@link Subscription} that can be used to manage the subscription etc.
      */
-    async subscribe<T>(
+    async subscribe(
         options: StreamDefinition & { resend?: ResendOptions },
-        onMessage?: MessageListener<T>
-    ): Promise<Subscription<T>> {
+        onMessage?: MessageListener
+    ): Promise<Subscription> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
         const sub = (options.resend !== undefined)
-            ? new ResendSubscription<T>(
+            ? new ResendSubscription(
                 streamPartId,
                 options.resend,
                 this.resends,
                 this.loggerFactory,
                 this.config
             )
-            : new Subscription<T>(streamPartId, this.loggerFactory)
-        await this.subscriber.add<T>(sub)
+            : new Subscription(streamPartId, this.loggerFactory)
+        await this.subscriber.add(sub)
         if (onMessage !== undefined) {
             sub.useLegacyOnMessageHandler(onMessage)
         }
@@ -201,7 +201,7 @@ export class StreamrClient {
      *
      * @param streamDefinition - leave as `undefined` to get all subscriptions
      */
-    getSubscriptions(streamDefinition?: StreamDefinition): Promise<Subscription<unknown>[]> {
+    getSubscriptions(streamDefinition?: StreamDefinition): Promise<Subscription[]> {
         return this.subscriber.getSubscriptions(streamDefinition)
     }
 
@@ -220,13 +220,13 @@ export class StreamrClient {
      * @returns a {@link MessageStream} that provides an alternative way of iterating messages. Rejects if the stream is
      * not stored (i.e. is not assigned to a storage node).
      */
-    async resend<T>(
+    async resend(
         streamDefinition: StreamDefinition,
         options: ResendOptions,
-        onMessage?: MessageListener<T>
-    ): Promise<MessageStream<T>> {
+        onMessage?: MessageListener
+    ): Promise<MessageStream> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const messageStream = await this.resends.resend<T>(streamPartId, options)
+        const messageStream = await this.resends.resend(streamPartId, options)
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -54,7 +54,7 @@ export class PublisherKeyExchange {
         })
     }
 
-    private async onMessage(request: StreamMessage<any>): Promise<void> {
+    private async onMessage(request: StreamMessage): Promise<void> {
         if (GroupKeyRequest.is(request)) {
             try {
                 const authenticatedUser = await this.authentication.getAddress()

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -111,7 +111,7 @@ export class SubscriberKeyExchange {
         })
     }
 
-    private async onMessage(msg: StreamMessage<any>): Promise<void> {
+    private async onMessage(msg: StreamMessage): Promise<void> {
         if (GroupKeyResponse.is(msg)) {
             try {
                 const authenticatedUser = await this.authentication.getAddress()

--- a/packages/client/src/subscribe/Decrypt.ts
+++ b/packages/client/src/subscribe/Decrypt.ts
@@ -11,7 +11,7 @@ import { Logger, waitForEvent } from '@streamr/utils'
 import { StreamrClientEventEmitter } from '../events'
 import { LoggerFactory } from '../utils/LoggerFactory'
 
-export class Decrypt<T> {
+export class Decrypt {
     private readonly logger: Logger
 
     constructor(
@@ -30,7 +30,7 @@ export class Decrypt<T> {
     // TODO if this.destroySignal.isDestroyed() is true, would it make sense to reject the promise
     // and not to return the original encrypted message?
     // - e.g. StoppedError, which is not visible to end-user
-    async decrypt(streamMessage: StreamMessage<T>): Promise<StreamMessage<T>> {
+    async decrypt(streamMessage: StreamMessage): Promise<StreamMessage> {
         if (this.destroySignal.isDestroyed()) {
             return streamMessage
         }
@@ -79,7 +79,7 @@ export class Decrypt<T> {
                 // newGroupKey has been converted into GroupKey
                 await this.groupKeyStore.add(clone.newGroupKey as unknown as GroupKey, streamMessage.getStreamId())
             }
-            return clone as StreamMessage<T>
+            return clone
         } catch (err) {
             this.logger.debug('failed to decrypt message %j, reason: %s', streamMessage.getMessageID(), err)
             // clear cached permissions if cannot decrypt, likely permissions need updating

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -146,7 +146,7 @@ export class OrderMessages {
         }
     }
 
-    transform(): (src: AsyncGenerator<StreamMessage, any, unknown>) => AsyncGenerator<StreamMessage, void, unknown> {
+    transform(): (src: AsyncGenerator<StreamMessage, any, unknown>) => AsyncGenerator<StreamMessage> {
         return async function* Transform(this: OrderMessages, src: AsyncGenerator<StreamMessage>) {
             if (!this.orderMessages) {
                 yield* src

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -8,8 +8,8 @@ import { LoggerFactory } from '../utils/LoggerFactory'
 import { StrictStreamrClientConfig } from './../Config'
 import { MessageStream } from './MessageStream'
 
-export class ResendSubscription<T> extends Subscription<T> {
-    private orderMessages: OrderMessages<T>
+export class ResendSubscription extends Subscription {
+    private orderMessages: OrderMessages
 
     /** @internal */
     constructor(
@@ -20,7 +20,7 @@ export class ResendSubscription<T> extends Subscription<T> {
         @inject(ConfigInjectionToken) config: StrictStreamrClientConfig
     ) {
         super(streamPartId, loggerFactory)
-        this.orderMessages = new OrderMessages<T>(
+        this.orderMessages = new OrderMessages(
             config,
             resends,
             streamPartId,
@@ -33,8 +33,8 @@ export class ResendSubscription<T> extends Subscription<T> {
         })
     }
 
-    private async getResent(): Promise<MessageStream<T>> {
-        const resentMsgs = await this.resends.resend<T>(this.streamPartId, this.resendOptions)
+    private async getResent(): Promise<MessageStream> {
+        const resentMsgs = await this.resends.resend(this.streamPartId, this.resendOptions)
 
         this.onBeforeFinally.listen(async () => {
             resentMsgs.end()
@@ -44,7 +44,7 @@ export class ResendSubscription<T> extends Subscription<T> {
         return resentMsgs
     }
 
-    private async* resendThenRealtime(src: AsyncGenerator<StreamMessage<T>>): AsyncGenerator<StreamMessage<T>, void, any> {
+    private async* resendThenRealtime(src: AsyncGenerator<StreamMessage>): AsyncGenerator<StreamMessage, void, any> {
         try {
             yield* (await this.getResent()).getStreamMessages()
         } catch (err) {

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -24,7 +24,7 @@ export interface SubscriptionEvents {
  *
  * @category Important
  */
-export class Subscription<T = unknown> extends MessageStream<T> {
+export class Subscription extends MessageStream {
     protected readonly logger: Logger
     readonly streamPartId: StreamPartID
     protected eventEmitter: EventEmitter<SubscriptionEvents>

--- a/packages/client/src/utils/waitForAssignmentsToPropagate.ts
+++ b/packages/client/src/utils/waitForAssignmentsToPropagate.ts
@@ -4,7 +4,7 @@ import { identity } from 'lodash'
 import { MessageStream } from '../subscribe/MessageStream'
 
 export function waitForAssignmentsToPropagate(
-    messageStream: MessageStream<any>,
+    messageStream: MessageStream,
     targetStream: {
         id: StreamID
         partitions: number

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -244,7 +244,7 @@ describe('MemoryLeaks', () => {
                     const sub1Done = new Defer<undefined>()
                     const received1: any[] = []
                     const SOME_MESSAGES = Math.floor(MAX_MESSAGES / 2)
-                    let sub1: Subscription<any> | undefined = await client.subscribe(stream, async (msg: any) => {
+                    let sub1: Subscription | undefined = await client.subscribe(stream, async (msg: any) => {
                         received1.push(msg)
                         if (received1.length === SOME_MESSAGES) {
                             if (!sub1) { return }

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -7,15 +7,15 @@ import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
-import { getPublishTestStreamMessages, Msg } from '../test-utils/publish'
+import { getPublishTestStreamMessages } from '../test-utils/publish'
 import { createTestStream } from '../test-utils/utils'
 
 const MAX_MESSAGES = 10
 
-function monkeypatchMessageHandler<T = any>(
+function monkeypatchMessageHandler(
     streamPartId: StreamPartID,
     client: StreamrClient,
-    fn: ((msg: StreamMessage<T>, count: number) => undefined | null)
+    fn: ((msg: StreamMessage, count: number) => undefined | null)
 ) {
     let count = 0
     // @ts-expect-error private
@@ -152,7 +152,7 @@ describe('GapFill', () => {
                     waitForLast: true,
                 })
 
-                const sub = await client.resend<typeof Msg>(
+                const sub = await client.resend(
                     stream.id,
                     {
                         last: MAX_MESSAGES

--- a/packages/client/test/integration/StreamrClient.test.ts
+++ b/packages/client/test/integration/StreamrClient.test.ts
@@ -78,7 +78,7 @@ describe('StreamrClient', () => {
             const done = new Defer<void>()
             const msg = Msg()
 
-            const sub = await client.subscribe<typeof msg>(streamDefinition)
+            const sub = await client.subscribe(streamDefinition)
 
             sub.onMessage.listen(done.wrap(async (streamMessage) => {
                 sub.unsubscribe()
@@ -97,7 +97,7 @@ describe('StreamrClient', () => {
         it('client.subscribe (realtime) with onMessage callback', async () => {
             const done = new Defer<void>()
             const mockMessage = Msg()
-            await client.subscribe<typeof mockMessage>(streamDefinition, done.wrap(async (content, metadata) => {
+            await client.subscribe(streamDefinition, done.wrap(async (content, metadata) => {
                 expect(content).toEqual(mockMessage)
                 expect(metadata.publisherId).toBeTruthy()
                 expect(metadata.signature).toBeTruthy()
@@ -148,7 +148,7 @@ describe('StreamrClient', () => {
         it('publish and subscribe a sequence of messages', async () => {
             const done = new Defer<unknown>()
             const received: MessageMetadata[] = []
-            const sub = await client.subscribe<any>(streamDefinition, (_content, metadata) => {
+            const sub = await client.subscribe(streamDefinition, (_content, metadata) => {
                 received.push(metadata)
                 expect(metadata.publisherId).toBeTruthy()
                 expect(metadata.signature).toBeTruthy()

--- a/packages/client/test/integration/Subscriber2.test.ts
+++ b/packages/client/test/integration/Subscriber2.test.ts
@@ -637,8 +637,8 @@ describe('Subscriber', () => {
     })
 
     describe('mid-stream stop methods', () => {
-        let sub1: Subscription<unknown>
-        let sub2: Subscription<unknown>
+        let sub1: Subscription
+        let sub2: Subscription
         let published: Message[]
 
         beforeEach(async () => {

--- a/packages/client/test/test-utils/fake/FakeHttpUtil.ts
+++ b/packages/client/test/test-utils/fake/FakeHttpUtil.ts
@@ -26,14 +26,14 @@ export class FakeHttpUtil extends HttpUtil {
         this.realHttpUtil = new HttpUtil(mockLoggerFactory())
     }
 
-    override async* fetchHttpStream<T>(url: string): AsyncIterable<StreamMessage<T>> {
+    override async* fetchHttpStream(url: string): AsyncIterable<StreamMessage> {
         const request = FakeHttpUtil.getResendRequest(url)
         if (request !== undefined) {
             const storageNode = this.network.getNode(request.nodeId) as FakeStorageNode
             const format = request.query!.get('format')
             if (format === 'raw') {
                 const count = Number(request.query!.get('count'))
-                let msgs: StreamMessage<any>[]
+                let msgs: StreamMessage[]
                 if (request.resendType === 'last') {
                     msgs = await storageNode.getLast(request.streamPartId, count)
                 } else if (request.resendType === 'range') {

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -24,11 +24,11 @@ export class FakeNetworkNode implements NetworkNodeStub {
         return this.id
     }
 
-    addMessageListener(listener: (msg: StreamMessage<unknown>) => void): void {
+    addMessageListener(listener: (msg: StreamMessage) => void): void {
         this.messageListeners.push(listener)
     }
 
-    removeMessageListener(listener: (msg: StreamMessage<unknown>) => void): void {
+    removeMessageListener(listener: (msg: StreamMessage) => void): void {
         pull(this.messageListeners, listener)
     }
 

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -96,7 +96,7 @@ type CreateMockMessageOptions = {
 
 export const createMockMessage = async (
     opts: CreateMockMessageOptions
-): Promise<StreamMessage<any>> => {
+): Promise<StreamMessage> => {
     const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(
         opts.streamPartId ?? opts.stream.getStreamParts()[0]
     )

--- a/packages/client/test/unit/HttpUtil.test.ts
+++ b/packages/client/test/unit/HttpUtil.test.ts
@@ -33,8 +33,8 @@ describe('HttpUtil', () => {
         const server = app.listen(MOCK_SERVER_PORT)
         await once(server, 'listening')
         const httpUtil = new HttpUtil(mockLoggerFactory())
-        const msgs = await collect(httpUtil.fetchHttpStream<any>(`http://localhost:${MOCK_SERVER_PORT}/endpoint`))
-        expect(msgs.map((m) => m.getParsedContent().mockId)).toEqual([0, 1, 2, 3, 4])
+        const msgs = await collect(httpUtil.fetchHttpStream(`http://localhost:${MOCK_SERVER_PORT}/endpoint`))
+        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual([0, 1, 2, 3, 4])
         server.close()
     })
 

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -37,7 +37,7 @@ const createMessageFactory = async (opts?: {
 const createMessage = async (
     opts: Omit<PublishMetadata, 'timestamp'> & { timestamp?: number, explicitPartition?: number },
     messageFactory: MessageFactory
-): Promise<StreamMessage<any>> => {
+): Promise<StreamMessage> => {
     return messageFactory.createMessage(CONTENT, {
         timestamp: TIMESTAMP,
         ...opts

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -28,7 +28,7 @@ describe('MessageStream', () => {
     })
 
     it('onMessage', async () => {
-        const stream = new MessageStream<any>()
+        const stream = new MessageStream()
         const onMessage = jest.fn()
         stream.useLegacyOnMessageHandler(onMessage)
         const msg1 = await createMockMessage()

--- a/packages/client/test/unit/PushPipeline.test.ts
+++ b/packages/client/test/unit/PushPipeline.test.ts
@@ -61,7 +61,7 @@ describe('PushPipeline', () => {
         leaksDetector.add('streamMessage', streamMessage)
         const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
-        const received: StreamMessage<typeof testMessage>[] = []
+        const received: StreamMessage[] = []
         s.pull((async function* g() {
             yield streamMessage
 
@@ -91,7 +91,7 @@ describe('PushPipeline', () => {
         leaksDetector.add('streamMessage', streamMessage)
         const s = new PushPipeline<StreamMessage>()
         leaksDetector.add(instanceId(s), s)
-        const received: StreamMessage<typeof testMessage>[] = []
+        const received: StreamMessage[] = []
         s.onError.listen((error) => {
             throw error
         })
@@ -119,7 +119,7 @@ describe('PushPipeline', () => {
         const streamMessage = await createMockMessage()
         s.push(streamMessage)
         leaksDetector.add('streamMessage', streamMessage)
-        const received: StreamMessage<typeof testMessage>[] = []
+        const received: StreamMessage[] = []
         await expect(async () => {
             for await (const msg of s) {
                 leaksDetector.add('receivedMessage', msg)
@@ -140,7 +140,7 @@ describe('PushPipeline', () => {
         const streamMessage = await createMockMessage()
         leaksDetector.add('streamMessage', streamMessage)
         s.push(streamMessage)
-        const received: StreamMessage<typeof testMessage>[] = []
+        const received: StreamMessage[] = []
         await expect(async () => {
             for await (const msg of s) {
                 leaksDetector.add('receivedMessage', msg)
@@ -166,7 +166,7 @@ describe('PushPipeline', () => {
         leaksDetector.add('streamMessage', streamMessage)
         s.push(streamMessage)
         s.endWrite(err)
-        const received: StreamMessage<typeof testMessage>[] = []
+        const received: StreamMessage[] = []
         await expect(async () => {
             for await (const msg of s) {
                 leaksDetector.add('receivedMessage', msg)

--- a/packages/client/test/unit/subscribePipeline.test.ts
+++ b/packages/client/test/unit/subscribePipeline.test.ts
@@ -30,7 +30,7 @@ describe('subscribePipeline', () => {
         serializedContent?: string
         encryptionType?: EncryptionType
         groupKeyId?: string
-    } = {}): Promise<StreamMessage<unknown>> => {
+    } = {}): Promise<StreamMessage> => {
         const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
         return createSignedMessage({
             messageId: new MessageID(

--- a/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -42,12 +42,12 @@ const TARGET_STREAM = Object.freeze({
 })
 
 describe(waitForAssignmentsToPropagate, () => {
-    let messageStream: MessageStream<any>
+    let messageStream: MessageStream
     let propagatePromiseState: 'rejected' | 'resolved' | 'pending'
     let propagatePromise: Promise<any>
 
     beforeEach(() => {
-        messageStream = new MessageStream<any>()
+        messageStream = new MessageStream()
         propagatePromiseState = 'pending'
         propagatePromise = waitForAssignmentsToPropagate(messageStream, TARGET_STREAM)
             .then((retValue) => {


### PR DESCRIPTION
## Summary

Remove extraneous and occasionally misleading generics. Many were related to`StreamMessage<T>` where the type `T` could not actually  be guaranteed to be what is claimed.

## Limitations and future improvements

- Potentially some missed spots here and there. However, public API should be pretty clean from these now.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [x] Updated documentation if applicable.
