### PR TITLE
feat(cli-tools): [NET-972] raw subscription and metadata support to `subscribe` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ found [here](packages/broker/CHANGELOG.md).
 #### Added
 
 - Add flag `--raw` (or shorthand `-r`) to command `stream subscribe` for raw subscription
+- Add flag `--with-metadata` (or shorthand `-m`) to command `stream subscribe` to include metadata in output
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Added
 
-- Add flag `--raw` (or shorthand `-r`) to command `stream subscribe` for raw subscription
-- Add flag `--with-metadata` (or shorthand `-m`) to command `stream subscribe` to include metadata in output
+- Add flag `--raw` (or shorthand `-r`) to command `stream subscribe` for raw subscription (https://github.com/streamr-dev/network/pull/1317)
+- Add flag `--with-metadata` (or shorthand `-m`) to command `stream subscribe` to include metadata in output (https://github.com/streamr-dev/network/pull/1317)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Added
 
+- Add flag `--raw` (or shorthand `-r`) to command `stream subscribe` for raw subscription
+
 #### Changed
 
 #### Deprecated

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 import omit from 'lodash/omit'
+import isString from 'lodash/isString'
 import StreamrClient, { MessageMetadata } from 'streamr-client'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { createFnParseInt } from '../src/common'
@@ -20,7 +21,10 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
         streamId,
         partition: options.partition,
         raw: options.raw
-    }, (message, metadata) => console.info(JSON.stringify(formMessage(message, metadata))))
+    }, (message, metadata) => {
+        const output = formMessage(message, metadata)
+        console.info(isString(output) ? output : JSON.stringify(output))
+    })
 }, {
     autoDestroyClient: false,
     clientOptionsFactory: (options) => ({

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -7,12 +7,14 @@ import { createFnParseInt } from '../src/common'
 interface Options extends BaseOptions {
     partition: number
     disableOrdering: boolean
+    raw: boolean
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
     await client.subscribe({
         streamId,
         partition: options.partition,
+        raw: options.raw
     }, (message) => console.info(JSON.stringify(message)))
 }, {
     autoDestroyClient: false,
@@ -24,4 +26,5 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
     .description('subscribe to a stream, prints JSON messages to stdout line-by-line')
     .option('-p, --partition [partition]', 'partition', createFnParseInt('--partition'), 0)
     .option('-d, --disable-ordering', 'disable ordering of messages by OrderingUtil', false)
+    .option('-r, --raw', 'subscribe raw', false)
     .parseAsync()

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -6,30 +6,55 @@ import { createTestClient, runCommand, startCommand } from './utils'
 
 describe('publish and subscribe', () => {
 
-    it('happy path', async () => {
-        const publisherPrivateKey = await fetchPrivateKeyWithGas()
-        const subscriberPrivateKey = await fetchPrivateKeyWithGas()
+    let publisherPrivateKey: string
+    let subscriberPrivateKey: string
+    let streamId: string
+
+    beforeAll(async () => {
+        publisherPrivateKey = await fetchPrivateKeyWithGas()
+        subscriberPrivateKey = await fetchPrivateKeyWithGas()
         const client = createTestClient(publisherPrivateKey)
         const stream = await client.createStream(`/${Date.now()}`)
         await stream.grantPermissions({
             user: new Wallet(subscriberPrivateKey).address,
             permissions: [StreamPermission.SUBSCRIBE]
         })
-        const subscriberAbortController = new AbortController()
-        const subscriberOutputIterable = startCommand(`stream subscribe ${stream.id}`, {
-            privateKey: subscriberPrivateKey,
-            abortSignal: subscriberAbortController.signal
-        })
+        streamId = stream.id
+        await client.destroy()
+    }, 40 * 1000)
+
+    function publishViaCliCommand() {
         setImmediate(async () => {
-            await runCommand(`stream publish ${stream.id}`, {
+            await runCommand(`stream publish ${streamId}`, {
                 inputLines: [JSON.stringify({ foo: 123 })],
                 privateKey: publisherPrivateKey
             })
         })
+    }
+
+    it('happy path', async () => {
+        const subscriberAbortController = new AbortController()
+        const subscriberOutputIterable = startCommand(`stream subscribe ${streamId}`, {
+            privateKey: subscriberPrivateKey,
+            abortSignal: subscriberAbortController.signal
+        })
+        publishViaCliCommand()
         const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
         subscriberAbortController.abort()
         expect(JSON.parse(receivedMessage)).toEqual({
             foo: 123
         })
     }, 40 * 1000)
+
+    it('raw subscription', async () => {
+        const subscriberAbortController = new AbortController()
+        const subscriberOutputIterable = startCommand(`stream subscribe ${streamId} --raw`, {
+            privateKey: subscriberPrivateKey,
+            abortSignal: subscriberAbortController.signal,
+        })
+        publishViaCliCommand()
+        const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
+        subscriberAbortController.abort()
+        expect(JSON.parse(receivedMessage)).toMatch(/[0-9a-fA-F]+/)
+    })
 })

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -55,7 +55,7 @@ describe('publish and subscribe', () => {
         publishViaCliCommand()
         const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
         subscriberAbortController.abort()
-        expect(JSON.parse(receivedMessage)).toMatch(/[0-9a-fA-F]+/)
+        expect(receivedMessage).toMatch(/[0-9a-fA-F]+/)
     })
 
     it('with metadata', async () => {

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -57,4 +57,28 @@ describe('publish and subscribe', () => {
         subscriberAbortController.abort()
         expect(JSON.parse(receivedMessage)).toMatch(/[0-9a-fA-F]+/)
     })
+
+    it('with metadata', async () => {
+        const subscriberAbortController = new AbortController()
+        const subscriberOutputIterable = startCommand(`stream subscribe ${streamId} --with-metadata`, {
+            privateKey: subscriberPrivateKey,
+            abortSignal: subscriberAbortController.signal,
+        })
+        publishViaCliCommand()
+        const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
+        subscriberAbortController.abort()
+        expect(JSON.parse(receivedMessage)).toMatchObject({
+            message: {
+                foo: 123
+            },
+            metadata: {
+                streamId,
+                streamPartition: 0,
+                timestamp: expect.any(Number),
+                sequenceNumber: 0,
+                publisherId: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf',
+                msgChainId: expect.stringMatching(/[0-9a-zA-Z]+/)
+            }
+        })
+    })
 })

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -55,7 +55,7 @@ describe('publish and subscribe', () => {
         publishViaCliCommand()
         const receivedMessage = (await collect(subscriberOutputIterable, 1))[0]
         subscriberAbortController.abort()
-        expect(receivedMessage).toMatch(/[0-9a-fA-F]+/)
+        expect(receivedMessage).toMatch(/^[0-9a-fA-F]+$/)
     })
 
     it('with metadata', async () => {


### PR DESCRIPTION
## Summary

Add raw subscription support to command `stream subscribe` with flag `--raw` or `-r`. Messages will be printed encrypted to stdout.

Add metadata support to command `streamr subscribe` with flag `--with-metadata` or `-m`. Messages will be printed with their associated metadata (publisherId, timestamp, sequenceNo etc.). 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
