### PR TITLE
fix(network): fix stun/turn URLs in Node.js

### DIFF
--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'events'
 import StrictEventEmitter from 'strict-event-emitter-types'
 import nodeDataChannel, { DataChannel, DescriptionType, LogLevel, PeerConnection } from 'node-datachannel'
-import { ConstructorOptions, WebRtcConnection } from './WebRtcConnection'
+import { ConstructorOptions, IceServer, WebRtcConnection } from './WebRtcConnection'
 import { Logger } from "@streamr/utils"
 import { NameDirectory } from "../../NameDirectory"
 import { WebRtcConnectionFactory } from "./WebRtcEndpoint"
+import { iceServerAsString } from './iceServerAsString'
 
 const loggerLevel = process.env.NODE_DATACHANNEL_LOG_LEVEL || 'Fatal'
 nodeDataChannel.initLogger(loggerLevel as LogLevel)
@@ -116,12 +117,7 @@ export class NodeWebRtcConnection extends WebRtcConnection {
 
     protected doConnect(): void {
         this.connection = new nodeDataChannel.PeerConnection(this.selfId, {
-            iceServers: this.iceServers.map(({ url, port, username, password }) => ({
-                hostname: url,
-                port,
-                username,
-                password
-            })),
+            iceServers: this.iceServers.map(iceServerAsString),
             maxMessageSize: this.maxMessageSize
         })
 

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import StrictEventEmitter from 'strict-event-emitter-types'
 import nodeDataChannel, { DataChannel, DescriptionType, LogLevel, PeerConnection } from 'node-datachannel'
-import { ConstructorOptions, IceServer, WebRtcConnection } from './WebRtcConnection'
+import { ConstructorOptions, WebRtcConnection } from './WebRtcConnection'
 import { Logger } from "@streamr/utils"
 import { NameDirectory } from "../../NameDirectory"
 import { WebRtcConnectionFactory } from "./WebRtcEndpoint"

--- a/packages/network/src/connection/webrtc/iceServerAsString.ts
+++ b/packages/network/src/connection/webrtc/iceServerAsString.ts
@@ -1,0 +1,15 @@
+import { IceServer } from './WebRtcConnection'
+
+export function iceServerAsString({ url, port, username, password }: IceServer): string {
+    const [protocol, hostname] = url.split(':')
+    if (hostname === undefined) {
+        throw new Error(`invalid stun/turn format: ${url}`)
+    }
+    if (username === undefined && password === undefined) {
+        return `${protocol}:${hostname}:${port}`
+    }
+    if (username !== undefined && password !== undefined) {
+        return `${protocol}:${username}:${password}@${hostname}:${port}`
+    }
+    throw new Error(`username (${username}) and password (${password}) must be supplied together`)
+}

--- a/packages/network/test/unit/iceServerAsString.test.ts
+++ b/packages/network/test/unit/iceServerAsString.test.ts
@@ -1,0 +1,50 @@
+import { iceServerAsString } from '../../src/connection/webrtc/iceServerAsString'
+
+describe('iceServerAsString', () => {
+    it('without password and username', () => {
+        expect(iceServerAsString({
+            url: 'stun:stun.streamr.network',
+            port: 5349
+        })).toEqual('stun:stun.streamr.network:5349')
+    })
+
+    it('with password and username', () => {
+        expect(iceServerAsString({
+            url: 'turn:turn.streamr.network',
+            port: 5349,
+            username: 'user',
+            password: 'foobar'
+        })).toEqual('turn:user:foobar@turn.streamr.network:5349')
+    })
+
+    it('throws if given url without protocol', () => {
+        expect(() => {
+            iceServerAsString({
+                url: 'turn.streamr.network',
+                port: 5349,
+                username: 'user',
+                password: 'foobar'
+            })
+        }).toThrowError('invalid stun/turn format: turn.streamr.network')
+    })
+
+    it('throws if given username without password', () => {
+        expect(() => {
+            iceServerAsString({
+                url: 'turn:turn.streamr.network',
+                port: 5349,
+                username: 'user'
+            })
+        }).toThrowError('username (user) and password (undefined) must be supplied together')
+    })
+
+    it('throws if given password without username', () => {
+        expect(() => {
+            iceServerAsString({
+                url: 'turn:turn.streamr.network',
+                port: 5349,
+                password: 'foobar'
+            })
+        }).toThrowError('username (undefined) and password (foobar) must be supplied together')
+    })
+})


### PR DESCRIPTION
## Summary

Fix issue (introduced in 7a19d6687) in which STUN / TURN URLs were not being accepted by node-datachannel therefore  STUN / TURN was not operational in Node.js environments.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
