### PR TITLE
fix(network): no longer subscribe when receiving messages or tracker instructions

### DIFF
--- a/packages/network/src/logic/NetworkNode.ts
+++ b/packages/network/src/logic/NetworkNode.ts
@@ -22,6 +22,7 @@ export class NetworkNode extends Node {
         if (this.isProxiedStreamPart(streamPartId, ProxyDirection.SUBSCRIBE) && streamMessage.messageType === StreamMessageType.MESSAGE) {
             throw new Error(`Cannot publish content data to ${streamPartId} as proxy subscribe connections have been set`)
         }
+        this.subscribeToStreamIfHaveNotYet(streamPartId)
         this.onDataReceived(streamMessage)
     }
 

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -163,7 +163,6 @@ export class Node extends EventEmitter {
                 version: "brubeck-1.0"
             }),
             {
-                subscribeToStreamPartIfHaveNotYet: this.subscribeToStreamIfHaveNotYet.bind(this),
                 subscribeToStreamPartOnNodes: this.subscribeToStreamPartOnNodes.bind(this),
                 unsubscribeFromStreamPartOnNode: this.unsubscribeFromStreamPartOnNode.bind(this),
                 emitJoinCompleted: this.emitJoinCompleted.bind(this),
@@ -247,8 +246,11 @@ export class Node extends EventEmitter {
     // Null source is used when a message is published by the node itself
     onDataReceived(streamMessage: StreamMessage, source: NodeId | null = null): void | never {
         const streamPartId = streamMessage.getStreamPartID()
+
+        if (!this.streamPartManager.isSetUp(streamPartId)) {
+            return
         // Check if the stream is set as one-directional and has inbound connection if message is content typed
-        if (source
+        } else if (source
             && this.streamPartManager.isSetUp(streamPartId)
             && this.streamPartManager.isBehindProxy(streamPartId)
             && streamMessage.messageType === StreamMessageType.MESSAGE
@@ -258,7 +260,6 @@ export class Node extends EventEmitter {
         }
 
         this.emit(Event.MESSAGE_RECEIVED, streamMessage, source)
-        this.subscribeToStreamIfHaveNotYet(streamPartId)
 
         // Check duplicate
         let isUnseen


### PR DESCRIPTION
## Summary

Remove `subscribeIfHaveNotYet` operations from places where it lead to nodes subscribing to streams that have already been unsubscribed from.

