### PR TITLE
chore(broker): improvements to `WebsocketPlugin`

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -14,12 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Info plugin provides more detailed diagnostic info
+- Websocket plugin includes more logging
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Websocket plugin cleans up subscriptions on client disconnect
 
 ### Security
 

--- a/packages/broker/src/plugins/websocket/Connection.ts
+++ b/packages/broker/src/plugins/websocket/Connection.ts
@@ -9,7 +9,7 @@ export const PING_PAYLOAD = 'ping'
 const PONG_PAYLOAD = 'pong'
 
 export interface Connection {
-    init: (ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat) => void
+    init(ws: WebSocket, socketId: string, streamrClient: StreamrClient, payloadFormat: PayloadFormat): Promise<void>
 }
 
 // Implements application layer ping support. We have this feature because 
@@ -23,7 +23,12 @@ export const addPingListener = (ws: WebSocket): void => {
     })
 }
 
-export const addPingSender = (ws: WebSocket, sendInterval: number, disconnectTimeout: number): void => {
+export const addPingSender = (
+    ws: WebSocket,
+    socketId: string,
+    sendInterval: number,
+    disconnectTimeout: number
+): void => {
     let pendingStateChange: NodeJS.Timeout
     type State = 'active' | 'idle' | 'disconnected'
 
@@ -37,7 +42,7 @@ export const addPingSender = (ws: WebSocket, sendInterval: number, disconnectTim
                 pendingStateChange = setTimeout(() => setState('disconnected'), disconnectTimeout)
             }
         } else if (state === 'disconnected') {
-            logger.debug('Terminate connection')
+            logger.debug('Terminate connection', { socketId })
             ws.terminate()
         }
     }

--- a/packages/broker/src/plugins/websocket/PublishConnection.ts
+++ b/packages/broker/src/plugins/websocket/PublishConnection.ts
@@ -7,8 +7,6 @@ import { parsePositiveInteger, parseQueryParameter } from '../../helpers/parser'
 import { Connection, PING_PAYLOAD } from './Connection'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
 
-const logger = new Logger(module)
-
 export class PublishConnection implements Connection {
 
     streamId: string
@@ -27,7 +25,13 @@ export class PublishConnection implements Connection {
         }
     }
 
-    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
+    async init(
+        ws: WebSocket,
+        socketId: string,
+        streamrClient: StreamrClient,
+        payloadFormat: PayloadFormat
+    ): Promise<void> {
+        const logger = new Logger(module, { socketId })
         const msgChainId = uuid()
         ws.on('message', async (data: WebSocket.RawData) => {
             const payload = data.toString()

--- a/packages/broker/src/plugins/websocket/SubscribeConnection.ts
+++ b/packages/broker/src/plugins/websocket/SubscribeConnection.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws'
-import { MessageMetadata, StreamrClient, Subscription } from 'streamr-client'
+import { StreamrClient, Subscription } from 'streamr-client'
 import { Connection } from './Connection'
 import { parsePositiveInteger, parseQueryParameterArray } from '../../helpers/parser'
 import { ParsedQs } from 'qs'

--- a/packages/broker/src/plugins/websocket/SubscribeConnection.ts
+++ b/packages/broker/src/plugins/websocket/SubscribeConnection.ts
@@ -1,29 +1,57 @@
 import WebSocket from 'ws'
-import { MessageMetadata, StreamrClient } from 'streamr-client'
+import { MessageMetadata, StreamrClient, Subscription } from 'streamr-client'
 import { Connection } from './Connection'
 import { parsePositiveInteger, parseQueryParameterArray } from '../../helpers/parser'
 import { ParsedQs } from 'qs'
 import { PayloadFormat } from '../../helpers/PayloadFormat'
+import { Logger } from '@streamr/utils'
 
 export class SubscribeConnection implements Connection {
 
-    streamId: string
-    partitions?: number[]
+    private readonly streamId: string
+    private readonly partitions?: number[]
+    private readonly subscriptions: Subscription[]
 
-    constructor(streamId: string, queryParams: ParsedQs) {
+    constructor( streamId: string, queryParams: ParsedQs) {
         this.streamId = streamId
         this.partitions = parseQueryParameterArray('partitions', queryParams, parsePositiveInteger)
+        this.subscriptions = []
     }
 
-    init(ws: WebSocket, streamrClient: StreamrClient, payloadFormat: PayloadFormat): void {
-        const streamPartDefitions = (this.partitions !== undefined)
+    async init(
+        ws: WebSocket,
+        socketId: string,
+        streamrClient: StreamrClient,
+        payloadFormat: PayloadFormat
+    ): Promise<void> {
+        const logger = new Logger(module, { socketId })
+        const streamPartDefinitions = (this.partitions !== undefined)
             ? this.partitions.map((partition: number) => ({ id: this.streamId, partition }))
             : [{ id: this.streamId }]
-        streamPartDefitions.forEach((streamDefinition) => {
-            streamrClient.subscribe(streamDefinition, (content: any, metadata: MessageMetadata) => {
-                const payload = payloadFormat.createPayload(content, metadata)
-                ws.send(payload)
-            })
+        logger.debug('Subscribing to stream partitions', {
+            streamId: this.streamId,
+            partitions: this.partitions
         })
+        for (const streamDefinition of streamPartDefinitions) {
+            let sub: Subscription
+            try {
+                sub = await streamrClient.subscribe(streamDefinition, (content, metadata) => {
+                    const payload = payloadFormat.createPayload(content as any, metadata)
+                    ws.send(payload)
+                })
+            } catch (err) {
+                await this.unsubAll()
+                throw err
+            }
+            this.subscriptions.push(sub)
+        }
+        logger.debug('Subscribed to stream partitions', {
+            streamId: this.streamId,
+            partitions: this.partitions
+        })
+    }
+
+    private async unsubAll(): Promise<void> {
+        await Promise.all(this.subscriptions.map((sub) => sub.unsubscribe()))
     }
 }

--- a/packages/broker/src/plugins/websocket/SubscribeConnection.ts
+++ b/packages/broker/src/plugins/websocket/SubscribeConnection.ts
@@ -12,7 +12,7 @@ export class SubscribeConnection implements Connection {
     private readonly partitions?: number[]
     private readonly subscriptions: Subscription[]
 
-    constructor( streamId: string, queryParams: ParsedQs) {
+    constructor(streamId: string, queryParams: ParsedQs) {
         this.streamId = streamId
         this.partitions = parseQueryParameterArray('partitions', queryParams, parsePositiveInteger)
         this.subscriptions = []

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -91,6 +91,7 @@ export class WebsocketServer {
 
         this.wss.on('connection', (ws: WebSocket, _request: http.IncomingMessage, connection: Connection) => {
             const socketId = randomString(5)
+            logger.info('Accept connection', { socketId })
             connection.init(ws, socketId, this.streamrClient, payloadFormat).then(() => {
                 addPingListener(ws)
                 if (this.pingSendInterval !== 0) {

--- a/packages/broker/src/plugins/websocket/WebsocketServer.ts
+++ b/packages/broker/src/plugins/websocket/WebsocketServer.ts
@@ -89,19 +89,19 @@ export class WebsocketServer {
             })
         })
 
-        this.wss.on('connection', (ws: WebSocket, _request: http.IncomingMessage, connection: Connection) => {
+        this.wss.on('connection', async (ws: WebSocket, _request: http.IncomingMessage, connection: Connection) => {
             const socketId = randomString(5)
             logger.info('Accept connection', { socketId })
-            connection.init(ws, socketId, this.streamrClient, payloadFormat).then(() => {
+            try {
+                await connection.init(ws, socketId, this.streamrClient, payloadFormat)
                 addPingListener(ws)
                 if (this.pingSendInterval !== 0) {
                     addPingSender(ws, socketId, this.pingSendInterval, this.disconnectTimeout)
                 }
-                return
-            }, (err) => {
+            } catch (err) {
                 logger.warn('Close connection', { socketId, reason: err?.message })
                 ws.close()
-            })
+            }
         })
 
         this.httpServer.listen(port)

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'ws'
 import qs from 'qs'
 import StreamrClient, { Subscription } from 'streamr-client'
-import { waitForEvent, waitForCondition, wait } from '@streamr/utils'
+import { waitForEvent, waitForCondition } from '@streamr/utils'
 import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
 import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
 import { mock, MockProxy } from 'jest-mock-extended'


### PR DESCRIPTION
## Summary

Add a few improvements to `WebsocketPlugin`.

Partly fixes NET-966.

## Changes

- Add more logging statements to help users see what happened & is happening.
- Attach a `socketId` to log messages to differentiate between WebSocket connections in the presence of multiple.
- Add error handling around `client#subscribe` to avoid unhandled promise rejections.
- Add cleanup logic so that subscriptions are unsubscribed from when the (a) WebSocket client disconnects or (b) Subscribing to multiple partitions fails.
