### PR TITLE
ci: release broker docker image on self-hosted runner

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,10 @@ on:
         type: string
       push_image:
         type: boolean
+      host_machine_platform:
+        type: string
+        required: false
+        default: ubuntu-20.04
       build_platforms:
         type: string
         required: true
@@ -31,7 +35,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ inputs.host_machine_platform }}
     steps:
       - uses: actions/checkout@v3.2.0
       - name: Cache Docker layers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       docker_file: Dockerfile.broker
       image_name: streamr/broker-node
+      host_machine_platform: self-hosted
       build_platforms: linux/amd64,linux/arm64
       push_image: true
       test_success: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

Configure CI to build & publish broker docker image using self-hosted GitHub action runner. This is needed to speed up the build time of arm64 image as it takes around 1.5 hours on GitHub's own runners.

## Changes

- Add optional parameter `host_machine_platform` to workflow file `docker-build.yml` for defining which host machine to run the build (& publish) process on. 
- In workflow file `release.yml` configure the broker image to be built & published on self-hosted runner.

## Limitations and future improvements

- Technically speaking the building of the broker image for `linux/amd64` under Github's own runner isn't the issue. But due to how the workflows have been built and defined, it is convenient to have that be part of the same process that builds and publishes the `arm64` image.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
