### PR TITLE
feat(broker): Minimal config

### DIFF
--- a/packages/broker/src/Plugin.ts
+++ b/packages/broker/src/Plugin.ts
@@ -1,4 +1,4 @@
-import { Config } from './config/config'
+import { StrictConfig } from './config/config'
 import express from 'express'
 import { validateConfig } from './config/validateConfig'
 import { Schema } from 'ajv'
@@ -9,7 +9,7 @@ export interface PluginOptions {
     name: string
     streamrClient: StreamrClient
     apiAuthenticator: ApiAuthenticator
-    brokerConfig: Config
+    brokerConfig: StrictConfig
 }
 
 export abstract class Plugin<T> {
@@ -17,7 +17,7 @@ export abstract class Plugin<T> {
     readonly name: string
     readonly streamrClient: StreamrClient
     readonly apiAuthenticator: ApiAuthenticator
-    readonly brokerConfig: Config
+    readonly brokerConfig: StrictConfig
     readonly pluginConfig: T
     private readonly httpServerRouters: express.Router[] = []
 

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -20,8 +20,8 @@ export interface Broker {
     stop: () => Promise<unknown>
 }
 
-export const createBroker = async (config: Config): Promise<Broker> => {
-    validateConfig(config, BROKER_CONFIG_SCHEMA)
+export const createBroker = async (configWithoutDefaults: Config): Promise<Broker> => {
+    const config = validateConfig(configWithoutDefaults, BROKER_CONFIG_SCHEMA)
     validateClientConfig(config.client)
 
     const streamrClient = new StreamrClient(config.client)

--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -54,7 +54,7 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
             await Promise.all(plugins.map((plugin) => plugin.start()))
             const httpServerRoutes = plugins.flatMap((plugin) => plugin.getHttpServerRoutes())
             if (httpServerRoutes.length > 0) {
-                httpServer = await startHttpServer(httpServerRoutes, config.httpServer!, apiAuthenticator)
+                httpServer = await startHttpServer(httpServerRoutes, config.httpServer, apiAuthenticator)
             }
 
             const nodeId = (await streamrClient.getNode()).getNodeId()

--- a/packages/broker/src/config/config.schema.json
+++ b/packages/broker/src/config/config.schema.json
@@ -3,10 +3,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Broker configuration format",
     "type": "object",
-    "required": [
-        "client",
-        "plugins"
-    ],
     "additionalProperties": false,
     "properties": {
         "$schema": {
@@ -41,12 +37,13 @@
                     ]
                 }
             },
-            "required": ["auth"]
+            "default": {}
         },
         "plugins": {
             "type": "object",
             "description": "Plugin configurations",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "default": {}
         },
         "httpServer": {
             "type": [

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -73,7 +73,9 @@ export function overrideConfigToEnvVarsIfGiven(config: Config): void {
             })
             const key = parts.join('.')
             const value = parseValue(process.env[variableName]!)
-            set(config, key, value)
+            if (value !== '') {
+                set(config, key, value)
+            }
         }
     })
 }

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -23,6 +23,7 @@ export interface Config {
 export type StrictConfig = Config & {
     client: Exclude<Config['client'], undefined>
     plugins: Exclude<Config['plugins'], undefined>
+    httpServer: Exclude<Config['httpServer'], undefined>
 }
 
 export interface ConfigFile extends Config {

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -4,7 +4,7 @@ import * as os from 'os'
 import { camelCase, set } from 'lodash'
 
 export interface Config {
-    client: StreamrClientConfig
+    client?: StreamrClientConfig
     httpServer?: {
         port: number
         sslCertificate?: {
@@ -15,7 +15,14 @@ export interface Config {
     apiAuthentication?: {
         keys: string[]
     }
-    plugins: Record<string, any>
+    plugins?: Record<string, any>
+}
+
+// StrictConfig is a config object to which some default values have been applied
+// (see `default` definitions in config.schema.json)
+export type StrictConfig = Config & {
+    client: Exclude<Config['client'], undefined>
+    plugins: Exclude<Config['plugins'], undefined>
 }
 
 export interface ConfigFile extends Config {

--- a/packages/broker/src/config/validateConfig.ts
+++ b/packages/broker/src/config/validateConfig.ts
@@ -1,7 +1,8 @@
 import Ajv, { Schema, ErrorObject } from 'ajv'
 import addFormats from 'ajv-formats'
+import { StrictConfig } from './config'
 
-export const validateConfig = (data: unknown, schema: Schema, contextName?: string, useDefaults = true): void | never => {
+export const validateConfig = (data: unknown, schema: Schema, contextName?: string, useDefaults = true): StrictConfig => {
     const ajv = new Ajv({
         useDefaults
     })
@@ -16,6 +17,7 @@ export const validateConfig = (data: unknown, schema: Schema, contextName?: stri
             return text
         }).join('\n'))
     }
+    return data as StrictConfig
 }
 
 export const isValidConfig = (data: unknown, schema: Schema): boolean => {

--- a/packages/broker/src/httpServer.ts
+++ b/packages/broker/src/httpServer.ts
@@ -5,7 +5,7 @@ import cors from 'cors'
 import express, { Request, Response } from 'express'
 import { Logger } from '@streamr/utils'
 import { once } from 'events'
-import { Config } from './config/config'
+import { StrictConfig } from './config/config'
 import { ApiAuthenticator } from './apiAuthenticator'
 
 const logger = new Logger(module)
@@ -36,7 +36,7 @@ const createAuthenticatorMiddleware = (apiAuthenticator: ApiAuthenticator) => {
 
 export const startServer = async (
     routers: express.Router[],
-    config: NonNullable<Config['httpServer']>,
+    config: StrictConfig['httpServer'],
     apiAuthenticator: ApiAuthenticator
 ): Promise<HttpServer | https.Server> => {
     const app = express()

--- a/packages/broker/test/integration/config.test.ts
+++ b/packages/broker/test/integration/config.test.ts
@@ -6,6 +6,12 @@ const PATH = './configs'
 
 describe('Config', () => {
 
+    it('start with minimal config', async () => {
+        const broker = await createBroker({})
+        await broker.start()
+        await broker.stop()
+    })
+
     const fileNames = fs.readdirSync(PATH)
 
     describe.each(fileNames.map((fileName) => [fileName]))('validate', (fileName: string) => {

--- a/packages/broker/test/unit/config.test.ts
+++ b/packages/broker/test/unit/config.test.ts
@@ -1,6 +1,16 @@
 import { overrideConfigToEnvVarsIfGiven } from '../../src/config/config'
 
 describe('overrideConfigToEnvVarsIfGiven', () => {
+
+    beforeEach(() => {
+        const PREFIX = 'STREAMR__BROKER__'
+        Object.keys(process.env).forEach((variableName: string) => {
+            if (variableName.startsWith(PREFIX)) {
+                delete process.env[variableName]
+            }
+        })
+    })
+
     it('happy path', () => {
         const config = {
             client: {
@@ -52,6 +62,20 @@ describe('overrideConfigToEnvVarsIfGiven', () => {
                     stunServerHost: null
                 },
                 info: {}
+            }
+        })
+    })
+
+    it('empty variable', () => {
+        process.env.STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = ''
+        process.env.STREAMR__BROKER__PLUGINS__BRUBECK_MINER__BENEFICIARY_ADDRESS = '0x222'
+        const config = {} as any
+        overrideConfigToEnvVarsIfGiven(config)
+        expect(config).toEqual({
+            plugins: {
+                brubeckMiner: {
+                    beneficiaryAddress: '0x222'
+                }
             }
         })
     })


### PR DESCRIPTION
All Broker config options are now optional. Previously a config file required that there were at least `client` and `plugins` sections. 

The client section was previously required mainly because Broker needed a private key (from `client.auth.privateKey`). We have since enhanced the authentication support, and support e.g. clients without authentication. In that case client autogenerates a private key for the node. In this PR there are no changes for that functionality.

Plugin section was required mainly because a Broker without plugins is more or less useless. We could have keep it is as required, but maybe optionality is fine too.

## Other changes

Empty environment variables will no longer set any config options
- Therefore if we use empty config file and set e.g. `process.env.STREAMR__BROKER__CLIENT__AUTH__PRIVATE_KEY = '' `, Broker will use autogenerated private key (as client generates the private key if it is not set in the config object). Before this PR that kind of environment variable would set the private key to empty string, which would not yield to the functionality which we want. (Of course usually it is possible to just not to set an environment variable if we don't need a value for that.)

Created a new helper type `StrictConfig` and updated also `httpServer` functionality to use that

## Future improvements

Now a minimal config file for Broker is just empty JSON: `{}`. It could make sense that the whole config file would be optional argument when we start a Broker instance.

