### PR TITLE
refactor(cli-tools): Remove obsolete interface

### DIFF
--- a/packages/cli-tools/src/client.ts
+++ b/packages/cli-tools/src/client.ts
@@ -5,7 +5,7 @@ import { GlobalCommandLineArgs } from './common'
 import { getConfig } from './config'
 
 export const getClientConfig = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
-    const environmentOptions = (commandLineArgs.dev !== undefined) ? omit(CONFIG_TEST, 'auth') : undefined
+    const environmentOptions = commandLineArgs.dev ? omit(CONFIG_TEST, 'auth') : undefined
     const configFileJson = getConfig(commandLineArgs.config)?.client
     const authenticationOptions = (commandLineArgs.privateKey !== undefined) ? { auth: { privateKey: commandLineArgs.privateKey } } : undefined
     return merge(

--- a/packages/cli-tools/src/client.ts
+++ b/packages/cli-tools/src/client.ts
@@ -1,13 +1,13 @@
 import omit from 'lodash/omit'
 import merge from 'lodash/merge'
 import { StreamrClientConfig, StreamrClient, CONFIG_TEST } from 'streamr-client'
-import { GlobalCommandLineArgs } from './common'
+import { Options } from './command'
 import { getConfig } from './config'
 
-export const getClientConfig = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
-    const environmentOptions = commandLineArgs.dev ? omit(CONFIG_TEST, 'auth') : undefined
-    const configFileJson = getConfig(commandLineArgs.config)?.client
-    const authenticationOptions = (commandLineArgs.privateKey !== undefined) ? { auth: { privateKey: commandLineArgs.privateKey } } : undefined
+export const getClientConfig = (commandOptions: Options, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
+    const environmentOptions = commandOptions.dev ? omit(CONFIG_TEST, 'auth') : undefined
+    const configFileJson = getConfig(commandOptions.config)?.client
+    const authenticationOptions = (commandOptions.privateKey !== undefined) ? { auth: { privateKey: commandOptions.privateKey } } : undefined
     return merge(
         environmentOptions,
         configFileJson,
@@ -27,8 +27,8 @@ const addInterruptHandler = (client: StreamrClient) => {
     })
 }
 
-export const createClient = (commandLineArgs: GlobalCommandLineArgs, overridenOptions: StreamrClientConfig = {}): StreamrClient => {
-    const config = getClientConfig(commandLineArgs, overridenOptions)
+export const createClient = (commandOptions: Options, overridenOptions: StreamrClientConfig = {}): StreamrClient => {
+    const config = getClientConfig(commandOptions, overridenOptions)
     const client = new StreamrClient(config)
     addInterruptHandler(client)
     return client

--- a/packages/cli-tools/src/command.ts
+++ b/packages/cli-tools/src/command.ts
@@ -33,9 +33,9 @@ export const createClientCommand = (
         .option('--config <file>', 'read connection and authentication settings from a config file')
         .option('--dev', 'use pre-defined development environment', false)
         .action(async (...args: any[]) => {
-            const commandLineOptions = args[args.length - 1].opts()
+            const commandOptions = args[args.length - 1].opts()
             try {
-                const client = createClient(commandLineOptions, opts.clientOptionsFactory!(commandLineOptions))
+                const client = createClient(commandOptions, opts.clientOptionsFactory!(commandOptions))
                 try {
                     await action(...[client].concat(args))
                 } finally {

--- a/packages/cli-tools/src/common.ts
+++ b/packages/cli-tools/src/common.ts
@@ -1,9 +1,3 @@
-export interface GlobalCommandLineArgs {
-    dev?: boolean
-    config?: string
-    privateKey?: string
-}
-
 export enum OptionType {
     FLAG, // e.g. "--enable"
     ARGUMENT  // e.g. "--private-key 0x1234"

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -29,7 +29,8 @@ export async function* startCommand(commandLine: string, opts?: StartCommandOpti
     const executable = spawn(`node`, args, {
         signal: opts?.abortSignal,
         env: {
-            PATH: process.env.PATH
+            PATH: process.env.PATH,
+            STREAMR_DOCKER_DEV_HOST: process.env.STREAMR_DOCKER_DEV_HOST
         }
     })
     executable.on('error', (err: any) => {


### PR DESCRIPTION
Remove `GlobalCommandLineArgs` interface. Use `Options` interface from `command.ts` instead.