### PR TITLE
NET-950 feat(network): prohibit setProxies when acceptProxyConnections=true

### DIFF
--- a/packages/network/src/logic/NetworkNode.ts
+++ b/packages/network/src/logic/NetworkNode.ts
@@ -33,6 +33,9 @@ export class NetworkNode extends Node {
         getUserId: () => Promise<string>,
         connectionCount?: number
     ): Promise<void> {
+        if (this.acceptProxyConnections) {
+            throw new Error('cannot set proxies when acceptProxyConnections=true')
+        }
         await this.doSetProxies(streamPartId, contactNodeIds, direction, getUserId, connectionCount)
     }
 

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -83,7 +83,7 @@ export class Node extends EventEmitter {
     private readonly metricsContext: MetricsContext
     private readonly metrics: Metrics
     protected extraMetadata: Record<string, unknown> = {}
-    private readonly acceptProxyConnections: boolean
+    protected readonly acceptProxyConnections: boolean
     private readonly proxyStreamConnectionClient: ProxyStreamConnectionClient
     private readonly proxyStreamConnectionServer: ProxyStreamConnectionServer
 

--- a/packages/network/test/unit/NetworkNode.test.ts
+++ b/packages/network/test/unit/NetworkNode.test.ts
@@ -1,19 +1,28 @@
 import { NetworkNode } from '../../src/logic/NetworkNode'
 import { Tracker } from '@streamr/network-tracker'
 import { createTestNetworkNode, startTestTracker } from '../utils'
+import { ProxyDirection, toStreamID, toStreamPartID } from '@streamr/protocol'
+import { randomEthereumAddress } from '@streamr/test-utils'
 
 describe('NetworkNode', () => {
     let tracker: Tracker
     let node: NetworkNode
+    let node2: NetworkNode | undefined
+
     beforeEach(async () => {
         tracker = await startTestTracker({
             port: 30410
         })
-        const trackerInfo = tracker.getConfigRecord()
         node = createTestNetworkNode({
             id: 'node-1',
-            trackers: [trackerInfo]
+            trackers: [tracker.getConfigRecord()]
         })
+    })
+
+    afterEach(async () => {
+        await tracker.stop()
+        await node.stop()
+        await node2?.stop()
     })
 
     it('has id & peerInfo', () => {
@@ -22,8 +31,18 @@ describe('NetworkNode', () => {
         expect(node.peerInfo.isTracker()).toEqual(false)
     })
 
-    afterEach(async () => {
-        await tracker.stop()
-        await node.stop()
+    it('setProxies throws error if acceptProxyConnections=true (NET-950)', async () => {
+        node2 = createTestNetworkNode({
+            id: 'node-1',
+            trackers: [tracker.getConfigRecord()],
+            acceptProxyConnections: true
+        })
+        await expect(() => node2!.setProxies(
+            toStreamPartID(toStreamID('/foobar', randomEthereumAddress()), 0),
+            ['0xa', '0xb'],
+            ProxyDirection.SUBSCRIBE,
+            () => Promise.resolve(''),
+            1
+        )).rejects.toThrow('cannot set proxies when acceptProxyConnections=true')
     })
 })


### PR DESCRIPTION
## Summary

Prevent the use of method `networkNode#setProxies` when accepting proxy connections (i.e. `acceptProxyConnections=true`). Throw a human readable error if such usage is attempted.

## Limitations and future improvements

The main reason for implementing this restriction is due to incomplete state management in the code when a node
- wishes to act as a proxy themselves, and
- wishes to subscribe / publish to a stream using another proxy node.

Our evaluation is that this is a very unlikely scenario in practice. If such behavior is wanted in the future, the restriction imposed in this PR should be removed and the state management logic should be changed to accommodate this scenario.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
