### PR TITLE
fix(client): `allOf` filters in `searchStreams`

### DIFF
--- a/packages/client/src/registry/searchStreams.ts
+++ b/packages/client/src/registry/searchStreams.ts
@@ -110,11 +110,11 @@ const buildQuery = (
         }
         if (permissionFilter.allOf !== undefined) {
             const now = String(Math.round(Date.now() / 1000))
-            variables.canEdit = permissionFilter.allOf.includes(StreamPermission.EDIT)
-            variables.canDelete = permissionFilter.allOf.includes(StreamPermission.DELETE)
+            variables.canEdit = permissionFilter.allOf.includes(StreamPermission.EDIT) ? true : undefined
+            variables.canDelete = permissionFilter.allOf.includes(StreamPermission.DELETE) ? true : undefined
             variables.publishExpiration_gt = permissionFilter.allOf.includes(StreamPermission.PUBLISH) ? now : undefined
             variables.subscribeExpiration_gt = permissionFilter.allOf.includes(StreamPermission.SUBSCRIBE) ? now : undefined
-            variables.canGrant = permissionFilter.allOf.includes(StreamPermission.GRANT)
+            variables.canGrant = permissionFilter.allOf.includes(StreamPermission.GRANT) ? true : undefined
         }
     }
     const query = `


### PR DESCRIPTION
Fixed the query for search stream functionality. If `allOf` filter is used to search streams, the result set didn't include streams which have `edit`, `delete` or `grant` permission granted unless those permissions are also included in the `allOf` filter.

The GraphQL query should have excluded the permissions which are not in the `allOf` filter by defining the permission query fields as `undefined`. For `publish` and `subscribe` permissions it was handled correctly. For `edit`, `delete` or `grant` the permission fields were incorrectly set to `false` instead of `undefined`.

## Test

No unit or end-to-end test caught this bug. Could consider adding a test.