### PR TITLE
feat(broker): [NET-945] ask for beneficiary address in broker config wizard

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add beneficiary address prompt to config wizard
+
 ### Changed
 
 ### Deprecated

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -160,7 +160,7 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
         type: 'confirm',
         name: 'wantToSetBeneficiaryAddress',
         // eslint-disable-next-line max-len
-        message: `By default the generated / imported Ethereum identity will be used for staking, would you like to change this to a different address (i.e. set a beneficiary address)?`,
+        message: 'It is recommended to set a separate beneficiary address for security reasons. Would you like to set one?',
         default: false,
         when: (answers: inquirer.Answers) => {
             return answers.enableMinerPlugin
@@ -170,7 +170,7 @@ const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion 
     const beneficiaryAddressPrompt: inquirer.DistinctQuestion = {
         type: 'input',
         name: 'beneficiaryAddress',
-        message: `Please provide a beneficiary (Ethereum) address`,
+        message: 'Please provide a beneficiary address (public key)',
         when: (answers: inquirer.Answers) => {
             return answers.wantToSetBeneficiaryAddress
         },

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -238,11 +238,8 @@ export const getConfig = (privateKey: string, pluginsAnswers: PluginAnswers): an
     })
 
     if (pluginsAnswers.enableMinerPlugin) {
-        config.plugins.brubeckMiner = {}
-        if (pluginsAnswers.beneficiaryAddress !== undefined) {
-            config.plugins.brubeckMiner = {
-                beneficiaryAddress: pluginsAnswers.beneficiaryAddress
-            }
+        config.plugins.brubeckMiner = {
+            beneficiaryAddress: pluginsAnswers.beneficiaryAddress
         }
     }
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -33,6 +33,7 @@ const createMockLogger = () => {
 describe('ConfigWizard', () => {
     const importPrivateKeyPrompt = PROMPTS.privateKey[1]
     const portPrompt = PROMPTS.plugins[1]
+    const beneficiaryAddressPrompt = PROMPTS.plugins[6]
 
     describe('importPrivateKey validate', () => {
         it('happy path, prefixed', () => {
@@ -81,6 +82,18 @@ describe('ConfigWizard', () => {
             const validate = portPrompt.validate!
             const port = 'Not A Number!'
             expect(validate(port)).toBe(`Non-numeric value provided`)
+        })
+    })
+
+    describe('beneficiary address validation', () => {
+        it('happy path, prefixed', () => {
+            const validate = beneficiaryAddressPrompt.validate!
+            expect(validate('0x535620aa186d3243A10b929c8A854510dE00bf77')).toBe(true)
+        })
+
+        it('invalid data', () => {
+            const validate = beneficiaryAddressPrompt.validate!
+            expect(validate('0xloremipsum')).toEqual('Invalid Ethereum address provided.')
         })
     })
 
@@ -269,6 +282,24 @@ describe('ConfigWizard', () => {
                     expect(config.plugins.brubeckMiner).toEqual({})
                     expect(config.plugins.http).toMatchObject({})
                     expect(config.httpServer.port).toBe(parseInt(pluginAnswers.httpPort!))
+                }
+            )
+        })
+
+        it('miner with beneficiaryAddress enabled', async () => {
+            const pluginAnswers: PluginAnswers = {
+                enabledApiPlugins: [],
+                enableMinerPlugin: true,
+                wantToSetBeneficiaryAddress: true,
+                beneficiaryAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            }
+            await assertValidFlow(
+                pluginAnswers,
+                (config: any) => {
+                    expect(Object.keys(config.plugins)).toIncludeSameMembers(['brubeckMiner'])
+                    expect(config.plugins.brubeckMiner).toEqual({
+                        beneficiaryAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+                    })
                 }
             )
         })


### PR DESCRIPTION
## Summary

Add beneficiary address prompt to broker config wizard.

An example prompt:
```
> Do you want to participate in mining and staking? Yes
> By default the generated / imported Ethereum identity will be used for staking, would you like to change this to a different address (i.e. set a beneficiary address)? Yes
> Please provide a beneficiary (Ethereum) address 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
``` 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
