### PR TITLE
style: add eslint rule `default-case`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,7 @@ module.exports = {
         'prefer-arrow-callback': ['error'],
         'promise/no-promise-in-callback': ['error'],
         //'@typescript-eslint/no-empty-function': 'error',
-        'no-multi-spaces': ["error", { ignoreEOLComments: true }]
+        'no-multi-spaces': ["error", { ignoreEOLComments: true }],
+        'default-case': ['error']
     }
 }


### PR DESCRIPTION
All `switch` statements should have `default` case so that all possible inputs are handled: https://eslint.org/docs/latest/rules/default-case.