### PR TITLE
chore(cli-tools): Type annotations for `options`

### DIFF
--- a/packages/cli-tools/bin/streamr-mock-data-generate.ts
+++ b/packages/cli-tools/bin/streamr-mock-data-generate.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 import pkg from '../package.json'
 import { createFnParseInt } from '../src/common'
-import { createCommand } from '../src/command'
+import { createCommand, Options as BaseOptions } from '../src/command'
 import { randomString } from '@streamr/utils'
+
+interface Options extends BaseOptions {
+    rate: number
+}
 
 function genArray<T>(size: number, elementFn: () => T): T[] {
     const arr = []
@@ -30,7 +34,7 @@ createCommand()
     .description('generate and print semi-random JSON data to stdout')
     .option('-r, --rate <n>', 'rate in milliseconds', createFnParseInt('--rate'), 500)
     .version(pkg.version)
-    .action((options: any) => {
+    .action((options: Options) => {
         generate(options.rate)
     })
     .parse()

--- a/packages/cli-tools/bin/streamr-storage-node-list.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list.ts
@@ -2,9 +2,13 @@
 import '../src/logLevel'
 import { StreamrClient } from 'streamr-client'
 import EasyTable from 'easy-table'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 
-createClientCommand(async (client: StreamrClient, options: any) => {
+interface Options extends BaseOptions {
+    stream?: string
+}
+
+createClientCommand(async (client: StreamrClient, options: Options) => {
     const streamId = options.stream
     const addresses = await client.getStorageNodes(streamId)
     if (addresses.length > 0) {

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -2,9 +2,15 @@
 import '../src/logLevel'
 import StreamrClient from 'streamr-client'
 import { createFnParseInt } from '../src/common'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 
-createClientCommand(async (client: StreamrClient, streamIdOrPath: string, options: any) => {
+interface Options extends BaseOptions {
+    description?: string
+    streamConfig?: any
+    partitions?: number
+}
+
+createClientCommand(async (client: StreamrClient, streamIdOrPath: string, options: Options) => {
     const body: any = {
         id: streamIdOrPath,
         description: options.description,

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -4,7 +4,11 @@ import { Writable } from 'stream'
 import { StreamrClient } from 'streamr-client'
 import { wait } from '@streamr/utils'
 import es from 'event-stream'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
+
+interface Options extends BaseOptions {
+    partitionKeyField?: string
+}
 
 const publishStream = (
     stream: string,
@@ -37,7 +41,7 @@ const publishStream = (
     return writable
 }
 
-createClientCommand(async (client: StreamrClient, streamId: string, options: any) => {
+createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
     const ps = publishStream(streamId, options.partitionKeyField, client)
     return new Promise((resolve, reject) => {
         process.stdin

--- a/packages/cli-tools/bin/streamr-stream-resend-from.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-from.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import StreamrClient from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { resend } from '../src/resend'
 
-createClientCommand(async (client: StreamrClient, from: string, streamId: string, options: any) => {
+interface Options extends BaseOptions {
+    publisherId?: string
+    disableOrdering: boolean
+    subscribe: boolean
+}
+
+createClientCommand(async (client: StreamrClient, from: string, streamId: string, options: Options) => {
     const resendOptions = {
         from: {
             timestamp: Date.parse(from),

--- a/packages/cli-tools/bin/streamr-stream-resend-last.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-last.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import StreamrClient from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { resend } from '../src/resend'
 
-createClientCommand(async (client: StreamrClient, n: string, streamId: string, options: any) => {
+interface Options extends BaseOptions {
+    disableOrdering: boolean
+    subscribe: boolean
+}
+
+createClientCommand(async (client: StreamrClient, n: string, streamId: string, options: Options) => {
     if (isNaN(n as any)) {
         console.error('argument n is not a number')
         process.exit(1)

--- a/packages/cli-tools/bin/streamr-stream-resend-range.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-range.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import { StreamrClient } from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { assertBothOrNoneDefined, resend } from '../src/resend'
 
-createClientCommand(async (client: StreamrClient, from: string, to: string, streamId: string, options: any) => {
+interface Options extends BaseOptions {
+    publisherId?: string
+    msgChainId?: string
+    subscribe: boolean
+}
+
+createClientCommand(async (client: StreamrClient, from: string, to: string, streamId: string, options: Options) => {
     const resendOptions = {
         from: {
             timestamp: Date.parse(from),

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import StreamrClient, { SearchStreamsPermissionFilter, StreamPermission } from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { Option } from 'commander'
 import { getPermission, PERMISSIONS } from '../src/permission'
 import { getOptionType, OptionType } from '../src/common'
+
+interface Options extends BaseOptions {
+    user?: string | true
+    public?: true
+    all?: StreamPermission[]
+    any?: StreamPermission[]
+}
 
 const createPermissionFilter = async (
     user: string | boolean | undefined,
@@ -32,7 +39,7 @@ const createPermissionListOption = (id: string) => {
         .argParser((value: string) => value.split(',').map((id) => getPermission(id)))
 }
 
-createClientCommand(async (client: StreamrClient, term: string | undefined, options: any ) => {
+createClientCommand(async (client: StreamrClient, term: string | undefined, options: Options) => {
     const permissionFilter = await createPermissionFilter(
         options.user,
         options.public,

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -8,14 +8,14 @@ import { getOptionType, OptionType } from '../src/common'
 
 interface Options extends BaseOptions {
     user?: string | true
-    public?: true
+    public: boolean
     all?: StreamPermission[]
     any?: StreamPermission[]
 }
 
 const createPermissionFilter = async (
-    user: string | boolean | undefined,
-    allowPublic: boolean | undefined,
+    user: string | true | undefined,
+    allowPublic: boolean,
     allOf: StreamPermission[] | undefined,
     anyOf: StreamPermission[] | undefined,
     client: StreamrClient
@@ -23,7 +23,7 @@ const createPermissionFilter = async (
     if (user !== undefined) {
         return {
             user: (getOptionType(user) === OptionType.ARGUMENT) ? user as string : await client.getAddress(),
-            allowPublic: allowPublic ?? false,
+            allowPublic,
             allOf,
             anyOf
         }
@@ -55,7 +55,7 @@ createClientCommand(async (client: StreamrClient, term: string | undefined, opti
     .arguments('[term]')
     .description('search streams')
     .option('--user [user]', 'a stream must have permissions for the given user, defaults to the authenticated user')
-    .option('--public', 'the permission can be implicit (a public permission to the stream)')
+    .option('--public', 'the permission can be implicit (a public permission to the stream)', false)
     .addOption(createPermissionListOption('all'))
     .addOption(createPermissionListOption('any'))
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -15,7 +15,7 @@ interface Options extends BaseOptions {
 
 const createPermissionFilter = async (
     user: string | true | undefined,
-    allowPublic: boolean,
+    allowPublic: boolean | undefined,
     allOf: StreamPermission[] | undefined,
     anyOf: StreamPermission[] | undefined,
     client: StreamrClient
@@ -23,7 +23,7 @@ const createPermissionFilter = async (
     if (user !== undefined) {
         return {
             user: (getOptionType(user) === OptionType.ARGUMENT) ? user as string : await client.getAddress(),
-            allowPublic,
+            allowPublic: allowPublic ?? false,
             allOf,
             anyOf
         }
@@ -55,7 +55,7 @@ createClientCommand(async (client: StreamrClient, term: string | undefined, opti
     .arguments('[term]')
     .description('search streams')
     .option('--user [user]', 'a stream must have permissions for the given user, defaults to the authenticated user')
-    .option('--public', 'the permission can be implicit (a public permission to the stream)', false)
+    .option('--public', 'the permission can be implicit (a public permission to the stream)')
     .addOption(createPermissionListOption('all'))
     .addOption(createPermissionListOption('any'))
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import StreamrClient from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { getPermissionId } from '../src/permission'
 
-createClientCommand(async (client: StreamrClient, streamId: string, options: any) => {
+interface Options extends BaseOptions {
+    includePermissions?: true
+}
+
+createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
     const stream = await client.getStream(streamId)
     const obj: any = { id: stream.id, ...stream.getMetadata() }
     if (options.includePermissions) {

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -5,7 +5,7 @@ import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { getPermissionId } from '../src/permission'
 
 interface Options extends BaseOptions {
-    includePermissions?: true
+    includePermissions: boolean
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
@@ -24,5 +24,5 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .arguments('<streamId>')
     .description('show detailed information about a stream')
-    .option('--include-permissions', 'include list of permissions')
+    .option('--include-permissions', 'include list of permissions', false)
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import StreamrClient from 'streamr-client'
-import { createClientCommand } from '../src/command'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { createFnParseInt } from '../src/common'
 
-createClientCommand(async (client: StreamrClient, streamId: string, options: any) => {
+interface Options extends BaseOptions {
+    partition: number
+    disableOrdering: boolean
+}
+
+createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
     await client.subscribe({
         streamId,
         partition: options.partition,

--- a/packages/cli-tools/src/command.ts
+++ b/packages/cli-tools/src/command.ts
@@ -6,7 +6,7 @@ import { createClient } from './client'
 export interface Options {
     privateKey?: string
     config?: string
-    dev?: true
+    dev: boolean
 }
 
 export const createCommand = (): commander.Command => {
@@ -31,7 +31,7 @@ export const createClientCommand = (
     return createCommand()
         .option('--private-key <key>', 'use an Ethereum private key to authenticate')
         .option('--config <file>', 'read connection and authentication settings from a config file')
-        .option('--dev', 'use pre-defined development environment')
+        .option('--dev', 'use pre-defined development environment', false)
         .action(async (...args: any[]) => {
             const commandLineOptions = args[args.length - 1].opts()
             try {

--- a/packages/cli-tools/src/command.ts
+++ b/packages/cli-tools/src/command.ts
@@ -3,6 +3,12 @@ import { StreamrClientConfig } from 'streamr-client'
 import pkg from '../package.json'
 import { createClient } from './client'
 
+export interface Options {
+    privateKey?: string
+    config?: string
+    dev?: true
+}
+
 export const createCommand = (): commander.Command => {
     return new Command()
         .version(pkg.version)

--- a/packages/cli-tools/src/resend.ts
+++ b/packages/cli-tools/src/resend.ts
@@ -1,10 +1,11 @@
 import { StreamrClient, ResendOptions } from 'streamr-client'
 
-export const assertBothOrNoneDefined = (
-    option1: string,
-    option2: string,
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+export const assertBothOrNoneDefined = <T extends { [k: string]: any }>(
+    option1: keyof T,
+    option2: keyof T,
     errorMessage: string,
-    commandOptions: Record<string, unknown>
+    commandOptions: T
 ): void | never => { 
     if ((option1 in commandOptions && !(option2 in commandOptions)) || (option2 in commandOptions && !(option1 in commandOptions))) {
         console.error(`option ${errorMessage}`)

--- a/packages/cli-tools/src/resend.ts
+++ b/packages/cli-tools/src/resend.ts
@@ -1,7 +1,6 @@
 import { StreamrClient, ResendOptions } from 'streamr-client'
 
-// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
-export const assertBothOrNoneDefined = <T extends { [k: string]: any }>(
+export const assertBothOrNoneDefined = <T extends object>(
     option1: keyof T,
     option2: keyof T,
     errorMessage: string,


### PR DESCRIPTION
Add `Options` interface for each command which annotates the configuration options of that command.

Also simplified boolean handling in some classes.