### PR TITLE
fix(client): Re-assign storage node

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -230,8 +230,15 @@ export class Stream {
      * storage node assignment to go through eventually.
      */
     async addToStorageNode(storageNodeAddress: string, waitOptions: { timeout?: number } = {}): Promise<void> {
-        let assignmentSubscription
         const normalizedNodeAddress = toEthereumAddress(storageNodeAddress)
+        // check whether the stream is already stored: the assignment event listener logic requires that 
+        // there must not be an existing assignment (it timeouts if there is an existing assignment as the 
+        // storage node doesn't send an assignment event in that case)
+        const isAlreadyStored = await this._streamStorageRegistry.isStoredStream(this.id, normalizedNodeAddress)
+        if (isAlreadyStored) {
+            return
+        }
+        let assignmentSubscription
         try {
             const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
             assignmentSubscription = new Subscription(streamPartId, false, this._loggerFactory)

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -85,6 +85,11 @@ describe('StorageNodeRegistry2', () => {
         await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
         const isStored = await client.isStoredStream(stream.id, DOCKER_DEV_STORAGE_NODE)
         expect(isStored).toEqual(true)
+
+        // assign again: no-op
+        await stream.addToStorageNode(DOCKER_DEV_STORAGE_NODE)
+        const isStored2 = await client.isStoredStream(stream.id, DOCKER_DEV_STORAGE_NODE)
+        expect(isStored2).toEqual(true)
     })
 
     it('delete a node', async () => {

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -26,11 +26,6 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
         this.streamIdBuilder = streamIdBuilder
     }
 
-    private async hasAssignment(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
-        const assignments = await this.getStorageNodes(streamIdOrPath)
-        return assignments.includes(nodeAddress)
-    }
-
     async getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
         if (streamIdOrPath !== undefined) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
@@ -56,7 +51,7 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
     }
 
     async addStreamToStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
-        if (!(await this.hasAssignment(streamIdOrPath, nodeAddress))) {
+        if (!(await this.isStoredStream(streamIdOrPath, nodeAddress))) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
             const node = this.network.getNode(nodeAddress)
             if (node !== undefined) {
@@ -73,9 +68,9 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
         throw new Error('not implemented')
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    isStoredStream(_streamIdOrPath: string, _nodeAddress: string): Promise<boolean> {
-        throw new Error('not implemented')
+    async isStoredStream(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {
+        const assignments = await this.getStorageNodes(streamIdOrPath)
+        return assignments.includes(nodeAddress)
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## Summary

If there was an existing storage node assignment, and `stream.addToStorageNode()` was called again for that same storage node, the operation timeouted.

## Changes

We explicitly check whether the stream is already stored. The assignment event listener logic requires that there must not be an existing assignment (as the storage node doesn't send an assignment event in that case).
