### PR TITLE
feat(client): Raw subscription

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add boolean option `raw` to method `.subscribe` to allow raw subscription a stream
+- Add boolean option `raw` to method `.subscribe` to allow raw subscription to a stream
 
 ### Changed
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add boolean option `raw` to method `.subscribe` to allow raw subscription a stream
+
 ### Changed
 
 - Increase default timeout of stream creation when ENS domains are used

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -232,7 +232,7 @@ export class Stream {
         const normalizedNodeAddress = toEthereumAddress(storageNodeAddress)
         try {
             const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
-            assignmentSubscription = new Subscription(streamPartId, this._loggerFactory)
+            assignmentSubscription = new Subscription(streamPartId, false, this._loggerFactory)
             await this._subscriber.add(assignmentSubscription)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
                 id: this.id,

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -36,7 +36,11 @@ import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
 import { StreamrClientError } from './StreamrClientError'
 
-export type SubscribeOptions = StreamDefinition & {
+// TODO: this type only exists to enable tsdoc to generate proper documentation
+export type SubscribeOptions = StreamDefinition & ExtraSubscribeOptions
+
+// TODO: this type only exists to enable tsdoc to generate proper documentation
+export interface ExtraSubscribeOptions {
     resend?: ResendOptions
 
     /**

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -36,7 +36,7 @@ import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
 import { StreamrClientError } from './StreamrClientError'
 
-export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions }
+export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions, isRaw?: boolean }
 
 /**
  * The main API used to interact with Streamr.
@@ -165,6 +165,9 @@ export class StreamrClient {
         options: SubscribeOptions,
         onMessage?: MessageListener
     ): Promise<Subscription> {
+        if ((options.isRaw === true) && (options.resend !== undefined)) {
+            throw new Error('Raw subscriptions are not supported for resend')
+        }
         const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
         const sub = (options.resend !== undefined)
             ? new ResendSubscription(
@@ -174,7 +177,7 @@ export class StreamrClient {
                 this.loggerFactory,
                 this.config
             )
-            : new Subscription(streamPartId, this.loggerFactory)
+            : new Subscription(streamPartId, options.isRaw ?? false, this.loggerFactory)
         await this.subscriber.add(sub)
         if (onMessage !== undefined) {
             sub.useLegacyOnMessageHandler(onMessage)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -36,7 +36,15 @@ import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
 import { StreamrClientError } from './StreamrClientError'
 
-export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions, raw?: boolean }
+export type SubscribeOptions = StreamDefinition & {
+    resend?: ResendOptions
+
+    /**
+     * Subscribe raw with validation, permission checking, ordering, gap filling,
+     * and decryption _disabled_.
+     */
+    raw?: boolean
+}
 
 /**
  * The main API used to interact with Streamr.

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -36,7 +36,7 @@ import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
 import { StreamrClientError } from './StreamrClientError'
 
-export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions, isRaw?: boolean }
+export type SubscribeOptions = StreamDefinition & { resend?: ResendOptions, raw?: boolean }
 
 /**
  * The main API used to interact with Streamr.
@@ -165,7 +165,7 @@ export class StreamrClient {
         options: SubscribeOptions,
         onMessage?: MessageListener
     ): Promise<Subscription> {
-        if ((options.isRaw === true) && (options.resend !== undefined)) {
+        if ((options.raw === true) && (options.resend !== undefined)) {
             throw new Error('Raw subscriptions are not supported for resend')
         }
         const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
@@ -177,7 +177,7 @@ export class StreamrClient {
                 this.loggerFactory,
                 this.config
             )
-            : new Subscription(streamPartId, options.isRaw ?? false, this.loggerFactory)
+            : new Subscription(streamPartId, options.raw ?? false, this.loggerFactory)
         await this.subscriber.add(sub)
         if (onMessage !== undefined) {
             sub.useLegacyOnMessageHandler(onMessage)

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -1,7 +1,7 @@
 /**
  * This file captures named exports so we can manipulate them for cjs/browser builds.
  */
-export { StreamrClient, SubscribeOptions } from './StreamrClient'
+export { StreamrClient, SubscribeOptions, ExtraSubscribeOptions } from './StreamrClient'
 export { Stream, StreamMetadata, Field, VALID_FIELD_TYPES } from './Stream'
 export { Message, MessageMetadata } from './Message'
 export { StreamrClientEvents } from './events'

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -22,7 +22,7 @@ export class ResendSubscription extends Subscription {
         loggerFactory: LoggerFactory,
         @inject(ConfigInjectionToken) config: StrictStreamrClientConfig
     ) {
-        super(streamPartId, loggerFactory)
+        super(streamPartId, false, loggerFactory)
         this.resendOptions = resendOptions
         this.resends = resends
         this.orderMessages = new OrderMessages(

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -28,11 +28,14 @@ export class Subscription extends MessageStream {
     protected readonly logger: Logger
     readonly streamPartId: StreamPartID
     protected eventEmitter: EventEmitter<SubscriptionEvents>
+    /** @internal */
+    readonly isRaw: boolean
 
     /** @internal */
-    constructor(streamPartId: StreamPartID, loggerFactory: LoggerFactory) {
+    constructor(streamPartId: StreamPartID, isRaw: boolean, loggerFactory: LoggerFactory) {
         super()
         this.streamPartId = streamPartId
+        this.isRaw = isRaw
         this.eventEmitter = new EventEmitter<SubscriptionEvents>()
         this.logger = loggerFactory.createLogger(module)
         this.onMessage.listen((msg) => {

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -103,7 +103,19 @@ export class SubscriptionSession {
             return
         }
 
-        await this.pipeline.push(msg)
+        const tasks = []
+        let hasNormalSubscriptions = false
+        for (const sub of this.subscriptions.values()) {
+            if (sub.isRaw) {
+                tasks.push(sub.push(msg))
+            } else {
+                hasNormalSubscriptions = true
+            }
+        }
+        if (hasNormalSubscriptions) {
+            tasks.push(this.pipeline.push(msg))
+        }
+        await Promise.all(tasks)
     }
 
     private async subscribe(): Promise<NetworkNodeStub> {

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -89,7 +89,7 @@ describe('Subscriber', () => {
 
     })
 
-    describe('normal subscription', () => {
+    describe('raw subscription', () => {
 
         it('without encryption', async () => {
             await stream.grantPermissions({

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -37,51 +37,106 @@ describe('Subscriber', () => {
         await environment.destroy()
     })
 
-    it('without encryption', async () => {
-        await stream.grantPermissions({
-            permissions: [StreamPermission.PUBLISH],
-            public: true
+    describe('normal subscription', () => {
+
+        it('without encryption', async () => {
+            await stream.grantPermissions({
+                permissions: [StreamPermission.PUBLISH],
+                public: true
+            })
+    
+            const sub = await subscriber.subscribe(stream.id)
+    
+            const publisherNode = environment.startNode(publisherWallet.address)
+            publisherNode.publish(await createMockMessage({
+                stream,
+                publisher: publisherWallet,
+                content: MOCK_CONTENT
+            }))
+    
+            const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
+            expect(receivedMessage!.content).toEqual(MOCK_CONTENT)
+        })
+    
+        it('with encryption', async () => {
+            await stream.grantPermissions({
+                permissions: [StreamPermission.PUBLISH],
+                user: publisherWallet.address
+            })
+    
+            const groupKey = GroupKey.generate()
+            const publisher = environment.createClient({
+                auth: {
+                    privateKey: publisherWallet.privateKey
+                }
+            })
+            await publisher.addEncryptionKey(groupKey, toEthereumAddress(publisherWallet.address))
+    
+            const sub = await subscriber.subscribe(stream.id)
+    
+            const publisherNode = await publisher.getNode()
+            publisherNode.publish(await createMockMessage({
+                stream,
+                publisher: publisherWallet,
+                content: MOCK_CONTENT,
+                encryptionKey: groupKey
+            }))
+    
+            const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
+            expect(receivedMessage!.content).toEqual(MOCK_CONTENT)
+            expect(receivedMessage!.streamMessage.groupKeyId).toEqual(groupKey.id)
         })
 
-        const sub = await subscriber.subscribe(stream.id)
-
-        const publisherNode = environment.startNode(publisherWallet.address)
-        publisherNode.publish(await createMockMessage({
-            stream,
-            publisher: publisherWallet,
-            content: MOCK_CONTENT
-        }))
-
-        const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
-        expect(receivedMessage!.content).toEqual(MOCK_CONTENT)
     })
 
-    it('with encryption', async () => {
-        await stream.grantPermissions({
-            permissions: [StreamPermission.PUBLISH],
-            user: publisherWallet.address
+    describe('normal subscription', () => {
+
+        it('without encryption', async () => {
+            await stream.grantPermissions({
+                permissions: [StreamPermission.PUBLISH],
+                public: true
+            })
+    
+            const sub = await subscriber.subscribe({ streamId: stream.id, isRaw: true })
+    
+            const publisherNode = environment.startNode(publisherWallet.address)
+            publisherNode.publish(await createMockMessage({
+                stream,
+                publisher: publisherWallet,
+                content: MOCK_CONTENT
+            }))
+    
+            const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
+            expect(receivedMessage!.content).toEqual(MOCK_CONTENT)
         })
-
-        const groupKey = GroupKey.generate()
-        const publisher = environment.createClient({
-            auth: {
-                privateKey: publisherWallet.privateKey
-            }
+    
+        it('with encryption', async () => {
+            await stream.grantPermissions({
+                permissions: [StreamPermission.PUBLISH],
+                user: publisherWallet.address
+            })
+    
+            const groupKey = GroupKey.generate()
+            const publisher = environment.createClient({
+                auth: {
+                    privateKey: publisherWallet.privateKey
+                }
+            })
+            await publisher.addEncryptionKey(groupKey, toEthereumAddress(publisherWallet.address))
+    
+            const sub = await subscriber.subscribe({ streamId: stream.id, isRaw: true })
+    
+            const publisherNode = await publisher.getNode()
+            publisherNode.publish(await createMockMessage({
+                stream,
+                publisher: publisherWallet,
+                content: MOCK_CONTENT,
+                encryptionKey: groupKey
+            }))
+    
+            const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
+            expect(receivedMessage!.content).toBeString()
+            expect(receivedMessage!.streamMessage.groupKeyId).toEqual(groupKey.id)
         })
-        await publisher.addEncryptionKey(groupKey, toEthereumAddress(publisherWallet.address))
-
-        const sub = await subscriber.subscribe(stream.id)
-
-        const publisherNode = await publisher.getNode()
-        publisherNode.publish(await createMockMessage({
-            stream,
-            publisher: publisherWallet,
-            content: MOCK_CONTENT,
-            encryptionKey: groupKey
-        }))
-
-        const receivedMessage = await nextValue(sub[Symbol.asyncIterator]())
-        expect(receivedMessage!.content).toEqual(MOCK_CONTENT)
-        expect(receivedMessage!.streamMessage.groupKeyId).toEqual(groupKey.id)
     })
 })

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -97,7 +97,7 @@ describe('Subscriber', () => {
                 public: true
             })
     
-            const sub = await subscriber.subscribe({ streamId: stream.id, isRaw: true })
+            const sub = await subscriber.subscribe({ streamId: stream.id, raw: true })
     
             const publisherNode = environment.startNode(publisherWallet.address)
             publisherNode.publish(await createMockMessage({
@@ -124,7 +124,7 @@ describe('Subscriber', () => {
             })
             await publisher.addEncryptionKey(groupKey, toEthereumAddress(publisherWallet.address))
     
-            const sub = await subscriber.subscribe({ streamId: stream.id, isRaw: true })
+            const sub = await subscriber.subscribe({ streamId: stream.id, raw: true })
     
             const publisherNode = await publisher.getNode()
             publisherNode.publish(await createMockMessage({


### PR DESCRIPTION
## Summary

Add boolean option `raw` to method `client#subscribe` to allow raw subscription to a stream.

## Limitations and future improvements

- Raw subscriptions do not support resend. Will throw human-readable error if you try. Maybe implement later.
- The subscription system as a whole is in need of a refactor. This implementation could be implemented in a cleaner way using a more straightforward subscription implementation.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
