### PR TITLE
fix(network): do not send duplicate messages when buffers full

### DIFF
--- a/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/BrowserWebRtcConnection.ts
@@ -178,9 +178,8 @@ export class BrowserWebRtcConnection extends WebRtcConnection {
         return this.lastGatheringState
     }
 
-    protected doSendMessage(message: string): boolean {
+    protected doSendMessage(message: string): void {
         this.dataChannel?.send(message)
-        return true
     }
 
     private setupDataChannel(dataChannel: RTCDataChannel): void {

--- a/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/NodeWebRtcConnection.ts
@@ -111,8 +111,8 @@ export class NodeWebRtcConnection extends WebRtcConnection {
 
     }
 
-    protected doSendMessage(message: string): boolean {
-        return this.dataChannel!.sendMessage(message)
+    protected doSendMessage(message: string): void {
+        this.dataChannel!.sendMessage(message)
     }
 
     protected doConnect(): void {

--- a/packages/network/src/connection/webrtc/WebRtcConnection.ts
+++ b/packages/network/src/connection/webrtc/WebRtcConnection.ts
@@ -417,10 +417,13 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
                 let sent = false
                 let isOpen
                 try {
+                    if (this.isOpen()) {
+                        this.doSendMessage(queueItem.getMessage())
+                        sent = true
+                    }
                     // this.isOpen() is checked immediately after the call to node-datachannel.sendMessage() as if
                     // this.isOpen() returns false after a "successful" send, the message is lost with a near 100% chance.
                     // This does not work as expected if this.isOpen() is checked before sending a message
-                    sent = this.isOpen() && this.doSendMessage(queueItem.getMessage())
                     isOpen = this.isOpen()
                     sent = sent && isOpen
                     this.messagesSent += 1
@@ -484,9 +487,8 @@ export abstract class WebRtcConnection extends ConnectionEmitter {
      * Invoked when a message is ready to be sent. Connectivity is ensured
      * with a check to `isOpen` before invocation.
      * @param message - mesasge to be sent
-     * @return return false if the message could not be delivered
      */
-    protected abstract doSendMessage(message: string): boolean
+    protected abstract doSendMessage(message: string): void
 
     /**
      * Subclass should call this method when the connection has opened.

--- a/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
+++ b/packages/network/src/simulator/NodeWebRtcConnection_simulator.ts
@@ -34,9 +34,8 @@ export class NodeWebRtcConnection extends WebRtcConnection {
         Simulator.instance().addWebRtcConnection(this.selfId, this.getPeerId(), this)
     }
 
-    protected doSendMessage(message: string): boolean {
+    protected doSendMessage(message: string): void {
         Simulator.instance().webRtcSend(this.selfId, this.getPeerId(), message)
-        return true
         //return this.dataChannel!.sendMessage(message)
     }
 


### PR DESCRIPTION
## Summary

Fixes an issue in the `network` package in which duplicate messages would be sent out when the send buffer of a WebRTC connection (on Node.js) had items in it.

## Detailed explanation

The root of this bug is in how our code interpreted the returned boolean value of method `dataChannel#send` of  `node-datachannel`. Our code assumed that this boolean value indicates the success of sending a message. However, it actually indicates whether the message could be sent immediately or whether it had to be buffered by the library (see https://github.com/murat-dogan/node-datachannel/issues/159). So when the return value was `false`, our code would re-send the same message later (up to 10 times) even though the message was already accepted by the library to be sent when its internal buffer cleared a bit.

Another side-effect of this bug: we may have warn logged messages as not having been sent even though they probably were (including duplicates). 

Fixed this issue by ignoring the return value. We already implement low / high buffer handling on our end (with the assistance of `dataChannel#setBufferedAmountLowThreshold`.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
