### PR TITLE
feat(client:) Validate `partitions` metadata field

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Validate `partitions` when parsing contract metadata
+
 ### Deprecated
 
 ### Removed

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -5,7 +5,8 @@ import { StreamRegistryCached } from './registry/StreamRegistryCached'
 import {
     StreamID,
     StreamPartID,
-    toStreamPartID
+    toStreamPartID,
+    ensureValidStreamPartition
 } from '@streamr/protocol'
 import range from 'lodash/range'
 import { StrictStreamrClientConfig } from './Config'
@@ -281,13 +282,13 @@ export class Stream {
     }
 
     /** @internal */
-    static parseMetadata(metadata: string): Partial<StreamMetadata> {
+    static parseMetadata(metadata: string): StreamMetadata {
         try {
             // TODO we could pick the fields of StreamMetadata explicitly, so that this
             // object can't contain extra fields
-            // TODO we should maybe also check that partitions field is available
-            // (if we do that we can return StreamMetadata instead of Partial<StreamMetadata>)
-            return JSON.parse(metadata)
+            const json = JSON.parse(metadata)
+            ensureValidStreamPartition(json.partitions)
+            return json
         } catch (error) {
             throw new Error(`Could not parse properties from onchain metadata: ${metadata}`)
         }

--- a/packages/client/test/unit/searchStreams.test.ts
+++ b/packages/client/test/unit/searchStreams.test.ts
@@ -62,10 +62,12 @@ describe('searchStreams', () => {
         const stream1 = toStreamID('/1', MOCK_USER)
         const stream2 = toStreamID('/2', MOCK_USER)
         const stream3 = toStreamID('/3', MOCK_USER)
+        const stream4 = toStreamID('/4', MOCK_USER)
         const graphQLClient = createMockGraphQLClient([
             createMockResultItem(stream1, JSON.stringify({ partitions: 11 })),
             createMockResultItem(stream2, 'invalid-json'),
-            createMockResultItem(stream3, JSON.stringify({ partitions: 33 }))
+            createMockResultItem(stream3, JSON.stringify({ partitions: 150 })),
+            createMockResultItem(stream4, JSON.stringify({ partitions: 44 }))
         ])
         const parseStream = (id: StreamID, metadata: string): Stream => {
             const props = Stream.parseMetadata(metadata)
@@ -89,7 +91,7 @@ describe('searchStreams', () => {
         expect(streams).toHaveLength(2)
         expect(streams[0].id).toBe(stream1)
         expect(streams[0].getMetadata().partitions).toBe(11)
-        expect(streams[1].id).toBe(stream3)
-        expect(streams[1].getMetadata().partitions).toBe(33)
+        expect(streams[1].id).toBe(stream4)
+        expect(streams[1].getMetadata().partitions).toBe(44)
     })
 })

--- a/packages/protocol/src/utils/StreamPartID.ts
+++ b/packages/protocol/src/utils/StreamPartID.ts
@@ -6,8 +6,8 @@ export const MAX_PARTITION_COUNT = 100
 
 export type StreamPartID = BrandedString<'StreamPartID'>
 
-function ensureValidStreamPartition(streamPartition: number): void | never {
-    if (!Number.isSafeInteger(streamPartition) || streamPartition < 0 || streamPartition >= MAX_PARTITION_COUNT) {
+export function ensureValidStreamPartition(streamPartition: number | undefined): void | never {
+    if (!Number.isSafeInteger(streamPartition) || streamPartition! < 0 || streamPartition! >= MAX_PARTITION_COUNT) {
         throw new Error(`invalid streamPartition value: ${streamPartition}`)
     }
 }

--- a/packages/protocol/src/utils/exports.ts
+++ b/packages/protocol/src/utils/exports.ts
@@ -1,6 +1,6 @@
 import { createTrackerRegistry, TrackerRegistry, TrackerRegistryRecord } from "./TrackerRegistry"
 import { StreamID, toStreamID, StreamIDUtils } from "./StreamID"
-import { StreamPartID, toStreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } from "./StreamPartID"
+import { StreamPartID, toStreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT, ensureValidStreamPartition } from "./StreamPartID"
 import { ProxyDirection } from "./types"
 
 export {
@@ -13,6 +13,7 @@ export {
     StreamIDUtils,
     StreamPartID,
     StreamPartIDUtils,
+    ensureValidStreamPartition,
     MAX_PARTITION_COUNT,
     ProxyDirection
 }


### PR DESCRIPTION
 Validate `partitions` field when parsing contract metadata.