### PR TITLE
refactor(client): Refactor `fetchResponse` utility

### DIFF
--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -1,5 +1,5 @@
 import fetch, { Response } from 'node-fetch'
-
+import { AbortSignal } from 'node-fetch/externals'
 import { getVersionString } from './utils/utils'
 import { Readable } from 'stream'
 import { WebStreamToNodeStream } from './utils/WebStreamToNodeStream'
@@ -77,7 +77,7 @@ export class HttpUtil {
         abortController = new AbortController()
     ): AsyncIterable<StreamMessage> {
         const response = await fetchResponse(url, this.logger, {
-            signal: abortController.signal
+            signal: abortController.signal as AbortSignal  // cast is needed until this is fixed: https://github.com/node-fetch/node-fetch/issues/1652
         })
         if (!response.body) {
             throw new Error('No Response Body')
@@ -115,7 +115,7 @@ export class HttpUtil {
 async function fetchResponse(
     url: string,
     logger: Logger,
-    opts?: any // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
+    opts: { signal: AbortSignal }
 ): Promise<Response> {
     const timeStart = Date.now()
 

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -119,7 +119,7 @@ async function fetchResponse(
 ): Promise<Response> {
     const timeStart = Date.now()
 
-    logger.debug('Send HTTP request', { url, opts })
+    logger.debug('Send HTTP request', { url })
 
     const response: Response = await fetch(url, opts)
     const timeEnd = Date.now()

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -15,10 +15,6 @@ export enum ErrorCode {
     UNKNOWN = 'UNKNOWN'
 }
 
-export const DEFAULT_HEADERS = {
-    'Streamr-Client': `streamr-client-javascript/${getVersionString()}`,
-}
-
 export class HttpError extends Error {
     public response?: Response
     public body?: any
@@ -123,18 +119,6 @@ async function fetchResponse(
     fetchFn: typeof fetch = fetch
 ): Promise<Response> {
     const timeStart = Date.now()
-
-    const options = {
-        ...opts,
-        headers: {
-            ...DEFAULT_HEADERS,
-            ...(opts && opts.headers),
-        },
-    }
-    // add default 'Content-Type: application/json' header for all POST and PUT requests
-    if (!options.headers['Content-Type'] && (options.method === 'POST' || options.method === 'PUT')) {
-        options.headers['Content-Type'] = 'application/json'
-    }
 
     logger.debug('Send HTTP request', { url, opts })
 

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -1,6 +1,5 @@
 import fetch, { Response } from 'node-fetch'
 import { AbortSignal } from 'node-fetch/externals'
-import { getVersionString } from './utils/utils'
 import { Readable } from 'stream'
 import { WebStreamToNodeStream } from './utils/WebStreamToNodeStream'
 import split2 from 'split2'

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -115,14 +115,13 @@ export class HttpUtil {
 async function fetchResponse(
     url: string,
     logger: Logger,
-    opts?: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
-    fetchFn: typeof fetch = fetch
+    opts?: any // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
 ): Promise<Response> {
     const timeStart = Date.now()
 
     logger.debug('Send HTTP request', { url, opts })
 
-    const response: Response = await fetchFn(url, opts)
+    const response: Response = await fetch(url, opts)
     const timeEnd = Date.now()
     logger.debug('Received HTTP response', {
         url,

--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -76,9 +76,8 @@ export class HttpUtil {
         url: string,
         abortController = new AbortController()
     ): AsyncIterable<StreamMessage> {
-        const response = await fetchResponse(url, this.logger, {
-            signal: abortController.signal as AbortSignal  // cast is needed until this is fixed: https://github.com/node-fetch/node-fetch/issues/1652
-        })
+        // cast is needed until this is fixed: https://github.com/node-fetch/node-fetch/issues/1652
+        const response = await fetchResponse(url, this.logger, abortController.signal as AbortSignal)
         if (!response.body) {
             throw new Error('No Response Body')
         }
@@ -115,13 +114,15 @@ export class HttpUtil {
 async function fetchResponse(
     url: string,
     logger: Logger,
-    opts: { signal: AbortSignal }
+    abortSignal: AbortSignal
 ): Promise<Response> {
     const timeStart = Date.now()
 
     logger.debug('Send HTTP request', { url })
 
-    const response: Response = await fetch(url, opts)
+    const response: Response = await fetch(url, {
+        signal: abortSignal
+    })
     const timeEnd = Date.now()
     logger.debug('Received HTTP response', {
         url,

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -1,8 +1,6 @@
 import LRU from '../../vendor/quick-lru'
 import { SEPARATOR } from './uuid'
 
-import pkg from '../../package.json'
-
 import { StreamID, toStreamID } from '@streamr/protocol'
 import { randomString, toEthereumAddress } from '@streamr/utils'
 
@@ -72,20 +70,6 @@ export interface AnyInstance {
 
 export function instanceId(instance: AnyInstance, suffix = ''): string {
     return counterId(instance.constructor.name) + suffix
-}
-
-function getVersion() {
-    // dev deps are removed for production build
-    const hasDevDependencies = !!(pkg.devDependencies && Object.keys(pkg.devDependencies).length)
-    const isProduction = process.env.NODE_ENV === 'production' || hasDevDependencies
-    return `${pkg.version}${!isProduction ? 'dev' : ''}`
-}
-
-// hardcode this at module exec time as can't change
-const versionString = getVersion()
-
-export function getVersionString(): string {
-    return versionString
 }
 
 export const getEndpointUrl = (baseUrl: string, ...pathParts: string[]): string => {


### PR DESCRIPTION
Small refactoring to `HttpUtil` `fetchResponse` utility:
- Remove unused code that handles options. The `options` variable is never used, we used just the `opts` method parameter instead.
  - Removed a utility that read client version number from `package.json` as there is no longer any code that uses it.
- Remove obsolete `fetch` method argument. Not used by any caller.
- Change signature so `AbortSignal` is not wrapped `into` opts parameter, but used as a normal method parameter.
- Do not include `opts` in the log statement. It contained just the `AbortSignal`, i.e. not any human readable information.