### PR TITLE
feat(broker): Config overrides from environment variables

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the syntax of environment variables which are used to override configuration files (see [configuration.md](configuration.md))
+
 ### Deprecated
 
 ### Removed

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -15,8 +15,10 @@ The names start with `STREAMR__BROKER__` and each configuration block is separat
 
 It is possible to defined arrays by adding a numeration suffix to a block/property:
 ```
-STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = 'foo'
-STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'bar'
+STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = '0x1234'
+STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_2__ID = '0x5678'
+STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'foo'
+STREAMR__BROKER__AUTHENTICATION__KEYS_2 = 'bar'
 ```
 
 Note that the first item of an array has index `1` (not `0`).

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -4,14 +4,27 @@ See [config.schema.json](src/config/config.schema.json).
 
 ### Environment variables
 
-You may use environment variables to override any configuration option read from the configuration file. This is not the recommended way to change these values. It is better to modify the actual configuration file.
+You may use environment variables to define any configuration option. This is not the recommended way to use configuration: it is better to modify the actual configuration file, is possible.
 
-The syntax of the variables names is like this:
+E.g. if you want to set a private key, you can define a variable like this:
 ```
-STREAMR__BROKER__PLUGINS__BRUBECK_MINER__BENEFICIARY_ADDRESS
-```
+STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = '0x1234'
+````
 
-The names start with `STREAMR__BROKER__` and each configuration block is separated by double underscore. Blocks and properties are defined in *CONSTANT_CASE* instead of *camelCase*.
+It corresponds to this configuration file:
+```
+{
+    "client": {
+        "auth": {
+            "privateKey": "0x1234"
+        }
+    },
+    ...
+}
+
+All environment variable names start with `STREAMR__BROKER__` and each configuration block is separated by double underscore. Blocks and properties are defined in *CONSTANT_CASE* instead of *camelCase*.
+
+If the value is defined both in an environment variable and the configuration file, the environment variable value is used.
 
 It is possible to defined arrays by adding a numeration suffix to a block/property:
 ```

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -21,6 +21,7 @@ It corresponds to this configuration file:
     },
     ...
 }
+```
 
 All environment variable names start with `STREAMR__BROKER__` and each configuration block is separated by double underscore. Blocks and properties are defined in *CONSTANT_CASE* instead of *camelCase*.
 

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -27,7 +27,7 @@ All environment variable names start with `STREAMR__BROKER__` and each configura
 
 If the value is defined both in an environment variable and a configuration file, the environment variable value is used.
 
-It is possible to defined arrays by adding a numeration suffix to a block/property:
+It is possible to define arrays by adding a numeration suffix to a block/property:
 ```
 STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = '0x1234'
 STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_2__ID = '0x5678'

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -6,7 +6,7 @@ See [config.schema.json](src/config/config.schema.json).
 
 You may use environment variables to define any configuration option. This is not the recommended way to use configuration: it is better to modify the actual configuration file, is possible.
 
-E.g. if you want to set a private key, you can define a variable like this:
+E.g. if you want to set the private key, you can define a variable like this:
 ```
 STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = '0x1234'
 ````
@@ -25,7 +25,7 @@ It corresponds to this configuration file:
 
 All environment variable names start with `STREAMR__BROKER__` and each configuration block is separated by double underscore. Blocks and properties are defined in *CONSTANT_CASE* instead of *camelCase*.
 
-If the value is defined both in an environment variable and the configuration file, the environment variable value is used.
+If the value is defined both in an environment variable and a configuration file, the environment variable value is used.
 
 It is possible to defined arrays by adding a numeration suffix to a block/property:
 ```

--- a/packages/broker/configuration.md
+++ b/packages/broker/configuration.md
@@ -4,7 +4,19 @@ See [config.schema.json](src/config/config.schema.json).
 
 ### Environment variables
 
-You may use environment variables `OVERRIDE_BROKER_PRIVATE_KEY` and/or `OVERRIDE_BROKER_BENEFICIARY_ADDRESS` to override
-the equivalent values read from the configuration file.
+You may use environment variables to override any configuration option read from the configuration file. This is not the recommended way to change these values. It is better to modify the actual configuration file.
 
-This is not the recommended way to change these values. It is better to modify the actual configuration file.
+The syntax of the variables names is like this:
+```
+STREAMR__BROKER__PLUGINS__BRUBECK_MINER__BENEFICIARY_ADDRESS
+```
+
+The names start with `STREAMR__BROKER__` and each configuration block is separated by double underscore. Blocks and properties are defined in *CONSTANT_CASE* instead of *camelCase*.
+
+It is possible to defined arrays by adding a numeration suffix to a block/property:
+```
+STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = 'foo'
+STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'bar'
+```
+
+Note that the first item of an array has index `1` (not `0`).

--- a/packages/broker/test/unit/config.test.ts
+++ b/packages/broker/test/unit/config.test.ts
@@ -1,35 +1,65 @@
 import { overrideConfigToEnvVarsIfGiven } from '../../src/config/config'
 
 describe('overrideConfigToEnvVarsIfGiven', () => {
-    it('environment variable OVERRIDE_BROKER_PRIVATE_KEY overrides config (NET-934)', async () => {
-        const PK = '0x222'
+    it('happy path', () => {
         const config = {
             client: {
                 auth: {
-                    privateKey: '0x111'
-                }
-            },
-            plugins: {}
-        }
-        process.env.OVERRIDE_BROKER_PRIVATE_KEY = PK
-        await overrideConfigToEnvVarsIfGiven(config)
-        expect(config.client.auth.privateKey).toEqual(PK)
-    })
-
-    it('environment variable OVERRIDE_BROKER_BENEFICIARY_ADDRESS overrides config (NET-934)', async () => {
-        const BENEFICIARY_ADDRESS = '0x1957abc2e960eb5f2c6a166e7a628ded7570e298'
-        const config = {
-            client: {
-                auth: {
-                    privateKey: '0x111'
+                    privateKey: 'will-be-overridden'
                 }
             },
             plugins: {
-                brubeckMiner: {}
+                info: {}
             }
         }
-        process.env.OVERRIDE_BROKER_BENEFICIARY_ADDRESS = BENEFICIARY_ADDRESS
-        await overrideConfigToEnvVarsIfGiven(config)
-        expect((config.plugins.brubeckMiner as any).beneficiaryAddress).toEqual(BENEFICIARY_ADDRESS)
+        process.env.STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = '0x111'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = 'tracker1-id'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__HTTP = 'tracker1-http'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_2__ID = 'tracker2-id'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_2__HTTP = 'tracker2-http'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__TRACKER_PING_INTERVAL = '-0.5'
+        process.env.STREAMR__BROKER__CLIENT__ORDER_MESSAGES = 'true'
+        process.env.STREAMR__BROKER__CLIENT__GAP_FILL = 'false'
+        process.env.STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'key-1'
+        process.env.STREAMR__BROKER__AUTHENTICATION__KEYS_2 = 'key-2'
+        process.env.STREAMR__BROKER__PLUGINS__BRUBECK_MINER__BENEFICIARY_ADDRESS = '0x222'
+        process.env.STREAMR__BROKER__PLUGINS__BRUBECK_MINER__STUN_SERVER_HOST = 'null'
+        overrideConfigToEnvVarsIfGiven(config)
+        expect(config).toEqual({
+            client: {
+                auth: {
+                    privateKey: '0x111'
+                },
+                network: {
+                    trackers: [{
+                        id: 'tracker1-id',
+                        http: 'tracker1-http'
+                    }, {
+                        id: 'tracker2-id',
+                        http: 'tracker2-http'
+                    }],
+                    trackerPingInterval: -0.5
+                },
+                orderMessages: true,
+                gapFill: false
+            },
+            authentication: {
+                keys: ['key-1', 'key-2']
+            },
+            plugins: {
+                brubeckMiner: {
+                    beneficiaryAddress: '0x222',
+                    stunServerHost: null
+                },
+                info: {}
+            }
+        })
+    })
+
+    it('malformed variable', () => {
+        expect(() => {
+            process.env.STREAMR__BROKER__AUTHENTICATION__KEYS1 = 'key-1'
+            overrideConfigToEnvVarsIfGiven({} as any)
+        }).toThrow('STREAMR__BROKER__AUTHENTICATION__KEYS1')
     })
 })


### PR DESCRIPTION
**BREAKING CHANGE!**

Changed the syntax of the environment variables. Now any configuration option can be defined by using an environment variable.

The new syntax is like this:
```
STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = '0x111'
STREAMR__BROKER__CLIENT__GAP_FILL = 'false'
STREAMR__BROKER__CLIENT__NETWORK__TRACKERS_1__ID = 'tracker1-id'
STREAMR__BROKER__CLIENT__NETWORK__TRACKER_PING_INTERVAL = '123'
STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'key-1'
STREAMR__BROKER__PLUGINS__BRUBECK_MINER__BENEFICIARY_ADDRESS = '0x222'
```

We support strings, numbers, booleans and `null` as the values of the environment variables.

### Removed functionality

Before this PR we supported only two variables: private key and beneficiary address. This syntax is no longer supported:
```
OVERRIDE_BROKER_PRIVATE_KEY = '0x111'
OVERRIDE_BROKER_BENEFICIARY_ADDRESS = '0x222'
```