### PR TITLE
feat(broker): collect Node.js version from miners

### DIFF
--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -60,6 +60,7 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
         node.setExtraMetadata({
             natType: this.natType || null,
             brokerVersion: CURRENT_VERSION,
+            nodeJs: process.version
         })
 
         await this.subscribe()

--- a/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
+++ b/packages/broker/src/plugins/brubeckMiner/BrubeckMinerPlugin.ts
@@ -60,7 +60,7 @@ export class BrubeckMinerPlugin extends Plugin<BrubeckMinerPluginConfig> {
         node.setExtraMetadata({
             natType: this.natType || null,
             brokerVersion: CURRENT_VERSION,
-            nodeJs: process.version
+            nodeJsVersion: process.version
         })
 
         await this.subscribe()

--- a/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
@@ -121,7 +121,7 @@ describe('BrubeckMinerPlugin', () => {
             {
                 natType: null,
                 brokerVersion: CURRENT_VERSION,
-                nodeJs: process.version
+                nodeJsVersion: process.version
             },
             {}, // broker metadata is empty
         ])

--- a/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/brubeckMiner/BrubeckMinerPlugin.test.ts
@@ -120,7 +120,8 @@ describe('BrubeckMinerPlugin', () => {
         expect(Object.values(tracker.getAllExtraMetadatas())).toEqual([
             {
                 natType: null,
-                brokerVersion: CURRENT_VERSION
+                brokerVersion: CURRENT_VERSION,
+                nodeJs: process.version
             },
             {}, // broker metadata is empty
         ])


### PR DESCRIPTION
## Summary

Include current Node.js version in (extra) metadata that gets shared with tracker when miner plugin is enabled in broker. Allows us to keep track of what versions are currently in use by our miners allowing us to make informed decisions on when and how to drop Node.js version support.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
