### PR TITLE
NET-846: split DhtRpc, change directory structure

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -11,10 +11,16 @@ import "packages/proto-rpc/protos/ProtoRpc.proto";
 service DhtRpcService {
   rpc getClosestPeers (ClosestPeersRequest) returns (ClosestPeersResponse);
   rpc ping (PingRequest) returns (PingResponse);
-  rpc routeMessage (RouteMessageWrapper) returns (RouteMessageAck);
-  rpc findRecursively (RouteMessageWrapper) returns (RouteMessageAck);
-  rpc forwardMessage (RouteMessageWrapper) returns (RouteMessageAck);
   rpc leaveNotice (LeaveNotice) returns (google.protobuf.Empty);
+}
+
+service RoutingService {
+  rpc routeMessage (RouteMessageWrapper) returns (RouteMessageAck);
+  rpc forwardMessage (RouteMessageWrapper) returns (RouteMessageAck);
+  rpc findRecursively (RouteMessageWrapper) returns (RouteMessageAck);
+}
+
+service StoreService {
   rpc storeData (StoreDataRequest) returns (StoreDataResponse);
 }
 

--- a/packages/dht/src/dht/DhtPeer.ts
+++ b/packages/dht/src/dht/DhtPeer.ts
@@ -32,8 +32,6 @@ export class DhtPeer extends Remote<IDhtRpcServiceClient> implements KBucketCont
         super(ownPeerDescriptor, peerDescriptor, client, serviceId)
         this.id = this.peerId.value
         this.vectorClock = DhtPeer.counter++
-        this.getClosestPeers = this.getClosestPeers.bind(this)
-        this.ping = this.ping.bind(this)
     }
 
     async getClosestPeers(kademliaId: Uint8Array): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/DhtPeer.ts
+++ b/packages/dht/src/dht/DhtPeer.ts
@@ -3,21 +3,13 @@ import {
     ClosestPeersRequest,
     LeaveNotice,
     PeerDescriptor,
-    PingRequest,
-    RouteMessageWrapper,
-    StoreDataRequest,
-    StoreDataResponse
+    PingRequest
 } from '../proto/packages/dht/protos/DhtRpc'
 import { v4 } from 'uuid'
-import { PeerID } from '../helpers/PeerID'
 import { DhtRpcOptions } from '../rpc-protocol/DhtRpcOptions'
 import { Logger } from '@streamr/utils'
 import { ProtoRpcClient } from '@streamr/proto-rpc'
-import {
-    isSamePeerDescriptor,
-    keyFromPeerDescriptor,
-    peerIdFromPeerDescriptor
-} from '../helpers/peerIdFromPeerDescriptor'
+import { Remote } from './contact/Remote'
 
 const logger = new Logger(module)
 
@@ -27,32 +19,19 @@ export interface KBucketContact {
     vectorClock: number
 }
 
-export class DhtPeer implements KBucketContact {
+export class DhtPeer extends Remote<IDhtRpcServiceClient> implements KBucketContact {
     private static counter = 0
-
-    public readonly peerId: PeerID
-
-    public get id(): Uint8Array {
-        return this.peerId.value
-    }
-
-    private peerDescriptor: PeerDescriptor
     public vectorClock: number
-    private readonly dhtClient: ProtoRpcClient<IDhtRpcServiceClient>
-    private readonly serviceId: string
-    private readonly ownPeerDescriptor: PeerDescriptor
-
-    constructor(ownPeerDescriptor: PeerDescriptor,
+    public readonly id: Uint8Array
+    constructor(
+        ownPeerDescriptor: PeerDescriptor,
         peerDescriptor: PeerDescriptor,
         client: ProtoRpcClient<IDhtRpcServiceClient>,
-        serviceId: string,
+        serviceId: string
     ) {
-        this.ownPeerDescriptor = ownPeerDescriptor
-        this.peerId = peerIdFromPeerDescriptor(peerDescriptor)
-        this.peerDescriptor = peerDescriptor
+        super(ownPeerDescriptor, peerDescriptor, client, serviceId)
+        this.id = this.peerId.value
         this.vectorClock = DhtPeer.counter++
-        this.dhtClient = client
-        this.serviceId = serviceId
         this.getClosestPeers = this.getClosestPeers.bind(this)
         this.ping = this.ping.bind(this)
     }
@@ -67,15 +46,13 @@ export class DhtPeer implements KBucketContact {
             sourceDescriptor: this.ownPeerDescriptor,
             targetDescriptor: this.peerDescriptor
         }
-
         try {
-            const peers = await this.dhtClient.getClosestPeers(request, options)
+            const peers = await this.client.getClosestPeers(request, options)
             return peers.peers
         } catch (err) {
             logger.debug(`failed getClosestPeers request: ${request.requestId}`)
             throw err
         }
-
     }
 
     async ping(): Promise<boolean> {
@@ -89,7 +66,7 @@ export class DhtPeer implements KBucketContact {
             timeout: 10000
         }
         try {
-            const pong = await this.dhtClient.ping(request, options)
+            const pong = await this.client.ping(request, options)
             if (pong.requestId === request.requestId) {
                 return true
             }
@@ -97,123 +74,6 @@ export class DhtPeer implements KBucketContact {
             logger.debug(`ping failed on ${this.serviceId} to ${this.peerId.toKey()}: ${err}`)
         }
         return false
-    }
-
-    async routeMessage(params: RouteMessageWrapper): Promise<boolean> {
-        const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
-            sourcePeer: params.sourcePeer,
-            previousPeer: params.previousPeer,
-            message: params.message,
-            requestId: params.requestId || v4(),
-            reachableThrough: params.reachableThrough || [],
-            routingPath: params.routingPath
-        }
-        const options: DhtRpcOptions = {
-            sourceDescriptor: params.previousPeer as PeerDescriptor,
-            targetDescriptor: this.peerDescriptor as PeerDescriptor,
-            timeout: 10000
-        }
-        try {
-            logger.trace('calling dhtClient.routeMessage')
-            const ack = await this.dhtClient.routeMessage(message, options)
-            logger.trace('dhtClient.routeMessage returned')
-
-            // Success signal if sent to destination and error includes duplicate
-            if (
-                isSamePeerDescriptor(params.destinationPeer!, this.peerDescriptor)
-                && ack.error.includes('duplicate')
-            ) {
-                return true
-            } else if (ack.error!.length > 0) {
-                return false
-            }
-        } catch (err) {
-            const fromNode = params.previousPeer ?
-                peerIdFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
-
-            logger.debug(
-                `Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`
-            )
-            return false
-        }
-        return true
-    }
-
-    async findRecursively(params: RouteMessageWrapper): Promise<boolean> {
-        const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
-            sourcePeer: params.sourcePeer,
-            previousPeer: params.previousPeer,
-            message: params.message,
-            requestId: params.requestId || v4(),
-            reachableThrough: params.reachableThrough || [],
-            routingPath: params.routingPath
-        }
-        const options: DhtRpcOptions = {
-            sourceDescriptor: params.previousPeer as PeerDescriptor,
-            targetDescriptor: this.peerDescriptor as PeerDescriptor,
-            timeout: 10000
-        }
-        try {
-            const ack = await this.dhtClient.findRecursively(message, options)
-            if (ack.error!.length > 0) {
-                return false
-            }
-        } catch (err) {
-            const fromNode = params.previousPeer ? keyFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
-            logger.debug(`Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`)
-            return false
-        }
-        return true
-    }
-
-    async storeData(request: StoreDataRequest): Promise<StoreDataResponse> {
-        
-        const options: DhtRpcOptions = {
-            sourceDescriptor: this.ownPeerDescriptor,
-            targetDescriptor: this.peerDescriptor,
-            timeout: 10000
-        }
-        try {
-            const result = await this.dhtClient.storeData(request, options)
-            return result
-        } catch (err) {
-            throw `Could not store data to ${keyFromPeerDescriptor(this.peerDescriptor)} from ${keyFromPeerDescriptor(this.ownPeerDescriptor)} ${err}`
-        }
-
-    }
-
-    async forwardMessage(params: RouteMessageWrapper): Promise<boolean> {
-        const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
-            sourcePeer: params.sourcePeer,
-            previousPeer: params.previousPeer,
-            message: params.message,
-            requestId: params.requestId || v4(),
-            reachableThrough: params.reachableThrough || [],
-            routingPath: params.routingPath
-        }
-        const options: DhtRpcOptions = {
-            sourceDescriptor: params.previousPeer as PeerDescriptor,
-            targetDescriptor: this.peerDescriptor as PeerDescriptor,
-            timeout: 10000
-        }
-        try {
-            const ack = await this.dhtClient.forwardMessage(message, options)
-            if (ack.error!.length > 0) {
-                return false
-            }
-        } catch (err) {
-            const fromNode = params.previousPeer ?
-                keyFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
-
-            logger.debug(
-                `Failed to send forwardMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`
-            )
-            return false
-        }
-        return true
     }
 
     leaveNotice(): void {
@@ -226,7 +86,7 @@ export class DhtPeer implements KBucketContact {
             targetDescriptor: this.peerDescriptor,
             notification: true
         }
-        this.dhtClient.leaveNotice(request, options).catch((e) => {
+        this.client.leaveNotice(request, options).catch((e) => {
             logger.trace('Failed to send leaveNotice' + e)
         })
     }
@@ -234,4 +94,5 @@ export class DhtPeer implements KBucketContact {
     getPeerDescriptor(): PeerDescriptor {
         return this.peerDescriptor
     }
+
 }

--- a/packages/dht/src/dht/DiscoverySession.ts
+++ b/packages/dht/src/dht/DiscoverySession.ts
@@ -69,11 +69,11 @@ export class DiscoverySession {
                 toProtoRpcClient(new DhtRpcServiceClient(this.rpcCommunicator!.getRpcClientTransport())),
                 this.serviceId
             )
-            if (!dhtPeer.peerId.equals(this.ownPeerId!)) {
+            if (!dhtPeer.getPeerId().equals(this.ownPeerId!)) {
                 if (this.newContactListener) {
                     this.newContactListener(dhtPeer)
                 }
-                if (!this.neighborList.getContact(dhtPeer.peerId)) {
+                if (!this.neighborList.getContact(dhtPeer.getPeerId())) {
                     this.neighborList!.addContact(dhtPeer)
                 }
             }
@@ -84,11 +84,11 @@ export class DiscoverySession {
         if (this.stopped) {
             return []
         }
-        logger.trace(`Getting closest peers from contact: ${contact.peerId.toKey()}`)
+        logger.trace(`Getting closest peers from contact: ${contact.getPeerId().toKey()}`)
         this.outgoingClosestPeersRequestsCounter++
-        this.neighborList!.setContacted(contact.peerId)
+        this.neighborList!.setContacted(contact.getPeerId())
         const returnedContacts = await contact.getClosestPeers(this.targetId)
-        this.neighborList!.setActive(contact.peerId)
+        this.neighborList!.setActive(contact.getPeerId())
         return returnedContacts
     }
 
@@ -106,9 +106,9 @@ export class DiscoverySession {
     }
 
     private onClosestPeersRequestFailed(peer: DhtPeer, _exception: Error) {
-        if (this.ongoingClosestPeersRequests.has(peer.peerId.toKey())) {
-            this.ongoingClosestPeersRequests.delete(peer.peerId.toKey())
-            this.neighborList!.removeContact(peer.peerId)
+        if (this.ongoingClosestPeersRequests.has(peer.getPeerId().toKey())) {
+            this.ongoingClosestPeersRequests.delete(peer.getPeerId().toKey())
+            this.neighborList!.removeContact(peer.getPeerId())
         }
     }
 
@@ -125,10 +125,10 @@ export class DiscoverySession {
         const uncontacted = this.neighborList!.getUncontactedContacts(this.parallelism)
         while (this.ongoingClosestPeersRequests.size < this.parallelism && uncontacted.length > 0) {
             const nextPeer = uncontacted.shift()
-            this.ongoingClosestPeersRequests.add(nextPeer!.peerId.toKey())
+            this.ongoingClosestPeersRequests.add(nextPeer!.getPeerId().toKey())
             // eslint-disable-next-line promise/catch-or-return
             this.getClosestPeersFromContact(nextPeer!)
-                .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer!.peerId, contacts))
+                .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer!.getPeerId(), contacts))
                 .catch((err) => this.onClosestPeersRequestFailed(nextPeer!, err))
                 .finally(() => {
                     this.outgoingClosestPeersRequestsCounter--

--- a/packages/dht/src/dht/PeerDiscovery.ts
+++ b/packages/dht/src/dht/PeerDiscovery.ts
@@ -40,7 +40,6 @@ export class PeerDiscovery {
     private stopped = false
     private rejoinOngoing = false
 
-    private getClosestPeersFromBucketIntervalRef?: NodeJS.Timeout
     private rejoinTimeoutRef?: NodeJS.Timeout
     private readonly abortController: AbortController
 
@@ -63,7 +62,7 @@ export class PeerDiscovery {
             toProtoRpcClient(new DhtRpcServiceClient(this.config.rpcCommunicator.getRpcClientTransport())),
             this.config.serviceId
         )
-        if (this.config.ownPeerId!.equals(entryPoint.peerId)) {
+        if (this.config.ownPeerId!.equals(entryPoint.getPeerId())) {
             return
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)

--- a/packages/dht/src/dht/contact/Contact.ts
+++ b/packages/dht/src/dht/contact/Contact.ts
@@ -12,7 +12,7 @@ export class ContactState<TContact> {
     }
 }
 
-export interface IContact { peerId: PeerID, getPeerDescriptor: () => PeerDescriptor }
+export interface IContact { getPeerId: () => PeerID, getPeerDescriptor: () => PeerDescriptor }
 
 export interface Events {
     contactRemoved: (removedDescriptor: PeerDescriptor, closestDescriptors: PeerDescriptor[]) => void
@@ -30,7 +30,7 @@ export class Contact implements IContact {
         return this.peerDescriptor
     }
 
-    public get peerId(): PeerID {
+    public getPeerId(): PeerID {
         return peerIdFromPeerDescriptor(this.peerDescriptor)
     }
 }

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -24,18 +24,18 @@ export class RandomContactList<Contact extends IContact> extends EventEmitter<Ev
     }
 
     addContact(contact: Contact): void {
-        if (this.ownId.equals(contact.peerId)) {
+        if (this.ownId.equals(contact.getPeerId())) {
             return
         }
-        if (!this.contactsById.has(contact.peerId.toKey())) {
+        if (!this.contactsById.has(contact.getPeerId().toKey())) {
             const roll = Math.random()
             if (roll < this.randomness) {
                 if (this.getSize() === this.maxSize && this.getSize() > 0) {
                     const toRemove = this.contactIds[0]
                     this.removeContact(toRemove)
                 }
-                this.contactIds.push(contact.peerId)
-                this.contactsById.set(contact.peerId.toKey(), new ContactState(contact))
+                this.contactIds.push(contact.getPeerId())
+                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
                 this.emit(
                     'newContact',
                     contact.getPeerDescriptor(),

--- a/packages/dht/src/dht/contact/Remote.ts
+++ b/packages/dht/src/dht/contact/Remote.ts
@@ -1,0 +1,40 @@
+import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
+import { ProtoRpcClient } from '@streamr/proto-rpc'
+import { peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { PeerID } from '../../helpers/PeerID'
+import { IContact } from './Contact'
+
+export abstract class Remote<T> implements IContact {
+
+    protected readonly peerId: PeerID
+    protected readonly peerDescriptor: PeerDescriptor
+    protected readonly client: ProtoRpcClient<T>
+    protected readonly serviceId: string
+    protected readonly ownPeerDescriptor: PeerDescriptor
+
+    constructor(
+        ownPeerDescriptor: PeerDescriptor,
+        peerDescriptor: PeerDescriptor,
+        client: ProtoRpcClient<T>,
+        serviceId: string
+    ) {
+        this.ownPeerDescriptor = ownPeerDescriptor
+        this.peerId = peerIdFromPeerDescriptor(peerDescriptor)
+        this.peerDescriptor = peerDescriptor
+        this.client = client
+        this.serviceId = serviceId
+    }
+
+    getPeerId(): PeerID {
+        return this.peerId
+    }
+
+    getPeerDescriptor(): PeerDescriptor {
+        return this.peerDescriptor
+    }
+
+    getServiceId(): string {
+        return this.serviceId
+    }
+
+}

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -41,24 +41,24 @@ export class SortedContactList<Contact extends IContact> extends EventEmitter<Ev
 
     public addContact(contact: Contact): void {
         if (this.excludedPeerIDs
-            && this.excludedPeerIDs.some((peerId) => contact.peerId.equals(peerId))) {
+            && this.excludedPeerIDs.some((peerId) => contact.getPeerId().equals(peerId))) {
             return
         }
         
-        if ((!this.allowOwnPeerId && this.ownId.equals(contact.peerId)) ||
-            (this.peerIdDistanceLimit !== undefined && this.compareIds(this.peerIdDistanceLimit, contact.peerId) < 0)) {
+        if ((!this.allowOwnPeerId && this.ownId.equals(contact.getPeerId())) ||
+            (this.peerIdDistanceLimit !== undefined && this.compareIds(this.peerIdDistanceLimit, contact.getPeerId()) < 0)) {
             return
         }
-        if (!this.contactsById.has(contact.peerId.toKey())) {
+        if (!this.contactsById.has(contact.getPeerId().toKey())) {
             if (this.contactIds.length < this.maxSize) {
-                this.contactsById.set(contact.peerId.toKey(), new ContactState(contact))
-                this.contactIds.push(contact.peerId)
+                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
+                this.contactIds.push(contact.getPeerId())
                 this.contactIds.sort(this.compareIds)
-            } else if (this.compareIds(this.contactIds[this.maxSize - 1], contact.peerId) > 0) {
+            } else if (this.compareIds(this.contactIds[this.maxSize - 1], contact.getPeerId()) > 0) {
                 const removed = this.contactIds.pop()
                 this.contactsById.delete(removed!.toKey())
-                this.contactsById.set(contact.peerId.toKey(), new ContactState(contact))
-                this.contactIds.push(contact.peerId)
+                this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
+                this.contactIds.push(contact.getPeerId())
                 this.contactIds.sort(this.compareIds)
                 this.emit(
                     'contactRemoved',

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -1,16 +1,16 @@
 import { ServerCallContext } from "@protobuf-ts/runtime-rpc"
 import { Logger } from "@streamr/utils"
 import EventEmitter from "eventemitter3"
-import { PeerID, PeerIDKey } from "../helpers/PeerID"
-import { DataEntry, PeerDescriptor, RecursiveFindReport } from "../proto/packages/dht/protos/DhtRpc"
-import { IRecursiveFindSessionService } from "../proto/packages/dht/protos/DhtRpc.server"
-import { Empty } from "../proto/google/protobuf/empty"
-import { ITransport } from "../transport/ITransport"
-import { ListeningRpcCommunicator } from "../transport/ListeningRpcCommunicator"
-import { Contact } from "./contact/Contact"
-import { SortedContactList } from "./contact/SortedContactList"
-import { RecursiveFindResult } from "./DhtNode"
-import { keyFromPeerDescriptor } from '../helpers/peerIdFromPeerDescriptor'
+import { PeerID, PeerIDKey } from "../../helpers/PeerID"
+import { DataEntry, PeerDescriptor, RecursiveFindReport } from "../../proto/packages/dht/protos/DhtRpc"
+import { IRecursiveFindSessionService } from "../../proto/packages/dht/protos/DhtRpc.server"
+import { Empty } from "../../proto/google/protobuf/empty"
+import { ITransport } from "../../transport/ITransport"
+import { ListeningRpcCommunicator } from "../../transport/ListeningRpcCommunicator"
+import { Contact } from "../contact/Contact"
+import { SortedContactList } from "../contact/SortedContactList"
+import { RecursiveFindResult } from "../DhtNode"
+import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 
 export interface RecursiveFindSessionEvents {
     findCompleted: (results: PeerDescriptor[]) => void

--- a/packages/dht/src/dht/find/RemoteRecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RemoteRecursiveFindSession.ts
@@ -2,13 +2,13 @@ import {
     DataEntry,
     PeerDescriptor,
     RecursiveFindReport
-} from '../proto/packages/dht/protos/DhtRpc'
-import { IRecursiveFindSessionServiceClient, RecursiveFindSessionServiceClient } from '../proto/packages/dht/protos/DhtRpc.client'
-import { DhtRpcOptions } from '../rpc-protocol/DhtRpcOptions'
+} from '../../proto/packages/dht/protos/DhtRpc'
+import { IRecursiveFindSessionServiceClient, RecursiveFindSessionServiceClient } from '../../proto/packages/dht/protos/DhtRpc.client'
+import { DhtRpcOptions } from '../../rpc-protocol/DhtRpcOptions'
 import { Logger } from '@streamr/utils'
 import { ProtoRpcClient, RpcCommunicator, toProtoRpcClient } from '@streamr/proto-rpc'
-import { ITransport } from '../transport/ITransport'
-import { ListeningRpcCommunicator } from '../exports'
+import { ITransport } from '../../transport/ITransport'
+import { ListeningRpcCommunicator } from '../../exports'
 
 const logger = new Logger(module)
 

--- a/packages/dht/src/dht/routing/RemoteRouter.ts
+++ b/packages/dht/src/dht/routing/RemoteRouter.ts
@@ -1,0 +1,114 @@
+import { PeerDescriptor, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
+import { v4 } from 'uuid'
+import { DhtRpcOptions } from '../../rpc-protocol/DhtRpcOptions'
+import {
+    isSamePeerDescriptor,
+    keyFromPeerDescriptor,
+    peerIdFromPeerDescriptor
+} from '../../helpers/peerIdFromPeerDescriptor'
+import { IRoutingServiceClient } from '../../proto/packages/dht/protos/DhtRpc.client'
+import { Remote } from '../contact/Remote'
+import { Logger } from '@streamr/utils'
+
+const logger = new Logger(module)
+
+export class RemoteRouter extends Remote<IRoutingServiceClient> {
+
+    async routeMessage(params: RouteMessageWrapper): Promise<boolean> {
+        const message: RouteMessageWrapper = {
+            destinationPeer: params.destinationPeer,
+            sourcePeer: params.sourcePeer,
+            previousPeer: params.previousPeer,
+            message: params.message,
+            requestId: params.requestId || v4(),
+            reachableThrough: params.reachableThrough || [],
+            routingPath: params.routingPath
+        }
+        const options: DhtRpcOptions = {
+            sourceDescriptor: params.previousPeer as PeerDescriptor,
+            targetDescriptor: this.peerDescriptor as PeerDescriptor,
+            timeout: 10000
+        }
+        try {
+            logger.trace('calling dhtClient.routeMessage')
+            const ack = await this.client.routeMessage(message, options)
+            logger.trace('dhtClient.routeMessage returned')
+            // Success signal if sent to destination and error includes duplicate
+            if (
+                isSamePeerDescriptor(params.destinationPeer!, this.peerDescriptor)
+                && ack.error.includes('duplicate')
+            ) {
+                return true
+            } else if (ack.error!.length > 0) {
+                return false
+            }
+        } catch (err) {
+            const fromNode = params.previousPeer ?
+                peerIdFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
+            logger.debug(`Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`)
+            return false
+        }
+        return true
+    }
+
+    async forwardMessage(params: RouteMessageWrapper): Promise<boolean> {
+        const message: RouteMessageWrapper = {
+            destinationPeer: params.destinationPeer,
+            sourcePeer: params.sourcePeer,
+            previousPeer: params.previousPeer,
+            message: params.message,
+            requestId: params.requestId || v4(),
+            reachableThrough: params.reachableThrough || [],
+            routingPath: params.routingPath
+        }
+        const options: DhtRpcOptions = {
+            sourceDescriptor: params.previousPeer as PeerDescriptor,
+            targetDescriptor: this.peerDescriptor as PeerDescriptor,
+            timeout: 10000
+        }
+        try {
+            const ack = await this.client.forwardMessage(message, options)
+            if (ack.error!.length > 0) {
+                return false
+            }
+        } catch (err) {
+            const fromNode = params.previousPeer ?
+                keyFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
+
+            logger.debug(
+                `Failed to send forwardMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`
+            )
+            return false
+        }
+        return true
+    }
+
+    async findRecursively(params: RouteMessageWrapper): Promise<boolean> {
+        const message: RouteMessageWrapper = {
+            destinationPeer: params.destinationPeer,
+            sourcePeer: params.sourcePeer,
+            previousPeer: params.previousPeer,
+            message: params.message,
+            requestId: params.requestId || v4(),
+            reachableThrough: params.reachableThrough || [],
+            routingPath: params.routingPath
+        }
+        const options: DhtRpcOptions = {
+            sourceDescriptor: params.previousPeer as PeerDescriptor,
+            targetDescriptor: this.peerDescriptor as PeerDescriptor,
+            timeout: 10000
+        }
+        try {
+            const ack = await this.client.findRecursively(message, options)
+            if (ack.error!.length > 0) {
+                return false
+            }
+        } catch (err) {
+            const fromNode = params.previousPeer ? keyFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
+            logger.debug(`Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`)
+            return false
+        }
+        return true
+    }
+
+}

--- a/packages/dht/src/dht/store/RemoteStore.ts
+++ b/packages/dht/src/dht/store/RemoteStore.ts
@@ -1,0 +1,23 @@
+import { Remote } from '../contact/Remote'
+import { IStoreServiceClient } from '../../proto/packages/dht/protos/DhtRpc.client'
+import { StoreDataRequest, StoreDataResponse } from '../../proto/packages/dht/protos/DhtRpc'
+import { DhtRpcOptions } from '../../rpc-protocol/DhtRpcOptions'
+import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+
+export class RemoteStore extends Remote<IStoreServiceClient> {
+
+    async storeData(request: StoreDataRequest): Promise<StoreDataResponse> {
+        const options: DhtRpcOptions = {
+            sourceDescriptor: this.ownPeerDescriptor,
+            targetDescriptor: this.peerDescriptor,
+            timeout: 10000
+        }
+        try {
+            const result = await this.client.storeData(request, options)
+            return result
+        } catch (err) {
+            throw `Could not store data to ${keyFromPeerDescriptor(this.peerDescriptor)} from ${keyFromPeerDescriptor(this.ownPeerDescriptor)} ${err}`
+        }
+    }
+
+}

--- a/packages/dht/src/dht/store/RemoteStore.ts
+++ b/packages/dht/src/dht/store/RemoteStore.ts
@@ -16,7 +16,9 @@ export class RemoteStore extends Remote<IStoreServiceClient> {
             const result = await this.client.storeData(request, options)
             return result
         } catch (err) {
-            throw `Could not store data to ${keyFromPeerDescriptor(this.peerDescriptor)} from ${keyFromPeerDescriptor(this.ownPeerDescriptor)} ${err}`
+            throw Error(
+                `Could not store data to ${keyFromPeerDescriptor(this.peerDescriptor)} from ${keyFromPeerDescriptor(this.ownPeerDescriptor)} ${err}`
+            )
         }
     }
 

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -16,15 +16,17 @@ import type { WebSocketConnectionResponse } from "./DhtRpc";
 import type { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindSessionService } from "./DhtRpc";
 import type { RecursiveFindReport } from "./DhtRpc";
+import { StoreService } from "./DhtRpc";
+import type { StoreDataResponse } from "./DhtRpc";
+import type { StoreDataRequest } from "./DhtRpc";
+import { RoutingService } from "./DhtRpc";
+import type { RouteMessageAck } from "./DhtRpc";
+import type { RouteMessageWrapper } from "./DhtRpc";
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { DhtRpcService } from "./DhtRpc";
-import type { StoreDataResponse } from "./DhtRpc";
-import type { StoreDataRequest } from "./DhtRpc";
 import type { Empty } from "../../../google/protobuf/empty";
 import type { LeaveNotice } from "./DhtRpc";
-import type { RouteMessageAck } from "./DhtRpc";
-import type { RouteMessageWrapper } from "./DhtRpc";
 import type { PingResponse } from "./DhtRpc";
 import type { PingRequest } from "./DhtRpc";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
@@ -45,25 +47,9 @@ export interface IDhtRpcServiceClient {
      */
     ping(input: PingRequest, options?: RpcOptions): UnaryCall<PingRequest, PingResponse>;
     /**
-     * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
      * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
      */
     leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty>;
-    /**
-     * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
-     */
-    storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse>;
 }
 /**
  * @generated from protobuf service dht.DhtRpcService
@@ -89,38 +75,84 @@ export class DhtRpcServiceClient implements IDhtRpcServiceClient, ServiceInfo {
         return stackIntercept<PingRequest, PingResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     */
+    leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<LeaveNotice, Empty>("unary", this._transport, method, opt, input);
+    }
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export interface IRoutingServiceClient {
+    /**
      * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[2], opt = this._transport.mergeOptions(options);
-        return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
-    }
+    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
+    /**
+     * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
+     */
+    forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
     /**
      * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[3], opt = this._transport.mergeOptions(options);
+    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export class RoutingServiceClient implements IRoutingServiceClient, ServiceInfo {
+    typeName = RoutingService.typeName;
+    methods = RoutingService.methods;
+    options = RoutingService.options;
+    constructor(private readonly _transport: RpcTransport) {
+    }
+    /**
+     * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
+     */
+    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
+        const method = this.methods[0], opt = this._transport.mergeOptions(options);
         return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[4], opt = this._transport.mergeOptions(options);
+        const method = this.methods[1], opt = this._transport.mergeOptions(options);
         return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
     }
     /**
-     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty> {
-        const method = this.methods[5], opt = this._transport.mergeOptions(options);
-        return stackIntercept<LeaveNotice, Empty>("unary", this._transport, method, opt, input);
+    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
+    }
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export interface IStoreServiceClient {
+    /**
+     * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
+     */
+    storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse>;
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export class StoreServiceClient implements IStoreServiceClient, ServiceInfo {
+    typeName = StoreService.typeName;
+    methods = StoreService.methods;
+    options = StoreService.options;
+    constructor(private readonly _transport: RpcTransport) {
     }
     /**
      * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
      */
     storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse> {
-        const method = this.methods[6], opt = this._transport.mergeOptions(options);
+        const method = this.methods[0], opt = this._transport.mergeOptions(options);
         return stackIntercept<StoreDataRequest, StoreDataResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -14,10 +14,10 @@ import { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindReport } from "./DhtRpc";
 import { StoreDataResponse } from "./DhtRpc";
 import { StoreDataRequest } from "./DhtRpc";
-import { Empty } from "../../../google/protobuf/empty";
-import { LeaveNotice } from "./DhtRpc";
 import { RouteMessageAck } from "./DhtRpc";
 import { RouteMessageWrapper } from "./DhtRpc";
+import { Empty } from "../../../google/protobuf/empty";
+import { LeaveNotice } from "./DhtRpc";
 import { PingResponse } from "./DhtRpc";
 import { PingRequest } from "./DhtRpc";
 import { ClosestPeersResponse } from "./DhtRpc";
@@ -36,21 +36,31 @@ export interface IDhtRpcService<T = ServerCallContext> {
      */
     ping(request: PingRequest, context: T): Promise<PingResponse>;
     /**
+     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     */
+    leaveNotice(request: LeaveNotice, context: T): Promise<Empty>;
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export interface IRoutingService<T = ServerCallContext> {
+    /**
      * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     routeMessage(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    findRecursively(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
     /**
      * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     forwardMessage(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
     /**
-     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    leaveNotice(request: LeaveNotice, context: T): Promise<Empty>;
+    findRecursively(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export interface IStoreService<T = ServerCallContext> {
     /**
      * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
      */

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -1144,10 +1144,20 @@ export const DisconnectNotice = new DisconnectNotice$Type();
 export const DhtRpcService = new ServiceType("dht.DhtRpcService", [
     { name: "getClosestPeers", options: {}, I: ClosestPeersRequest, O: ClosestPeersResponse },
     { name: "ping", options: {}, I: PingRequest, O: PingResponse },
+    { name: "leaveNotice", options: {}, I: LeaveNotice, O: Empty }
+]);
+/**
+ * @generated ServiceType for protobuf service dht.RoutingService
+ */
+export const RoutingService = new ServiceType("dht.RoutingService", [
     { name: "routeMessage", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
-    { name: "findRecursively", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
     { name: "forwardMessage", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
-    { name: "leaveNotice", options: {}, I: LeaveNotice, O: Empty },
+    { name: "findRecursively", options: {}, I: RouteMessageWrapper, O: RouteMessageAck }
+]);
+/**
+ * @generated ServiceType for protobuf service dht.StoreService
+ */
+export const StoreService = new ServiceType("dht.StoreService", [
     { name: "storeData", options: {}, I: StoreDataRequest, O: StoreDataResponse }
 ]);
 /**

--- a/packages/dht/test/benchmark/kademlia-simulation/Contact.ts
+++ b/packages/dht/test/benchmark/kademlia-simulation/Contact.ts
@@ -6,6 +6,7 @@ export class Contact {
     private static counter = 0
 
     public peerId: PeerID
+    public id: Uint8Array
     public vectorClock = 0
     public dhtNode: SimulationNode | undefined
 
@@ -13,10 +14,7 @@ export class Contact {
         this.peerId = ownId
         this.vectorClock = Contact.counter++
         this.dhtNode = dhtNode
-    }
-
-    get id(): Uint8Array {
-        return this.peerId.value
+        this.id = ownId.value
     }
 
     getPeerDescriptor(): PeerDescriptor {
@@ -25,6 +23,10 @@ export class Contact {
             type: NodeType.NODEJS
         }
         return peerDescriptor
+    }
+
+    getPeerId(): PeerID {
+        return this.peerId
     }
 
 }

--- a/packages/dht/test/integration/RemoteRouter.test.ts
+++ b/packages/dht/test/integration/RemoteRouter.test.ts
@@ -1,0 +1,83 @@
+import { RpcCommunicator, toProtoRpcClient } from "@streamr/proto-rpc"
+import { RemoteRouter } from "../../src/dht/routing/RemoteRouter"
+import { Message, MessageType, PeerDescriptor, RouteMessageAck, RouteMessageWrapper } from "../../src/proto/packages/dht/protos/DhtRpc"
+import { RoutingServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
+import { RpcMessage } from "../../src/proto/packages/proto-rpc/protos/ProtoRpc"
+import { DhtCallContext } from "../../src/rpc-protocol/DhtCallContext"
+import { createWrappedClosestPeersRequest, generateId, MockRoutingService } from "../utils"
+
+describe('RemoteRouter', () => {
+
+    let remoteRouter: RemoteRouter
+    let clientRpcCommunicator: RpcCommunicator
+    let serverRpcCommunicator: RpcCommunicator
+    const serviceId = 'test'
+    const clientPeerDescriptor: PeerDescriptor = {
+        kademliaId: generateId('dhtPeer'),
+        type: 0
+    }
+    const serverPeerDescriptor: PeerDescriptor = {
+        kademliaId: generateId('server'),
+        type: 0
+    }
+
+    beforeEach(() => {
+        clientRpcCommunicator = new RpcCommunicator()
+        serverRpcCommunicator = new RpcCommunicator()
+        serverRpcCommunicator.registerRpcMethod(RouteMessageWrapper, RouteMessageAck, 'routeMessage', MockRoutingService.routeMessage)
+        clientRpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: DhtCallContext) => {
+            serverRpcCommunicator.handleIncomingMessage(message)
+        })
+        serverRpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: DhtCallContext) => {
+            clientRpcCommunicator.handleIncomingMessage(message)
+        })
+        const client = toProtoRpcClient(new RoutingServiceClient(clientRpcCommunicator.getRpcClientTransport()))
+        remoteRouter = new RemoteRouter(clientPeerDescriptor, serverPeerDescriptor, client, serviceId)
+    })
+
+    it('routeMessage happy path', async () => {
+        const rpcWrapper = createWrappedClosestPeersRequest(clientPeerDescriptor, serverPeerDescriptor)
+        const routed: Message = {
+            serviceId: serviceId,
+            messageId: 'routed',
+            messageType: MessageType.RPC,
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: rpcWrapper
+            }
+        }
+        const routable = await remoteRouter.routeMessage({
+            requestId: 'routed',
+            message: routed,
+            sourcePeer: clientPeerDescriptor,
+            destinationPeer: serverPeerDescriptor,
+            reachableThrough: [],
+            routingPath: []
+        })
+        expect(routable).toEqual(true)
+    })
+
+    it('routeMessage error path', async () => {
+        serverRpcCommunicator.registerRpcMethod(RouteMessageWrapper, RouteMessageAck, 'routeMessage', MockRoutingService.throwRouteMessageError)
+        const rpcWrapper = createWrappedClosestPeersRequest(clientPeerDescriptor, serverPeerDescriptor)
+        const routed: Message = {
+            serviceId: serviceId,
+            messageId: 'routed',
+            messageType: MessageType.RPC,
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: rpcWrapper
+            }
+        }
+        const routable = await remoteRouter.routeMessage({
+            requestId: 'routed',
+            message: routed,
+            sourcePeer: clientPeerDescriptor,
+            destinationPeer: serverPeerDescriptor,
+            reachableThrough: [],
+            routingPath: []
+        })
+        expect(routable).toEqual(false)
+    })
+
+})

--- a/packages/dht/test/integration/RemoteStore.test.ts
+++ b/packages/dht/test/integration/RemoteStore.test.ts
@@ -1,0 +1,66 @@
+import { RpcCommunicator, toProtoRpcClient } from '@streamr/proto-rpc'
+import {
+    PeerDescriptor,
+    StoreDataRequest,
+    StoreDataResponse
+} from '../../src/proto/packages/dht/protos/DhtRpc'
+import { generateId, MockStoreService } from '../utils'
+import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
+import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
+import { StoreServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
+import { RemoteStore } from '../../src/dht/store/RemoteStore'
+import { Any } from '../../src/proto/google/protobuf/any'
+
+describe('RemoteStore', () => {
+
+    let remoteStore: RemoteStore
+    let clientRpcCommunicator: RpcCommunicator
+    let serverRpcCommunicator: RpcCommunicator
+    const serviceId = 'test'
+    const clientPeerDescriptor: PeerDescriptor = {
+        kademliaId: generateId('dhtPeer'),
+        type: 0
+    }
+    const serverPeerDescriptor: PeerDescriptor = {
+        kademliaId: generateId('server'),
+        type: 0
+    }
+    const data = Any.pack(clientPeerDescriptor, PeerDescriptor)
+    const request: StoreDataRequest = {
+        kademliaId: clientPeerDescriptor.kademliaId,
+        data,
+        ttl: 10
+    }
+
+    beforeEach(() => {
+        clientRpcCommunicator = new RpcCommunicator()
+        serverRpcCommunicator = new RpcCommunicator()
+        serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', MockStoreService.storeData)
+        clientRpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: DhtCallContext) => {
+            serverRpcCommunicator.handleIncomingMessage(message)
+        })
+        serverRpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: DhtCallContext) => {
+            clientRpcCommunicator.handleIncomingMessage(message)
+        })
+        const client = toProtoRpcClient(new StoreServiceClient(clientRpcCommunicator.getRpcClientTransport()))
+        remoteStore = new RemoteStore(clientPeerDescriptor, serverPeerDescriptor, client, serviceId)
+    })
+
+    it('storeData happy path', async () => {
+        const response = await remoteStore.storeData(request)
+        expect(response.error).toBeEmpty()
+    })
+
+    it('storeData rejects', async () => {
+        serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', MockStoreService.throwStoreDataError)
+        await expect(remoteStore.storeData(request))
+            .rejects.toThrowError('Could not store data to 736572766572 from 64687450656572 Error: Mock')
+    })
+
+    it('storeData response error', async () => {
+        serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', MockStoreService.storeDataErrorString)
+        const response = await remoteStore.storeData(request)
+        expect(response.error).toEqual('Mock')
+    })
+
+})

--- a/packages/dht/test/utils.ts
+++ b/packages/dht/test/utils.ts
@@ -1,15 +1,20 @@
 import { DhtNode } from '../src/dht/DhtNode'
 import {
-    ClosestPeersRequest, ClosestPeersResponse, LeaveNotice,
+    ClosestPeersRequest,
+    ClosestPeersResponse,
+    LeaveNotice,
     NodeType,
-    PeerDescriptor, PingRequest, PingResponse, RouteMessageAck, RouteMessageWrapper,
-    StoreDataRequest,
-    StoreDataResponse,
-    WebSocketConnectionRequest, WebSocketConnectionResponse
+    PeerDescriptor,
+    PingRequest,
+    PingResponse,
+    RouteMessageAck,
+    RouteMessageWrapper,
+    WebSocketConnectionRequest,
+    WebSocketConnectionResponse
 } from '../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { PeerID } from '../src/helpers/PeerID'
-import { IDhtRpcService, IWebSocketConnectorService } from '../src/proto/packages/dht/protos/DhtRpc.server'
+import { IDhtRpcService, IRoutingService, IWebSocketConnectorService } from '../src/proto/packages/dht/protos/DhtRpc.server'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Simulator } from '../src/connection/Simulator/Simulator'
 import { ConnectionManager } from '../src/connection/ConnectionManager'
@@ -104,7 +109,6 @@ interface IDhtRpcWithError extends IDhtRpcService {
     throwPingError: (request: PingRequest, _context: ServerCallContext) => Promise<PingResponse>
     respondPingWithTimeout: (request: PingRequest, _context: ServerCallContext) => Promise<PingResponse>
     throwGetClosestPeersError: (request: ClosestPeersRequest, _context: ServerCallContext) => Promise<ClosestPeersResponse>
-    throwRouteMessageError: (request: RouteMessageWrapper, _context: ServerCallContext) => Promise<RouteMessageAck>
 }
 
 export const MockDhtRpc: IDhtRpcWithError = {
@@ -119,36 +123,6 @@ export const MockDhtRpc: IDhtRpcWithError = {
     async ping(request: PingRequest, _context: ServerCallContext): Promise<PingResponse> {
         const response: PingResponse = {
             requestId: request.requestId
-        }
-        return response
-    },
-    async routeMessage(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
-        const response: RouteMessageAck = {
-            requestId: routed.requestId,
-            destinationPeer: routed.sourcePeer,
-            sourcePeer: routed.destinationPeer,
-            error: ''
-        }
-        return response
-    },
-    async findRecursively(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
-        const response: RouteMessageAck = {
-            requestId: routed.requestId,
-            destinationPeer: routed.sourcePeer,
-            sourcePeer: routed.destinationPeer,
-            error: ''
-        }
-        return response
-    },
-    async storeData(_request: StoreDataRequest, _context: ServerCallContext): Promise<StoreDataResponse> {
-        return StoreDataResponse.create()
-    },
-    async forwardMessage(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
-        const response: RouteMessageAck = {
-            requestId: routed.requestId,
-            destinationPeer: routed.sourcePeer,
-            sourcePeer: routed.destinationPeer,
-            error: ''
         }
         return response
     },
@@ -168,6 +142,40 @@ export const MockDhtRpc: IDhtRpcWithError = {
     },
     async throwGetClosestPeersError(_urequest: ClosestPeersRequest, _context: ServerCallContext): Promise<ClosestPeersResponse> {
         throw new Error('Closest peers error')
+    }
+}
+
+interface IRouterServiceWithError extends IRoutingService {
+    throwRouteMessageError: (request: RouteMessageWrapper, _context: ServerCallContext) => Promise<RouteMessageAck>
+}
+
+export const MockRoutingService: IRouterServiceWithError = {
+    async routeMessage(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
+        const response: RouteMessageAck = {
+            requestId: routed.requestId,
+            destinationPeer: routed.sourcePeer,
+            sourcePeer: routed.destinationPeer,
+            error: ''
+        }
+        return response
+    },
+    async findRecursively(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
+        const response: RouteMessageAck = {
+            requestId: routed.requestId,
+            destinationPeer: routed.sourcePeer,
+            sourcePeer: routed.destinationPeer,
+            error: ''
+        }
+        return response
+    },
+    async forwardMessage(routed: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
+        const response: RouteMessageAck = {
+            requestId: routed.requestId,
+            destinationPeer: routed.sourcePeer,
+            sourcePeer: routed.destinationPeer,
+            error: ''
+        }
+        return response
     },
     async throwRouteMessageError(_urequest: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
         throw new Error()

--- a/packages/dht/test/utils.ts
+++ b/packages/dht/test/utils.ts
@@ -9,12 +9,19 @@ import {
     PingResponse,
     RouteMessageAck,
     RouteMessageWrapper,
+    StoreDataRequest,
+    StoreDataResponse,
     WebSocketConnectionRequest,
     WebSocketConnectionResponse
 } from '../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { PeerID } from '../src/helpers/PeerID'
-import { IDhtRpcService, IRoutingService, IWebSocketConnectorService } from '../src/proto/packages/dht/protos/DhtRpc.server'
+import {
+    IDhtRpcService,
+    IRoutingService,
+    IStoreService,
+    IWebSocketConnectorService
+} from '../src/proto/packages/dht/protos/DhtRpc.server'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Simulator } from '../src/connection/Simulator/Simulator'
 import { ConnectionManager } from '../src/connection/ConnectionManager'
@@ -179,6 +186,27 @@ export const MockRoutingService: IRouterServiceWithError = {
     },
     async throwRouteMessageError(_urequest: RouteMessageWrapper, _context: ServerCallContext): Promise<RouteMessageAck> {
         throw new Error()
+    }
+}
+
+interface IStoreServiceWithError extends IStoreService {
+    throwStoreDataError: (request: StoreDataRequest, _context: ServerCallContext) => Promise<StoreDataResponse>
+    storeDataErrorString: (request: StoreDataRequest, _context: ServerCallContext) => Promise<StoreDataResponse>
+}
+
+export const MockStoreService: IStoreServiceWithError = {
+    async storeData(_request: StoreDataRequest, _context: ServerCallContext): Promise<StoreDataResponse> {
+        return {
+            error: ''
+        }
+    },
+    async throwStoreDataError(_request: StoreDataRequest, _context: ServerCallContext): Promise<StoreDataResponse> {
+        throw new Error('Mock')
+    },
+    async storeDataErrorString(_request: StoreDataRequest, _context: ServerCallContext): Promise<StoreDataResponse> {
+        return {
+            error: 'Mock'
+        }
     }
 }
 

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -16,15 +16,17 @@ import type { WebSocketConnectionResponse } from "./DhtRpc";
 import type { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindSessionService } from "./DhtRpc";
 import type { RecursiveFindReport } from "./DhtRpc";
+import { StoreService } from "./DhtRpc";
+import type { StoreDataResponse } from "./DhtRpc";
+import type { StoreDataRequest } from "./DhtRpc";
+import { RoutingService } from "./DhtRpc";
+import type { RouteMessageAck } from "./DhtRpc";
+import type { RouteMessageWrapper } from "./DhtRpc";
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { DhtRpcService } from "./DhtRpc";
-import type { StoreDataResponse } from "./DhtRpc";
-import type { StoreDataRequest } from "./DhtRpc";
 import type { Empty } from "../../../google/protobuf/empty";
 import type { LeaveNotice } from "./DhtRpc";
-import type { RouteMessageAck } from "./DhtRpc";
-import type { RouteMessageWrapper } from "./DhtRpc";
 import type { PingResponse } from "./DhtRpc";
 import type { PingRequest } from "./DhtRpc";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
@@ -45,25 +47,9 @@ export interface IDhtRpcServiceClient {
      */
     ping(input: PingRequest, options?: RpcOptions): UnaryCall<PingRequest, PingResponse>;
     /**
-     * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
-    /**
      * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
      */
     leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty>;
-    /**
-     * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
-     */
-    storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse>;
 }
 /**
  * @generated from protobuf service dht.DhtRpcService
@@ -89,38 +75,84 @@ export class DhtRpcServiceClient implements IDhtRpcServiceClient, ServiceInfo {
         return stackIntercept<PingRequest, PingResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     */
+    leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<LeaveNotice, Empty>("unary", this._transport, method, opt, input);
+    }
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export interface IRoutingServiceClient {
+    /**
      * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[2], opt = this._transport.mergeOptions(options);
-        return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
-    }
+    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
+    /**
+     * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
+     */
+    forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
     /**
      * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[3], opt = this._transport.mergeOptions(options);
+    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck>;
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export class RoutingServiceClient implements IRoutingServiceClient, ServiceInfo {
+    typeName = RoutingService.typeName;
+    methods = RoutingService.methods;
+    options = RoutingService.options;
+    constructor(private readonly _transport: RpcTransport) {
+    }
+    /**
+     * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
+     */
+    routeMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
+        const method = this.methods[0], opt = this._transport.mergeOptions(options);
         return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     forwardMessage(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
-        const method = this.methods[4], opt = this._transport.mergeOptions(options);
+        const method = this.methods[1], opt = this._transport.mergeOptions(options);
         return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
     }
     /**
-     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty> {
-        const method = this.methods[5], opt = this._transport.mergeOptions(options);
-        return stackIntercept<LeaveNotice, Empty>("unary", this._transport, method, opt, input);
+    findRecursively(input: RouteMessageWrapper, options?: RpcOptions): UnaryCall<RouteMessageWrapper, RouteMessageAck> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RouteMessageWrapper, RouteMessageAck>("unary", this._transport, method, opt, input);
+    }
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export interface IStoreServiceClient {
+    /**
+     * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
+     */
+    storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse>;
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export class StoreServiceClient implements IStoreServiceClient, ServiceInfo {
+    typeName = StoreService.typeName;
+    methods = StoreService.methods;
+    options = StoreService.options;
+    constructor(private readonly _transport: RpcTransport) {
     }
     /**
      * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
      */
     storeData(input: StoreDataRequest, options?: RpcOptions): UnaryCall<StoreDataRequest, StoreDataResponse> {
-        const method = this.methods[6], opt = this._transport.mergeOptions(options);
+        const method = this.methods[0], opt = this._transport.mergeOptions(options);
         return stackIntercept<StoreDataRequest, StoreDataResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -14,10 +14,10 @@ import { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindReport } from "./DhtRpc";
 import { StoreDataResponse } from "./DhtRpc";
 import { StoreDataRequest } from "./DhtRpc";
-import { Empty } from "../../../google/protobuf/empty";
-import { LeaveNotice } from "./DhtRpc";
 import { RouteMessageAck } from "./DhtRpc";
 import { RouteMessageWrapper } from "./DhtRpc";
+import { Empty } from "../../../google/protobuf/empty";
+import { LeaveNotice } from "./DhtRpc";
 import { PingResponse } from "./DhtRpc";
 import { PingRequest } from "./DhtRpc";
 import { ClosestPeersResponse } from "./DhtRpc";
@@ -36,21 +36,31 @@ export interface IDhtRpcService<T = ServerCallContext> {
      */
     ping(request: PingRequest, context: T): Promise<PingResponse>;
     /**
+     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     */
+    leaveNotice(request: LeaveNotice, context: T): Promise<Empty>;
+}
+/**
+ * @generated from protobuf service dht.RoutingService
+ */
+export interface IRoutingService<T = ServerCallContext> {
+    /**
      * @generated from protobuf rpc: routeMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     routeMessage(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
-    /**
-     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
-     */
-    findRecursively(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
     /**
      * @generated from protobuf rpc: forwardMessage(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
     forwardMessage(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
     /**
-     * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
+     * @generated from protobuf rpc: findRecursively(dht.RouteMessageWrapper) returns (dht.RouteMessageAck);
      */
-    leaveNotice(request: LeaveNotice, context: T): Promise<Empty>;
+    findRecursively(request: RouteMessageWrapper, context: T): Promise<RouteMessageAck>;
+}
+/**
+ * @generated from protobuf service dht.StoreService
+ */
+export interface IStoreService<T = ServerCallContext> {
     /**
      * @generated from protobuf rpc: storeData(dht.StoreDataRequest) returns (dht.StoreDataResponse);
      */

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -1144,10 +1144,20 @@ export const DisconnectNotice = new DisconnectNotice$Type();
 export const DhtRpcService = new ServiceType("dht.DhtRpcService", [
     { name: "getClosestPeers", options: {}, I: ClosestPeersRequest, O: ClosestPeersResponse },
     { name: "ping", options: {}, I: PingRequest, O: PingResponse },
+    { name: "leaveNotice", options: {}, I: LeaveNotice, O: Empty }
+]);
+/**
+ * @generated ServiceType for protobuf service dht.RoutingService
+ */
+export const RoutingService = new ServiceType("dht.RoutingService", [
     { name: "routeMessage", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
-    { name: "findRecursively", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
     { name: "forwardMessage", options: {}, I: RouteMessageWrapper, O: RouteMessageAck },
-    { name: "leaveNotice", options: {}, I: LeaveNotice, O: Empty },
+    { name: "findRecursively", options: {}, I: RouteMessageWrapper, O: RouteMessageAck }
+]);
+/**
+ * @generated ServiceType for protobuf service dht.StoreService
+ */
+export const StoreService = new ServiceType("dht.StoreService", [
     { name: "storeData", options: {}, I: StoreDataRequest, O: StoreDataResponse }
 ]);
 /**


### PR DESCRIPTION
## Summary

Split DhtRpc and DhtPeer into feature specific services.

## Limitations and future improvements

RoutingService could be split in two parts, routing + forwarding and recursiveFind.

