### PR TITLE
test(cli-tools): Add end-to-end tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -116,6 +116,13 @@ jobs:
       docker-services: init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph
       run-brokers-and-trackers: true
       command: npm run test-browser
+  cli-tools:
+    needs: build
+    uses: ./.github/workflows/test-setup.yml
+    with:
+      package: cli-tools
+      docker-services: parity-node0 graph-deploy-streamregistry-subgraph broker-node-storage-1
+      command: npm run test
   tracker-docker-image:
     uses: ./.github/workflows/docker-build.yml
     with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26976,8 +26976,11 @@
                 "streamr": "dist/bin/streamr.js"
             },
             "devDependencies": {
+                "@streamr/test-utils": "8.3.0",
                 "@types/event-stream": "^4.0.0",
-                "@types/lodash": "^4.14.175"
+                "@types/lodash": "^4.14.175",
+                "@types/merge2": "^1.4.0",
+                "merge2": "^1.4.1"
             }
         },
         "packages/client": {

--- a/packages/cli-tools/.npmignore
+++ b/packages/cli-tools/.npmignore
@@ -1,2 +1,5 @@
 cli-tools.iml
 .idea
+jest.config.js
+jest.teardown.js
+tsconfig.jest.json

--- a/packages/cli-tools/jest.config.js
+++ b/packages/cli-tools/jest.config.js
@@ -1,0 +1,2 @@
+const rootConfig = require('../../jest.config')
+module.exports = rootConfig

--- a/packages/cli-tools/jest.config.js
+++ b/packages/cli-tools/jest.config.js
@@ -1,2 +1,5 @@
 const rootConfig = require('../../jest.config')
-module.exports = rootConfig
+module.exports = {
+    ...rootConfig,
+    globalTeardown: './jest.teardown.js'
+}

--- a/packages/cli-tools/jest.teardown.js
+++ b/packages/cli-tools/jest.teardown.js
@@ -1,0 +1,5 @@
+const { KeyServer } = require('@streamr/test-utils')
+
+module.exports = async () => {
+    await KeyServer.stopIfRunning()
+}

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -15,7 +15,7 @@
     "check": "tsc -p ./tsconfig.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run build && jest --forceExit"
   },
   "keywords": [
     "streamr",
@@ -36,7 +36,10 @@
     "streamr-client": "8.3.0"
   },
   "devDependencies": {
+    "@streamr/test-utils": "8.3.0",
     "@types/event-stream": "^4.0.0",
-    "@types/lodash": "^4.14.175"
+    "@types/lodash": "^4.14.175",
+    "@types/merge2": "^1.4.0",
+    "merge2": "^1.4.1"
   }
 }

--- a/packages/cli-tools/test/mock-data.test.ts
+++ b/packages/cli-tools/test/mock-data.test.ts
@@ -1,0 +1,18 @@
+import 'jest-extended'
+import { collect, startCommand } from './utils'
+
+describe('mock-data', () => {
+
+    it('generate', async () => {
+        const abortController = new AbortController()
+        const outputIterable = startCommand('mock-data generate', {
+            abortSignal: abortController.signal,
+            devEnvironment: false
+        })
+        const firstLine = (await collect(outputIterable, 1))[0]
+        abortController.abort()
+        const json = JSON.parse(firstLine)
+        expect(json).toBeObject()
+    })
+
+})

--- a/packages/cli-tools/test/storage-node.test.ts
+++ b/packages/cli-tools/test/storage-node.test.ts
@@ -1,0 +1,32 @@
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import 'jest-extended'
+import { StreamID } from 'streamr-client'
+import { DOCKER_DEV_STORAGE_NODE, createTestClient, runCommand } from './utils'
+
+const isStored = async (streamId: StreamID): Promise<boolean> => {
+    const output = await runCommand(`storage-node list-streams ${DOCKER_DEV_STORAGE_NODE}`)
+    return output.join().includes(streamId)
+}
+
+describe('storage node', () => {
+
+    it('add and remove stream', async () => {
+        const privateKey = await fetchPrivateKeyWithGas()
+        const client = createTestClient(privateKey)
+        const stream = await client.createStream(`/${Date.now()}`)
+        await client.destroy()
+        await runCommand(`storage-node add-stream ${DOCKER_DEV_STORAGE_NODE} ${stream.id}`, {
+            privateKey
+        })
+        expect(await isStored(stream.id)).toBeTrue()
+        await runCommand(`storage-node remove-stream ${DOCKER_DEV_STORAGE_NODE} ${stream.id}`, {
+            privateKey
+        })
+        expect(await isStored(stream.id)).toBeFalse()
+    }, 80 * 1000)
+
+    it('list nodes', async () => {
+        const outputLines = await runCommand('storage-node list')
+        expect(outputLines[2]).toEqual(DOCKER_DEV_STORAGE_NODE.toLowerCase())
+    })
+})

--- a/packages/cli-tools/test/stream-create.test.ts
+++ b/packages/cli-tools/test/stream-create.test.ts
@@ -1,0 +1,26 @@
+import { Wallet } from '@ethersproject/wallet'
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { createTestClient, runCommand } from './utils'
+
+describe('create stream', () => {
+
+    it('happy path', async () => {
+        const privateKey = await fetchPrivateKeyWithGas()
+        const address = new Wallet(privateKey).address.toLowerCase()
+        const path = `/${Date.now()}`
+        const streamId = `${address}${path}`
+        const outputLines = await runCommand(`stream create ${path}`, {
+            privateKey
+        })
+        const outputJson = JSON.parse(outputLines.join(''))
+        expect(outputJson).toMatchObject({
+            id: streamId,
+            partitions: 1
+        })
+        const client = createTestClient()
+        const stream = await client.getStream(streamId)
+        expect(stream.getMetadata().partitions).toBe(1)
+        await client.destroy()
+    }, 20 * 1000)
+
+})

--- a/packages/cli-tools/test/stream-permission.test.ts
+++ b/packages/cli-tools/test/stream-permission.test.ts
@@ -1,0 +1,29 @@
+import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
+import 'jest-extended'
+import { StreamPermission } from 'streamr-client'
+import { createTestClient, runCommand } from './utils'
+
+describe('permission', () => {
+
+    it('grant and revoke', async () => {
+        const privateKey = await fetchPrivateKeyWithGas()
+        const client = createTestClient(privateKey)
+        const stream = await client.createStream(`/${Date.now()}`)
+        const otherUser = randomEthereumAddress()
+        const hasPermission = () => client.hasPermission({
+            user: otherUser,
+            permission: StreamPermission.PUBLISH,
+            streamId: stream.id,
+            allowPublic: false
+        })
+        await runCommand(`stream grant-permission ${stream.id} ${otherUser} publish`, {
+            privateKey
+        })
+        expect(await hasPermission()).toBeTrue()
+        await runCommand(`stream revoke-permission ${stream.id} ${otherUser} publish`, {
+            privateKey
+        })
+        expect(await hasPermission()).toBeFalse()
+        await client.destroy()
+    }, 40 * 1000)
+})

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -1,0 +1,34 @@
+import { Wallet } from '@ethersproject/wallet'
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { StreamPermission } from 'streamr-client'
+import { collect, createTestClient, runCommand, startCommand } from './utils'
+
+describe('publish and subscribe', () => {
+
+    it('happy path', async () => {
+        const publisherPrivateKey = await fetchPrivateKeyWithGas()
+        const subscriberPrivateKey = await fetchPrivateKeyWithGas()
+        const client = createTestClient(publisherPrivateKey)
+        const stream = await client.createStream(`/${Date.now()}`)
+        await stream.grantPermissions({
+            user: new Wallet(subscriberPrivateKey).address,
+            permissions: [StreamPermission.SUBSCRIBE]
+        })
+        const subscriberAbortController = new AbortController()
+        const subscriberOutputIterable = startCommand(`stream subscribe ${stream.id}`, {
+            privateKey: subscriberPrivateKey,
+            abortSignal: subscriberAbortController.signal
+        })
+        setImmediate(async () => {
+            await runCommand(`stream publish ${stream.id}`, {
+                inputLines: [JSON.stringify({ foo: 123 })],
+                privateKey: publisherPrivateKey
+            })
+        })
+        const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
+        subscriberAbortController.abort()
+        expect(JSON.parse(receivedMessage)).toEqual({
+            foo: 123
+        })
+    }, 40 * 1000)
+})

--- a/packages/cli-tools/test/stream-resend.test.ts
+++ b/packages/cli-tools/test/stream-resend.test.ts
@@ -2,6 +2,7 @@ import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import range from 'lodash/range'
 import { Message, Stream } from 'streamr-client'
 import { DOCKER_DEV_STORAGE_NODE, createTestClient, runCommand } from './utils'
+import { wait } from '@streamr/utils'
 
 const parseJSONs = (lines: string[]): any[] => {
     return lines.map((line) => JSON.parse(line))
@@ -19,12 +20,13 @@ describe('resend stream', () => {
         stream = await client.createStream(`/${Date.now()}`)
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         for (const msgId of range(10)) {
+            await wait(10) // to prevent duplicate timestamps (to make test assertions simpler)
             const msg = await stream.publish({ msgId })
             messages.push(msg)
         }
-        // TODO some delay needed?
+        await wait(1000)
         await client.destroy()
-    }, 40 * 1000) // TODO is this timeout enough?
+    }, 20 * 1000)
 
     it('last', async () => {
         const outputLines = await runCommand(`stream resend last 3 ${stream.id}`, {

--- a/packages/cli-tools/test/stream-resend.test.ts
+++ b/packages/cli-tools/test/stream-resend.test.ts
@@ -1,0 +1,64 @@
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import range from 'lodash/range'
+import { Message, Stream } from 'streamr-client'
+import { DOCKER_DEV_STORAGE_NODE, createTestClient, runCommand } from './utils'
+
+const parseJSONs = (lines: string[]): any[] => {
+    return lines.map((line) => JSON.parse(line))
+}
+
+describe('resend stream', () => {
+
+    let privateKey: string
+    let stream: Stream
+    const messages: Message[] = []
+
+    beforeAll(async () => {
+        privateKey = await fetchPrivateKeyWithGas()
+        const client = createTestClient(privateKey)
+        stream = await client.createStream(`/${Date.now()}`)
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+        for (const msgId of range(10)) {
+            const msg = await stream.publish({ msgId })
+            messages.push(msg)
+        }
+        // TODO some delay needed?
+        await client.destroy()
+    }, 40 * 1000) // TODO is this timeout enough?
+
+    it('last', async () => {
+        const outputLines = await runCommand(`stream resend last 3 ${stream.id}`, {
+            privateKey
+        })
+        expect(parseJSONs(outputLines)).toEqual([
+            { msgId: 7 },
+            { msgId: 8 },
+            { msgId: 9 }
+        ])
+    }, 20 * 1000)
+
+    it('from', async () => {
+        const minTimestamp = new Date(messages[8].timestamp).toISOString()
+        const outputLines = await runCommand(`stream resend from ${minTimestamp} ${stream.id}`, {
+            privateKey
+        })
+        expect(parseJSONs(outputLines)).toEqual([
+            { msgId: 8 },
+            { msgId: 9 }
+        ])
+    }, 20 * 1000)
+
+    it('range', async () => {
+        const minTimestamp = new Date(messages[2].timestamp).toISOString()
+        const maxTimestamp = new Date(messages[4].timestamp).toISOString()
+        const outputLines = await runCommand(`stream resend range ${minTimestamp} ${maxTimestamp} ${stream.id}`, {
+            privateKey
+        })
+        expect(parseJSONs(outputLines)).toEqual([
+            { msgId: 2 },
+            { msgId: 3 },
+            { msgId: 4 }
+        ])
+    }, 20 * 1000)
+
+})

--- a/packages/cli-tools/test/stream-search.test.ts
+++ b/packages/cli-tools/test/stream-search.test.ts
@@ -1,0 +1,20 @@
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { randomString } from '@streamr/utils'
+import { createTestClient, runCommand } from './utils'
+
+describe('search streams', () => {
+
+    it('happy path', async () => {
+        const testId = randomString(10)
+        const client = createTestClient(await fetchPrivateKeyWithGas())
+        const stream1 = await client.createStream(`/${testId}-1`)
+        const stream2 = await client.createStream(`/${testId}-2`)
+        await client.destroy()
+        const outputLines = await runCommand(`stream search ${testId}`)
+        expect(outputLines).toEqual([
+            stream1.id,
+            stream2.id
+        ])
+    }, 20 * 1000)
+
+})

--- a/packages/cli-tools/test/stream-show.test.ts
+++ b/packages/cli-tools/test/stream-show.test.ts
@@ -1,0 +1,30 @@
+import { Wallet } from '@ethersproject/wallet'
+import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { createTestClient, runCommand } from './utils'
+
+describe('show stream', () => {
+
+    it('happy path', async () => {
+        const creatorPrivateKey = await fetchPrivateKeyWithGas()
+        const client = createTestClient(creatorPrivateKey)
+        const stream = await client.createStream(`/${Date.now()}`)
+        await client.destroy()
+        const outputLines = await runCommand(`stream show ${stream.id} --include-permissions`)
+        const outputJson = JSON.parse(outputLines.join(''))
+        expect(outputJson).toMatchObject({
+            id: stream.id,
+            partitions: 1,
+            permissions: [{
+                permissions: [
+                    'edit',
+                    'delete',
+                    'publish',
+                    'subscribe',
+                    'grant'
+                ],
+                user: new Wallet(creatorPrivateKey).address.toLowerCase()
+            }]
+        })
+    }, 20 * 1000)
+
+})

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -1,0 +1,84 @@
+import merge2 from 'merge2'
+import { StreamrClient, CONFIG_TEST } from 'streamr-client'
+import { spawn } from 'child_process'
+
+export const DOCKER_DEV_STORAGE_NODE = '0xde1112f631486CfC759A50196853011528bC5FA0'
+
+export interface StartCommandOptions {
+    privateKey?: string
+    devEnvironment?: boolean
+    inputLines?: string[]
+    abortSignal?: AbortSignal
+}
+
+export const runCommand = async (commandLine: string, opts?: StartCommandOptions): Promise<string[]> => {
+    const lines = startCommand(commandLine, opts)
+    return await collect(lines)
+}
+
+export async function* startCommand(commandLine: string, opts?: StartCommandOptions): AsyncGenerator<string> {
+    const args: string[] = ['dist/bin/streamr.js']
+    args.push(...commandLine.split(' '))
+    if (opts?.privateKey !== undefined) {
+        args.push('--private-key', opts.privateKey)
+    }
+    if (opts?.devEnvironment !== false) {
+        args.push('--dev')
+    }
+    const executable = spawn(`node`, args, {
+        signal: opts?.abortSignal,
+        env: {
+            PATH: process.env.PATH
+        }
+    })
+    executable.on('error', (err: any) => {
+        // expected error when AbortSignal#abort is called
+        if (err.code !== 'ABORT_ERR') {
+            console.error(err)
+        }
+    })
+    const outputs = merge2(executable.stdout, executable.stderr)
+    if (opts?.inputLines !== undefined) {
+        setImmediate(() => {
+            executable.stdin.write(opts.inputLines!.join('\n') + '\n')
+        })
+    }
+    yield* lines(outputs[Symbol.asyncIterator]())
+}
+
+async function* lines(src: AsyncIterable<Buffer>): AsyncGenerator<string, any, any> {
+    let buffer = ''
+    for await (const chunk of src) {
+        buffer += chunk.toString('utf-8')
+        while (true) {
+            const delimeterPos = buffer.indexOf('\n')
+            if (delimeterPos === -1) {
+                break
+            }
+            const line = buffer.substring(0, delimeterPos)
+            yield line
+            buffer = buffer.substring(delimeterPos + 1)
+        }
+    }
+    if (buffer !== '') {
+        yield buffer
+    }
+}
+
+export const collect = async <T>(source: AsyncIterable<T>, maxCount?: number): Promise<T[]> => {
+    const items: T[] = []
+    for await (const item of source) {
+        items.push(item)
+        if ((maxCount !== undefined) && (items.length >= maxCount)) {
+            break
+        }
+    }
+    return items
+}
+
+export const createTestClient = (privateKey?: string): StreamrClient => {
+    return new StreamrClient({
+        ...CONFIG_TEST,
+        auth: (privateKey !== undefined) ? { privateKey } : undefined
+    })
+}

--- a/packages/cli-tools/test/wallet.test.ts
+++ b/packages/cli-tools/test/wallet.test.ts
@@ -1,0 +1,11 @@
+import { runCommand } from './utils'
+
+describe('wallet', () => {
+
+    it('whoami', async () => {
+        const outputLines = await runCommand('wallet whoami')
+        expect(outputLines.length).toBe(1)
+        expect(outputLines[0]).toMatch(/^0x[0-9a-f]{40}$/)
+    })
+
+})

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.jest.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary

Add end-to-end test for `cli-tools` package. Most functionality is now under tests.

## Implementation

We build the `cli-tools` package before running the tests. It allows us to run the scripts with `node` instead of e.g. `ts-node`. Alternatively we could install `ts-node` as a dev dependency and run scripts like this: `../../node_modules/.bin/ts-node bin/streamr-wallet-whoami.ts`. But with that approach the startup of the interpreter is significantly slower (~30s).

## Limitations and future improvements

- Add tests for the `governance vote` command
- Improve test coverage so that all command line arguments have some test case
- Move `collect` to `@streamr/utils` package and also refactor client to use this shared function

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
