### PR TITLE
fix(cli-tools): Output of `stream create` command

### DIFF
--- a/packages/cli-tools/CHANGELOG.md
+++ b/packages/cli-tools/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `stream create` ouput (now valid JSON without extra characters)
+
 ### Security
 
 

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -12,7 +12,7 @@ createClientCommand(async (client: StreamrClient, streamIdOrPath: string, option
         partitions: options.partitions
     }
     const stream = await client.createStream(body)
-    console.info({ id: stream.id, ...stream.getMetadata() }, null, 2)
+    console.info(JSON.stringify({ id: stream.id, ...stream.getMetadata() }, null, 2))
 })
     .arguments('<streamId>')
     .description('create a new stream')


### PR DESCRIPTION
There was a bug in `stream create` command, which caused the output to be like this
```
{
  id: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo',
  partitions: 1,
  config: { fields: [] }
} null 2
```

Now it is valid JSON, similarly to other commands:
```
{
  "id": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf/foo",
  "partitions": 1,
  "config": {
    "fields": []
  }
}
```