### PR TITLE
test: use dev brokers instead of isolated entrypoints per test

### DIFF
--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -59,7 +59,7 @@ describe('MemoryLeaks', () => {
         expect(leaksDetector).toBeTruthy()
         if (!leaksDetector) { return }
         const detector = leaksDetector
-        await wait(15000)
+        await wait(5000)
         snapshot()
         await detector.checkNoLeaks() // this is very slow
         detector.clear()

--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -59,7 +59,7 @@ describe('MemoryLeaks', () => {
         expect(leaksDetector).toBeTruthy()
         if (!leaksDetector) { return }
         const detector = leaksDetector
-        await wait(5000)
+        await wait(15000)
         snapshot()
         await detector.checkNoLeaks() // this is very slow
         detector.clear()

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -5,7 +5,7 @@ import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { until } from '../../src/utils/promises'
-import { createTestStream } from '../test-utils/utils'
+import { createTestStream, createTestClient } from '../test-utils/utils'
 
 const TEST_TIMEOUT = 60 * 1000
 
@@ -19,58 +19,8 @@ describe('StorageNodeRegistry', () => {
     beforeAll(async () => {
         creatorWallet = new Wallet(await fetchPrivateKeyWithGas())
         listenerWallet = new Wallet(await fetchPrivateKeyWithGas())
-        creatorClient = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: creatorWallet.privateKey,
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "storage-node-registry-1-creator",
-                        type: 0,
-                        websocket: {
-                            ip: 'localhost',
-                            port: 43235
-                        }
-                    }
-                }
-            }
-        })
-        listenerClient = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: listenerWallet.privateKey,
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "storage-node-registry-1-listener",
-                        type: 0,
-                        websocket: {
-                            ip: 'localhost',
-                            port: 43234
-                        }
-                    }
-                }
-            }
-        })
+        creatorClient = createTestClient(creatorWallet.privateKey, 'storage-node-registry-1-creator', 43235)
+        listenerClient = createTestClient(listenerWallet.privateKey, 'storage-node-registry-1-listener', 43234)
     }, TEST_TIMEOUT)
 
     afterAll(async () => {
@@ -158,5 +108,5 @@ describe('StorageNodeRegistry', () => {
             nodeAddress: DOCKER_DEV_STORAGE_NODE,
             streamId: stream.id,
         })
-    }, TEST_TIMEOUT)
+    }, TEST_TIMEOUT * 2)
 })

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -1,10 +1,10 @@
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 import { Wallet } from '@ethersproject/wallet'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
-import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
-import { createTestStream } from '../test-utils/utils'
+import { createTestStream, createTestClient } from '../test-utils/utils'
 
 jest.setTimeout(30000)
 
@@ -19,59 +19,9 @@ describe('StorageNodeRegistry2', () => {
     let storageNodeAddress: EthereumAddress
 
     beforeAll(async () => {
-        client = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: await fetchPrivateKeyWithGas()
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "storage-node-registry-2-client",
-                        type: 0,
-                        websocket: {
-                            ip: 'localhost',
-                            port: 43237
-                        }
-                    }
-                }
-            }
-        })
+        client = createTestClient(await fetchPrivateKeyWithGas(), 'storage-node-registry-2-client', 43236)
         const storageNodeWallet = new Wallet(await fetchPrivateKeyWithGas())
-        storageNodeClient = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: storageNodeWallet.privateKey
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "storage-node-registry-2-storage-node-client",
-                        type: 0,
-                        websocket: {
-                            ip: 'localhost',
-                            port: 43236
-                        }
-                    }
-                }
-            }
-        })
+        storageNodeClient = createTestClient(storageNodeWallet.privateKey, 'storage-node-registry-2-storage-node', 43237)
         storageNodeAddress = toEthereumAddress(storageNodeWallet.address)
         createdStream = await createTestStream(client, module)
     })

--- a/packages/client/test/end-to-end/resend.test.ts
+++ b/packages/client/test/end-to-end/resend.test.ts
@@ -1,7 +1,7 @@
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { createTestStream } from '../test-utils/utils'
+import { createTestStream, createTestClient } from '../test-utils/utils'
 import range from 'lodash/range'
-import { CONFIG_TEST, DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
+import { DOCKER_DEV_STORAGE_NODE } from '../../src/ConfigTest'
 import { wait, waitForCondition } from '@streamr/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'
@@ -16,60 +16,9 @@ describe('resend', () => {
     let resendClient: StreamrClient
 
     beforeEach(async () => {
-        publisherClient = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: await fetchPrivateKeyWithGas()
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "resend-e2e-publisher-client",
-                        type: 0,
-                        websocket: {
-                            ip: '127.0.0.1',
-                            port: 43232
-                        }
-                    }
-                }
-            },
-
-        })
-        resendClient = new StreamrClient({
-            ...CONFIG_TEST,
-            auth: {
-                privateKey: fastPrivateKey()
-            },
-            network: {
-                layer0: {
-                    entryPoints: [{
-                        kademliaId: "entryPointBroker",
-                        type: 0,
-                        websocket: {
-                            ip: "127.0.0.1",
-                            port: 40401
-                        }
-                    }],
-                    peerDescriptor: {
-                        kademliaId: "resend-e2e-resend-client",
-                        type: 0,
-                        websocket: {
-                            ip: '127.0.0.1',
-                            port: 43233
-                        }
-                    }
-                }
-            }
-        })
-    }, TIMEOUT * 2)
+        publisherClient = createTestClient(await fetchPrivateKeyWithGas(), 'resend-e2e-publisher-client', 43232)
+        resendClient = createTestClient(fastPrivateKey(), 'resend-e2e-resend-client', 43233)
+    }, TIMEOUT)
 
     afterEach(async () => {
         await Promise.allSettled([

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -218,3 +218,25 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
         return `Timeout while waiting for calls: got ${mockFunction.mock.calls.length} out of ${n}`
     })
 }
+
+export const createTestClient = (privateKey: string, stringKademliaId: string, wsPort?: number): StreamrClient => {
+    return new StreamrClient({
+        ...CONFIG_TEST,
+        auth: {
+            privateKey
+        },
+        network: {
+            layer0: {
+                ...CONFIG_TEST.network!.layer0,
+                peerDescriptor: {
+                    kademliaId: stringKademliaId,
+                    type: 0,
+                    websocket: wsPort ? {
+                        ip: 'localhost',
+                        port: wsPort
+                    } : undefined
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
## Summary

End to end tests now use the dev brokers instead of requiring entrypoint configuration per test.
