### PR TITLE
test(client): NET-956 Check docs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,6 +86,7 @@ jobs:
       command: |
         npm run test-unit
         npm run test-integration
+        npm run docs
   client-e2e:
     needs: build
     uses: ./.github/workflows/test-setup.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -7926,6 +7926,12 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+            "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+            "dev": true
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "license": "MIT",
@@ -17833,8 +17839,9 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.2.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -25856,13 +25863,15 @@
             "optional": true
         },
         "node_modules/shiki": {
-            "version": "0.11.1",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+            "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
             }
         },
         "node_modules/side-channel": {
@@ -27893,14 +27902,15 @@
             "license": "MIT"
         },
         "node_modules/typedoc": {
-            "version": "0.23.20",
+            "version": "0.23.28",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+            "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "lunr": "^2.3.9",
-                "marked": "^4.0.19",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.11.1"
+                "marked": "^4.2.12",
+                "minimatch": "^7.1.3",
+                "shiki": "^0.14.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
@@ -27909,21 +27919,23 @@
                 "node": ">= 14.14"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x"
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/typedoc/node_modules/marked": {
-            "version": "4.0.19",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -27932,14 +27944,18 @@
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {
-            "version": "5.1.0",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.5.tgz",
+            "integrity": "sha512-OzOamaOmNBJZUv2qqY1OSWa+++4YPpOkLgkc0w30Oov5ufKlWWXnFUl0l4dgmSv5Shq/zRVkEOXAe2NaqO4l5Q==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/typescript": {
@@ -28379,14 +28395,16 @@
             }
         },
         "node_modules/vscode-oniguruma": {
-            "version": "1.6.2",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
         },
         "node_modules/vscode-textmate": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
         },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
@@ -29495,7 +29513,7 @@
                 "terser-webpack-plugin": "^5.2.5",
                 "ts-essentials": "^9.3.0",
                 "ts-loader": "^9.3.1",
-                "typedoc": "^0.23.20",
+                "typedoc": "^0.23.28",
                 "util": "^0.12.4",
                 "weak-napi": "^2.0.2",
                 "webpack": "^5.64.1",
@@ -37798,6 +37816,12 @@
             "version": "6.0.1",
             "dev": true
         },
+        "ansi-sequence-parser": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+            "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+            "dev": true
+        },
         "ansi-styles": {
             "version": "4.3.0",
             "requires": {
@@ -44396,6 +44420,8 @@
         },
         "jsonc-parser": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
             "dev": true
         },
         "jsonfile": {
@@ -49956,12 +49982,15 @@
             "optional": true
         },
         "shiki": {
-            "version": "0.11.1",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+            "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
             "dev": true,
             "requires": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
             }
         },
         "side-channel": {
@@ -50779,7 +50808,7 @@
                 "ts-loader": "^9.3.1",
                 "ts-toolbelt": "^9.6.0",
                 "tsyringe": "^4.6.0",
-                "typedoc": "^0.23.20",
+                "typedoc": "^0.23.28",
                 "utf-8-validate": "^5.0.7",
                 "util": "^0.12.4",
                 "uuid": "^8.3.2",
@@ -51507,28 +51536,36 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.23.20",
+            "version": "0.23.28",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+            "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
             "dev": true,
             "requires": {
                 "lunr": "^2.3.9",
-                "marked": "^4.0.19",
-                "minimatch": "^5.1.0",
-                "shiki": "^0.11.1"
+                "marked": "^4.2.12",
+                "minimatch": "^7.1.3",
+                "shiki": "^0.14.1"
             },
             "dependencies": {
                 "brace-expansion": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
                     }
                 },
                 "marked": {
-                    "version": "4.0.19",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+                    "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
                     "dev": true
                 },
                 "minimatch": {
-                    "version": "5.1.0",
+                    "version": "7.4.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.5.tgz",
+                    "integrity": "sha512-OzOamaOmNBJZUv2qqY1OSWa+++4YPpOkLgkc0w30Oov5ufKlWWXnFUl0l4dgmSv5Shq/zRVkEOXAe2NaqO4l5Q==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
@@ -51799,11 +51836,15 @@
             "dev": true
         },
         "vscode-oniguruma": {
-            "version": "1.6.2",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
             "dev": true
         },
         "vscode-textmate": {
-            "version": "6.0.0",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
             "dev": true
         },
         "w3c-hr-time": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "^5.2.5",
     "ts-essentials": "^9.3.0",
     "ts-loader": "^9.3.1",
-    "typedoc": "^0.23.20",
+    "typedoc": "^0.23.28",
     "util": "^0.12.4",
     "weak-napi": "^2.0.2",
     "webpack": "^5.64.1",

--- a/packages/client/typedoc.js
+++ b/packages/client/typedoc.js
@@ -10,5 +10,6 @@ module.exports = {
     excludeInternal: true,
     includeVersion: true,
     disableSources: true,
-    categorizeByGroup: false
+    categorizeByGroup: false,
+    treatWarningsAsErrors: true
 }


### PR DESCRIPTION
Run `npm run check` in CI to check if there are any warnings when we generate API docs with `typedoc`. A warning typically means that we have not exported some type/class/interface should be part of the public API.

Also updated `typedoc` as the previous version didn't fully support TypeScript 4.9.