### PR TITLE
feat(broker): Websocket plugin sends pings

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Application layer ping support in `websocket` plugin
+- Ping features in `websocket` plugin:
+  - server sends pings and disconnects if client doesn't respond with pong
+  - application layer ping support
 
 ### Changed
 

--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -145,9 +145,12 @@ const socket = new WebSocket(`wss://...`)
 
 #### Ping messages
 
-Websocket server supports standard protocol level ping and pong messages. To detect broken connections, you can use e.g. [this pattern](https://github.com/websockets/ws#how-to-detect-and-close-broken-connections).
+Websocket server supports standard protocol level ping and pong messages. If you want to detect broken connections at client side, you can use e.g. [this pattern](https://github.com/websockets/ws#how-to-detect-and-close-broken-connections).
 
 In browser environment clients are not able to send pings, as there is no `ping()` method in the standard websocket API. Therefore the websocket plugin supports also application level ping-pong: if a client sends a message which has payload of `"ping"`, server responds to it with a message which has payload of `"pong"`.
+
+The server side has a built-it detection of broken connections. It sends a ping message if a connection has been idle for a while. All standard websocket clients respond automatically to the ping by sending a pong message. If the server doesn't receive a pong message (or other traffic) within 15 seconds, it closes the connection. 
+- See also  `pingSendInterval` and `disconnectTimeout` config options
 
 ## MQTT
 

--- a/packages/broker/src/plugins/websocket/Connection.ts
+++ b/packages/broker/src/plugins/websocket/Connection.ts
@@ -1,6 +1,9 @@
 import WebSocket from 'ws'
 import { StreamrClient } from 'streamr-client'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
+import { Logger } from '@streamr/utils'
+
+const logger = new Logger(module)
 
 export const PING_PAYLOAD = 'ping'
 const PONG_PAYLOAD = 'pong'
@@ -34,6 +37,7 @@ export const addPingSender = (ws: WebSocket, sendInterval: number, disconnectTim
                 pendingStateChange = setTimeout(() => setState('disconnected'), disconnectTimeout)
             }
         } else if (state === 'disconnected') {
+            logger.debug('Terminate connection  ')
             ws.terminate()
         }
     }

--- a/packages/broker/src/plugins/websocket/Connection.ts
+++ b/packages/broker/src/plugins/websocket/Connection.ts
@@ -2,6 +2,35 @@ import WebSocket from 'ws'
 import { StreamrClient } from 'streamr-client'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
 
+export const PING_PAYLOAD = 'ping'
+
 export interface Connection {
     init: (ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) => void
+}
+
+export const addPingSender = (ws: WebSocket, sendInterval: number, disconnectTimeout: number): void => {
+    let pendingStateChange: NodeJS.Timeout
+    type State = 'active' | 'idle' | 'disconnected'
+
+    const setState = (state: State) => {
+        clearTimeout(pendingStateChange)
+        if (state === 'active') {
+            pendingStateChange = setTimeout(() => setState('idle'), sendInterval)
+        } else if (state === 'idle') {
+            ws.ping()
+            if (disconnectTimeout !== 0) {
+                pendingStateChange = setTimeout(() => setState('disconnected'), disconnectTimeout)
+            }
+        } else if (state === 'disconnected') {
+            ws.terminate()
+        }
+    }
+    
+    const events = ['message', 'ping', 'pong']
+    events.forEach((eventName) => {
+        ws.on(eventName, () => setState('active'))
+    })
+    ws.on('close', () => clearTimeout(pendingStateChange))
+    
+    setState('idle')
 }

--- a/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketPlugin.ts
@@ -7,6 +7,8 @@ import { Schema } from 'ajv'
 export interface WebsocketPluginConfig {
     port: number
     payloadMetadata: boolean
+    pingSendInterval: number
+    disconnectTimeout: number
     sslCertificate?: {
         privateKeyFileName: string
         certFileName: string
@@ -17,7 +19,7 @@ export class WebsocketPlugin extends Plugin<WebsocketPluginConfig> {
     private server?: WebsocketServer
 
     async start(): Promise<void> {
-        this.server = new WebsocketServer(this.streamrClient!)
+        this.server = new WebsocketServer(this.streamrClient!, this.pluginConfig.pingSendInterval, this.pluginConfig.disconnectTimeout)
         await this.server.start(
             this.pluginConfig.port, 
             getPayloadFormat(this.pluginConfig.payloadMetadata),

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -2,7 +2,6 @@ import http from 'http'
 import https from 'https'
 import fs from 'fs'
 import WebSocket from 'ws'
-import util from 'util'
 import { once } from 'events'
 import { Socket } from 'net'
 import qs, { ParsedQs } from 'qs'
@@ -115,7 +114,7 @@ export class WebsocketServer {
     }
 
     async stop(): Promise<void> {
-        await util.promisify((cb: any) => this.wss!.close(cb))()
+        this.wss!.close()
         for (const ws of this.wss!.clients) {
             ws.terminate()
         }

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -7,7 +7,7 @@ import { Socket } from 'net'
 import qs, { ParsedQs } from 'qs'
 import StreamrClient from 'streamr-client'
 import { Logger } from '@streamr/utils'
-import { Connection } from './Connection'
+import { addPingSender, Connection } from './Connection'
 import { ApiAuthenticator } from '../../apiAuthenticator'
 import { PublishConnection } from './PublishConnection'
 import { SubscribeConnection } from './SubscribeConnection'
@@ -37,9 +37,13 @@ export class WebsocketServer {
     private wss?: WebSocket.Server
     private httpServer?: http.Server | https.Server
     private streamrClient: StreamrClient
+    private pingSendInterval: number
+    private disconnectTimeout: number
 
-    constructor(streamrClient: StreamrClient) {
+    constructor(streamrClient: StreamrClient, pingSendInterval: number, disconnectTimeout: number) {
         this.streamrClient = streamrClient
+        this.pingSendInterval = pingSendInterval
+        this.disconnectTimeout = disconnectTimeout
     }
 
     async start(
@@ -79,6 +83,9 @@ export class WebsocketServer {
 
         this.wss.on('connection', (ws: WebSocket, _request: http.IncomingMessage, connection: Connection) => {
             connection.init(ws, this.streamrClient, payloadFormat)
+            if (this.pingSendInterval !== 0) {
+                addPingSender(ws, this.pingSendInterval, this.disconnectTimeout)
+            }
         })
 
         this.httpServer.listen(port)

--- a/packages/broker/src/plugins/websocket/config.schema.json
+++ b/packages/broker/src/plugins/websocket/config.schema.json
@@ -15,6 +15,16 @@
             "description": "The format of payloads: payload is wrapped as { content, metadata } or is a plain content JSON",
             "default": false
         },
+        "pingSendInterval": {
+            "type": "integer",
+            "description": "Interval (in milliseconds) in which to pings are sent to clients if there is no other trafic in the connection (0 = disable)",
+            "default": 15000
+        },
+        "disconnectTimeout": {
+            "type": "integer",
+            "description": "Timeout (in milliseconds) after a connection is closed if there is no trafic after ping is sent (0 = disable)",
+            "default": 15000
+        },
         "sslCertificate": {
             "description": "Files to use for SSL",
             "type": "object",

--- a/packages/broker/test/integration/plugins/websocket/close.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/close.test.ts
@@ -1,0 +1,31 @@
+import { wait, waitForEvent } from '@streamr/utils'
+import WebSocket from 'ws'
+import { createApiAuthenticator } from '../../../../src/apiAuthenticator'
+import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
+import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
+
+const WEBSOCKET_PORT = 12405
+const STREAM_ID = 'stream'
+
+describe('close', () => {
+    it('connection is closed when server stops', async () => {
+        const server = new WebsocketServer(undefined as any)
+        await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
+        const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
+        await waitForEvent(client, 'open')
+        const onClose = jest.fn()
+        client.on('close', onClose)
+        server.stop()
+        await wait(100)
+        expect(onClose).toBeCalled()
+    })
+
+    it('paused client doesn\'t prevent server stop', async () => {
+        const server = new WebsocketServer(undefined as any)
+        await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
+        const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
+        await waitForEvent(client, 'open')
+        client.pause()
+        await server.stop()
+    })
+})

--- a/packages/broker/test/integration/plugins/websocket/close.test.ts
+++ b/packages/broker/test/integration/plugins/websocket/close.test.ts
@@ -9,7 +9,7 @@ const STREAM_ID = 'stream'
 
 describe('close', () => {
     it('connection is closed when server stops', async () => {
-        const server = new WebsocketServer(undefined as any)
+        const server = new WebsocketServer(undefined as any, 0, 0)
         await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
         const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
         await waitForEvent(client, 'open')
@@ -21,7 +21,7 @@ describe('close', () => {
     })
 
     it('paused client doesn\'t prevent server stop', async () => {
-        const server = new WebsocketServer(undefined as any)
+        const server = new WebsocketServer(undefined as any, 0, 0)
         await server.start(WEBSOCKET_PORT, new PlainPayloadFormat(), createApiAuthenticator({} as any))
         const client = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}/streams/${encodeURIComponent(STREAM_ID)}/publish`)
         await waitForEvent(client, 'open')

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -38,7 +38,7 @@ describe('WebsocketServer', () => {
             publish: jest.fn().mockResolvedValue(undefined),
             subscribe: jest.fn().mockResolvedValue(undefined),
         } as Partial<StreamrClient>
-        wsServer = new WebsocketServer(streamrClient as StreamrClient)
+        wsServer = new WebsocketServer(streamrClient as StreamrClient, 0, 0)
         await wsServer.start(PORT, new PlainPayloadFormat(), {
             isValidAuthentication: (apiKey?: string) => (apiKey === REQUIRED_API_KEY)
         })


### PR DESCRIPTION
Whenever there is no traffic (normal messages or ping/pong control messages) in `pingSendInterval` milliseconds, client send protocol level ping message to the connected client. Then client should respond with a pong. If there is no traffic (e.g. that pong) is received, client disconnects the client after `disconnectTimeout` milliseconds.