### PR TITLE
NET-948 (client): rename and increase ens stream creation timeout

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increase default timeout of stream creation when ENS domains are used
+
 ### Deprecated
 
 ### Removed

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -144,7 +144,7 @@ export interface StreamrClientConfig {
             timeout?: number
             retryInterval?: number
         }
-        jsonRpc?: {
+        ensStreamCreation?: {
             timeout?: number
             retryInterval?: number
         }

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -61,7 +61,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
             timeout: 30 * 1000,
             retryInterval: 500
         },
-        jsonRpc: {
+        ensStreamCreation: {
             timeout: 20 * 1000,
             retryInterval: 500
         },

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -288,6 +288,8 @@ export class StreamrClient {
      *
      * @param propsOrStreamIdOrPath - the stream id to be used for the new stream, and optionally, any
      * associated metadata
+     *
+     * @remarks when creating a stream with an ENS domain, the returned promise can take several minutes to settle
      */
     async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
@@ -304,6 +306,8 @@ export class StreamrClient {
      * @category Important
      *
      * @param props - the stream id to get or create. Field `partitions` is only used if creating the stream.
+     *
+     * @remarks when creating a stream with an ENS domain, the returned promise can take several minutes to settle
      */
     async getOrCreateStream(props: { id: string, partitions?: number }): Promise<Stream> {
         try {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -436,7 +436,7 @@
                     },
                     "default": {}
                 },
-                "jsonRpc": {
+                "ensStreamCreation": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -442,7 +442,7 @@
                     "properties": {
                         "timeout": {
                             "type": "number",
-                            "default": 30000
+                            "default": 180000
                         },
                         "retryInterval": {
                             "type": "number",

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -144,9 +144,9 @@ export class StreamRegistry {
                 await until(
                     async () => this.streamExistsOnChain(streamId),
                     // eslint-disable-next-line no-underscore-dangle
-                    this.config._timeouts.jsonRpc.timeout,
+                    this.config._timeouts.ensStreamCreation.timeout,
                     // eslint-disable-next-line no-underscore-dangle
-                    this.config._timeouts.jsonRpc.retryInterval
+                    this.config._timeouts.ensStreamCreation.retryInterval
                 )
             } catch (e) {
                 throw new Error(`unable to create stream "${streamId}"`)

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -16,7 +16,7 @@ const PARTITION_COUNT = 3
 const TIMEOUT_CONFIG = {
     // eslint-disable-next-line no-underscore-dangle
     ...CONFIG_TEST._timeouts!,
-    jsonRpc: {
+    ensStreamCreation: {
         timeout: 5000,
         retryInterval: 200
     }


### PR DESCRIPTION
## Summary

Rename config options `jsonRpc.timeout` and `jsonRpc.retryInterval` to `ensStreamCreation.timeout` and `ensStreamCreation.retryInterval` to more accurately portray their use. Also increase default timeout from 30 seconds to 180 seconds.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
