### PR TITLE
NET-846: entrypoint recaching

### DIFF
--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -146,6 +146,7 @@ export class StreamrNode extends EventEmitter<Events> {
             stream.layer1.stop()
             this.streams.delete(streamPartID)
         }
+        this.streamEntryPointDiscovery!.stopRecaching(streamPartID)
     }
 
     async joinStream(streamPartID: string, knownEntryPointDescriptors: PeerDescriptor[]): Promise<void> {

--- a/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
+++ b/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
@@ -3,12 +3,14 @@ import { PeerDescriptor, RecursiveFindResult, PeerID } from '@streamr/dht'
 import { StreamObject } from '../../src/logic/StreamrNode'
 import { DataEntry } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { Any } from '../../src/proto/google/protobuf/any'
+import { wait } from '@streamr/utils'
 
 describe('StreamEntryPointDiscovery', () => {
 
     let streamEntryPointDiscoveryWithData: StreamEntryPointDiscovery
     let streamEntryPointDiscoveryWithoutData: StreamEntryPointDiscovery
     let storeCalled: number
+    let streams = new Map<string, StreamObject>()
 
     const peerDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString('mock').value,
@@ -46,17 +48,21 @@ describe('StreamEntryPointDiscovery', () => {
 
     beforeEach(() => {
         storeCalled = 0
+        streams = new Map()
+        streams.set(stream, {} as any)
         streamEntryPointDiscoveryWithData = new StreamEntryPointDiscovery({
             ownPeerDescriptor: peerDescriptor,
-            streams: new Map<string, StreamObject>(),
+            streams,
             getEntryPointData: mockGetEntryPointData,
-            storeEntryPointData: mockStoreEntryPointData
+            storeEntryPointData: mockStoreEntryPointData,
+            cacheInterval: 2000
         })
         streamEntryPointDiscoveryWithoutData = new StreamEntryPointDiscovery({
             ownPeerDescriptor: peerDescriptor,
             streams: new Map<string, StreamObject>(),
             getEntryPointData: emptyGetEntryPointData,
-            storeEntryPointData: mockStoreEntryPointData
+            storeEntryPointData: mockStoreEntryPointData,
+            cacheInterval: 2000
         })
     })
 
@@ -97,6 +103,22 @@ describe('StreamEntryPointDiscovery', () => {
 
     it('store on stream without saturated entrypoint count', async () => {
         await streamEntryPointDiscoveryWithData.storeSelfAsEntryPointIfNecessary(stream, false, true, 0)
+        expect(storeCalled).toEqual(1)
+    })
+
+    it('will keep recaching until stream stopped', async () => {
+        await streamEntryPointDiscoveryWithData.storeSelfAsEntryPointIfNecessary(stream, true, true, 0)
+        expect(storeCalled).toEqual(1)
+        await wait(4500)
+        streamEntryPointDiscoveryWithData.stopRecaching(stream)
+        expect(storeCalled).toEqual(3)
+    })
+
+    it('will stop recaching is stream is left', async () => {
+        await streamEntryPointDiscoveryWithData.storeSelfAsEntryPointIfNecessary(stream, true, true, 0)
+        expect(storeCalled).toEqual(1)
+        streams.delete(stream)
+        await wait(4500)
         expect(storeCalled).toEqual(1)
     })
 


### PR DESCRIPTION
## Summary

Nodes that store themselves as entrypoints will now periodically send new store requests to the DHT for keep-alive
