### PR TITLE
ci: update to Node 18.14

### DIFF
--- a/Dockerfile.broker
+++ b/Dockerfile.broker
@@ -1,8 +1,5 @@
 FROM node:18-bullseye as build
 WORKDIR /usr/src/network
-RUN npm config set \
-	unsafe-perm=true \
-	python="$(which python3)"
 COPY . .
 RUN --mount=type=cache,target=/root/.npm \
 	npm run bootstrap-pkg --package=streamr-client && \

--- a/Dockerfile.tracker
+++ b/Dockerfile.tracker
@@ -1,8 +1,5 @@
 FROM node:18-bullseye as build
 WORKDIR /usr/src/network
-RUN npm config set \
-	unsafe-perm=true \
-	python="$(which python3)"
 COPY . .
 RUN --mount=type=cache,target=/root/.npm \
 	npm run bootstrap-pkg --package=@streamr/network-tracker && \


### PR DESCRIPTION
Remove `Dockerfile` definitions which set obsolete `npm config` options. These are no longer supported in Node. 18.14. A new version of `node:18-bullseye` was released yesterday, and that broke the Docker builds.

Building Broker/Tracker Docker image failed with error:
```
RUN npm config set unsafe-perm=true python="$(which python3)":                                                                                                                                                    
npm ERR! `unsafe-perm` is not a valid npm option
```

Neither of those config options is no longer supported.

https://github.com/nodejs/docker-node/commit/f996e97a2e6d2aae2de3b869e083a253733f07a8
https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.14.0
- `npm config set will no longer accept deprecated or invalid config options.`