### PR TITLE
refactor(client): Inline network config

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- Deprecate TypeScript interface `NetworkNodeConfig`
+
 ### Removed
 
 ### Fixed

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Deprecate TypeScript interfaces `StrictStreamrClientConfig`
+- Deprecate TypeScript interface `StrictStreamrClientConfig`
 - Deprecate `gasPriceStrategy` config option in `contracts.ethereumNetworks`, use `highGasPriceStrategy` instead
 - Deprecate method parameter of `.waitForStorage()`
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -65,7 +65,7 @@ export interface StrictStreamrClientConfig {
 
     network: {
         id?: string
-        acceptProxyConnections?: boolean
+        acceptProxyConnections: boolean
         trackers: TrackerRegistryRecord[] | TrackerRegistryContract
         trackerPingInterval?: number
         trackerConnectionMaintenanceInterval?: number
@@ -76,7 +76,7 @@ export interface StrictStreamrClientConfig {
         disconnectionWaitTime?: number
         peerPingInterval?: number
         rttUpdateTimeout?: number
-        iceServers?: ReadonlyArray<IceServer>
+        iceServers: ReadonlyArray<IceServer>
         location?: Location
     }
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -73,7 +73,7 @@ export interface StrictStreamrClientConfig {
         newWebrtcConnectionTimeout?: number
         webrtcDatachannelBufferThresholdLow?: number
         webrtcDatachannelBufferThresholdHigh?: number
-        disconnectionWaitTime?: number
+        disconnectionWaitTime: number
         peerPingInterval?: number
         rttUpdateTimeout?: number
         iceServers: ReadonlyArray<IceServer>
@@ -166,7 +166,8 @@ export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'aut
                 username: 'BrubeckTurn1',
                 password: 'MIlbgtMw4nhpmbgqRrht1Q=='
             }
-        ]
+        ],
+        disconnectionWaitTime: 200
     },
 
     // For ethers.js provider params, see https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#provider

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -10,7 +10,7 @@ import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'
 import { LogLevel } from '@streamr/utils'
 
-import { NetworkNodeOptions } from '@streamr/network-node'
+import { IceServer, Location } from '@streamr/network-node'
 import type { ConnectionInfo } from '@ethersproject/web'
 import { generateClientId } from './utils/utils'
 
@@ -63,8 +63,21 @@ export interface StrictStreamrClientConfig {
     retryResendAfter: number
     gapFillTimeout: number
 
-    network: Omit<NetworkNodeOptions, 'trackers' | 'metricsContext'> & {
+    network: {
+        id?: string
+        acceptProxyConnections?: boolean
         trackers: TrackerRegistryRecord[] | TrackerRegistryContract
+        trackerPingInterval?: number
+        trackerConnectionMaintenanceInterval?: number
+        webrtcDisallowPrivateAddresses?: boolean
+        newWebrtcConnectionTimeout?: number
+        webrtcDatachannelBufferThresholdLow?: number
+        webrtcDatachannelBufferThresholdHigh?: number
+        disconnectionWaitTime?: number
+        peerPingInterval?: number
+        rttUpdateTimeout?: number
+        iceServers?: ReadonlyArray<IceServer>
+        location?: Location
     }
 
     contracts: {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -121,7 +121,6 @@ export class NetworkNodeFacade {
 
         const networkOptions = await this.getNormalizedNetworkOptions()
         const node = this.networkNodeFactory.createNetworkNode({
-            disconnectionWaitTime: 200,
             ...networkOptions,
             id,
             metricsContext: new MetricsContext()

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -134,7 +134,8 @@
                     "type": "number"
                 },
                 "disconnectionWaitTime": {
-                    "type": "number"
+                    "type": "number",
+                    "default": 200
                 },
                 "peerPingInterval": {
                     "type": "number"

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -47,7 +47,11 @@ export { formStorageNodeAssignmentStreamId } from './utils/utils'
 export type { StreamID, StreamPartID, TrackerRegistryRecord } from '@streamr/protocol'
 export { ProxyDirection } from '@streamr/protocol'
 export type { BrandedString, EthereumAddress, LogLevel, Metric, MetricsContext, MetricsDefinition, MetricsReport } from '@streamr/utils'
-export type { IceServer, NetworkNodeOptions as NetworkNodeConfig, Location } from '@streamr/network-node'
+export type { IceServer, Location } from '@streamr/network-node'
+import type { NetworkNodeOptions } from '@streamr/network-node'
+/** @deprecated */
+type NetworkNodeConfig = NetworkNodeOptions
+export { NetworkNodeConfig }
 
 // These are currently exported because NetworkNodeStub uses methods which operate on StreamMessage.
 // If we remove that semi-public class we can maybe remove these exports.


### PR DESCRIPTION
Inlined `NetworkNodeOptions` interface to `StrictStreamrClientConfig` so that it is easier to see what all the possible network config options for a `StreamrClient` instance. This way the type definition is more straightforward and therefore more readable e.g. in API reference. 

The network settings of `StreamrClientConfig` are quite similar to the `NetworkNodeOptions` interface (which is defined in `network` package), but the end-user config interface is maybe a good boundary where we explicitly state what field of that interface we use in a client. E.g. if we'd rename a field from `NetworkNodeOptions` we'd need to do some deprecation process (if we plan to release a new minor version), and this boundary enforces us to do so.

## Related changes

- Moved `disconnectionWaitTime` default value from `NetworkNodeFacade` to schema
- Annotated `acceptProxyConnections`, `iceServers` and  `disconnectionWaitTime` as required in `StrictStreamrClientConfig` as those options get default values from the schema

