### PR TITLE
feat(Broker): Application layer ping support

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Application layer ping support in `websocket` plugin
+
 ### Changed
 
 - Changed the syntax of environment variables which are used to override configuration files (see [configuration.md](configuration.md))

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -143,6 +143,12 @@ const socket = new WebSocket(`wss://...`)
 
 **Note**: self-signed certificates don't work well in browser environments (the connection may not open at all). In Node environment self-signed certificates can be trusted by setting the an environment variable `NODE_TLS_REJECT_UNAUTHORIZED=0`. If possible, please obtain an authorized certificate, e.g. from [Let's Encrypt](https://letsencrypt.org).
 
+#### Ping messages
+
+Websocket server supports standard protocol level ping and pong messages. To detect broken connections, you can use e.g. [this pattern](https://github.com/websockets/ws#how-to-detect-and-close-broken-connections).
+
+In browser environment clients are not able to send pings, as there is no `ping()` method in the standard websocket API. Therefore the websocket plugin supports also application level ping-pong: if a client sends a message which has payload of `"ping"`, server responds to it with a message which has payload of `"pong"`.
+
 ## MQTT
 
 You can publish and subscribe to a stream using [MQTT](https://mqtt.org), making the Broker appear like a traditional MQTT broker towards connected applications and devices. To enable the MQTT plugin, define an `mqtt` object in the `plugins` section of the Broker configuration file:

--- a/packages/broker/src/plugins/websocket/Connection.ts
+++ b/packages/broker/src/plugins/websocket/Connection.ts
@@ -2,6 +2,20 @@ import WebSocket from 'ws'
 import { StreamrClient } from 'streamr-client'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
 
+export const PING_PAYLOAD = 'ping'
+const PONG_PAYLOAD = 'pong'
+
 export interface Connection {
     init: (ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) => void
+}
+
+// Implements application layer ping support. We have this feature because 
+// browsers can't send pings in protocol level
+export const addPingListener = (ws: WebSocket): void => {
+    ws.on('message', (data: WebSocket.RawData) => {
+        const payload = data.toString()
+        if (payload === PING_PAYLOAD) {
+            ws.send(PONG_PAYLOAD)
+        }
+    })
 }

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -4,7 +4,7 @@ import { Logger } from '@streamr/utils'
 import { ParsedQs } from 'qs'
 import { v4 as uuid } from 'uuid'
 import { parsePositiveInteger, parseQueryParameter } from '../../helpers/parser'
-import { Connection } from './Connection'
+import { Connection, PING_PAYLOAD } from './Connection'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
 
 const logger = new Logger(module)
@@ -31,19 +31,21 @@ export class PublishConnection implements Connection {
         const msgChainId = uuid()
         ws.on('message', async (data: WebSocket.RawData) => {
             const payload = data.toString()
-            try {
-                const { content, metadata } = payloadFormat.createMessage(payload)
-                const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
-                await streamrClient.publish({
-                    id: this.streamId,
-                    partition: this.partition
-                }, content, {
-                    timestamp: metadata.timestamp,
-                    partitionKey,
-                    msgChainId
-                })
-            } catch (err: any) {
-                logger.warn('Unable to publish, reason: %s', err)
+            if (payload !== PING_PAYLOAD) {
+                try {
+                    const { content, metadata } = payloadFormat.createMessage(payload)
+                    const partitionKey = this.partitionKey ?? (this.partitionKeyField ? (content[this.partitionKeyField] as string) : undefined)
+                    await streamrClient.publish({
+                        id: this.streamId,
+                        partition: this.partition
+                    }, content, {
+                        timestamp: metadata.timestamp,
+                        partitionKey,
+                        msgChainId
+                    })
+                } catch (err: any) {
+                    logger.warn('Unable to publish, reason: %s', err)
+                }
             }
         })
     }

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -38,7 +38,6 @@ export class WebsocketServer {
     private wss?: WebSocket.Server
     private httpServer?: http.Server | https.Server
     private streamrClient: StreamrClient
-    private abortController: AbortController = new AbortController()
 
     constructor(streamrClient: StreamrClient) {
         this.streamrClient = streamrClient
@@ -117,7 +116,6 @@ export class WebsocketServer {
     }
 
     async stop(): Promise<void> {
-        this.abortController.abort()
         await util.promisify((cb: any) => this.wss!.close(cb))()
         for (const ws of this.wss!.clients) {
             ws.terminate()

--- a/packages/broker/test/integration/plugins/websocket/ping.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/ping.test.ts
@@ -1,0 +1,64 @@
+import { Queue } from '@streamr/test-utils'
+import { waitForEvent } from '@streamr/utils'
+import StreamrClient from 'streamr-client'
+import WebSocket from 'ws'
+import { createApiAuthenticator } from '../../../../src/apiAuthenticator'
+import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
+
+const WEBSOCKET_PORT = 12404
+const STREAM_ID = 'stream'
+
+describe('ping', () => {
+
+    describe('when client sends ping, server responds with pong', () => {
+
+        let server: WebsocketServer
+        let client: WebSocket
+        let streamrClient: StreamrClient
+        
+        beforeAll(async () => {
+            streamrClient = {
+                publish: jest.fn()
+            } as any
+            server = new WebsocketServer(streamrClient)
+            await server.start(WEBSOCKET_PORT, undefined as any, createApiAuthenticator({} as any))
+        })
+    
+        afterAll(async () => {
+            await server.stop()
+        })
+
+        beforeEach(async () => {
+            client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
+            await waitForEvent(client, 'open')
+        })
+
+        afterEach(() => {
+            client.close()
+        })
+
+        it('protocol layer', async () => {
+            const PAYLOAD = 'mock-payload'
+            const payloads = new Queue<string>()
+            client.on('pong', (payload: Buffer) => {
+                payloads.push(payload.toString())
+            })
+            client.ping(PAYLOAD)
+            const pongMessage = await payloads.pop()
+            expect(pongMessage).toBe(PAYLOAD)
+            expect(streamrClient.publish).not.toBeCalled()
+        })
+
+        it('application layer', async () => {
+            const messages = new Queue<string>()
+            client.on('message', (data: WebSocket.RawData) => {
+                const payload = data.toString()
+                messages.push(payload)
+            })
+            client.send('ping')
+            const pongMessage = await messages.pop()
+            expect(pongMessage).toBe('pong')
+            expect(streamrClient.publish).not.toBeCalled()
+        })
+    })
+})


### PR DESCRIPTION
Add application layer ping support to Broker `websocket` plugin. 

If a websocket client sends a message, which has payload `"ping"`, the server sends a message which contains `"pong"` as the payload. 

Browser websocket clients don't support protocol level pings (there is no `client.ping()` method). With this feature browser clients can analyse connection aliveness and e.g. try re-connect to the server when client doesn't get response for a ping message. 