### PR TITLE
fix(client): Handle `undefined` partition count in `client#createStream()`

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Handling of `undefined` partition in `.createStream`
+
 ### Security
 
 

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -34,6 +34,7 @@ import { LoggerFactory } from './utils/LoggerFactory'
 import { convertStreamMessageToMessage, Message } from './Message'
 import { ErrorCode } from './HttpUtil'
 import omit from 'lodash/omit'
+import merge from 'lodash/merge'
 import { StreamrClientError } from './StreamrClientError'
 
 // TODO: this type only exists to enable tsdoc to generate proper documentation
@@ -311,10 +312,7 @@ export class StreamrClient {
     async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
-        return this.streamRegistry.createStream(streamId, {
-            partitions: 1,
-            ...omit(props, 'id')
-        })
+        return this.streamRegistry.createStream(streamId, merge({ partitions: 1 }, omit(props, 'id') ))
     }
 
     /**


### PR DESCRIPTION
Fix for `createStream` method. It created streams with invalid metadata if `undefined` was provided in the `propsOrStreamIdOrPath` argument. That is a valid argument of `Partial<StreamMetadata>` field as TypeScript allows any field of Partial can have value of `undefined`.

### Implications in production

E.g. CLI-tool passes `undefined` value: https://github.com/streamr-dev/network/blob/67d3cf330819db7c1a9a64a452fbd0674ee58b2e/packages/cli-tools/bin/streamr-stream-create.ts#L12

That's why we have created some streams which have invalid metadata. In production there are currently 65 out of 2382 streams which have invalid metadata. Out of those 47 are invalid because there is no `partitions` field.

Client has a non-released feature which validates the `partitions` field value: https://github.com/streamr-dev/network/commit/97cbac452d0f76f1e126ade875e9b9c61671eded

Should we enhance that feature with a fallback: if there is no `partitions` field, the stream would be considered to have 1 partition. Not ideal solution, though.

### Related issues

We may use similar pattern in some other places in our codebase. We should check + fix those, too.

