### PR TITLE
fix: switch 'stream-creation with ENS owner sync from mainnet' e2e te…

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,7 +92,7 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: client
-      docker-services: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph chainlink
+      docker-services: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph ens-sync-script
       run-brokers-and-trackers: true
       command: npm run test-end-to-end
   broker:

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -113,7 +113,7 @@ describe('StreamRegistry', () => {
         })
 
         // skipped until fix by smart contract
-        describe.skip('ENS', () => {
+        describe('ENS', () => {
 
             it('domain owned by user', async () => {
                 const streamId = 'testdomain1.eth/foobar/' + Date.now()


### PR DESCRIPTION
…st from chainlink over to ENS script

## Summary

switch 'stream-creation with ENS owner sync from mainnet' e2e test from chainlink over to ENS script

## Changes

- CI: e2e test changed to not include chainlink but include ENS-sync-script docker container instead
