### PR TITLE
fix(network): crashing behavior in ProxyStreamManagerServer

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix crashing issue in network library when `acceptProxyConnections` is enabled.
+
 ### Security
 
 

--- a/packages/network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -97,8 +97,8 @@ export class ProxyStreamConnectionServer {
     }
 
     public getNodeIdsForUserId(streamPartId: StreamPartID, userId: string): NodeId[] {
-        const connections = this.connections.get(streamPartId)!
-        return Array.from(connections.keys()).filter((nodeId) => connections.get(nodeId)!.userId === userId)
+        const connections = this.connections.get(streamPartId)
+        return connections ? Array.from(connections.keys()).filter((nodeId) => connections.get(nodeId)!.userId === userId) : []
     }
 
     stop(): void {

--- a/packages/network/test/unit/ProxyStreamConnectionServer.test.ts
+++ b/packages/network/test/unit/ProxyStreamConnectionServer.test.ts
@@ -1,0 +1,32 @@
+import { ProxyStreamConnectionServer } from '../../src/logic/proxy/ProxyStreamConnectionServer'
+import { StreamPartManager } from '../../src/logic/StreamPartManager'
+import { NodeToNode } from '../../src/protocol/NodeToNode'
+import { Propagation } from '../../src/logic/propagation/Propagation'
+import { Node } from '../../src/logic/Node'
+import { mock } from 'jest-mock-extended'
+import { toStreamID, toStreamPartID } from '@streamr/protocol'
+
+const streamPartId = toStreamPartID(toStreamID('test.ens/foobar'), 0)
+
+describe('ProxyStreamConnectionServer', () => {
+    let connectionServer: ProxyStreamConnectionServer
+
+    beforeEach(() => {
+        connectionServer = new ProxyStreamConnectionServer({
+            streamPartManager: new StreamPartManager(),
+            nodeToNode: mock<NodeToNode>(),
+            propagation: mock<Propagation>(),
+            node: mock<Node>(),
+            acceptProxyConnections: true
+        })
+    })
+
+    afterEach(() => {
+        connectionServer.stop()
+    })
+
+    it('getNodeIdsForUserId returns empty array on non-existing stream part', () => {
+        const actual = connectionServer.getNodeIdsForUserId(streamPartId, 'aaa')
+        expect(actual).toEqual([])
+    })
+})


### PR DESCRIPTION
## Summary

ProxyStreamManagerServer no longer crashes on getNodeIdsForUserId-method if proxy connections have not been requested on a stream partition and the server is propagating a KeyExchange-message for the stream partition.

