### PR TITLE
feat(client): Key request timeout for v5

### DIFF
--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -56,6 +56,7 @@ export type StrictStreamrClientOptions = {
     publisherStoreKeyHistory: boolean
     publishAutoDisconnectDelay: number,
     groupKeys: Todo
+    keyRequestTimeout?: number
     keyExchange: Todo
 
     binanceRPC: ConnectionInfo & { chainId?: number }
@@ -136,6 +137,7 @@ export const STREAM_CLIENT_DEFAULTS: StrictStreamrClientOptions = {
     verifySignatures: 'auto',
     publisherStoreKeyHistory: true,
     groupKeys: {}, // {streamId: groupKey}
+    keyRequestTimeout: 30 * 1000,
     keyExchange: {},
 
     // Ethereum and Data Union related options

--- a/packages/client/src/stream/encryption/KeyExchangeUtils.ts
+++ b/packages/client/src/stream/encryption/KeyExchangeUtils.ts
@@ -71,4 +71,5 @@ export async function subscribeToKeyExchangeStream(client: StreamrClient, onKeyE
 
 export type KeyExchangeOptions = {
     groupKeys?: Record<string, GroupKeysSerialized>
+    keyRequestTimeout?: number
 }

--- a/packages/client/src/subscribe/Decrypt.js
+++ b/packages/client/src/subscribe/Decrypt.js
@@ -22,7 +22,8 @@ export default function Decrypt(client, options = {}) {
         groupKeys: {
             ...client.options.groupKeys,
             ...options.groupKeys,
-        }
+        },
+        keyRequestTimeout: options.keyRequestTimeout ?? client.options.keyRequestTimeout
     })
 
     async function* decrypt(src, onError = async () => {}) {


### PR DESCRIPTION
If client can't fetch a group key from a publisher, it timeouts with an error. Before this PR the request didn't have timeout and therefore it could freeze the whole subscribe/resend process.

The default timeout is 30s, and can be configured with `keyRequestTimeout` configuration option.