### PR TITLE
feat: enable TCP turn

### DIFF
--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -179,6 +179,13 @@ export const STREAM_CLIENT_DEFAULTS:
                 port: 5349,
                 username: 'BrubeckTurn1',
                 password: 'MIlbgtMw4nhpmbgqRrht1Q=='
+            },
+            {
+                url: 'turn:turn.streamr.network',
+                port: 5349,
+                username: 'BrubeckTurn1',
+                password: 'MIlbgtMw4nhpmbgqRrht1Q==',
+                tcp: true
             }
         ]
     },

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -172,6 +172,9 @@
                             },
                             "password": {
                                 "type": "string"
+                            },
+                            "tcp": {
+                                "type": "boolean"
                             }
                         }
                     },
@@ -185,6 +188,13 @@
                             "port": 5349,
                             "username": "BrubeckTurn1",
                             "password": "MIlbgtMw4nhpmbgqRrht1Q=="
+                        },
+                        {
+                            "url": "turn:turn.streamr.network",
+                            "port": 5349,
+                            "username": "BrubeckTurn1",
+                            "password": "MIlbgtMw4nhpmbgqRrht1Q==",
+                            "tcp": true
                         }
                     ]
                 },

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -12,6 +12,7 @@ export interface IceServer {
     port: number
     username?: string
     password?: string
+    tcp?: boolean
 }
 
 export interface ConstructorOptions {

--- a/packages/network/src/connection/webrtc/iceServerAsString.ts
+++ b/packages/network/src/connection/webrtc/iceServerAsString.ts
@@ -1,6 +1,6 @@
 import { IceServer } from './WebRtcConnection'
 
-export function iceServerAsString({ url, port, username, password }: IceServer): string {
+export function iceServerAsString({ url, port, username, password, tcp }: IceServer): string {
     const [protocol, hostname] = url.split(':')
     if (hostname === undefined) {
         throw new Error(`invalid stun/turn format: ${url}`)
@@ -9,7 +9,7 @@ export function iceServerAsString({ url, port, username, password }: IceServer):
         return `${protocol}:${hostname}:${port}`
     }
     if (username !== undefined && password !== undefined) {
-        return `${protocol}:${username}:${password}@${hostname}:${port}`
+        return `${protocol}:${username}:${password}@${hostname}:${port}${tcp ? '?transport=tcp' : ''}`
     }
     throw new Error(`username (${username}) and password (${password}) must be supplied together`)
 }

--- a/packages/network/test/unit/iceServerAsString.test.ts
+++ b/packages/network/test/unit/iceServerAsString.test.ts
@@ -17,6 +17,16 @@ describe('iceServerAsString', () => {
         })).toEqual('turn:user:foobar@turn.streamr.network:5349')
     })
 
+    it('with password, username and tcp', () => {
+        expect(iceServerAsString({
+            url: 'turn:turn.streamr.network',
+            port: 5349,
+            username: 'user',
+            password: 'foobar',
+            tcp: true
+        })).toEqual('turn:user:foobar@turn.streamr.network:5349?transport=tcp')
+    })
+
     it('throws if given url without protocol', () => {
         expect(() => {
             iceServerAsString({


### PR DESCRIPTION
## Summary

Makes adding TCP TURN servers possible.

## Changes

- Add configurability for TCP TURN
- Add TCP TURN to the client config by default.

## Limitations and future improvements

As the list of IceServers increases the time to establish connections could increase. It is possible that the default timeouts for opening connections need to be adjusted after this change, especially if overlay performance is detected to be reduced.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
