### PR TITLE
deps: remove @types/easy-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6601,16 +6601,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/easy-table": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/easy-table/-/easy-table-1.2.0.tgz",
-            "integrity": "sha512-gVQkR2G/q6UK3wQT+waY9tCrbFauzMoBfJpMxHSuemHLQ8HpHdUIQ9YyRwYMfNX4CfoAoj/eJATyECGkFr65Pg==",
-            "deprecated": "This is a stub types definition. easy-table provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "easy-table": "*"
-            }
-        },
         "node_modules/@types/eslint": {
             "version": "8.37.0",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
@@ -27131,7 +27121,6 @@
                 "streamr": "dist/bin/streamr.js"
             },
             "devDependencies": {
-                "@types/easy-table": "1.2.0",
                 "@types/event-stream": "^4.0.0",
                 "@types/lodash": "^4.14.175"
             }

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -36,7 +36,6 @@
     "streamr-client": "8.3.0-beta.0"
   },
   "devDependencies": {
-    "@types/easy-table": "1.2.0",
     "@types/event-stream": "^4.0.0",
     "@types/lodash": "^4.14.175"
   }


### PR DESCRIPTION
> npm WARN deprecated @types/easy-table@1.2.0: This is a stub types definition. easy-table provides its own type definitions, so you do not need this installed.

Remove package from cli-tools.