### PR TITLE
refactor(client): Publish error

### DIFF
--- a/packages/client/src/StreamrClientError.ts
+++ b/packages/client/src/StreamrClientError.ts
@@ -1,4 +1,10 @@
-export type StreamrClientErrorCode = 'NO_STORAGE_NODES' | 'INVALID_ARGUMENT' | 'CLIENT_DESTROYED' | 'PIPELINE_ERROR'
+export type StreamrClientErrorCode = 
+    'MISSING_PERMISSION' | 
+    'NO_STORAGE_NODES' | 
+    'INVALID_ARGUMENT' | 
+    'CLIENT_DESTROYED' | 
+    'PIPELINE_ERROR' |
+    'UNKNOWN_ERROR'
 
 export class StreamrClientError extends Error {
     constructor(message: string, public readonly code: StreamrClientErrorCode) {

--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -18,6 +18,7 @@ import { Mapping } from '../utils/Mapping'
 import { Authentication } from '../Authentication'
 import { StreamRegistryCached } from '../registry/StreamRegistryCached'
 import { formLookupKey } from '../utils/utils'
+import { StreamrClientError } from '../StreamrClientError'
 
 export interface MessageFactoryOptions {
     streamId: StreamID
@@ -72,7 +73,7 @@ export class MessageFactory {
         const publisherId = await this.authentication.getAddress()
         const isPublisher = await this.streamRegistry.isStreamPublisher(this.streamId, publisherId)
         if (!isPublisher) {
-            throw new Error(`${publisherId} is not a publisher on stream ${this.streamId}`)
+            throw new StreamrClientError(`You don't have permission to publish to this stream. Using address: ${publisherId}`, 'MISSING_PERMISSION')
         }
 
         const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -11,28 +11,7 @@ import { StreamRegistryCached } from '../registry/StreamRegistryCached'
 import { GroupKeyStore } from '../encryption/GroupKeyStore'
 import { GroupKeyQueue } from './GroupKeyQueue'
 import { Mapping } from '../utils/Mapping'
-
-export class PublishError extends Error {
-
-    public readonly streamId: StreamID
-    public readonly timestamp: number
-
-    constructor(streamId: StreamID, timestamp: number, cause: Error) {
-        // Currently Node and Firefox show the full error chain (this error and
-        // the message and the stack of the "cause" variable) when an error is printed
-        // to console.log. Chrome shows only the root error.
-        // TODO: Remove the cause suffix from the error message when Chrome adds the support:
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=1211260
-        // eslint-disable-next-line max-len
-        // @ts-expect-error typescript definitions don't support error cause
-        super(`Failed to publish to stream ${streamId} (timestamp=${timestamp}), cause: ${cause.message}`, { cause })
-        this.streamId = streamId
-        this.timestamp = timestamp
-        if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, this.constructor)
-        }
-    }
-}
+import { StreamrClientError } from '../StreamrClientError'
 
 export interface PublishMetadata {
     timestamp?: string | number | Date
@@ -118,7 +97,8 @@ export class Publisher {
                 await this.node.publishToNode(message)
                 return message
             } catch (e) {
-                throw new PublishError(streamId, timestamp, e)
+                const errorCode = (e instanceof StreamrClientError) ? e.code : 'UNKNOWN_ERROR'
+                throw new StreamrClientError(`Failed to publish to stream ${streamId}. Cause: ${e.message}`, errorCode)
             }
         })
     }

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -220,7 +220,7 @@ describe('Stream permissions', () => {
         const message = {
             foo: Date.now()
         }
-        const errorSnippet = `${toEthereumAddress(otherUser.address)} is not a publisher on stream ${stream.id}`
+        const errorSnippet = `You don't have permission to publish to this stream. Using address: ${toEthereumAddress(otherUser.address)}`
         await expect(() => otherUserClient.publish(stream.id, message)).rejects.toThrow(errorSnippet)
         await client.grantPermissions(stream.id, {
             user: otherUser.address,

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -121,7 +121,7 @@ describe('MessageFactory', () => {
         })
         return expect(() =>
             createMessage({}, messageFactory)
-        ).rejects.toThrow(/is not a publisher on stream/)
+        ).rejects.toThrow(/You don't have permission to publish to this stream/)
     })
 
     describe('partitions', () => {

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -1,0 +1,30 @@
+import 'reflect-metadata'
+
+import { Publisher } from '../../src/publish/Publisher'
+import { StreamIDBuilder } from '../../src/StreamIDBuilder'
+import { createRandomAuthentication } from '../test-utils/utils'
+
+describe('Publisher', () => {
+    it('error message', async () => {
+        const authentication = createRandomAuthentication()
+        const streamIdBuilder = new StreamIDBuilder(authentication)
+        const streamRegistry = {
+            isStreamPublisher: async () => false
+        }
+        const publisher = new Publisher(
+            streamIdBuilder,
+            authentication,
+            streamRegistry as any,
+            undefined as any,
+            undefined as any
+        )
+        const streamId = await streamIdBuilder.toStreamID('/test')
+        await expect(async () => {
+            await publisher.publish(streamId, {})
+        }).rejects.toThrowStreamError({
+            code: 'MISSING_PERMISSION',
+            // eslint-disable-next-line max-len
+            message: `Failed to publish to stream ${streamId}. Cause: You don't have permission to publish to this stream. Using address: ${await authentication.getAddress()}`
+        })
+    })
+})


### PR DESCRIPTION
Refactored the error message which is shown if a user tries to publish to a stream, but doesn't have permission to do so.

New error message:

```
StreamrClientError: Failed to publish to stream 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo. Cause: You don't have permission to publish to this stream. Using address: 0xe1ab8145f7e55dc933d51a18c793f901a3a0b276
    at .../network-monorepo/packages/client/src/publish/Publisher.ts:100:23
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: MISSING_PERMISSION
}
```

Before this PR:

```
PublishError: Failed to publish to stream 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo (timestamp=1234567890123), cause: 0xe1ab8145f7e55dc933d51a18c793f901a3a0b276 is not a publisher on stream 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo
    at .../network-monorepo/packages/client/src/publish/Publisher.ts:121:23
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  streamId: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo',
  timestamp: 1673562505056,
  [cause]: Error: 0xe1ab8145f7e55dc933d51a18c793f901a3a0b276 is not a publisher on stream 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo
      at MessageFactory.createMessage (.../network-monorepo/packages/client/src/publish/MessageFactory.ts:75:19)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async .../network-monorepo/packages/client/src/publish/Publisher.ts:110:33
}
```

Now we use the standard `StreamrClientError` instead of a custom error class (`PublishError`). The main benefit of using the standard class is the error code field. In this case, the error code is `MISSING_PERMISSION`, which clearly communicates the root cause of the error.

### Removed metadata

The custom class contained some metadata about the originating message:
- `streamId`
- `timestamp`

These fields are not included in the new error. This way the error message is shorter and more readable.

In practice the metadata was quite redundant:
- the stream id is included in the error message
- if a log file is used, timestamp information can be read from it (as any log file would most likely have timestamps for the log lines)

### Possible future enhancements

`StreamrClientError` could support error chaining. Some situations are easier to debug if we have a full chain of causes. For end users, a chain is maybe harder to decipher as the root cause is "hidden" at the end of the chain. Error chaining is currently not supported in Chrome, see the comment in `PublishError`.

Some error constructors use `Error.captureStackTrace`. Would we get better stack traces in some environments if we added that functionality to `StreamrClientError`?