### PR TITLE
ci: multiple tags issue in Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,10 +58,10 @@ jobs:
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_token }}
 
-      - name: Get current git tag (for Docker meta) # assuming one tag on current HEAD
+      - name: Get current Broker git tag (for Docker meta)
         run: |
           git fetch --tags origin --force
-          echo "head_tag=$(git tag --points-at HEAD)" >> $GITHUB_ENV
+          echo "broker_head_tag=$(git tag --points-at HEAD --list 'broker/v*')" >> $GITHUB_ENV
 
 
       - name: Docker meta
@@ -73,7 +73,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=match,pattern=broker/(v.*),group=1,value=${{ env.head_tag }}
+            type=match,pattern=broker/(v.*),group=1,value=${{ env.broker_head_tag }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build


### PR DESCRIPTION
### Error

Docker builds jobs fail if there were multiple tags pointing to `HEAD`:
```
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'client/v8.2.0'
```
e.g. https://github.com/streamr-dev/network/actions/runs/4668656728/jobs/8266022274

### Changes

Now we collect only Broker-release tags (`broker/v*`) to the environment variable. We can safely ignore other tags because the Docker meta task uses only tags which match that same pattern (line 76).