### PR TITLE
refactor(client): Simple config type definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27464,6 +27464,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-essentials": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.0.tgz",
+            "integrity": "sha512-XeiCboEyBG8UqXZtXl59bWEi4ZgOqRsogFDI6WDGIF1LmzbYiAkIwjkXN6zZWWl4re/lsOqMlYfe8KA0XiiEPw==",
+            "dev": true,
+            "peerDependencies": {
+                "typescript": ">=4.1.0"
+            }
+        },
         "node_modules/ts-jest": {
             "version": "28.0.8",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
@@ -29270,7 +29279,7 @@
         },
         "packages/broker": {
             "name": "streamr-broker",
-            "version": "32.0.0-beta.3",
+            "version": "32.0.0-beta.4",
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
@@ -29443,6 +29452,7 @@
                 "nightwatch": "^1.7.12",
                 "node-polyfill-webpack-plugin": "^1.1.4",
                 "terser-webpack-plugin": "^5.2.5",
+                "ts-essentials": "^9.3.0",
                 "ts-loader": "^9.3.1",
                 "typedoc": "^0.23.20",
                 "util": "^0.12.4",
@@ -52993,6 +53003,7 @@
                 "sqlite3": "^5.0.3",
                 "strict-event-emitter-types": "^2.0.0",
                 "terser-webpack-plugin": "^5.2.5",
+                "ts-essentials": "^9.3.0",
                 "ts-loader": "^9.3.1",
                 "ts-toolbelt": "^9.6.0",
                 "tsyringe": "^4.6.0",
@@ -53713,6 +53724,12 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+        },
+        "ts-essentials": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.0.tgz",
+            "integrity": "sha512-XeiCboEyBG8UqXZtXl59bWEi4ZgOqRsogFDI6WDGIF1LmzbYiAkIwjkXN6zZWWl4re/lsOqMlYfe8KA0XiiEPw==",
+            "dev": true
         },
         "ts-jest": {
             "version": "28.0.8",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -73,6 +73,7 @@
     "nightwatch": "^1.7.12",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "terser-webpack-plugin": "^5.2.5",
+    "ts-essentials": "^9.3.0",
     "ts-loader": "^9.3.1",
     "typedoc": "^0.23.20",
     "util": "^0.12.4",

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -5,6 +5,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import Ajv, { ErrorObject } from 'ajv'
 import addFormats from 'ajv-formats'
 import type { ExternalProvider } from '@ethersproject/providers'
+import { MarkOptional, DeepRequired } from 'ts-essentials'
 
 import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'
@@ -46,10 +47,13 @@ export interface EthereumNetworkConfig {
     gasPriceStrategy?: (estimatedGasPrice: BigNumber) => BigNumber
 }
 
-export interface StrictStreamrClientConfig {
+/**
+ * @category Important
+ */
+export interface StreamrClientConfig {
     /** Custom human-readable debug id for client. Used in logging. */
-    id: string
-    logLevel: LogLevel
+    id?: string
+    logLevel?: LogLevel
     /**
     * Authentication: identity used by this StreamrClient instance.
     * Can contain member privateKey or (window.)ethereum
@@ -57,45 +61,45 @@ export interface StrictStreamrClientConfig {
     auth?: PrivateKeyAuthConfig | ProviderAuthConfig
 
     /** Attempt to order messages */
-    orderMessages: boolean
-    gapFill: boolean
-    maxGapRequests: number
-    retryResendAfter: number
-    gapFillTimeout: number
+    orderMessages?: boolean
+    gapFill?: boolean
+    maxGapRequests?: number
+    retryResendAfter?: number
+    gapFillTimeout?: number
 
-    network: {
+    network?: {
         id?: string
-        acceptProxyConnections: boolean
-        trackers: TrackerRegistryRecord[] | TrackerRegistryContract
-        trackerPingInterval: number
-        trackerConnectionMaintenanceInterval: number
-        webrtcDisallowPrivateAddresses: boolean
-        newWebrtcConnectionTimeout: number
-        webrtcDatachannelBufferThresholdLow: number
-        webrtcDatachannelBufferThresholdHigh: number
-        disconnectionWaitTime: number
-        peerPingInterval: number
-        rttUpdateTimeout: number
-        iceServers: ReadonlyArray<IceServer>
+        acceptProxyConnections?: boolean
+        trackers?: TrackerRegistryRecord[] | TrackerRegistryContract
+        trackerPingInterval?: number
+        trackerConnectionMaintenanceInterval?: number
+        webrtcDisallowPrivateAddresses?: boolean
+        newWebrtcConnectionTimeout?: number
+        webrtcDatachannelBufferThresholdLow?: number
+        webrtcDatachannelBufferThresholdHigh?: number
+        disconnectionWaitTime?: number
+        peerPingInterval?: number
+        rttUpdateTimeout?: number
+        iceServers?: ReadonlyArray<IceServer>
         location?: Location
     }
 
-    contracts: {
-        streamRegistryChainAddress: string
-        streamStorageRegistryChainAddress: string
-        storageNodeRegistryChainAddress: string
-        mainChainRPCs: ChainConnectionInfo
-        streamRegistryChainRPCs: ChainConnectionInfo
+    contracts?: {
+        streamRegistryChainAddress?: string
+        streamStorageRegistryChainAddress?: string
+        storageNodeRegistryChainAddress?: string
+        mainChainRPCs?: ChainConnectionInfo
+        streamRegistryChainRPCs?: ChainConnectionInfo
         // most of the above should go into ethereumNetworks configs once ETH-184 is ready
-        ethereumNetworks: Record<string, EthereumNetworkConfig>
+        ethereumNetworks?: Record<string, EthereumNetworkConfig>
         /** Some TheGraph instance, that indexes the streamr registries */
-        theGraphUrl: string
-        maxConcurrentCalls: number
+        theGraphUrl?: string
+        maxConcurrentCalls?: number
     }
 
-    decryption: {
-        keyRequestTimeout: number
-        maxKeyRequestsPerSecond: number
+    decryption?: {
+        keyRequestTimeout?: number
+        maxKeyRequestsPerSecond?: number
     }
 
     metrics?: {
@@ -106,42 +110,43 @@ export interface StrictStreamrClientConfig {
         maxPublishDelay?: number
     } | boolean
 
-    cache: {
+    cache?: {
         maxSize: number
         maxAge: number
     }
 
     /** @internal */
-    _timeouts: {
-        theGraph: {
-            timeout: number
-            retryInterval: number
+    _timeouts?: {
+        theGraph?: {
+            timeout?: number
+            retryInterval?: number
         }
-        storageNode: {
-            timeout: number
-            retryInterval: number
+        storageNode?: {
+            timeout?: number
+            retryInterval?: number
         }
-        jsonRpc: {
-            timeout: number
-            retryInterval: number
+        jsonRpc?: {
+            timeout?: number
+            retryInterval?: number
         }
-        httpFetchTimeout: number
+        httpFetchTimeout?: number
     }
 }
 
-/**
- * @category Important
- */
-export type StreamrClientConfig = Partial<Omit<StrictStreamrClientConfig, 'network' | 'contracts' | 'decryption'> & {
-    network: Partial<StrictStreamrClientConfig['network']>
-    contracts: Partial<StrictStreamrClientConfig['contracts']>
-    decryption: Partial<StrictStreamrClientConfig['decryption']>
-}>
+export type StrictStreamrClientConfig = MarkOptional<Required<StreamrClientConfig>, 'auth' | 'metrics'> & {
+    network: MarkOptional<Exclude<Required<StreamrClientConfig['network']>, undefined>, 'location'>
+    contracts: Exclude<Required<StreamrClientConfig['contracts']>, undefined>
+    decryption: Exclude<Required<StreamrClientConfig['decryption']>, undefined>
+    cache: Exclude<Required<StreamrClientConfig['cache']>, undefined>
+    _timeouts: Exclude<DeepRequired<StreamrClientConfig['_timeouts']>, undefined>
+}
 
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
 /** @deprecated */
-export const STREAM_CLIENT_DEFAULTS: Omit<StrictStreamrClientConfig, 'id' | 'auth'> = {
+export const STREAM_CLIENT_DEFAULTS: 
+    Omit<StrictStreamrClientConfig, 'id' | 'auth' | 'network'> & { network: Omit<StrictStreamrClientConfig['network'], 'id'> }
+= {
     logLevel: 'info',
 
     orderMessages: true,

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -111,8 +111,8 @@ export interface StreamrClientConfig {
     } | boolean
 
     cache?: {
-        maxSize: number
-        maxAge: number
+        maxSize?: number
+        maxAge?: number
     }
 
     /** @internal */


### PR DESCRIPTION
Before this PR the main config type `StreamrClientConfig` was derived from `StrictStreamrClientConfig`. Therefore it was not trivial to see the actual field definitions e.g. in API documentation.

Now we derive the types in the opposite way: `StreamrClientConfig` has the actual fields, and `StrictStreamrClientConfig` is a stricter (i.e. many fields required) version of that type.

Also fixed the `cache` and `_timeouts` definitions so that it is possible to define those blocks partially (before this PR we needed to provide both `maxAge` and `maxSize` if we defined `cache` config).

## Dependency

Added `ts-essentials` TypeScript utility library as dev dependency. We use `MarkOptional` and `DeepRequired` types from the library. 

Another possible TypeScript library is `type-fest`. It has significantly more weekly downloads compared to `ts-essentials`. We could later use that additionally/alternatively. It doesn't currently provide `DeepRequired` utility type (but maybe it will, as it already provides e.g. `PartialDeep`).

## Future improvements

We have custom the `MaybeAsync` utility type in `types.ts`. Both `ts-essentials` and `type-fest` have a potential replacement type for that.