### PR TITLE
fix(network): Browser build

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -10,7 +10,7 @@
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "author": "Streamr Network AG <contact@streamr.network>",
   "main": "dist/src/exports.js",
-  "browser": "dist/streamr-network.js",
+  "browser": "dist/streamr-network-node.web.js",
   "types": "dist/src/exports.d.ts",
   "bin": {
     "network": "bin/network.js",

--- a/packages/network/webpack.config.js
+++ b/packages/network/webpack.config.js
@@ -2,9 +2,6 @@ const path = require('path')
 const webpack = require('webpack')
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 
-const pkg = require('./package.json')
-const libraryName = pkg.name
-
 const externals = (env) => {
     const externals = {
         'geoip-lite': 'commonjs geoip-lite',
@@ -93,7 +90,7 @@ module.exports = (env, argv) => {
             fallback: fallbacks(environment)
         },
         output: {
-            filename: `${libraryName}.js`,
+            filename: `streamr-network-node.web.js`,
             sourceMapFilename: `[name].[contenthash].js.map`,
             chunkFilename: '[id].[contenthash].js',
             path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
The `"browser"` definition in `package.json` referred to non-existent `streamr-network.js` file. 

## Root cause

We changed package name from `streamr-network` to `@streamr/network-node` in https://github.com/streamr-dev/network/pull/943. That caused Webpack's output file to change to `@streamr/network-node.js` (as it used the `name` field from `package.json`).

## Change

Modified Webpack config so that it doesn't evaluate the target file name from `package.json`'s `"name"` field. Started to use explicit name `streamr-network-node.web.js` and updated  `package.json` to use that name.

## Other changes

Small cleanup to client's Webpack config.

