### PR TITLE
feat(client): [NET-968] Missing partition count in metadata

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Validate `partitions` when parsing contract metadata
+- Use default partition count if there is no information in contract metadata
 
 ### Deprecated
 

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -24,6 +24,7 @@ import { Subscription } from './subscribe/Subscription'
 import { LoggerFactory } from './utils/LoggerFactory'
 import { Message } from './Message'
 import { convertStreamMessageToMessage } from './Message'
+import { StreamrClientError } from './StreamrClientError' 
 
 export interface StreamMetadata {
     /**
@@ -285,7 +286,7 @@ export class Stream {
     static parseMetadata(metadata: string): StreamMetadata {
         // TODO we could pick the fields of StreamMetadata explicitly, so that this
         // object can't contain extra fields
-        const err = new Error(`Could not parse properties from onchain metadata: ${metadata}`)
+        const err = new StreamrClientError(`Invalid stream metadata: ${metadata}`, 'INVALID_STREAM_METADATA')
         let json
         try {
             json = JSON.parse(metadata)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -286,6 +286,11 @@ export class Stream {
     static parseMetadata(metadata: string): StreamMetadata {
         // TODO we could pick the fields of StreamMetadata explicitly, so that this
         // object can't contain extra fields
+        if (metadata === '') {
+            return {
+                partitions: 1
+            }
+        }
         const err = new StreamrClientError(`Invalid stream metadata: ${metadata}`, 'INVALID_STREAM_METADATA')
         let json
         try {
@@ -302,6 +307,7 @@ export class Stream {
             }
         } else {
             return {
+                ...json,
                 partitions: 1
             }
         }

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -283,14 +283,26 @@ export class Stream {
 
     /** @internal */
     static parseMetadata(metadata: string): StreamMetadata {
+        // TODO we could pick the fields of StreamMetadata explicitly, so that this
+        // object can't contain extra fields
+        const err = new Error(`Could not parse properties from onchain metadata: ${metadata}`)
+        let json
         try {
-            // TODO we could pick the fields of StreamMetadata explicitly, so that this
-            // object can't contain extra fields
-            const json = JSON.parse(metadata)
-            ensureValidStreamPartitionCount(json.partitions)
-            return json
-        } catch (error) {
-            throw new Error(`Could not parse properties from onchain metadata: ${metadata}`)
+            json = JSON.parse(metadata)
+        } catch (_ignored) {
+            throw err
+        }
+        if (json.partitions !== undefined) {
+            try {
+                ensureValidStreamPartitionCount(json.partitions)
+                return json
+            } catch (_ignored) {
+                throw err
+            }
+        } else {
+            return {
+                partitions: 1
+            }
         }
     }
 

--- a/packages/client/src/StreamrClientError.ts
+++ b/packages/client/src/StreamrClientError.ts
@@ -5,6 +5,7 @@ export type StreamrClientErrorCode =
     'CLIENT_DESTROYED' | 
     'PIPELINE_ERROR' |
     'UNSUPPORTED_OPERATION' |
+    'INVALID_STREAM_METADATA' |
     'UNKNOWN_ERROR'
 
 export class StreamrClientError extends Error {

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -73,16 +73,30 @@ describe('Stream', () => {
     describe('parse metadata', () => {
         it('happy path', () => {
             const metadata = JSON.stringify({
-                partitions: 50
+                partitions: 50,
+                foo: 'bar'
             })
-            expect(Stream.parseMetadata(metadata).partitions).toBe(50)
+            expect(Stream.parseMetadata(metadata)).toEqual({
+                partitions: 50,
+                foo: 'bar'
+            })
         })
 
         it('no value in valid JSON', () => {
             const metadata = JSON.stringify({
                 foo: 'bar'
             })
-            expect(Stream.parseMetadata(metadata).partitions).toBe(1)
+            expect(Stream.parseMetadata(metadata)).toEqual({
+                partitions: 1,
+                foo: 'bar'
+            })
+        })
+
+        it('empty metadata', () => {
+            const metadata = ''
+            expect(Stream.parseMetadata(metadata)).toEqual({
+                partitions: 1
+            })
         })
 
         it('invalid value', () => {

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -1,9 +1,10 @@
 import 'reflect-metadata'
 
 import { toStreamID } from '@streamr/protocol'
+import { Stream } from '../../src/Stream'
+import { StreamFactory } from '../../src/StreamFactory'
 import { StreamRegistry } from '../../src/registry/StreamRegistry'
 import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
-import { StreamFactory } from './../../src/StreamFactory'
 
 const createStreamFactory = (streamRegistry?: StreamRegistry, streamRegistryCached?: StreamRegistryCached) => {
     return new StreamFactory(
@@ -66,6 +67,34 @@ describe('Stream', () => {
             }).rejects.toThrow('mock-error')
             expect(stream.getMetadata().description).toBe('original-description')
             expect(clearStream).toBeCalledWith('mock-id')
+        })
+    })
+
+    describe('parse metadata', () => {
+        it('happy path', () => {
+            const metadata = JSON.stringify({
+                partitions: 50
+            })
+            expect(Stream.parseMetadata(metadata).partitions).toBe(50)
+        })
+
+        it('no value in valid JSON', () => {
+            const metadata = JSON.stringify({
+                foo: 'bar'
+            })
+            expect(Stream.parseMetadata(metadata).partitions).toBe(1)
+        })
+
+        it('invalid value', () => {
+            const metadata = JSON.stringify({
+                partitions: 150
+            })
+            expect(() => Stream.parseMetadata(metadata)).toThrowError('Could not parse properties from onchain metadata: {\"partitions\":150}')
+        })
+
+        it('invalid JSON', () => {
+            const metadata = 'invalid-json'
+            expect(() => Stream.parseMetadata(metadata)).toThrowError('Could not parse properties from onchain metadata: invalid-json')
         })
     })
 })

--- a/packages/client/test/unit/Stream.test.ts
+++ b/packages/client/test/unit/Stream.test.ts
@@ -89,12 +89,18 @@ describe('Stream', () => {
             const metadata = JSON.stringify({
                 partitions: 150
             })
-            expect(() => Stream.parseMetadata(metadata)).toThrowError('Could not parse properties from onchain metadata: {\"partitions\":150}')
+            expect(() => Stream.parseMetadata(metadata)).toThrowStreamrError({
+                message: 'Invalid stream metadata: {"partitions":150}',
+                code: 'INVALID_STREAM_METADATA'
+            })
         })
 
         it('invalid JSON', () => {
             const metadata = 'invalid-json'
-            expect(() => Stream.parseMetadata(metadata)).toThrowError('Could not parse properties from onchain metadata: invalid-json')
+            expect(() => Stream.parseMetadata(metadata)).toThrowStreamrError({
+                message: 'Invalid stream metadata: invalid-json',
+                code: 'INVALID_STREAM_METADATA'
+            })
         })
     })
 })


### PR DESCRIPTION
When we parse stream data, we fallback to partition count 1 if there is no information about the partition count in the contract metadata:
- if the metadata JSON doesn't have `partitions` field
- if the metadata is not a JSON

In all other cases the functionality is the same as previously: i.e. invalid partition count throws an error. That error is now `StreamrClientError` instead of generic `Error` so that we can provide an error code to end users.

### Open questions

- What abstraction level we should use in our error codes? Is `INVALID_STREAM_METADATA` too specific, or should we just have some generic `VALIDATION_FAILED` error code?