### PR TITLE
feat(network, client): webrtc port range and max message size configurability

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add optional config option `network.webrtcPortRange`
+- Add optional config option `network.webrtcMaxMessageSize`
+
 ### Changed
 
 ### Deprecated

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -10,7 +10,7 @@ import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'
 import { LogLevel } from '@streamr/utils'
 
-import { IceServer, Location } from '@streamr/network-node'
+import { IceServer, Location, WebRtcPortRange } from '@streamr/network-node'
 import type { ConnectionInfo } from '@ethersproject/web'
 import { generateClientId } from './utils/utils'
 
@@ -95,6 +95,8 @@ export interface StreamrClientConfig {
         newWebrtcConnectionTimeout?: number
         webrtcDatachannelBufferThresholdLow?: number
         webrtcDatachannelBufferThresholdHigh?: number
+        webrtcDatachannelMaxMessageSize?: number
+        webrtcPortRange?: WebRtcPortRange
         /**
          * The maximum amount of outgoing messages to be buffered on a single WebRTC connection.
          */
@@ -104,6 +106,7 @@ export interface StreamrClientConfig {
         rttUpdateTimeout?: number
         iceServers?: ReadonlyArray<IceServer>
         location?: Location
+
     }
 
     contracts?: {

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -106,7 +106,6 @@ export interface StreamrClientConfig {
         rttUpdateTimeout?: number
         iceServers?: ReadonlyArray<IceServer>
         location?: Location
-
     }
 
     contracts?: {

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -95,7 +95,7 @@ export interface StreamrClientConfig {
         newWebrtcConnectionTimeout?: number
         webrtcDatachannelBufferThresholdLow?: number
         webrtcDatachannelBufferThresholdHigh?: number
-        webrtcDatachannelMaxMessageSize?: number
+        webrtcMaxMessageSize?: number
         webrtcPortRange?: WebRtcPortRange
         /**
          * The maximum amount of outgoing messages to be buffered on a single WebRTC connection.

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -143,7 +143,7 @@
                     "type": "number",
                     "default": 500
                 },
-                "webrtcDatachannelMaxMessageSize": {
+                "webrtcMaxMessageSize": {
                     "type": "number",
                     "default": 1048576
                 },

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -151,14 +151,14 @@
                     "type": "object",
                     "additionalProperties": false,
                     "required": [
-                        "begin",
-                        "end"
+                        "min",
+                        "max"
                     ],
                     "properties": {
-                        "begin": {
+                        "min": {
                             "type": "number"
                         },
-                        "end": {
+                        "max": {
                             "type": "number"
                         }
                     }

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -143,6 +143,26 @@
                     "type": "number",
                     "default": 500
                 },
+                "webrtcDatachannelMaxMessageSize": {
+                    "type": "number",
+                    "default": 1048576
+                },
+                "webrtcPortRange": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "begin",
+                        "end"
+                    ],
+                    "properties": {
+                        "begin": {
+                            "type": "number"
+                        },
+                        "end": {
+                            "type": "number"
+                        }
+                    }
+                },
                 "disconnectionWaitTime": {
                     "type": "number",
                     "default": 200

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -161,6 +161,10 @@
                         "max": {
                             "type": "number"
                         }
+                    },
+                    "default": {
+                        "min": 6000,
+                        "max": 65535
                     }
                 },
                 "disconnectionWaitTime": {

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -119,8 +119,8 @@ export class NodeWebRtcConnection extends WebRtcConnection {
         this.connection = new nodeDataChannel.PeerConnection(this.selfId, {
             iceServers: this.iceServers.map(iceServerAsString),
             maxMessageSize: this.maxMessageSize,
-            portRangeBegin: this.portRange.begin,
-            portRangeEnd: this.portRange.end
+            portRangeBegin: this.portRange.min,
+            portRangeEnd: this.portRange.max
         })
 
         this.connectionEmitter = PeerConnectionEmitter(this.connection)

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -118,7 +118,9 @@ export class NodeWebRtcConnection extends WebRtcConnection {
     protected doConnect(): void {
         this.connection = new nodeDataChannel.PeerConnection(this.selfId, {
             iceServers: this.iceServers.map(iceServerAsString),
-            maxMessageSize: this.maxMessageSize
+            maxMessageSize: this.maxMessageSize,
+            portRangeBegin: this.portRangeBegin,
+            portRangeEnd: this.portRangeEnd
         })
 
         this.connectionEmitter = PeerConnectionEmitter(this.connection)

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -119,8 +119,8 @@ export class NodeWebRtcConnection extends WebRtcConnection {
         this.connection = new nodeDataChannel.PeerConnection(this.selfId, {
             iceServers: this.iceServers.map(iceServerAsString),
             maxMessageSize: this.maxMessageSize,
-            portRangeBegin: this.portRangeBegin,
-            portRangeEnd: this.portRangeEnd
+            portRangeBegin: this.portRange.begin,
+            portRangeEnd: this.portRange.end
         })
 
         this.connectionEmitter = PeerConnectionEmitter(this.connection)

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -21,15 +21,15 @@ export interface ConstructorOptions {
     routerId: string
     iceServers: ReadonlyArray<IceServer>
     pingInterval: number
-    bufferThresholdLow?: number
-    bufferThresholdHigh?: number
-    maxMessageSize?: number
-    newConnectionTimeout?: number
-    maxPingPongAttempts?: number
-    flushRetryTimeout?: number
     messageQueue: MessageQueue<string>
     deferredConnectionAttempt: DeferredConnectionAttempt
     portRange: WebRtcPortRange
+    maxMessageSize: number
+    bufferThresholdLow?: number
+    bufferThresholdHigh?: number
+    newConnectionTimeout?: number
+    maxPingPongAttempts?: number
+    flushRetryTimeout?: number
 }
 
 export interface WebRtcPortRange {
@@ -133,12 +133,12 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         deferredConnectionAttempt,
         pingInterval,
         portRange,
+        maxMessageSize,
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,
         maxPingPongAttempts = 5,
-        flushRetryTimeout = 500,
-        maxMessageSize = 1048576
+        flushRetryTimeout = 500
     }: ConstructorOptions) {
         super()
 

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -132,7 +132,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         messageQueue,
         deferredConnectionAttempt,
         pingInterval,
-        portRange = { min: 6000, max: 65535 },
+        portRange,
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -29,8 +29,12 @@ export interface ConstructorOptions {
     flushRetryTimeout?: number
     messageQueue: MessageQueue<string>
     deferredConnectionAttempt: DeferredConnectionAttempt
-    portRangeBegin?: number
-    portRangeEnd?: number
+    portRange: WebRtcPortRange
+}
+
+export interface WebRtcPortRange {
+    begin: number
+    end: number
 }
 
 let ID = 0
@@ -119,8 +123,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
     protected readonly iceServers: ReadonlyArray<IceServer>
     protected readonly bufferThresholdHigh: number
     protected readonly bufferThresholdLow: number
-    protected readonly portRangeBegin?: number
-    protected readonly portRangeEnd?: number
+    protected readonly portRange: WebRtcPortRange
 
     constructor({
         selfId,
@@ -129,8 +132,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         messageQueue,
         deferredConnectionAttempt,
         pingInterval,
-        portRangeBegin,
-        portRangeEnd,
+        portRange,
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,
@@ -154,8 +156,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         this.flushRetryTimeout = flushRetryTimeout
         this.messageQueue = messageQueue
         this.deferredConnectionAttempt = deferredConnectionAttempt
-        this.portRangeBegin = portRangeBegin
-        this.portRangeEnd = portRangeEnd
+        this.portRange = portRange
         this.baseLogger = new Logger(module, `${NameDirectory.getName(this.getPeerId())}/${ID}`)
         this.isFinished = false
         this.paused = false

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -132,7 +132,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         messageQueue,
         deferredConnectionAttempt,
         pingInterval,
-        portRange,
+        portRange = { begin: 6000, end: 65535 },
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -29,6 +29,8 @@ export interface ConstructorOptions {
     flushRetryTimeout?: number
     messageQueue: MessageQueue<string>
     deferredConnectionAttempt: DeferredConnectionAttempt
+    portRangeBegin?: number
+    portRangeEnd?: number
 }
 
 let ID = 0
@@ -117,6 +119,8 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
     protected readonly iceServers: ReadonlyArray<IceServer>
     protected readonly bufferThresholdHigh: number
     protected readonly bufferThresholdLow: number
+    protected readonly portRangeBegin?: number
+    protected readonly portRangeEnd?: number
 
     constructor({
         selfId,
@@ -125,12 +129,14 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         messageQueue,
         deferredConnectionAttempt,
         pingInterval,
+        portRangeBegin,
+        portRangeEnd,
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,
         maxPingPongAttempts = 5,
         flushRetryTimeout = 500,
-        maxMessageSize = 1048576,
+        maxMessageSize = 1048576
     }: ConstructorOptions) {
         super()
 
@@ -148,6 +154,8 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         this.flushRetryTimeout = flushRetryTimeout
         this.messageQueue = messageQueue
         this.deferredConnectionAttempt = deferredConnectionAttempt
+        this.portRangeBegin = portRangeBegin
+        this.portRangeEnd = portRangeEnd
         this.baseLogger = new Logger(module, `${NameDirectory.getName(this.getPeerId())}/${ID}`)
         this.isFinished = false
         this.paused = false

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -33,8 +33,8 @@ export interface ConstructorOptions {
 }
 
 export interface WebRtcPortRange {
-    begin: number
-    end: number
+    min: number
+    max: number
 }
 
 let ID = 0
@@ -132,7 +132,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         messageQueue,
         deferredConnectionAttempt,
         pingInterval,
-        portRange = { begin: 6000, end: 65535 },
+        portRange = { min: 6000, max: 65535 },
         bufferThresholdHigh = 2 ** 17,
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 15000,

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -3,7 +3,7 @@ import { Event, IWebRtcEndpoint } from './IWebRtcEndpoint'
 import { Logger } from "@streamr/utils"
 import { PeerId, PeerInfo } from '../PeerInfo'
 import { DeferredConnectionAttempt } from './DeferredConnectionAttempt'
-import { WebRtcConnection, ConstructorOptions, isOffering, IceServer } from './WebRtcConnection'
+import { WebRtcConnection, ConstructorOptions, isOffering, IceServer, WebRtcPortRange } from './WebRtcConnection'
 import { CountMetric, LevelMetric, Metric, MetricsContext, MetricsDefinition, RateMetric } from '@streamr/utils'
 import {
     AnswerOptions,
@@ -55,9 +55,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private readonly bufferThresholdHigh: number
     private readonly sendBufferMaxMessageCount: number
     private readonly disallowPrivateAddresses: boolean
-    private readonly maxMessageSize: number
-    private readonly portRangeBegin?: number
-    private readonly portRangeEnd?: number
+    private readonly maxMessageSize?: number
+    private readonly portRange: WebRtcPortRange
 
     private statusReportTimer?: NodeJS.Timeout
 
@@ -74,9 +73,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         webrtcDatachannelBufferThresholdHigh: number,
         webrtcSendBufferMaxMessageCount: number,
         webrtcDisallowPrivateAddresses: boolean,
+        portRange: WebRtcPortRange,
         maxMessageSize = 1048576,
-        portRangeBegin?: number,
-        portRangeEnd?: number
     ) {
         super()
         this.peerInfo = peerInfo
@@ -94,8 +92,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.sendBufferMaxMessageCount = webrtcSendBufferMaxMessageCount
         this.disallowPrivateAddresses = webrtcDisallowPrivateAddresses
         this.maxMessageSize = maxMessageSize
-        this.portRangeBegin = portRangeBegin
-        this.portRangeEnd = portRangeEnd
+        this.portRange = portRange
 
         this.connectionFactory.registerWebRtcEndpoint()
 
@@ -181,8 +178,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             deferredConnectionAttempt: deferredConnectionAttempt || new DeferredConnectionAttempt(),
             newConnectionTimeout: this.newConnectionTimeout,
             pingInterval: this.pingInterval,
-            portRangeBegin: this.portRangeBegin,
-            portRangeEnd: this.portRangeEnd
+            portRange: this.portRange
         }
 
         const connection = this.connectionFactory.createConnection(connectionOptions)

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -56,6 +56,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private readonly sendBufferMaxMessageCount: number
     private readonly disallowPrivateAddresses: boolean
     private readonly maxMessageSize: number
+    private readonly portRangeBegin?: number
+    private readonly portRangeEnd?: number
 
     private statusReportTimer?: NodeJS.Timeout
 
@@ -73,6 +75,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         webrtcSendBufferMaxMessageCount: number,
         webrtcDisallowPrivateAddresses: boolean,
         maxMessageSize = 1048576,
+        portRangeBegin?: number,
+        portRangeEnd?: number
     ) {
         super()
         this.peerInfo = peerInfo
@@ -90,6 +94,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         this.sendBufferMaxMessageCount = webrtcSendBufferMaxMessageCount
         this.disallowPrivateAddresses = webrtcDisallowPrivateAddresses
         this.maxMessageSize = maxMessageSize
+        this.portRangeBegin = portRangeBegin
+        this.portRangeEnd = portRangeEnd
 
         this.connectionFactory.registerWebRtcEndpoint()
 

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -55,7 +55,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
     private readonly bufferThresholdHigh: number
     private readonly sendBufferMaxMessageCount: number
     private readonly disallowPrivateAddresses: boolean
-    private readonly maxMessageSize?: number
+    private readonly maxMessageSize: number
     private readonly portRange: WebRtcPortRange
 
     private statusReportTimer?: NodeJS.Timeout
@@ -74,7 +74,7 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         webrtcSendBufferMaxMessageCount: number,
         webrtcDisallowPrivateAddresses: boolean,
         portRange: WebRtcPortRange,
-        maxMessageSize = 1048576,
+        maxMessageSize: number,
     ) {
         super()
         this.peerInfo = peerInfo
@@ -178,7 +178,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             deferredConnectionAttempt: deferredConnectionAttempt || new DeferredConnectionAttempt(),
             newConnectionTimeout: this.newConnectionTimeout,
             pingInterval: this.pingInterval,
-            portRange: this.portRange
+            portRange: this.portRange,
+            maxMessageSize: this.maxMessageSize
         }
 
         const connection = this.connectionFactory.createConnection(connectionOptions)

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -181,6 +181,8 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
             deferredConnectionAttempt: deferredConnectionAttempt || new DeferredConnectionAttempt(),
             newConnectionTimeout: this.newConnectionTimeout,
             pingInterval: this.pingInterval,
+            portRangeBegin: this.portRangeBegin,
+            portRangeEnd: this.portRangeEnd
         }
 
         const connection = this.connectionFactory.createConnection(connectionOptions)

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -42,8 +42,8 @@ export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsC
     acceptProxyConnections: false,
     trackerPingInterval: 60 * 1000,
     webrtcPortRange: {
-        begin: 6000,
-        end: 65535
+        min: 6000,
+        max: 65535
     },
     webrtcDatachannelMaxMessageSize: 1048576
 }

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -9,7 +9,7 @@ import NodeClientWsEndpoint from './connection/ws/NodeClientWsEndpoint'
 import { WebRtcEndpoint } from './connection/webrtc/WebRtcEndpoint'
 import { webRtcConnectionFactory } from './connection/webrtc/NodeWebRtcConnection'
 import { TrackerRegistryRecord } from '@streamr/protocol'
-import { IceServer } from './connection/webrtc/WebRtcConnection'
+import { IceServer, WebRtcPortRange } from './connection/webrtc/WebRtcConnection'
 
 export interface NetworkNodeOptions extends AbstractNodeOptions {
     trackers: TrackerRegistryRecord[]
@@ -24,9 +24,8 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     trackerConnectionMaintenanceInterval: number
     webrtcDisallowPrivateAddresses: boolean
     acceptProxyConnections: boolean
-    webrtcDatachannelMaxMessageSize?: number
-    webrtcDatachannelPortRangeBegin?: number
-    webrtcDatachannelPortRangeEnd?: number
+    webrtcDatachannelMaxMessageSize: number
+    webrtcPortRange: WebRtcPortRange
 }
 
 export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsContext'> = {
@@ -41,7 +40,12 @@ export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsC
     trackerConnectionMaintenanceInterval: 5 * 1000,
     webrtcDisallowPrivateAddresses: false,
     acceptProxyConnections: false,
-    trackerPingInterval: 60 * 1000
+    trackerPingInterval: 60 * 1000,
+    webrtcPortRange: {
+        begin: 6000,
+        end: 65535
+    },
+    webrtcDatachannelMaxMessageSize: 1048576
 }
 
 export const createNetworkNode = ({
@@ -61,9 +65,8 @@ export const createNetworkNode = ({
     trackerConnectionMaintenanceInterval,
     webrtcDisallowPrivateAddresses,
     acceptProxyConnections,
+    webrtcPortRange,
     webrtcDatachannelMaxMessageSize,
-    webrtcDatachannelPortRangeBegin,
-    webrtcDatachannelPortRangeEnd
 }: NetworkNodeOptions): NetworkNode => {
     const peerInfo = PeerInfo.newNode(id, undefined, undefined, location)
     const endpoint = new NodeClientWsEndpoint(peerInfo, trackerPingInterval)
@@ -84,9 +87,8 @@ export const createNetworkNode = ({
         webrtcDatachannelBufferThresholdHigh,
         webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses,
-        webrtcDatachannelMaxMessageSize,
-        webrtcDatachannelPortRangeBegin,
-        webrtcDatachannelPortRangeEnd
+        webrtcPortRange,
+        webrtcDatachannelMaxMessageSize
     ))
 
     return new NetworkNode({

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -24,6 +24,9 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     trackerConnectionMaintenanceInterval: number
     webrtcDisallowPrivateAddresses: boolean
     acceptProxyConnections: boolean
+    webrtcDatachannelMaxMessageSize?: number
+    webrtcDatachannelPortRangeBegin?: number
+    webrtcDatachannelPortRangeEnd?: number
 }
 
 export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsContext'> = {
@@ -57,7 +60,10 @@ export const createNetworkNode = ({
     iceServers,
     trackerConnectionMaintenanceInterval,
     webrtcDisallowPrivateAddresses,
-    acceptProxyConnections
+    acceptProxyConnections,
+    webrtcDatachannelMaxMessageSize,
+    webrtcDatachannelPortRangeBegin,
+    webrtcDatachannelPortRangeEnd
 }: NetworkNodeOptions): NetworkNode => {
     const peerInfo = PeerInfo.newNode(id, undefined, undefined, location)
     const endpoint = new NodeClientWsEndpoint(peerInfo, trackerPingInterval)
@@ -77,7 +83,10 @@ export const createNetworkNode = ({
         webrtcDatachannelBufferThresholdLow,
         webrtcDatachannelBufferThresholdHigh,
         webrtcSendBufferMaxMessageCount,
-        webrtcDisallowPrivateAddresses
+        webrtcDisallowPrivateAddresses,
+        webrtcDatachannelMaxMessageSize,
+        webrtcDatachannelPortRangeBegin,
+        webrtcDatachannelPortRangeEnd
     ))
 
     return new NetworkNode({

--- a/packages/network/src/createNetworkNode.ts
+++ b/packages/network/src/createNetworkNode.ts
@@ -24,7 +24,7 @@ export interface NetworkNodeOptions extends AbstractNodeOptions {
     trackerConnectionMaintenanceInterval: number
     webrtcDisallowPrivateAddresses: boolean
     acceptProxyConnections: boolean
-    webrtcDatachannelMaxMessageSize: number
+    webrtcMaxMessageSize: number
     webrtcPortRange: WebRtcPortRange
 }
 
@@ -45,7 +45,7 @@ export const TEST_CONFIG: Omit<NetworkNodeOptions, 'id' | 'trackers' | 'metricsC
         min: 6000,
         max: 65535
     },
-    webrtcDatachannelMaxMessageSize: 1048576
+    webrtcMaxMessageSize: 1048576
 }
 
 export const createNetworkNode = ({
@@ -66,7 +66,7 @@ export const createNetworkNode = ({
     webrtcDisallowPrivateAddresses,
     acceptProxyConnections,
     webrtcPortRange,
-    webrtcDatachannelMaxMessageSize,
+    webrtcMaxMessageSize,
 }: NetworkNodeOptions): NetworkNode => {
     const peerInfo = PeerInfo.newNode(id, undefined, undefined, location)
     const endpoint = new NodeClientWsEndpoint(peerInfo, trackerPingInterval)
@@ -88,7 +88,7 @@ export const createNetworkNode = ({
         webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses,
         webrtcPortRange,
-        webrtcDatachannelMaxMessageSize
+        webrtcMaxMessageSize
     ))
 
     return new NetworkNode({

--- a/packages/network/src/exports.ts
+++ b/packages/network/src/exports.ts
@@ -13,7 +13,7 @@ export {
     COUNTER_UNSUBSCRIBE,
     DEFAULT_MAX_NEIGHBOR_COUNT
 } from './constants'
-export { IceServer } from './connection/webrtc/WebRtcConnection'
+export { IceServer, WebRtcPortRange } from './connection/webrtc/WebRtcConnection'
 export { NetworkNode } from './logic/NetworkNode'
 export { Event as NodeEvent } from './logic/Node'
 export { NameDirectory } from './NameDirectory'

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -14,7 +14,7 @@ const connectionOpts1: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -26,7 +26,7 @@ const connectionOpts2: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 describe('BrowserWebRtcConnection', () => {

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -12,7 +12,8 @@ const connectionOpts1: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -22,7 +23,8 @@ const connectionOpts2: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 describe('BrowserWebRtcConnection', () => {

--- a/packages/network/test/browser/BrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/BrowserWebRtcConnection.test.ts
@@ -13,7 +13,8 @@ const connectionOpts1: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -24,7 +25,8 @@ const connectionOpts2: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 describe('BrowserWebRtcConnection', () => {

--- a/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
@@ -25,7 +25,8 @@ describe('Connection', () => {
             iceServers: [],
             pingInterval: 5000,
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-            deferredConnectionAttempt: new DeferredConnectionAttempt()
+            deferredConnectionAttempt: new DeferredConnectionAttempt(),
+            portRange: TEST_CONFIG.webrtcPortRange
         }
 
         const connectionOpts2: ConstructorOptions = {
@@ -35,7 +36,8 @@ describe('Connection', () => {
             iceServers: [],
             pingInterval: 5000,
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-            deferredConnectionAttempt: new DeferredConnectionAttempt()
+            deferredConnectionAttempt: new DeferredConnectionAttempt(),
+            portRange: TEST_CONFIG.webrtcPortRange
         }
 
         conn1 = new BrowserWebRtcConnection(connectionOpts1)

--- a/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
@@ -27,7 +27,7 @@ describe('Connection', () => {
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt(),
             portRange: TEST_CONFIG.webrtcPortRange,
-            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+            maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
         }
 
         const connectionOpts2: ConstructorOptions = {
@@ -39,7 +39,7 @@ describe('Connection', () => {
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt(),
             portRange: TEST_CONFIG.webrtcPortRange,
-            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+            maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
         }
 
         conn1 = new BrowserWebRtcConnection(connectionOpts1)

--- a/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
+++ b/packages/network/test/browser/IntegrationBrowserWebRtcConnection.test.ts
@@ -26,7 +26,8 @@ describe('Connection', () => {
             pingInterval: 5000,
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt(),
-            portRange: TEST_CONFIG.webrtcPortRange
+            portRange: TEST_CONFIG.webrtcPortRange,
+            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
         }
 
         const connectionOpts2: ConstructorOptions = {
@@ -37,7 +38,8 @@ describe('Connection', () => {
             pingInterval: 5000,
             messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
             deferredConnectionAttempt: new DeferredConnectionAttempt(),
-            portRange: TEST_CONFIG.webrtcPortRange
+            portRange: TEST_CONFIG.webrtcPortRange,
+            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
         }
 
         conn1 = new BrowserWebRtcConnection(connectionOpts1)

--- a/packages/network/test/integration/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/integration/NodeWebRtcConnection.test.ts
@@ -53,7 +53,8 @@ describe('Connection', () => {
             pingInterval: 5000,
             iceServers: [],
             messageQueue: messageQueueOne,
-            deferredConnectionAttempt: deferredConnectionAttemptOne
+            deferredConnectionAttempt: deferredConnectionAttemptOne,
+            portRange: TEST_CONFIG.webrtcPortRange
         })
         connectionOne.on('localDescription', (...args) => oneFunctions.onLocalDescription(...args))
         connectionOne.on('localCandidate', (...args) => oneFunctions.onLocalCandidate(...args))
@@ -65,7 +66,8 @@ describe('Connection', () => {
             pingInterval: 5000,
             iceServers: [],
             messageQueue: messageQueueTwo,
-            deferredConnectionAttempt: deferredConnectionAttemptTwo
+            deferredConnectionAttempt: deferredConnectionAttemptTwo,
+            portRange: TEST_CONFIG.webrtcPortRange
         })
 
         connectionTwo.on('localDescription', (...args) => twoFunctions.onLocalDescription(...args))

--- a/packages/network/test/integration/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/integration/NodeWebRtcConnection.test.ts
@@ -55,7 +55,7 @@ describe('Connection', () => {
             messageQueue: messageQueueOne,
             deferredConnectionAttempt: deferredConnectionAttemptOne,
             portRange: TEST_CONFIG.webrtcPortRange,
-            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+            maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
         })
         connectionOne.on('localDescription', (...args) => oneFunctions.onLocalDescription(...args))
         connectionOne.on('localCandidate', (...args) => oneFunctions.onLocalCandidate(...args))
@@ -69,7 +69,7 @@ describe('Connection', () => {
             messageQueue: messageQueueTwo,
             deferredConnectionAttempt: deferredConnectionAttemptTwo,
             portRange: TEST_CONFIG.webrtcPortRange,
-            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+            maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
         })
 
         connectionTwo.on('localDescription', (...args) => twoFunctions.onLocalDescription(...args))

--- a/packages/network/test/integration/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/integration/NodeWebRtcConnection.test.ts
@@ -54,7 +54,8 @@ describe('Connection', () => {
             iceServers: [],
             messageQueue: messageQueueOne,
             deferredConnectionAttempt: deferredConnectionAttemptOne,
-            portRange: TEST_CONFIG.webrtcPortRange
+            portRange: TEST_CONFIG.webrtcPortRange,
+            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
         })
         connectionOne.on('localDescription', (...args) => oneFunctions.onLocalDescription(...args))
         connectionOne.on('localCandidate', (...args) => oneFunctions.onLocalCandidate(...args))
@@ -67,7 +68,8 @@ describe('Connection', () => {
             iceServers: [],
             messageQueue: messageQueueTwo,
             deferredConnectionAttempt: deferredConnectionAttemptTwo,
-            portRange: TEST_CONFIG.webrtcPortRange
+            portRange: TEST_CONFIG.webrtcPortRange,
+            maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
         })
 
         connectionTwo.on('localDescription', (...args) => twoFunctions.onLocalDescription(...args))

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -13,7 +13,7 @@ const connectionOpts1: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -25,7 +25,7 @@ const connectionOpts2: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -11,7 +11,8 @@ const connectionOpts1: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -21,7 +22,8 @@ const connectionOpts2: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection-errors.test.ts
@@ -12,7 +12,8 @@ const connectionOpts1: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -23,7 +24,8 @@ const connectionOpts2: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -13,7 +13,8 @@ const connectionOpts1: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -24,7 +25,8 @@ const connectionOpts2: ConstructorOptions = {
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
-    portRange: TEST_CONFIG.webrtcPortRange
+    portRange: TEST_CONFIG.webrtcPortRange,
+    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -12,7 +12,8 @@ const connectionOpts1: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -22,7 +23,8 @@ const connectionOpts2: ConstructorOptions = {
     iceServers: [],
     pingInterval: 5000,
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
-    deferredConnectionAttempt: new DeferredConnectionAttempt()
+    deferredConnectionAttempt: new DeferredConnectionAttempt(),
+    portRange: TEST_CONFIG.webrtcPortRange
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/unit/NodeWebRtcConnection.test.ts
+++ b/packages/network/test/unit/NodeWebRtcConnection.test.ts
@@ -14,7 +14,7 @@ const connectionOpts1: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 const connectionOpts2: ConstructorOptions = {
@@ -26,7 +26,7 @@ const connectionOpts2: ConstructorOptions = {
     messageQueue: new MessageQueue<string>(TEST_CONFIG.webrtcSendBufferMaxMessageCount),
     deferredConnectionAttempt: new DeferredConnectionAttempt(),
     portRange: TEST_CONFIG.webrtcPortRange,
-    maxMessageSize: TEST_CONFIG.webrtcDatachannelMaxMessageSize
+    maxMessageSize: TEST_CONFIG.webrtcMaxMessageSize
 }
 
 describe('NodeWebRtcConnection', () => {

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -51,7 +51,7 @@ export const createTestWebRtcEndpoint = (
         TEST_CONFIG.webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses ?? false,
         TEST_CONFIG.webrtcPortRange,
-        TEST_CONFIG.webrtcDatachannelMaxMessageSize,
+        TEST_CONFIG.webrtcMaxMessageSize,
     )
 }
 

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -50,6 +50,7 @@ export const createTestWebRtcEndpoint = (
         webrtcDatachannelBufferThresholdHigh ?? TEST_CONFIG.webrtcDatachannelBufferThresholdHigh,
         TEST_CONFIG.webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses ?? false,
+        { begin: 6000, end: 65535 }
     )
 }
 

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -50,7 +50,8 @@ export const createTestWebRtcEndpoint = (
         webrtcDatachannelBufferThresholdHigh ?? TEST_CONFIG.webrtcDatachannelBufferThresholdHigh,
         TEST_CONFIG.webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses ?? false,
-        TEST_CONFIG.webrtcPortRange
+        TEST_CONFIG.webrtcPortRange,
+        TEST_CONFIG.webrtcDatachannelMaxMessageSize,
     )
 }
 

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -50,7 +50,7 @@ export const createTestWebRtcEndpoint = (
         webrtcDatachannelBufferThresholdHigh ?? TEST_CONFIG.webrtcDatachannelBufferThresholdHigh,
         TEST_CONFIG.webrtcSendBufferMaxMessageCount,
         webrtcDisallowPrivateAddresses ?? false,
-        { begin: 6000, end: 65535 }
+        TEST_CONFIG.webrtcPortRange
     )
 }
 


### PR DESCRIPTION
## Summary

Configurability for the UDP port range configurability and max message size in webrtc in the network and the client.

## Changes

-  Added configurability to the NetworkNode for setting port ranges for webrtc connections.
-  Added an option for setting max sizes for webrtc messages in the NetworkNode

