### PR TITLE
feat: diagnostic info

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Info plugin provides more detailed diagnostic info
+
 ### Deprecated
 
 ### Removed

--- a/packages/broker/src/plugins/info/InfoPlugin.ts
+++ b/packages/broker/src/plugins/info/InfoPlugin.ts
@@ -13,10 +13,7 @@ export class InfoPlugin extends Plugin<ApiPluginConfig> {
             path: '/info',
             method: 'get',
             requestHandlers: [async (_req: Request, res: Response) => {
-                const node = await this.streamrClient.getNode()
-                res.json({
-                    nodeId: node.getNodeId()
-                })
+                res.json(await this.streamrClient.getDiagnosticInfo())
             }]
         }
     }

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add method `.getDiagnosticInfo` for getting diagnostic information for debugging purposes
+
 ### Changed
 
 - Validate `partitions` when parsing contract metadata

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -30,7 +30,7 @@ export interface NetworkNodeStub {
     getRtt: (nodeId: string) => number | undefined
     setExtraMetadata: (metadata: Record<string, unknown>) => void
     getMetricsContext: () => MetricsContext
-    getDiagnosticData: () => Record<string, unknown>
+    getDiagnosticInfo: () => Record<string, unknown>
     hasStreamPart: (streamPartId: StreamPartID) => boolean
     /** @internal */
     hasProxyConnection: (streamPartId: StreamPartID, contactNodeId: string, direction: ProxyDirection) => boolean

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -30,6 +30,7 @@ export interface NetworkNodeStub {
     getRtt: (nodeId: string) => number | undefined
     setExtraMetadata: (metadata: Record<string, unknown>) => void
     getMetricsContext: () => MetricsContext
+    getDiagnosticData: () => Record<string, unknown>
     hasStreamPart: (streamPartId: StreamPartID) => boolean
     /** @internal */
     hasProxyConnection: (streamPartId: StreamPartID, contactNodeId: string, direction: ProxyDirection) => boolean

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -582,6 +582,15 @@ export class StreamrClient {
         await Promise.all(tasks)
     })
 
+    /**
+     * Get diagnostic info about the underlying network. Useful for debugging issues.
+     *
+     * @remark returned object's structure can change without semver considerations
+     */
+    async getDiagnosticInfo(): Promise<Record<string, unknown>> {
+        return (await this.node.getNode()).getDiagnosticData()
+    }
+
     // --------------------------------------------------------------------------------------------
     // Events
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -588,7 +588,7 @@ export class StreamrClient {
      * @remark returned object's structure can change without semver considerations
      */
     async getDiagnosticInfo(): Promise<Record<string, unknown>> {
-        return (await this.node.getNode()).getDiagnosticData()
+        return (await this.node.getNode()).getDiagnosticInfo()
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/test/end-to-end/get-diagnostic-info.test.ts
+++ b/packages/client/test/end-to-end/get-diagnostic-info.test.ts
@@ -1,0 +1,37 @@
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { StreamPermission } from '../../src/permission'
+import { Stream } from '../../src/Stream'
+import { StreamrClient } from '../../src/StreamrClient'
+import { getCreateClient } from '../test-utils/utils'
+
+describe('getDiagnosticInfo', () => {
+    let client: StreamrClient
+    let otherClient: StreamrClient
+    let stream: Stream
+    const createClient = getCreateClient()
+
+    beforeAll(async () => {
+        const streamPath = `/get-diagnostic-info.test.ts/${Date.now()}`
+        client = await createClient({
+            auth: {
+                privateKey: await fetchPrivateKeyWithGas()
+            }
+        })
+        stream = await client.createStream(streamPath)
+        await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
+        otherClient = await createClient()
+        await client.subscribe(stream.id)
+        await otherClient.subscribe(stream.id)
+    }, 30 * 1000)
+
+    afterAll(async () => {
+        await Promise.all([
+            client.destroy(),
+            otherClient.destroy()
+        ])
+    })
+
+    it('does not reject', async () => {
+        await expect(client.getDiagnosticInfo()).toResolve()
+    })
+})

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -119,6 +119,11 @@ export class FakeNetworkNode implements NetworkNodeStub {
     ): Promise<void> {
         throw new Error('not implemented')
     }
+
+    // eslint-disable-next-line class-methods-use-this
+    getDiagnosticData(): Record<string, unknown> {
+        return {}
+    }
 }
 
 @scoped(Lifecycle.ContainerScoped)

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -121,7 +121,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getDiagnosticData(): Record<string, unknown> {
+    getDiagnosticInfo(): Record<string, unknown> {
         return {}
     }
 }

--- a/packages/network/src/connection/webrtc/IWebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/IWebRtcEndpoint.ts
@@ -30,4 +30,5 @@ export interface IWebRtcEndpoint {
     getDefaultMessageLayerProtocolVersion(): number
     getDefaultControlLayerProtocolVersion(): number
     getAllConnectionNodeIds(): PeerId[]
+    getDiagnosticInfo(): Record<string, unknown>
 }

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -125,6 +125,14 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
     protected readonly bufferThresholdLow: number
     protected readonly portRange: WebRtcPortRange
 
+    // diagnostic info
+    private messagesSent = 0
+    private messagesRecv = 0
+    private bytesSent = 0
+    private bytesRecv = 0
+    private sendFailures = 0
+    private openSince: number | null = null
+
     constructor({
         selfId,
         targetPeerId,
@@ -252,6 +260,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
             this.deferredConnectionAttempt = null
             def.reject(reason)
         }
+        this.openSince = null
         this.emit('close')
     }
 
@@ -346,15 +355,21 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
             connectionId: this.getConnectionId(),
             peerId: this.getPeerId(),
             rtt: this.getRtt(),
-            isOffering: this.isOffering(),
+            ageInSec: this.openSince !== null ? Math.round((Date.now() - this.openSince) / 1000) : null,
             messageQueueLength: this.messageQueue.size(),
             bufferedAmount: this.getBufferedAmount(),
+            messagesSent: this.messagesSent,
+            messagesRecv: this.messagesRecv,
+            bytesSend: this.bytesSent,
+            bytesRecv: this.bytesRecv,
+            sendFailures: this.sendFailures,
             open: this.isOpen(),
             paused: this.paused,
             finished: this.isFinished,
+            pingAttempts: this.pingAttempts,
+            isOffering: this.isOffering(),
             lastState: this.getLastState(),
             lastGatheringState: this.getLastGatheringState(),
-            pingAttempts: this.pingAttempts
         }
     }
 
@@ -408,7 +423,10 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
                     sent = this.isOpen() && this.doSendMessage(queueItem.getMessage())
                     isOpen = this.isOpen()
                     sent = sent && isOpen
+                    this.messagesSent += 1
+                    this.bytesSent += queueItem.getMessage().length
                 } catch (e) {
+                    this.sendFailures += 1
                     this.processFailedMessage(queueItem, e)
                     return // method rescheduled by `this.flushTimeoutRef`
                 }
@@ -482,6 +500,7 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
             this.deferredConnectionAttempt = null
             def.resolve(this.peerInfo.peerId)
         }
+        this.openSince = Date.now()
         this.hasOpened = true
         this.setFlushRef()
         this.emit('open')
@@ -511,6 +530,8 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
             this.pingAttempts = 0
             this.rtt = Date.now() - this.rttStart!
         } else {
+            this.messagesRecv += 1
+            this.bytesRecv += msg.length
             this.emit('message', msg)
         }
     }

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -341,6 +341,23 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
         return isOffering(this.selfId, this.peerInfo.peerId)
     }
 
+    getDiagnosticInfo(): Record<string, unknown> {
+        return {
+            connectionId: this.getConnectionId(),
+            peerId: this.getPeerId(),
+            rtt: this.getRtt(),
+            isOffering: this.isOffering(),
+            messageQueueLength: this.messageQueue.size(),
+            bufferedAmount: this.getBufferedAmount(),
+            open: this.isOpen(),
+            paused: this.paused,
+            finished: this.isFinished,
+            lastState: this.getLastState(),
+            lastGatheringState: this.getLastGatheringState(),
+            pingAttempts: this.pingAttempts
+        }
+    }
+
     private setFlushRef(): void {
         if (this.flushRef === null) {
             this.flushRef = setImmediate(() => {

--- a/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
+++ b/packages/network/src/connection/webrtc/WebRtcEndpoint.ts
@@ -508,6 +508,12 @@ export class WebRtcEndpoint extends EventEmitter implements IWebRtcEndpoint {
         return Object.keys(this.connections)
     }
 
+    getDiagnosticInfo(): Record<string, unknown> {
+        return {
+            connections: Object.values(this.connections).map((c) => c.getDiagnosticInfo())
+        }
+    }
+
     private onConnectionCountChange() {
         this.metrics.connectionAverageCount.record(Object.keys(this.connections).length)
     }

--- a/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
+++ b/packages/network/src/connection/ws/AbstractClientWsEndpoint.ts
@@ -167,4 +167,12 @@ export abstract class AbstractClientWsEndpoint<C extends AbstractWsConnection> e
         this.onNewConnection(connection)
         return connection.getPeerId()
     }
+
+    getDiagnosticInfo(): Record<string, unknown> {
+        return {
+            connections: this.getConnections().map((c) => c.getDiagnosticInfo()),
+            serverUrls: Object.fromEntries(this.serverUrlByPeerId),
+            pendingConnections: Object.keys(this.pendingConnections)
+        }
+    }
 }

--- a/packages/network/src/connection/ws/AbstractWsConnection.ts
+++ b/packages/network/src/connection/ws/AbstractWsConnection.ts
@@ -84,6 +84,17 @@ export abstract class AbstractWsConnection {
         return this.getPeerInfo().peerId
     }
 
+    getDiagnosticInfo(): Record<string, unknown> {
+        return {
+            peerId: this.getPeerId(),
+            rtt: this.getRtt(),
+            respondedPong: this.getRespondedPong(),
+            readyState: this.getReadyState(),
+            bufferedAmount: this.getBufferedAmount(),
+            highBackPressure: this.highBackPressure,
+        }
+    }
+
     abstract sendPing(): void
     abstract getBufferedAmount(): number
     abstract send(message: string): Promise<void>

--- a/packages/network/src/connection/ws/AbstractWsConnection.ts
+++ b/packages/network/src/connection/ws/AbstractWsConnection.ts
@@ -85,11 +85,20 @@ export abstract class AbstractWsConnection {
     }
 
     getDiagnosticInfo(): Record<string, unknown> {
+        const getHumanReadableReadyState = (n: number): string => {
+            switch (n) {
+                case 0: return 'connecting'
+                case 1: return 'open'
+                case 2: return 'closing'
+                case 3: return 'closed'
+                default: return `unknown (${n})`
+            }
+        }
         return {
             peerId: this.getPeerId(),
             rtt: this.getRtt(),
             respondedPong: this.getRespondedPong(),
-            readyState: this.getReadyState(),
+            readyState: getHumanReadableReadyState(this.getReadyState()),
             bufferedAmount: this.getBufferedAmount(),
             highBackPressure: this.highBackPressure,
         }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -388,7 +388,7 @@ export class Node extends EventEmitter {
         return this.metricsContext
     }
 
-    getDiagnosticData(): Record<string, unknown> {
+    getDiagnosticInfo(): Record<string, unknown> {
         return {
             nodeId: this.getNodeId(),
             started: this.started,
@@ -397,7 +397,7 @@ export class Node extends EventEmitter {
             streamState: {
                 streamParts: [...this.getStreamParts()],
                 neighbors: this.getNeighbors(),
-                assignments: this.streamPartManager.getDiagnosticData(),
+                assignments: this.streamPartManager.getDiagnosticInfo(),
                 activePropagationTasks: this.propagation.numOfActivePropagationTasks()
             }
         }

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -394,7 +394,7 @@ export class Node extends EventEmitter {
             started: this.started,
             nodeToNode: this.nodeToNode.getDiagnosticInfo(),
             trackers: this.trackerManager.getDiagnosticInfo(),
-            streamState: {
+            node: {
                 streamParts: [...this.getStreamParts()],
                 neighbors: this.getNeighbors(),
                 assignments: this.streamPartManager.getDiagnosticInfo(),

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -94,7 +94,7 @@ export class Node extends EventEmitter {
         this.peerInfo = opts.peerInfo
         this.nodeConnectTimeout = opts.nodeConnectTimeout || 15000
         this.consecutiveDeliveryFailures = {}
-        this.started = new Date().toLocaleString()
+        this.started = new Date().toISOString()
         this.acceptProxyConnections = opts.acceptProxyConnections
 
         this.metricsContext = opts.metricsContext || new MetricsContext()

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -388,6 +388,19 @@ export class Node extends EventEmitter {
         return this.metricsContext
     }
 
+    getDiagnosticData(): Record<string, unknown> {
+        return {
+            nodeId: this.getNodeId(),
+            started: this.started,
+            webrtc: this.nodeToNode.getDiagnosticInfo(),
+            ws: this.trackerManager.getDiagnosticInfo(),
+            streamParts: [...this.getStreamParts()],
+            neighbors: this.getNeighbors(),
+            streamStates: this.streamPartManager.getDiagnosticData(),
+            consecutiveDeliveryFailures: this.consecutiveDeliveryFailures
+        }
+    }
+
     async subscribeAndWaitForJoinOperation(streamPartId: StreamPartID, timeout = this.nodeConnectTimeout): Promise<number> {
         if (this.streamPartManager.isSetUp(streamPartId)) {
             return this.streamPartManager.getAllNodesForStreamPart(streamPartId).length

--- a/packages/network/src/logic/Node.ts
+++ b/packages/network/src/logic/Node.ts
@@ -392,12 +392,14 @@ export class Node extends EventEmitter {
         return {
             nodeId: this.getNodeId(),
             started: this.started,
-            webrtc: this.nodeToNode.getDiagnosticInfo(),
-            ws: this.trackerManager.getDiagnosticInfo(),
-            streamParts: [...this.getStreamParts()],
-            neighbors: this.getNeighbors(),
-            streamStates: this.streamPartManager.getDiagnosticData(),
-            consecutiveDeliveryFailures: this.consecutiveDeliveryFailures
+            nodeToNode: this.nodeToNode.getDiagnosticInfo(),
+            trackers: this.trackerManager.getDiagnosticInfo(),
+            streamState: {
+                streamParts: [...this.getStreamParts()],
+                neighbors: this.getNeighbors(),
+                assignments: this.streamPartManager.getDiagnosticData(),
+                activePropagationTasks: this.propagation.numOfActivePropagationTasks()
+            }
         }
     }
 

--- a/packages/network/src/logic/StreamPartManager.ts
+++ b/packages/network/src/logic/StreamPartManager.ts
@@ -207,7 +207,7 @@ export class StreamPartManager {
         return this.isSetUp(streamPartId) && this.streamParts.get(streamPartId)!.isBehindProxy
     }
 
-    getDiagnosticData(): Record<string, unknown> {
+    getDiagnosticInfo(): Record<string, unknown> {
         const state: Record<string, unknown> = {}
         for (const streamPartId of this.getStreamParts()) {
             state[streamPartId] = this.getNeighborsForStreamPart(streamPartId)

--- a/packages/network/src/logic/StreamPartManager.ts
+++ b/packages/network/src/logic/StreamPartManager.ts
@@ -207,6 +207,14 @@ export class StreamPartManager {
         return this.isSetUp(streamPartId) && this.streamParts.get(streamPartId)!.isBehindProxy
     }
 
+    getDiagnosticData(): Record<string, unknown> {
+        const state: Record<string, unknown> = {}
+        for (const streamPartId of this.getStreamParts()) {
+            state[streamPartId] = this.getNeighborsForStreamPart(streamPartId)
+        }
+        return state
+    }
+
     private ensureThatIsSetUp(streamPartId: StreamPartID): void | never {
         if (!this.isSetUp(streamPartId)) {
             throw new Error(`Stream part ${streamPartId} is not set up`)

--- a/packages/network/src/logic/TrackerManager.ts
+++ b/packages/network/src/logic/TrackerManager.ts
@@ -257,4 +257,8 @@ export class TrackerManager {
     getTrackerAddress(streamPartId: StreamPartID): TrackerId {
         return this.trackerRegistry.getTracker(streamPartId).ws
     }
+
+    getDiagnosticInfo(): Record<string, unknown> {
+        return this.nodeToTracker.getDiagnosticInfo()
+    }
 }

--- a/packages/network/src/logic/propagation/FifoMapWithTtl.ts
+++ b/packages/network/src/logic/propagation/FifoMapWithTtl.ts
@@ -101,4 +101,8 @@ export class FifoMapWithTtl<K, V> {
         }
         return item.value
     }
+
+    size(): number {
+        return this.items.size
+    }
 }

--- a/packages/network/src/logic/propagation/Propagation.ts
+++ b/packages/network/src/logic/propagation/Propagation.ts
@@ -63,6 +63,10 @@ export class Propagation {
         }
     }
 
+    numOfActivePropagationTasks(): number {
+        return this.activeTaskStore.size()
+    }
+
     private sendAndAwaitThenMark({ message, source, handledNeighbors }: PropagationTask, neighborId: NodeId): void {
         if (!handledNeighbors.has(neighborId) && neighborId !== source) {
             (async () => {

--- a/packages/network/src/logic/propagation/PropagationTaskStore.ts
+++ b/packages/network/src/logic/propagation/PropagationTaskStore.ts
@@ -64,4 +64,8 @@ export class PropagationTaskStore {
         }
         return tasks
     }
+
+    size(): number {
+        return this.tasks.size()
+    }
 }

--- a/packages/network/src/protocol/NodeToNode.ts
+++ b/packages/network/src/protocol/NodeToNode.ts
@@ -179,4 +179,8 @@ export class NodeToNode extends EventEmitter {
     getAllConnectionNodeIds(): NodeId[] {
         return this.endpoint.getAllConnectionNodeIds()
     }
+
+    getDiagnosticInfo(): Record<string, unknown> {
+        return this.endpoint.getDiagnosticInfo()
+    }
 }

--- a/packages/network/src/protocol/NodeToTracker.ts
+++ b/packages/network/src/protocol/NodeToTracker.ts
@@ -151,6 +151,10 @@ export class NodeToTracker extends EventEmitter {
         return this.endpoint.getServerUrlByPeerId(trackerId)
     }
 
+    getDiagnosticInfo(): Record<string, unknown> {
+        return this.endpoint.getDiagnosticInfo()
+    }
+
     stop(): Promise<void> {
         return this.endpoint.stop()
     }


### PR DESCRIPTION
## Summary

Collect diagnostic information about the network and provide ways to access the data thru client or broker.

This information can become handy when diagnosing or debugging connectivity or message throughput issues.

## Changes
- Add method `StreamClient#getDiagnosticInfo()`
- Broker plugin `InfoPlugin` now includes diagnostic info as part of its JSON output
- `Node#started` format changed to ISO-8601 in network package
- Added methods to internal classes and such to access data. Added a few new fields to collect more intricate info about WebRTC connections

## Limitations and future improvements

More values could be collected. I included the low-hanging fruits. Let's see if this proves useful enough to warrant more.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
