### PR TITLE
chore: remove exported validateConfig

### DIFF
--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -1,5 +1,5 @@
 import { Logger, toEthereumAddress } from '@streamr/utils'
-import StreamrClient, { validateConfig as validateClientConfig, NetworkNodeStub } from 'streamr-client'
+import StreamrClient, { NetworkNodeStub } from 'streamr-client'
 import { Server as HttpServer } from 'http'
 import { Server as HttpsServer } from 'https'
 import { createPlugin } from './pluginRegistry'
@@ -21,8 +21,6 @@ export interface Broker {
 
 export const createBroker = async (configWithoutDefaults: Config): Promise<Broker> => {
     const config = validateConfig(configWithoutDefaults, BROKER_CONFIG_SCHEMA)
-    validateClientConfig(config.client)
-
     const streamrClient = new StreamrClient(config.client)
 
     const plugins: Plugin<any>[] = Object.keys(config.plugins).map((name) => {

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -9,7 +9,6 @@ const MOCK_PRIVATE_KEY = '0x1111111111111111111111111111111111111111111111111111
 
 const validateTargetConfig = async (config: any): Promise<void> | never => {
     validateConfig(config, BROKER_CONFIG_SCHEMA)
-    validateClientConfig(config.client)
     for (const pluginName of Object.keys(config.plugins)) {
         const pluginConfig = config.plugins[pluginName]
         // validates the config against the schema

--- a/packages/broker/test/unit/configMigration.test.ts
+++ b/packages/broker/test/unit/configMigration.test.ts
@@ -1,5 +1,4 @@
 import merge from 'lodash/merge'
-import { validateConfig as validateClientConfig } from 'streamr-client'
 import { createMigratedConfig, CURRENT_CONFIGURATION_VERSION, formSchemaUrl, needsMigration } from '../../src/config/migration'
 import BROKER_CONFIG_SCHEMA from '../../src/config/config.schema.json'
 import { validateConfig } from '../../src/config/validateConfig'

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -29,7 +29,6 @@ export {
     ProviderAuthConfig,
     PrivateKeyAuthConfig,
     STREAMR_STORAGE_NODE_GERMANY,
-    validateConfig
 } from './Config'
 export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'


### PR DESCRIPTION
## Summary

Remove exported function `validateConfig` from client. It was used by broker to validate config but this is done within `StreamrClient` constructor as well so no need to double validate. (There used to be a good reason to do the validation in broker.)

## Limitations and future improvements

This is technically a breaking change with regards to semver; in practice this function is used internally only. So will be a bit naughty here and not increase major version.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
