### PR TITLE
fix(utils): Duplicate invocations in `scheduleAtFixedRate`

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix scheduler algorithm: it produced partial metrics samples on rare occasions
+
 ### Security
 
 

--- a/packages/utils/src/scheduleAtFixedRate.ts
+++ b/packages/utils/src/scheduleAtFixedRate.ts
@@ -12,13 +12,19 @@ export const scheduleAtFixedRate = (
     interval: number,
     abortSignal: AbortSignal
 ): void  => {
+    const initTime = Date.now()
+    let invocationTime = initTime - (initTime % interval)
     repeatScheduleTask((doneCb) => {
         const now = Date.now()
-        const next = now - (now % interval) + interval
-        setAbortableTimeout(async () => {
-            await task(next)
+        invocationTime += interval
+        if (now < invocationTime) {
+            setAbortableTimeout(async () => {
+                await task(invocationTime)
+                doneCb()
+            }, (invocationTime - now), abortSignal)
+        } else {
             doneCb()
-        }, (next - now), abortSignal)
+        }
     }, abortSignal)
 }
 


### PR DESCRIPTION
Bug fix to `scheduleAtFixedRate`.

### Previous functionality

It seems that before this fix the scheduler invoked the callback twice in some rare situations. We were not able to reproduce that in our environments.  Instead we have observed a bug that some Broker nodes published metrics samples twice for some periods.  

The first of those duplicated samples was corrupted: it did not contain any `RateMetric` fields. In `RateMetric` the values are `undefined` if the start and stop times are the same. The reason for the identical timestamp is most likely that the callback in `MetricsContext#createReportProducer` the callback of `scheduleAtFixedRate` was sometimes called twice for the same `now` value.

The previous implementation assumed that when we:
- run a task at `T0`, which takes `s1` milliseconds
- and then we wait for (`interval` - `s1` milliseconds)
- then there is at least an `interval` milliseconds delay between `T0` and `T1`

That the assumption is not always valid, see e.g. https://github.com/streamr-dev/network/blob/main/packages/utils/test/wait.test.ts#L12

### New functionality

The new implementation ensures that we don't invocate a task multiple times for any `now` value. There is now an explicit variable which stores the timestamp of current invocation. We increment that value explicitly instead of calculating the new value from the current `now` value.