### PR TITLE
fix: tracker invalidates status messages with empty stream ids

### DIFF
--- a/packages/network-tracker/src/helpers/schemas.ts
+++ b/packages/network-tracker/src/helpers/schemas.ts
@@ -2,7 +2,8 @@ const streamStatusSchemaLatest = {
     type: 'object',
     properties: {
         id: {
-            type: 'string'
+            type: 'string',
+            minLength: 1
         },
         partition: {
             type: 'number'

--- a/packages/network-tracker/test/unit/statusValidation.test.ts
+++ b/packages/network-tracker/test/unit/statusValidation.test.ts
@@ -1,0 +1,36 @@
+import { StatusMessage } from "@streamr/protocol"
+import { StatusValidator } from '../../src/helpers/SchemaValidators'
+
+describe('statusValidation', () => {
+    it('happy path', () => {
+        const validator = new StatusValidator()
+        const statusMessage = new StatusMessage({
+            status: {
+                streamPart: {
+                    id: 'a',
+                    partition: 0,
+                    neighbors: [],
+                    counter: 0
+                }
+            },
+            requestId: 'request'
+        })
+        expect(validator.validate(statusMessage.status)).toEqual(true)
+    })
+
+    it('fails with empty string as streamId', () => {
+        const validator = new StatusValidator()
+        const statusMessage = new StatusMessage({
+            status: {
+                streamPart: {
+                    id: '',
+                    partition: 0,
+                    neighbors: [],
+                    counter: 0
+                }
+            },
+            requestId: 'request'
+        })
+        expect(validator.validate(statusMessage.status)).toEqual(false)
+    })
+})


### PR DESCRIPTION
## Summary

Tracker now validates status messages with empty strings as stream ids
