### PR TITLE
fix(cli-tools): fix a few issues

### DIFF
--- a/packages/cli-tools/src/client.ts
+++ b/packages/cli-tools/src/client.ts
@@ -5,7 +5,7 @@ import { GlobalCommandLineArgs } from './common'
 import { getConfig } from './config'
 
 export const getClientConfig = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
-    const environmentOptions = (commandLineArgs.dev !== undefined) ? omit(CONFIG_TEST, 'auth') : undefined
+    const environmentOptions = commandLineArgs.dev ? omit(CONFIG_TEST, 'auth') : undefined
     const configFileJson = getConfig(commandLineArgs.config)?.client
     const authenticationOptions = (commandLineArgs.privateKey !== undefined) ? { auth: { privateKey: commandLineArgs.privateKey } } : undefined
     return merge(

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -29,7 +29,8 @@ export async function* startCommand(commandLine: string, opts?: StartCommandOpti
     const executable = spawn(`node`, args, {
         signal: opts?.abortSignal,
         env: {
-            PATH: process.env.PATH
+            PATH: process.env.PATH,
+            STREAMR_DOCKER_DEV_HOST: process.env.STREAMR_DOCKER_DEV_HOST
         }
     })
     executable.on('error', (err: any) => {


### PR DESCRIPTION
## Summary

- `dev` was enabled by default. Fixed in 1st commit.
- Pass environment variable `STREAMR_DOCKER_DEV_HOST` to child processes so tests run properly on external docker setup.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
