### PR TITLE
fix(broker): Do not wait for server close event

### DIFF
--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -2,7 +2,6 @@ import http from 'http'
 import https from 'https'
 import fs from 'fs'
 import WebSocket from 'ws'
-import util from 'util'
 import { once } from 'events'
 import { Socket } from 'net'
 import qs, { ParsedQs } from 'qs'
@@ -115,7 +114,7 @@ export class WebsocketServer {
     }
 
     async stop(): Promise<void> {
-        await util.promisify((cb: any) => this.wss!.close(cb))()
+        this.wss!.close()
         for (const ws of this.wss!.clients) {
             ws.terminate()
         }

--- a/packages/broker/test/integration/plugins/websocket/close.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/close.test.ts
@@ -1,0 +1,31 @@
+import { wait, waitForEvent } from '@streamr/utils'
+import WebSocket from 'ws'
+import { createApiAuthenticator } from '../../../../src/apiAuthenticator'
+import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
+import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
+
+const WEBSOCKET_PORT = 12405
+const STREAM_ID = 'stream'
+
+describe('close', () => {
+    it('connection is closed when server stops', async () => {
+        const server = new WebsocketServer(undefined as any)
+        await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
+        const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
+        await waitForEvent(client, 'open')
+        const onClose = jest.fn()
+        client.on('close', onClose)
+        server.stop()
+        await wait(100)
+        expect(onClose).toBeCalled()
+    })
+
+    it('paused client doesn\'t prevent server stop', async () => {
+        const server = new WebsocketServer(undefined as any)
+        await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
+        const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
+        await waitForEvent(client, 'open')
+        client.pause()
+        await server.stop()
+    })
+})


### PR DESCRIPTION
Before this PR if a connected client didn't respond to server-initiated close, the server wasn't able to stop. It waited for callback from `this.wss.close()` . That callback is not called if the client doesn't respond to that action.

E.g. if a client is paused (`client.pause()`), it doesn't send any response to `this.wss.close()` and therefore we can't wait for such clients to respond before stopping the server.

The issue is solved in this PR by ignoring the callback. The callback is redundant as we already explicitly terminate each connection by calling `ws.terminate()`.

