### PR TITLE
fix(client): Include all modules in browser bundle

### DIFF
--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -69,6 +69,9 @@ module.exports = (env, argv) => {
                 GIT_VERSION: gitRevisionPlugin.version(),
                 GIT_COMMITHASH: gitRevisionPlugin.commithash(),
                 GIT_BRANCH: gitRevisionPlugin.branch(),
+            }),
+            new webpack.optimize.LimitChunkCountPlugin({
+                maxChunks: 1
             })
         ],
         performance: {


### PR DESCRIPTION
Before this PR `npm run build-production` created three chunks for the browser bundle:
e.g. 
```
streamr-client.web.js
137.web.js
767.web.js
```

Chunks with similar names were created also for the minified version of the browser bundle. 

There are no references to those numerical chunks in `streamr-client.web.js`, `package.json`, or `README`. Therefore some required modules may not be available in the browser environment?

There are 3+56 modules in those numerical chunks. The modules seem to be related `web3modal` functionality used by `lit` js-client.

### Fix

Added webpack `LimitChunkCountPlugin` so that each bundle contains only one chunk.

### Sanity check

`grep 'CONCATENATED MODULE' filename | wc -l`

|                    | before                        | after    | difference   |
| :---               | :---                          | :---     | :---         |
| modules            | 338+3+56=397                  | 397      | 0            |
| non-minified size  | 9099014+24583+307605=9431202  | 9422503  | -8699        |
| minified size      | 4691583+14088+212515=4918186  | 4915409  | -2777        |