### PR TITLE
NET-846: remove preinstall protoc

### DIFF
--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -26,8 +26,7 @@
     "test-end-to-end": "jest test/end-to-end",
     "benchmark": "jest test/benchmark",
     "prepare-kademlia-simulation": "cd test/data && node --max-old-space-size=8096 -- ../../../../node_modules/.bin/ts-node -P ../../tsconfig.node.json generateGroundTruthData.ts",
-    "run-kademlia-simulation": "ts-node --project tsconfig.node.json $NODE_DEBUG_OPTION --files test/benchmark/kademlia-simulation/KademliaSimulation.ts",
-    "preinstall": "./proto.sh"
+    "run-kademlia-simulation": "ts-node --project tsconfig.node.json $NODE_DEBUG_OPTION --files test/benchmark/kademlia-simulation/KademliaSimulation.ts"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.8.2",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -22,8 +22,7 @@
     "test": "jest",
     "test-browser": "npm run build-browser && karma start karma.config.js",
     "test-unit": "jest test/unit",
-    "test-integration": "jest test/integration",
-    "preinstall": "./proto.sh"
+    "test-integration": "jest test/integration"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.8.2",


### PR DESCRIPTION
## Summary

No longer run proto.sh in preinstall as it causes the CI build to crash due to:
`npm ERR! @protobuf-ts/protoc failed unzip the downloaded protoc release v22.0: Error: ETXTBSY: text file is busy, open '/home/runner/work/network/network/node_modules/@protobuf-ts/protoc/installed/protoc-22.0-linux-x86_64/bin/protoc'`

