### PR TITLE
feat: add param `webrtcSendBufferMaxMessageCount`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add config option `network.webrtcSendBufferMaxMessageCount`
 
 ### Changed
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -77,6 +77,7 @@ export interface StreamrClientConfig {
         newWebrtcConnectionTimeout?: number
         webrtcDatachannelBufferThresholdLow?: number
         webrtcDatachannelBufferThresholdHigh?: number
+        webrtcSendBufferMaxMessageCount?: number
         disconnectionWaitTime?: number
         peerPingInterval?: number
         rttUpdateTimeout?: number
@@ -166,6 +167,7 @@ export const STREAM_CLIENT_DEFAULTS:
         newWebrtcConnectionTimeout: 15 * 1000,
         webrtcDatachannelBufferThresholdLow: 2 ** 15,
         webrtcDatachannelBufferThresholdHigh: 2 ** 17,
+        webrtcSendBufferMaxMessageCount: 500,
         disconnectionWaitTime: 200,
         peerPingInterval: 30 * 1000,
         rttUpdateTimeout: 15 * 1000,

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -77,6 +77,9 @@ export interface StreamrClientConfig {
         newWebrtcConnectionTimeout?: number
         webrtcDatachannelBufferThresholdLow?: number
         webrtcDatachannelBufferThresholdHigh?: number
+        /**
+         * The maximum amount of outgoing messages to be buffered on a single WebRTC connection.
+         */
         webrtcSendBufferMaxMessageCount?: number
         disconnectionWaitTime?: number
         peerPingInterval?: number

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -139,6 +139,10 @@
                     "type": "number",
                     "default": 131072
                 },
+                "webrtcSendBufferMaxMessageCount": {
+                    "type": "number",
+                    "default": 500
+                },
                 "disconnectionWaitTime": {
                     "type": "number",
                     "default": 200

--- a/packages/network/src/connection/MessageQueue.ts
+++ b/packages/network/src/connection/MessageQueue.ts
@@ -64,7 +64,7 @@ export class MessageQueue<M> {
     private readonly logger: Logger
     private readonly maxSize: number
 
-    constructor(maxSize = 500) {
+    constructor(maxSize: number) {
         this.heap = new Heap<QueueItem<M>>((a, b) => a.no - b.no)
         this.logger = new Logger(module)
         this.maxSize = maxSize

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -60,6 +60,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private stopped = false
     private readonly bufferThresholdLow: number
     private readonly bufferThresholdHigh: number
+    private readonly sendBufferMaxMessageCount: number
     private readonly disallowPrivateAddresses: boolean
     private readonly maxMessageSize: number
 
@@ -76,6 +77,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         pingInterval: number,
         webrtcDatachannelBufferThresholdLow: number,
         webrtcDatachannelBufferThresholdHigh: number,
+        webrtcSendBufferMaxMessageCount: number,
         webrtcDisallowPrivateAddresses: boolean,
         maxMessageSize = 1048576,
     ) {
@@ -92,6 +94,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.logger = new Logger(module)
         this.bufferThresholdLow = webrtcDatachannelBufferThresholdLow
         this.bufferThresholdHigh = webrtcDatachannelBufferThresholdHigh
+        this.sendBufferMaxMessageCount = webrtcSendBufferMaxMessageCount
         this.disallowPrivateAddresses = webrtcDisallowPrivateAddresses
         this.maxMessageSize = maxMessageSize
 
@@ -167,7 +170,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         routerId: string,
         deferredConnectionAttempt: DeferredConnectionAttempt | null
     ) {
-        const messageQueue = this.messageQueues[targetPeerId] = this.messageQueues[targetPeerId] || new MessageQueue()
+        const messageQueue = this.messageQueues[targetPeerId] = this.messageQueues[targetPeerId] || new MessageQueue(this.sendBufferMaxMessageCount)
         const connectionOptions: ConstructorOptions = {
             selfId: this.peerInfo.peerId,
             targetPeerId,

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -18,6 +18,7 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     newWebrtcConnectionTimeout: number
     webrtcDatachannelBufferThresholdLow: number
     webrtcDatachannelBufferThresholdHigh: number
+    webrtcSendBufferMaxMessageCount: number
     iceServers: ReadonlyArray<IceServer>
     rttUpdateTimeout: number
     trackerConnectionMaintenanceInterval: number
@@ -31,6 +32,7 @@ export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsC
     newWebrtcConnectionTimeout: 15 * 1000,
     webrtcDatachannelBufferThresholdLow: 2 ** 15,
     webrtcDatachannelBufferThresholdHigh: 2 ** 17,
+    webrtcSendBufferMaxMessageCount: 500,
     iceServers: [],
     rttUpdateTimeout: 15 * 1000,
     trackerConnectionMaintenanceInterval: 5 * 1000,
@@ -51,6 +53,7 @@ export const createNetworkNode = ({
     rttUpdateTimeout,
     webrtcDatachannelBufferThresholdLow,
     webrtcDatachannelBufferThresholdHigh,
+    webrtcSendBufferMaxMessageCount,
     iceServers,
     trackerConnectionMaintenanceInterval,
     webrtcDisallowPrivateAddresses,
@@ -73,6 +76,7 @@ export const createNetworkNode = ({
         peerPingInterval,
         webrtcDatachannelBufferThresholdLow,
         webrtcDatachannelBufferThresholdHigh,
+        webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses
     ))
 

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -3,6 +3,7 @@ import { runAndWaitForEvents } from '@streamr/test-utils'
 import { MessageQueue } from "../../src/connection/MessageQueue"
 import { ConstructorOptions } from "../../src/connection/webrtc/WebRtcConnection"
 import { DeferredConnectionAttempt } from "../../src/connection/webrtc/DeferredConnectionAttempt"
+import { TEST_CONFIG } from '../../src/createNetworkNode'
 
 const connectionOpts1: ConstructorOptions = {
     selfId: 'peer1',
@@ -10,7 +11,7 @@ const connectionOpts1: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 
@@ -20,7 +21,7 @@ const connectionOpts2: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 

--- a/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
@@ -4,6 +4,7 @@ import { MessageQueue } from '../../src/connection/MessageQueue'
 import { BrowserWebRtcConnection } from '../../src/connection/webrtc/BrowserWebRtcConnection'
 import { DeferredConnectionAttempt } from '../../src/connection/webrtc/DeferredConnectionAttempt'
 import { ConstructorOptions } from "../../src/connection/webrtc/WebRtcConnection"
+import { TEST_CONFIG } from '../../src/createNetworkNode'
 /**
  * Test that Connections can be established and message sent between them successfully. Tracker
  * is "abstracted away" by local functions.
@@ -23,7 +24,7 @@ describe('Connection', () => {
             routerId: 'tracker',
             iceServers: [],
             pingInterval: 5000,
-            messageQueue: new MessageQueue<string>(),
+            messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt()
         }
 
@@ -33,7 +34,7 @@ describe('Connection', () => {
             routerId: 'tracker',
             iceServers: [],
             pingInterval: 5000,
-            messageQueue: new MessageQueue<string>(),
+            messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt()
         }
 

--- a/packages/network/test/integration/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/integration/NodeWebRtcConnection.test.ts
@@ -5,6 +5,7 @@ import { NodeWebRtcConnection } from '../../src/connection/webrtc/NodeWebRtcConn
 import { DeferredConnectionAttempt } from '../../src/connection/webrtc/DeferredConnectionAttempt'
 import { runAndWaitForEvents } from '@streamr/test-utils'
 import { wait, waitForCondition } from '@streamr/utils'
+import { TEST_CONFIG } from '../../src/createNetworkNode'
 
 /**
  * Test that Connections can be established and message sent between them successfully. Tracker
@@ -41,8 +42,8 @@ describe('Connection', () => {
                 connectionOne.addRemoteCandidate(candidate, mid)
             },
         }
-        const messageQueueOne = new MessageQueue<string>()
-        const messageQueueTwo = new MessageQueue<string>()
+        const messageQueueOne = new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount)
+        const messageQueueTwo = new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount)
         const deferredConnectionAttemptOne = new DeferredConnectionAttempt()
         const deferredConnectionAttemptTwo = new DeferredConnectionAttempt()
         connectionOne = new NodeWebRtcConnection({

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -2,6 +2,7 @@ import { webRtcConnectionFactory } from "../../src/connection/webrtc/NodeWebRtcC
 import { MessageQueue } from "../../src/connection/MessageQueue"
 import { ConstructorOptions } from "../../src/connection/webrtc/WebRtcConnection"
 import { DeferredConnectionAttempt } from "../../src/connection/webrtc/DeferredConnectionAttempt"
+import { TEST_CONFIG } from '../../src/createNetworkNode'
 
 const connectionOpts1: ConstructorOptions = {
     selfId: 'peer1',
@@ -9,7 +10,7 @@ const connectionOpts1: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 
@@ -19,7 +20,7 @@ const connectionOpts2: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -3,6 +3,7 @@ import { runAndWaitForEvents } from '@streamr/test-utils'
 import { MessageQueue } from '../../src/connection/MessageQueue'
 import { ConstructorOptions } from '../../src/connection/webrtc/WebRtcConnection'
 import { DeferredConnectionAttempt } from '../../src/connection/webrtc/DeferredConnectionAttempt'
+import { TEST_CONFIG } from '../../src/createNetworkNode'
 
 const connectionOpts1: ConstructorOptions = {
     selfId: 'peer1',
@@ -10,7 +11,7 @@ const connectionOpts1: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 
@@ -20,7 +21,7 @@ const connectionOpts2: ConstructorOptions = {
     routerId: 'tracker',
     iceServers: [],
     pingInterval: 5000,
-    messageQueue: new MessageQueue<string>(),
+    messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt()
 }
 

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -48,6 +48,7 @@ export const createTestWebRtcEndpoint = (
         pingInterval ?? TEST_CONFIG.peerPingInterval,
         webrtcDatachannelBufferThresholdLow ?? TEST_CONFIG.webrtcDatachannelBufferThresholdLow,
         webrtcDatachannelBufferThresholdHigh ?? TEST_CONFIG.webrtcDatachannelBufferThresholdHigh,
+        TEST_CONFIG.webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses ?? false,
     )
 }


### PR DESCRIPTION
## Summary

Add config option `network.webrtcSendBufferMaxMessageCount` to control maximum amount of outgoing messages to be buffered on a single WebRTC connection.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
