### PR TITLE
NET-846: Reduce log levels

### DIFF
--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -229,17 +229,12 @@ export class ManagedConnection extends EventEmitter<Events> {
     }
 
     async send(data: Uint8Array, doNotConnect = false): Promise<void> {
-
         if (this.stopped) {
-            logger.error('send() called on stopped connection')
             return
         }
-
         if (this.closing) {
-            logger.error('send() called on closing connection')
             return
         }
-
         this.lastUsed = Date.now()
 
         if (doNotConnect && !this.implementation) {
@@ -278,7 +273,7 @@ export class ManagedConnection extends EventEmitter<Events> {
                         result2 = await raceEvents3<Events>(this,
                             ['bufferSentByOtherConnection', 'closing', 'disconnected'], 15000)
                     } catch (ex) {
-                        logger.error(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName +
+                        logger.debug(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName +
                             ' Exception from raceEvents3 while waiting bufferSentByOtherConnection or closing ' + ex)
                         logger.trace(this.connectionId + ' Exception from raceEvents3 while waiting bufferSentByOtherConnection')
                         throw ex

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -131,7 +131,7 @@ export class Router implements IRouter {
                     this.removeRoutingSession(session.sessionId)
                 })
                 .catch(() => {
-                    logger.error('raceEvents timed out for routingSession ' + session.sessionId) 
+                    logger.debug('raceEvents timed out for routingSession ' + session.sessionId) 
                     this.removeRoutingSession(session.sessionId) 
                 })
             session.start()

--- a/packages/dht/src/dht/store/DataStore.ts
+++ b/packages/dht/src/dht/store/DataStore.ts
@@ -149,7 +149,7 @@ export class DataStore implements IStoreService {
     }
 
     public async storeDataToDht(key: Uint8Array, data: Any): Promise<PeerDescriptor[]> {
-        logger.info(`Storing data to DHT ${this.serviceId} with key ${PeerID.fromValue(key)}`)
+        logger.debug(`Storing data to DHT ${this.serviceId}`)
         const result = await this.recursiveFinder!.startRecursiveFind(key)
         const closestNodes = result.closestNodes
         const successfulNodes: PeerDescriptor[] = []


### PR DESCRIPTION
## Summary

Reduce log levels and avoid logging hashed peerIds as they cause alerts on MacOS terminal
