### PR TITLE
Improve docker tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,15 +68,8 @@ jobs:
         with:
           images: ${{inputs.image_name}}
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=semver,pattern=v{{version}}
             type=raw,value=dev,enable=${{ inputs.test_success }}
-            type=raw,value=debug,enable=${{ !inputs.test_success }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=schedule,pattern=nightly
 
       - name: Build
         if: ${{!inputs.push_image}}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           images: ${{inputs.image_name}}
           tags: |
+            type=match,pattern=broker/v(.*),group=1
             type=raw,value=dev,enable=${{ inputs.test_success }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,8 +66,8 @@ jobs:
           images: ${{inputs.image_name}}
           tags: |
             type=match,pattern=broker/v(.*),group=1
-            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/broker/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
 
       - name: Build
         if: ${{!inputs.push_image}}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{inputs.image_name}}
           tags: |
-            type=match,pattern=broker/v(.*),group=1
+            type=match,pattern=broker/(v.*),group=1
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/broker/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha') }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,9 +22,6 @@ on:
       build_platforms:
         type: string
         required: true
-      test_success:
-        description: required when pushing images
-        type: boolean
 
     secrets:
       dockerhub_username:
@@ -69,7 +66,7 @@ jobs:
           images: ${{inputs.image_name}}
           tags: |
             type=match,pattern=broker/v(.*),group=1
-            type=raw,value=dev,enable=${{ inputs.test_success }}
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       docker_file: Dockerfile.tracker
       image_name: streamr/tracker
       build_platforms: linux/amd64
-      push_image: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+      push_image: ${{ github.event.workflow_run.conclusion == 'success' }}
     secrets:
       dockerhub_username: ${{secrets.DOCKERHUB_USERNAME}}
       dockerhub_token: ${{secrets.DOCKERHUB_TOKEN}}
@@ -23,7 +23,7 @@ jobs:
       image_name: streamr/broker-node
       host_machine_platform: self-hosted
       build_platforms: linux/amd64,linux/arm64
-      push_image: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+      push_image: ${{ github.event.workflow_run.conclusion == 'success' }}
     secrets:
       dockerhub_username: ${{secrets.DOCKERHUB_USERNAME}}
       dockerhub_token: ${{secrets.DOCKERHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: release
 on:
-  workflow_dispatch:
   workflow_run:
     branches: [main]
     workflows: [validate]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,7 @@ jobs:
       docker_file: Dockerfile.tracker
       image_name: streamr/tracker
       build_platforms: linux/amd64
-      push_image: true
-      test_success: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+      push_image: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     secrets:
       dockerhub_username: ${{secrets.DOCKERHUB_USERNAME}}
       dockerhub_token: ${{secrets.DOCKERHUB_TOKEN}}
@@ -25,8 +24,7 @@ jobs:
       image_name: streamr/broker-node
       host_machine_platform: self-hosted
       build_platforms: linux/amd64,linux/arm64
-      push_image: true
-      test_success: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+      push_image: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     secrets:
       dockerhub_username: ${{secrets.DOCKERHUB_USERNAME}}
       dockerhub_token: ${{secrets.DOCKERHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -187,9 +187,5 @@ npm publish
 
 #### Docker release
 
-1. Go to https://github.com/streamr-dev/network/actions/workflows/release.yml
-2. From "run workflow" dropdown:
-   - select `main` branch
-   - click "Run workflow"
-3. You can manually cancel other queued workflows (triggered by possible previous commits to `main`)
-4. After ~1 hour a new release is ready, annotated with `latest` tag: https://hub.docker.com/r/streamr/broker-node/tags
+After pushing the broker tag, GitHub Actions will build and publish the Docker image automatically if
+tests pass.


### PR DESCRIPTION
## Summary

Change the way broker docker image tags are published to Docker Hub. We want the following rules to be observed:
- When pushing a git tag, e.g.`broker/v31.8.9` then the equivalent broker docker image is published under `v31.8.9` tag to Docker Hub.
- When pushing anything into `main` branch, the equivalent broker docker image get published to Docker Hub with tag `dev`.
- When pushing a git tag, e.g.`broker/v31.8.9` that *does not* contain words `beta` or `alpha`, then the equivalent broker docker image is published under tag `latest`.

Notice that we may publish a version tag and `latest` tag in one go.

## Limitations and future improvements

There is one particularly annoying edge case that may lead to unintended `latest` tags.

Say you have published a version `31.8.9` and then later decide to publisher `32.0.0`. Now if you decide you want to release a patch version `31.8.10`, it will become `latest`. This is most likely not be what is wanted as the intention of `latest` would be to have the very recent latest major version. This needs to be addressed in a later PR, probably in the near future.
