### PR TITLE
fix(network): proxy server no longer propagates messages before sending handshake response

### DIFF
--- a/packages/network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -53,6 +53,7 @@ export class ProxyStreamConnectionServer {
     private async processHandshakeRequest(message: ProxyConnectionRequest, nodeId: NodeId): Promise<void> {
         const streamPartId = message.getStreamPartID()
         const isAccepted = this.acceptProxyConnections && this.streamPartManager.isSetUp(streamPartId)
+        await this.nodeToNode.respondToProxyConnectionRequest(nodeId, streamPartId, message.direction, isAccepted)
         if (isAccepted) {
             this.addConnection(streamPartId, nodeId, message.direction, message.userId)
             if (message.direction === ProxyDirection.PUBLISH) {
@@ -62,7 +63,6 @@ export class ProxyStreamConnectionServer {
                 this.propagation.onNeighborJoined(nodeId, streamPartId)
             }
         }
-        await this.nodeToNode.respondToProxyConnectionRequest(nodeId, streamPartId, message.direction, isAccepted)
     }
 
     private addConnection(streamPartId: StreamPartID, nodeId: NodeId, direction: ProxyDirection, userId: string): void {


### PR DESCRIPTION
## Summary

Proxy Subscribers used to receive messages before receiving the handshake response from the proxy. This caused warning errors to be logged.

## Changes

- ProxyStreamConnectionServer now sends the handshake response before altering StreamManager state.

