### PR TITLE
fix(client): `SubscribeOptions` type

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -36,6 +36,8 @@ import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
 import { StreamrClientError } from './StreamrClientError'
 
+export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions }
+
 /**
  * The main API used to interact with Streamr.
  *
@@ -160,7 +162,7 @@ export class StreamrClient {
      * @returns a {@link Subscription} that can be used to manage the subscription etc.
      */
     async subscribe(
-        options: StreamDefinition & { resend?: ResendOptions },
+        options: SubscribeOptions,
         onMessage?: MessageListener
     ): Promise<Subscription> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(options)

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -1,7 +1,7 @@
 /**
  * This file captures named exports so we can manipulate them for cjs/browser builds.
  */
-export { StreamrClient } from './StreamrClient'
+export { StreamrClient, SubscribeOptions } from './StreamrClient'
 export { Stream, StreamMetadata, Field, VALID_FIELD_TYPES } from './Stream'
 export { Message, MessageMetadata } from './Message'
 export { StreamrClientEvents } from './events'


### PR DESCRIPTION
Use named type so that TypeDoc renders the type correctly. Before this PR the type of `subscribe(opts`) was rendered as `Object` in the API docs.

TODO maybe we have similar problem with other types?