### PR TITLE
fix: use merge instead of object spread

### DIFF
--- a/packages/broker/src/helpers/fetchOrThrow.ts
+++ b/packages/broker/src/helpers/fetchOrThrow.ts
@@ -1,12 +1,10 @@
 import fetch, { RequestInit, Response } from 'node-fetch'
+import merge from 'lodash/merge'
 
 const DEFAULT_TIMEOUT = 30 * 1000
 
 export const fetchOrThrow = async (url: string, init?: RequestInit): Promise<Response> => {
-    const res = await fetch(url, {
-        timeout: DEFAULT_TIMEOUT,
-        ...init
-    })
+    const res = await fetch(url, merge({ timeout: DEFAULT_TIMEOUT }, init))
     if (res.ok) {
         return res
     } else {

--- a/packages/broker/src/helpers/fetchOrThrow.ts
+++ b/packages/broker/src/helpers/fetchOrThrow.ts
@@ -1,5 +1,5 @@
 import fetch, { RequestInit, Response } from 'node-fetch'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const DEFAULT_TIMEOUT = 30 * 1000
 

--- a/packages/broker/src/plugins/storage/BatchManager.ts
+++ b/packages/broker/src/plugins/storage/BatchManager.ts
@@ -4,7 +4,7 @@ import { Logger } from '@streamr/utils'
 import type { StreamMessage } from '@streamr/protocol'
 import { Batch, BatchId, DoneCallback } from './Batch'
 import { BucketId } from './Bucket'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const INSERT_STATEMENT = 'INSERT INTO stream_data '
     + '(stream_id, partition, bucket_id, ts, sequence_no, publisher_id, msg_chain_id, payload) '

--- a/packages/broker/src/plugins/storage/BatchManager.ts
+++ b/packages/broker/src/plugins/storage/BatchManager.ts
@@ -4,6 +4,7 @@ import { Logger } from '@streamr/utils'
 import type { StreamMessage } from '@streamr/protocol'
 import { Batch, BatchId, DoneCallback } from './Batch'
 import { BucketId } from './Bucket'
+import merge from 'lodash/merge'
 
 const INSERT_STATEMENT = 'INSERT INTO stream_data '
     + '(stream_id, partition, bucket_id, ts, sequence_no, publisher_id, msg_chain_id, payload) '
@@ -47,10 +48,7 @@ export class BatchManager extends EventEmitter {
             batchMaxRetries: 1000 // in total max ~16 minutes timeout
         }
 
-        this.opts = {
-            ...defaultOptions,
-            ...opts
-        }
+        this.opts = merge(defaultOptions, opts)
 
         // bucketId => batch
         this.batches = Object.create(null)

--- a/packages/broker/src/plugins/storage/BucketManager.ts
+++ b/packages/broker/src/plugins/storage/BucketManager.ts
@@ -3,6 +3,8 @@ import Heap from 'heap'
 import { types as cassandraTypes } from 'cassandra-driver'
 import { Logger } from '@streamr/utils'
 import { Bucket, BucketId } from './Bucket'
+import merge from 'lodash/merge'
+
 const { TimeUuid } = cassandraTypes
 
 const logger = new Logger(module)
@@ -49,10 +51,7 @@ export class BucketManager {
             bucketKeepAliveSeconds: 60
         }
 
-        this.opts = {
-            ...defaultOptions,
-            ...opts
-        }
+        this.opts = merge(defaultOptions, opts)
 
         this.streamParts = Object.create(null)
         this.buckets = Object.create(null)

--- a/packages/broker/src/plugins/storage/BucketManager.ts
+++ b/packages/broker/src/plugins/storage/BucketManager.ts
@@ -3,7 +3,7 @@ import Heap from 'heap'
 import { types as cassandraTypes } from 'cassandra-driver'
 import { Logger } from '@streamr/utils'
 import { Bucket, BucketId } from './Bucket'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const { TimeUuid } = cassandraTypes
 

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -6,6 +6,7 @@ import { Broker } from '../../src/broker'
 import { Message } from '../../src/helpers/PayloadFormat'
 import { createClient, startBroker, createTestStream, startTestTracker } from '../utils'
 import { wait } from '@streamr/utils'
+import merge from 'lodash/merge'
 
 interface MessagingPluginApi<T> {
     createClient: (action: 'publish' | 'subscribe', streamId: string, apiKey?: string) => Promise<T>
@@ -67,14 +68,16 @@ export const createMessagingPluginTest = <T>(
                 privateKey: brokerUser.privateKey,
                 trackerPort: ports.tracker,
                 extraPlugins: {
-                    [pluginName]: {
-                        port: ports.plugin,
-                        payloadMetadata: true,
-                        apiAuthentication: {
-                            keys: [MOCK_API_KEY]
+                    [pluginName]: merge(
+                        {
+                            port: ports.plugin,
+                            payloadMetadata: true,
+                            apiAuthentication: {
+                                keys: [MOCK_API_KEY]
+                            }
                         },
-                        ...pluginConfig
-                    }
+                        pluginConfig
+                    )
                 }
             })
         })

--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -6,7 +6,7 @@ import { Broker } from '../../src/broker'
 import { Message } from '../../src/helpers/PayloadFormat'
 import { createClient, startBroker, createTestStream, startTestTracker } from '../utils'
 import { wait } from '@streamr/utils'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 interface MessagingPluginApi<T> {
     createClient: (action: 'publish' | 'subscribe', streamId: string, apiKey?: string) => Promise<T>

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -5,7 +5,7 @@ import { waitForEvent, waitForCondition } from '@streamr/utils'
 import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
 import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
 import { mock, MockProxy } from 'jest-mock-extended'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const PORT = 12398
 const MOCK_STREAM_ID = '0x1234567890123456789012345678901234567890/mock-path'

--- a/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/broker/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -4,6 +4,7 @@ import StreamrClient from 'streamr-client'
 import { waitForEvent, waitForCondition } from '@streamr/utils'
 import { WebsocketServer } from '../../../../src/plugins/websocket/WebsocketServer'
 import { PlainPayloadFormat } from '../../../../src/helpers/PayloadFormat'
+import merge from 'lodash/merge'
 
 const PORT = 12398
 const MOCK_STREAM_ID = '0x1234567890123456789012345678901234567890/mock-path'
@@ -15,10 +16,14 @@ const PATH_SUBSCRIBE_MOCK_STREAM = `/streams/${encodeURIComponent(MOCK_STREAM_ID
 const REQUIRED_API_KEY = 'required-api-key'
 
 const createTestClient = (path: string, queryParams?: any): WebSocket => {
-    const queryParamsSuffix = qs.stringify({
-        apiKey: REQUIRED_API_KEY,
-        ...queryParams
-    })
+    const queryParamsSuffix = qs.stringify(
+        merge(
+            {
+                apiKey: REQUIRED_API_KEY
+            },
+            queryParams
+        )
+    )
     return new WebSocket(`ws://localhost:${PORT}${path}?${queryParamsSuffix}`)
 }
 

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -13,7 +13,7 @@ import { Config } from '../src/config/config'
 import { StreamPartID } from '@streamr/protocol'
 import { EthereumAddress, MetricsContext, toEthereumAddress } from '@streamr/utils'
 import { TEST_CONFIG } from '@streamr/network-node'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
 

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -13,6 +13,7 @@ import { Config } from '../src/config/config'
 import { StreamPartID } from '@streamr/protocol'
 import { EthereumAddress, MetricsContext, toEthereumAddress } from '@streamr/utils'
 import { TEST_CONFIG } from '@streamr/network-node'
+import merge from 'lodash/merge'
 
 export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
 
@@ -112,19 +113,23 @@ export const createClient = async (
     privateKey: string,
     clientOptions?: StreamrClientConfig
 ): Promise<StreamrClient> => {
-    const networkOptions = {
-        ...CONFIG_TEST?.network,
-        trackers: [tracker.getConfigRecord()],
-        ...clientOptions?.network
-    }
-    return new StreamrClient({
-        ...CONFIG_TEST,
-        auth: {
-            privateKey
+    const opts = merge(
+        CONFIG_TEST,
+        {
+            auth: {
+                privateKey
+            },
+            network: merge(
+                CONFIG_TEST?.network,
+                { 
+                    trackers: [tracker.getConfigRecord()]
+                },
+                clientOptions?.network
+            )
         },
-        network: networkOptions,
-        ...clientOptions,
-    })
+        clientOptions
+    )
+    return new StreamrClient(opts)
 }
 
 export const getTestName = (module: NodeModule): string => {

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -6,7 +6,7 @@ import { Publisher } from './publish/Publisher'
 import { ConfigInjectionToken, StreamrClientConfig, ProviderAuthConfig } from './Config'
 import { pOnce } from './utils/promises'
 import { MetricsReport, wait } from '@streamr/utils'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 type NormalizedConfig = NonNullable<Required<Exclude<StreamrClientConfig['metrics'], boolean>>>
 

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -6,6 +6,7 @@ import { Publisher } from './publish/Publisher'
 import { ConfigInjectionToken, StreamrClientConfig, ProviderAuthConfig } from './Config'
 import { pOnce } from './utils/promises'
 import { MetricsReport, wait } from '@streamr/utils'
+import merge from 'lodash/merge'
 
 type NormalizedConfig = NonNullable<Required<Exclude<StreamrClientConfig['metrics'], boolean>>>
 
@@ -36,10 +37,7 @@ const getNormalizedConfig = (config: Pick<StreamrClientConfig, 'metrics' | 'auth
             periods: []
         }
     } else if (config.metrics !== undefined) {
-        return {
-            ...DEFAULTS,
-            ...config.metrics
-        }
+        return merge(DEFAULTS, config.metrics)
     } else {
         const isEthereumAuth = ((config.auth as ProviderAuthConfig)?.ethereum !== undefined)
         return {

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -24,7 +24,7 @@ import { Subscription } from './subscribe/Subscription'
 import { LoggerFactory } from './utils/LoggerFactory'
 import { Message } from './Message'
 import { convertStreamMessageToMessage } from './Message'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 export interface StreamMetadata {
     /**

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -24,6 +24,7 @@ import { Subscription } from './subscribe/Subscription'
 import { LoggerFactory } from './utils/LoggerFactory'
 import { Message } from './Message'
 import { convertStreamMessageToMessage } from './Message'
+import merge from 'lodash/merge'
 
 export interface StreamMetadata {
     /**
@@ -117,14 +118,16 @@ export class Stream {
         config: Pick<StrictStreamrClientConfig, '_timeouts'>
     ) {
         this.id = id
-        this.metadata = {
-            partitions: 1,
-            // TODO should we remove this default or make config as a required StreamMetadata field?
-            config: {
-                fields: []
+        this.metadata = merge(
+            {
+                partitions: 1,
+                // TODO should we remove this default or make config as a required StreamMetadata field?
+                config: {
+                    fields: []
+                }
             },
-            ...metadata
-        }
+            metadata
+        )
         this._resends = resends
         this._publisher = publisher
         this._subscriber = subscriber
@@ -140,10 +143,7 @@ export class Stream {
      * Updates the metadata of the stream by merging with the existing metadata.
      */
     async update(metadata: Partial<StreamMetadata>): Promise<void> {
-        const merged = {
-            ...this.getMetadata(),
-            ...metadata
-        }
+        const merged = merge(this.getMetadata(), metadata)
         try {
             await this._streamRegistry.updateStream(this.id, merged)
         } finally {

--- a/packages/client/src/utils/HttpFetcher.ts
+++ b/packages/client/src/utils/HttpFetcher.ts
@@ -3,6 +3,7 @@ import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import fetch, { Response } from 'node-fetch'
 import { Logger } from '@streamr/utils'
 import { LoggerFactory } from './LoggerFactory'
+import merge from 'lodash/merge'
 
 @scoped(Lifecycle.ContainerScoped)
 export class HttpFetcher {
@@ -22,9 +23,6 @@ export class HttpFetcher {
         // eslint-disable-next-line no-underscore-dangle
         const timeout = this.config._timeouts.httpFetchTimeout
         this.logger.debug('Fetch', { url, timeout })
-        return fetch(url, {
-            timeout,
-            ...init
-        } as any)
+        return fetch(url, merge({ timeout }, init))
     }
 }

--- a/packages/client/src/utils/HttpFetcher.ts
+++ b/packages/client/src/utils/HttpFetcher.ts
@@ -3,7 +3,7 @@ import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import fetch, { Response } from 'node-fetch'
 import { Logger } from '@streamr/utils'
 import { LoggerFactory } from './LoggerFactory'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 @scoped(Lifecycle.ContainerScoped)
 export class HttpFetcher {

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -21,7 +21,7 @@ import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
 import { DestroySignal } from '../../src/DestroySignal'
 import { MessageMetadata } from '../../src/Message'
 import { AuthenticationInjectionToken, createAuthentication } from '../../src/Authentication'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const Dependencies = {
     NetworkNodeFacade,

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -21,6 +21,7 @@ import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
 import { DestroySignal } from '../../src/DestroySignal'
 import { MessageMetadata } from '../../src/Message'
 import { AuthenticationInjectionToken, createAuthentication } from '../../src/Authentication'
+import merge from 'lodash/merge'
 
 const Dependencies = {
     NetworkNodeFacade,
@@ -72,13 +73,17 @@ describe('MemoryLeaks', () => {
                 config: StrictStreamrClientConfig
                 childContainer: DependencyContainer
             }> => {
-                const config = createStrictConfig({
-                    ...CONFIG_TEST,
-                    auth: {
-                        privateKey: await fetchPrivateKeyWithGas(),
-                    },
-                    ...opts,
-                })
+                const config = createStrictConfig(
+                    merge(
+                        CONFIG_TEST,
+                        {
+                            auth: {
+                                privateKey: await fetchPrivateKeyWithGas(),
+                            }
+                        },
+                        opts
+                    )
+                )
                 const childContainer = rootContainer.createChildContainer()
                 childContainer.register(AuthenticationInjectionToken, { useValue: createAuthentication(config) })
                 childContainer.register(ConfigInjectionToken, { useValue: config })
@@ -113,13 +118,17 @@ describe('MemoryLeaks', () => {
         let createClient: () => Promise<StreamrClient>
         beforeAll(() => {
             createClient = async (opts: any = {}) => {
-                const c = new StreamrClient({
-                    ...CONFIG_TEST,
-                    auth: {
-                        privateKey: await fetchPrivateKeyWithGas(),
-                    },
-                    ...opts,
-                })
+                const c = new StreamrClient(
+                    merge(
+                        CONFIG_TEST,
+                        {
+                            auth: {
+                                privateKey: await fetchPrivateKeyWithGas(),
+                            }
+                        },
+                        opts
+                    )
+                )
                 return c
             }
         })

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -9,6 +9,7 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
 import { getPublishTestStreamMessages } from '../test-utils/publish'
 import { createTestStream } from '../test-utils/utils'
+import merge from 'lodash/merge'
 
 const MAX_MESSAGES = 10
 
@@ -41,12 +42,16 @@ describe('GapFill', () => {
     let environment: FakeEnvironment
 
     async function setupClient(opts: StreamrClientConfig) {
-        client = environment.createClient({
-            maxGapRequests: 2,
-            gapFillTimeout: 500,
-            retryResendAfter: 1000,
-            ...opts
-        })
+        client = environment.createClient(
+            merge(
+                {
+                    maxGapRequests: 2,
+                    gapFillTimeout: 500,
+                    retryResendAfter: 1000
+                },
+                opts
+            )
+        )
         stream = await createTestStream(client, module)
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         await stream.addToStorageNode(storageNode.id)

--- a/packages/client/test/integration/GapFill.test.ts
+++ b/packages/client/test/integration/GapFill.test.ts
@@ -9,7 +9,7 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
 import { getPublishTestStreamMessages } from '../test-utils/publish'
 import { createTestStream } from '../test-utils/utils'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const MAX_MESSAGES = 10
 

--- a/packages/client/test/integration/Sequencing.test.ts
+++ b/packages/client/test/integration/Sequencing.test.ts
@@ -8,7 +8,7 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { getWaitForStorage } from '../test-utils/publish'
 import { createTestStream, uid } from '../test-utils/utils'
 import { Message } from '../../src/Message'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const Msg = (opts?: any) => {
     return merge(

--- a/packages/client/test/integration/Sequencing.test.ts
+++ b/packages/client/test/integration/Sequencing.test.ts
@@ -8,11 +8,16 @@ import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { getWaitForStorage } from '../test-utils/publish'
 import { createTestStream, uid } from '../test-utils/utils'
 import { Message } from '../../src/Message'
+import merge from 'lodash/merge'
 
-const Msg = (opts?: any) => ({
-    value: uid('msg'),
-    ...opts,
-})
+const Msg = (opts?: any) => {
+    return merge(
+        {
+            value: uid('msg')
+        },
+        opts
+    )
+}
 
 function toSeq(requests: Message[], ts = Date.now()) {
     return requests.map((msg) => {

--- a/packages/client/test/integration/revoke-permissions.test.ts
+++ b/packages/client/test/integration/revoke-permissions.test.ts
@@ -13,7 +13,7 @@ import {
     createTestStream
 } from '../test-utils/utils'
 import { Message } from '../../src/Message'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 // this has publisher & subscriber clients
 // publisher begins publishing `maxMessages` messages

--- a/packages/client/test/integration/revoke-permissions.test.ts
+++ b/packages/client/test/integration/revoke-permissions.test.ts
@@ -13,6 +13,7 @@ import {
     createTestStream
 } from '../test-utils/utils'
 import { Message } from '../../src/Message'
+import merge from 'lodash/merge'
 
 // this has publisher & subscriber clients
 // publisher begins publishing `maxMessages` messages
@@ -61,24 +62,32 @@ describe('revoke permissions', () => {
         publisherPrivateKey = fastPrivateKey()
         subscriberPrivateKey = fastPrivateKey()
         // eslint-disable-next-line require-atomic-updates
-        publisher = environment.createClient({
-            id: 'publisher',
-            auth: {
-                privateKey: publisherPrivateKey
-            },
-            ...opts
-        })
+        publisher = environment.createClient(
+            merge(
+                {
+                    id: 'publisher',
+                    auth: {
+                        privateKey: publisherPrivateKey
+                    },
+                },
+                opts
+            )
+        )
         // eslint-disable-next-line require-atomic-updates
-        subscriber = environment.createClient({
-            id: 'subscriber',
-            auth: {
-                privateKey: subscriberPrivateKey
-            },
-            encryption: {
-                keyRequestTimeout: 200
-            },
-            ...opts
-        })
+        subscriber = environment.createClient(
+            merge(
+                {
+                    id: 'subscriber',
+                    auth: {
+                        privateKey: subscriberPrivateKey
+                    },
+                    encryption: {
+                        keyRequestTimeout: 200
+                    }
+                },
+                opts
+            )
+        )
     }
 
     async function testRevokeDuringSubscribe({

--- a/packages/client/test/test-utils/publish.ts
+++ b/packages/client/test/test-utils/publish.ts
@@ -5,7 +5,7 @@ import { StreamDefinition } from '../../src/types'
 import { PublishMetadata } from '../../src/publish/Publisher'
 import { uid } from './utils'
 import { Message } from './../../src/Message'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 export function Msg<T extends object = object>(opts?: T): any {
     return merge(

--- a/packages/client/test/test-utils/publish.ts
+++ b/packages/client/test/test-utils/publish.ts
@@ -5,12 +5,15 @@ import { StreamDefinition } from '../../src/types'
 import { PublishMetadata } from '../../src/publish/Publisher'
 import { uid } from './utils'
 import { Message } from './../../src/Message'
+import merge from 'lodash/merge'
 
 export function Msg<T extends object = object>(opts?: T): any {
-    return {
-        value: uid('msg'),
-        ...opts,
-    }
+    return merge(
+        {
+            value: uid('msg')
+        },
+        opts,
+    )
 }
 
 type TestMessageOptions = Partial<{
@@ -83,10 +86,7 @@ export function getPublishTestStreamMessages(
             waitForLastTimeout,
             retainMessages = true,
             ...options
-        } = {
-            ...defaultOpts,
-            ...opts,
-        }
+        } = merge(defaultOpts, opts)
 
         const publishStream = publishTestMessagesGenerator(client, streamDefinition, maxMessages, options)
         let streamMessages = []
@@ -120,9 +120,6 @@ export function getWaitForStorage(client: StreamrClient, defaultOpts = {}): (las
     messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
 }) => Promise<void> {
     return async (lastPublished: Message, opts = {}) => {
-        return client.waitForStorage(lastPublished, {
-            ...defaultOpts,
-            ...opts,
-        })
+        return client.waitForStorage(lastPublished, merge(defaultOpts, opts))
     }
 }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -25,6 +25,7 @@ import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
 import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
 import { DestroySignal } from '../../src/DestroySignal'
 import { PersistenceManager } from '../../src/PersistenceManager'
+import merge from 'lodash/merge'
 
 const logger = new Logger(module)
 
@@ -70,14 +71,16 @@ export const getCreateClient = (
         } else {
             key = await fetchPrivateKeyWithGas()
         }
-        const client = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: key,
+        const client = new StreamrClient(merge(
+            CONFIG_TEST,
+            {
+                auth: {
+                    privateKey: key,
+                }
             },
-            ...defaultOpts,
-            ...opts,
-        }, defaultParentContainer ?? parentContainer)
+            defaultOpts,
+            opts,
+        ), defaultParentContainer ?? parentContainer)
 
         addAfter(async () => {
             await wait(0)

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -25,7 +25,7 @@ import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
 import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
 import { DestroySignal } from '../../src/DestroySignal'
 import { PersistenceManager } from '../../src/PersistenceManager'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const logger = new Logger(module)
 

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -6,10 +6,10 @@ import { createPrivateKeyAuthentication } from '../../src/Authentication'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { PublishMetadata } from '../../src/publish/Publisher'
 import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
-import { MessageFactory } from '../../src/publish/MessageFactory'
+import { MessageFactory, MessageFactoryOptions } from '../../src/publish/MessageFactory'
 import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
 import { createGroupKeyQueue, createStreamRegistryCached } from '../test-utils/utils'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const WALLET = fastWallet()
 const STREAM_ID = toStreamID('/path', toEthereumAddress(WALLET.address))
@@ -24,7 +24,7 @@ const createMessageFactory = async (opts?: {
 }) => {
     const authentication = createPrivateKeyAuthentication(WALLET.privateKey, undefined as any)
     return new MessageFactory(
-        merge(
+        merge<MessageFactoryOptions>(
             {
                 streamId: STREAM_ID,
                 authentication,

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -9,6 +9,7 @@ import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
 import { MessageFactory } from '../../src/publish/MessageFactory'
 import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
 import { createGroupKeyQueue, createStreamRegistryCached } from '../test-utils/utils'
+import merge from 'lodash/merge'
 
 const WALLET = fastWallet()
 const STREAM_ID = toStreamID('/path', toEthereumAddress(WALLET.address))
@@ -22,27 +23,33 @@ const createMessageFactory = async (opts?: {
     groupKeyQueue?: GroupKeyQueue
 }) => {
     const authentication = createPrivateKeyAuthentication(WALLET.privateKey, undefined as any)
-    return new MessageFactory({
-        streamId: STREAM_ID,
-        authentication,
-        streamRegistry: createStreamRegistryCached({
-            partitionCount: PARTITION_COUNT,
-            isPublicStream: false,
-            isStreamPublisher: true
-        }),
-        groupKeyQueue: await createGroupKeyQueue(authentication, GROUP_KEY),
-        ...opts
-    })
+    return new MessageFactory(
+        merge(
+            {
+                streamId: STREAM_ID,
+                authentication,
+                streamRegistry: createStreamRegistryCached({
+                    partitionCount: PARTITION_COUNT,
+                    isPublicStream: false,
+                    isStreamPublisher: true
+                }),
+                groupKeyQueue: await createGroupKeyQueue(authentication, GROUP_KEY)
+            },
+            opts
+        )
+    )
 }
 
 const createMessage = async (
     opts: Omit<PublishMetadata, 'timestamp'> & { timestamp?: number, explicitPartition?: number },
     messageFactory: MessageFactory
 ): Promise<StreamMessage> => {
-    return messageFactory.createMessage(CONTENT, {
-        timestamp: TIMESTAMP,
-        ...opts
-    }, opts.explicitPartition)
+    return messageFactory.createMessage(CONTENT, merge(
+        {
+            timestamp: TIMESTAMP
+        },
+        opts
+    ), opts.explicitPartition)
 }
 
 describe('MessageFactory', () => {

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -14,14 +14,19 @@ import { MetricsContext } from '@streamr/utils'
 import { NegotiatedProtocolVersions } from '../src/connection/NegotiatedProtocolVersions'
 import NodeClientWsEndpoint from '../src/connection/ws/NodeClientWsEndpoint'
 import { NetworkNode } from '../src/logic/NetworkNode'
+import merge from 'lodash/merge'
 
 export const createTestNetworkNode = (opts: Partial<NetworkNodeOptions> & Pick<NetworkNodeOptions, 'trackers'>): NetworkNode => {
-    return createNetworkNode({
-        ...TEST_CONFIG,
-        id: uuidv4(),
-        metricsContext: new MetricsContext(),
-        ...opts
-    })
+    return createNetworkNode(
+        merge(
+            TEST_CONFIG,
+            {
+                id: uuidv4(),
+                metricsContext: new MetricsContext()
+            },
+            opts
+        )
+    )
 }
 
 export const createTestWebRtcEndpoint = (

--- a/packages/network/test/utils.ts
+++ b/packages/network/test/utils.ts
@@ -14,11 +14,11 @@ import { MetricsContext } from '@streamr/utils'
 import { NegotiatedProtocolVersions } from '../src/connection/NegotiatedProtocolVersions'
 import NodeClientWsEndpoint from '../src/connection/ws/NodeClientWsEndpoint'
 import { NetworkNode } from '../src/logic/NetworkNode'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 export const createTestNetworkNode = (opts: Partial<NetworkNodeOptions> & Pick<NetworkNodeOptions, 'trackers'>): NetworkNode => {
     return createNetworkNode(
-        merge(
+        merge<NetworkNodeOptions>(
             TEST_CONFIG,
             {
                 id: uuidv4(),

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -10,7 +10,7 @@ import '../../../../src/protocol/message_layer/StreamMessageSerializerV32'
 import { Serializer } from '../../../../src/Serializer'
 import { toStreamID } from '../../../../src/utils/StreamID'
 import { StreamPartIDUtils } from '../../../../src/utils/StreamPartID'
-import merge from 'lodash/merge'
+import { merge } from '@streamr/utils'
 
 const content = {
     hello: 'world',

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -10,6 +10,7 @@ import '../../../../src/protocol/message_layer/StreamMessageSerializerV32'
 import { Serializer } from '../../../../src/Serializer'
 import { toStreamID } from '../../../../src/utils/StreamID'
 import { StreamPartIDUtils } from '../../../../src/utils/StreamPartID'
+import merge from 'lodash/merge'
 
 const content = {
     hello: 'world',
@@ -18,16 +19,20 @@ const content = {
 const newGroupKey = new EncryptedGroupKey('groupKeyId', 'encryptedGroupKeyHex')
 
 const msg = ({ timestamp = 1564046332168, sequenceNumber = 10, ...overrides } = {}) => {
-    return new StreamMessage({
-        messageId: new MessageID(toStreamID('streamId'), 0, timestamp, sequenceNumber, PUBLISHER_ID, 'msgChainId'),
-        prevMsgRef: new MessageRef(timestamp, 5),
-        content: JSON.stringify(content),
-        messageType: StreamMessageType.MESSAGE,
-        encryptionType: EncryptionType.NONE,
-        signature: 'signature',
-        newGroupKey,
-        ...overrides
-    })
+    return new StreamMessage(
+        merge(
+            {
+                messageId: new MessageID(toStreamID('streamId'), 0, timestamp, sequenceNumber, PUBLISHER_ID, 'msgChainId'),
+                prevMsgRef: new MessageRef(timestamp, 5),
+                content: JSON.stringify(content),
+                messageType: StreamMessageType.MESSAGE,
+                encryptionType: EncryptionType.NONE,
+                signature: 'signature',
+                newGroupKey
+            },
+            overrides
+        )
+    )
 }
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -29,6 +29,7 @@ import { waitForCondition } from './waitForCondition'
 import { withRateLimit } from './withRateLimit'
 import { ObservableEventEmitter } from './ObservableEventEmitter'
 import { initEventGateway } from './initEventGateway'
+import { merge } from './merge'
 
 export {
     BrandedString,
@@ -59,7 +60,8 @@ export {
     withTimeout,
     Events,
     ObservableEventEmitter,
-    initEventGateway
+    initEventGateway,
+    merge
 }
 
 export {

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -1,0 +1,11 @@
+export const merge = (...sources: readonly Record<string, unknown>[]): Record<string, unknown> => {
+    const result: Record<string, unknown> = {}
+    for (const source of sources) {
+        for (const [key, value] of Object.entries(source)) {
+            if (value !== undefined) {
+                result[key] = value
+            }
+        }
+    }
+    return result
+}

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -1,4 +1,4 @@
-export const merge = (...sources: (object | undefined)[]): Record<PropertyKey, unknown>  => {
+export const merge = <TTarget>(...sources: (Partial<TTarget> | undefined)[]): TTarget => {
     const result: Record<string, unknown> = {}
     for (const source of sources) {
         if (source !== undefined) {
@@ -9,5 +9,5 @@ export const merge = (...sources: (object | undefined)[]): Record<PropertyKey, u
             }
         }
     }
-    return result
+    return result as TTarget
 }

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -1,4 +1,4 @@
-export const merge = (...sources: readonly (Record<string, unknown> | undefined)[]): Record<string, unknown> => {
+export const merge = (...sources: (object | undefined)[]): Record<PropertyKey, unknown>  => {
     const result: Record<string, unknown> = {}
     for (const source of sources) {
         if (source !== undefined) {

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -1,9 +1,11 @@
-export const merge = (...sources: readonly Record<string, unknown>[]): Record<string, unknown> => {
+export const merge = (...sources: readonly (Record<string, unknown> | undefined)[]): Record<string, unknown> => {
     const result: Record<string, unknown> = {}
     for (const source of sources) {
-        for (const [key, value] of Object.entries(source)) {
-            if (value !== undefined) {
-                result[key] = value
+        if (source !== undefined) {
+            for (const [key, value] of Object.entries(source)) {
+                if (value !== undefined) {
+                    result[key] = value
+                }
             }
         }
     }

--- a/packages/utils/test/merge.test.ts
+++ b/packages/utils/test/merge.test.ts
@@ -63,19 +63,23 @@ describe('merge', () => {
     })
 
     it('not deeply', () => {
+        interface Bar {
+            lorem: number | undefined
+            ipsum: number | undefined
+        }
         const o1 = {
             foo: 1,
             bar: {
                 lorem: undefined,
                 ipsum: 1
-            }
+            } as Bar
         }
         const o2 = {
             foo: 2,
             bar: {
                 lorem: 2,
                 ipsum: undefined
-            }
+            } as Bar
         }
         expect(merge(o1, o2)).toEqual({
             foo: 2,

--- a/packages/utils/test/merge.test.ts
+++ b/packages/utils/test/merge.test.ts
@@ -1,0 +1,88 @@
+import { merge } from '../src/merge'
+
+describe('merge', () => {
+
+    it('two objects', () => {
+        const o1 = {
+            foo: 123,
+            bar: 456,
+            lorem: undefined
+        }
+        const o2 = {
+            foo: 789,
+            bar: undefined,
+            ipsum: undefined
+        }
+        expect(merge(o1, o2)).toEqual({
+            foo: 789,
+            bar: 456
+        })
+    })
+
+    it('multiple objects', () => {
+        const o1 = {
+            foo: 1,
+        }
+        const o2 = {
+            foo: 2,
+        }
+        const o3 = {
+            foo: 3,
+        }
+        expect(merge(o1, o2, o3)).toEqual({
+            foo: 3
+        })
+    })
+
+    it('no objects', () => {
+        expect(merge()).toEqual({})
+    })
+
+    it('do not mutate', () => {
+        const o1 = {
+            foo: 123,
+            bar: 456,
+            lorem: undefined
+        }
+        const o2 = {
+            foo: 789,
+            bar: undefined,
+            ipsum: undefined
+        }
+        merge(o1, o2)
+        expect(o1).toEqual({
+            foo: 123,
+            bar: 456,
+            lorem: undefined
+        })
+        expect(o2).toEqual({
+            foo: 789,
+            bar: undefined,
+            ipsum: undefined
+        })
+    })
+
+    it('not deeply', () => {
+        const o1 = {
+            foo: 1,
+            bar: {
+                lorem: undefined,
+                ipsum: 1
+            }
+        }
+        const o2 = {
+            foo: 2,
+            bar: {
+                lorem: 2,
+                ipsum: undefined
+            }
+        }
+        expect(merge(o1, o2)).toEqual({
+            foo: 2,
+            bar: {
+                lorem: 2,
+                ipsum: undefined
+            }
+        })
+    })
+})

--- a/packages/utils/test/merge.test.ts
+++ b/packages/utils/test/merge.test.ts
@@ -85,4 +85,16 @@ describe('merge', () => {
             }
         })
     })
+
+    it('undefineds are skipped', () => {
+        const o1 = {
+            foo: 1,
+        }
+        const o2 = {
+            foo: 2,
+        }
+        expect(merge(undefined, o1, undefined, o2, undefined)).toEqual({
+            foo: 2
+        })
+    })
 })


### PR DESCRIPTION
### Issue

It is very easy to merge two JavaScript objects incorrectly using the spread operator. Typically when we want merge some defaults and overrides, we use `const result = { ...defaults, ...overrides }`. While it works, it may not produce the expected value if any property of `overrides` is `undefined`.

For all _missing_ properties in the `overrides` object, the functionality is correct. But if there is an object property and the value of that property is `undefined`, the merged object doesn't fallback to the default value. 

E.g.
```ts
interface SomeOptions {
    a: string
}
const defaultValues = {
    a: 'foobar'
}
const overrideValues: Partial<SomeOptions> = {
    a: undefined,
}
const result = {
    ...defaultValues,
    ...overrideValues
}
console.log(result) // { a: undefined }
```

Any property which is annotated with question mark (directly, or via `Partial`) can have explicit value of `undefined`.

Note also that e.g. in VS Code and IntelliJ IDEA the inferred type of `result` is shown as:
```ts
{
    a: string;
}
```

(There is a TypeScript configuration option to control this: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)

### Fix

We need to use something else than the spread operator.

In this PR we added a new `merge` utility function to `@streamr/utils`. It does a simple non-recursive merge and doesn't mutate any of the argument objects. But it skips all `undefined` properties.

Alternatively we could use `merge` from `lodash` if recursive merge is needed (and if mutating the target argument is ok).

With both methods we get valid merged object:
```ts
console.log(merge(defaultValues, overrideValues))  // { a: 'foobar' }
```

