### PR TITLE
refactor(client): Remove redundant `OrderedMsgChain` defaults

### DIFF
--- a/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
+++ b/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
@@ -170,7 +170,7 @@ class OrderedMsgChain extends MsgChainEmitter {
     msgChainId: string
     inOrderHandler: MessageHandler
     gapHandler: GapHandler
-    propagationTimeout: number
+    gapFillTimeout: number
     resendTimeout: number
     nextGaps: ReturnType<typeof setTimeout> | null = null
     markedExplicitly = new StreamMessageSet()
@@ -180,7 +180,7 @@ class OrderedMsgChain extends MsgChainEmitter {
         msgChainId: string,
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
-        propagationTimeout = DEFAULT_PROPAGATION_TIMEOUT,
+        gapFillTimeout = DEFAULT_PROPAGATION_TIMEOUT,
         resendTimeout = DEFAULT_RESEND_TIMEOUT,
         maxGapRequests = MAX_GAP_REQUESTS
     ) {
@@ -192,7 +192,7 @@ class OrderedMsgChain extends MsgChainEmitter {
         this.inOrderHandler = inOrderHandler
         this.gapHandler = gapHandler
         this.lastOrderedMsgRef = null
-        this.propagationTimeout = propagationTimeout
+        this.gapFillTimeout = gapFillTimeout
         this.resendTimeout = resendTimeout
         this.maxGapRequests = maxGapRequests
     }
@@ -386,7 +386,7 @@ class OrderedMsgChain extends MsgChainEmitter {
             return
         }
 
-        logger.trace('scheduleGap', { timeoutMs: this.propagationTimeout })
+        logger.trace('scheduleGap', { timeoutMs: this.gapFillTimeout })
         const nextGap = (timeout: number) => {
             clearTimeout(this.nextGaps!)
             this.nextGaps = setTimeout(async () => {
@@ -396,7 +396,7 @@ class OrderedMsgChain extends MsgChainEmitter {
                 nextGap(this.resendTimeout)
             }, timeout)
         }
-        nextGap(this.propagationTimeout)
+        nextGap(this.gapFillTimeout)
     }
 
     /**

--- a/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
+++ b/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
@@ -171,7 +171,7 @@ class OrderedMsgChain extends MsgChainEmitter {
     inOrderHandler: MessageHandler
     gapHandler: GapHandler
     gapFillTimeout: number
-    resendTimeout: number
+    retryResendAfter: number
     nextGaps: ReturnType<typeof setTimeout> | null = null
     markedExplicitly = new StreamMessageSet()
 
@@ -181,7 +181,7 @@ class OrderedMsgChain extends MsgChainEmitter {
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
         gapFillTimeout = DEFAULT_PROPAGATION_TIMEOUT,
-        resendTimeout = DEFAULT_RESEND_TIMEOUT,
+        retryResendAfter = DEFAULT_RESEND_TIMEOUT,
         maxGapRequests = MAX_GAP_REQUESTS
     ) {
         super()
@@ -193,7 +193,7 @@ class OrderedMsgChain extends MsgChainEmitter {
         this.gapHandler = gapHandler
         this.lastOrderedMsgRef = null
         this.gapFillTimeout = gapFillTimeout
-        this.resendTimeout = resendTimeout
+        this.retryResendAfter = retryResendAfter
         this.maxGapRequests = maxGapRequests
     }
 
@@ -393,7 +393,7 @@ class OrderedMsgChain extends MsgChainEmitter {
                 if (!this.hasPendingGap) { return }
                 await this.requestGapFill()
                 if (!this.hasPendingGap) { return }
-                nextGap(this.resendTimeout)
+                nextGap(this.retryResendAfter)
             }, timeout)
         }
         nextGap(this.gapFillTimeout)

--- a/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
+++ b/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
@@ -147,14 +147,6 @@ interface Events {
 // eslint-disable-next-line @typescript-eslint/prefer-function-type
 export const MsgChainEmitter = EventEmitter as { new(): StrictEventEmitter<EventEmitter, Events> }
 
-// The time it takes to propagate messages in the network. If we detect a gap, we first wait this amount of time because the missing
-// messages might still be propagated.
-const DEFAULT_PROPAGATION_TIMEOUT = 5000
-// The round trip time it takes to request a resend and receive the answer. If the messages are still missing after the propagation
-// delay, we request a resend and periodically wait this amount of time before requesting it again.
-const DEFAULT_RESEND_TIMEOUT = 5000
-const MAX_GAP_REQUESTS = 10
-
 let ID = 0
 
 const logger = new Logger(module)
@@ -180,9 +172,9 @@ class OrderedMsgChain extends MsgChainEmitter {
         msgChainId: string,
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
-        gapFillTimeout = DEFAULT_PROPAGATION_TIMEOUT,
-        retryResendAfter = DEFAULT_RESEND_TIMEOUT,
-        maxGapRequests = MAX_GAP_REQUESTS
+        gapFillTimeout: number,
+        retryResendAfter: number,
+        maxGapRequests: number
     ) {
         super()
         ID += 1

--- a/packages/client/src/subscribe/ordering/OrderingUtil.ts
+++ b/packages/client/src/subscribe/ordering/OrderingUtil.ts
@@ -5,17 +5,17 @@ import { EthereumAddress } from '@streamr/utils'
 export default class OrderingUtil extends MsgChainEmitter {
     inOrderHandler: MessageHandler
     gapHandler: GapHandler
-    gapFillTimeout?: number
-    retryResendAfter?: number
-    maxGapRequests?: number
+    gapFillTimeout: number
+    retryResendAfter: number
+    maxGapRequests: number
     orderedChains: Record<string, OrderedMsgChain>
 
     constructor(
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
-        gapFillTimeout?: number,
-        retryResendAfter?: number,
-        maxGapRequests?: number
+        gapFillTimeout: number,
+        retryResendAfter: number,
+        maxGapRequests: number
     ) {
         super()
         this.inOrderHandler = inOrderHandler

--- a/packages/client/src/subscribe/ordering/OrderingUtil.ts
+++ b/packages/client/src/subscribe/ordering/OrderingUtil.ts
@@ -5,7 +5,7 @@ import { EthereumAddress } from '@streamr/utils'
 export default class OrderingUtil extends MsgChainEmitter {
     inOrderHandler: MessageHandler
     gapHandler: GapHandler
-    propagationTimeout?: number
+    gapFillTimeout?: number
     resendTimeout?: number
     maxGapRequests?: number
     orderedChains: Record<string, OrderedMsgChain>
@@ -13,14 +13,14 @@ export default class OrderingUtil extends MsgChainEmitter {
     constructor(
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
-        propagationTimeout?: number,
+        gapFillTimeout?: number,
         resendTimeout?: number,
         maxGapRequests?: number
     ) {
         super()
         this.inOrderHandler = inOrderHandler
         this.gapHandler = gapHandler
-        this.propagationTimeout = propagationTimeout
+        this.gapFillTimeout = gapFillTimeout
         this.resendTimeout = resendTimeout
         this.maxGapRequests = maxGapRequests
         this.orderedChains = {}
@@ -36,7 +36,7 @@ export default class OrderingUtil extends MsgChainEmitter {
         if (!this.orderedChains[key]) {
             const chain = new OrderedMsgChain(
                 publisherId, msgChainId, this.inOrderHandler, this.gapHandler,
-                this.propagationTimeout, this.resendTimeout, this.maxGapRequests
+                this.gapFillTimeout, this.resendTimeout, this.maxGapRequests
             )
             chain.on('error', (...args) => this.emit('error', ...args))
             chain.on('skip', (...args) => this.emit('skip', ...args))

--- a/packages/client/src/subscribe/ordering/OrderingUtil.ts
+++ b/packages/client/src/subscribe/ordering/OrderingUtil.ts
@@ -6,7 +6,7 @@ export default class OrderingUtil extends MsgChainEmitter {
     inOrderHandler: MessageHandler
     gapHandler: GapHandler
     gapFillTimeout?: number
-    resendTimeout?: number
+    retryResendAfter?: number
     maxGapRequests?: number
     orderedChains: Record<string, OrderedMsgChain>
 
@@ -14,14 +14,14 @@ export default class OrderingUtil extends MsgChainEmitter {
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
         gapFillTimeout?: number,
-        resendTimeout?: number,
+        retryResendAfter?: number,
         maxGapRequests?: number
     ) {
         super()
         this.inOrderHandler = inOrderHandler
         this.gapHandler = gapHandler
         this.gapFillTimeout = gapFillTimeout
-        this.resendTimeout = resendTimeout
+        this.retryResendAfter = retryResendAfter
         this.maxGapRequests = maxGapRequests
         this.orderedChains = {}
     }
@@ -36,7 +36,7 @@ export default class OrderingUtil extends MsgChainEmitter {
         if (!this.orderedChains[key]) {
             const chain = new OrderedMsgChain(
                 publisherId, msgChainId, this.inOrderHandler, this.gapHandler,
-                this.gapFillTimeout, this.resendTimeout, this.maxGapRequests
+                this.gapFillTimeout, this.retryResendAfter, this.maxGapRequests
             )
             chain.on('error', (...args) => this.emit('error', ...args))
             chain.on('skip', (...args) => this.emit('skip', ...args))

--- a/packages/client/test/unit/OrderingUtil.test.ts
+++ b/packages/client/test/unit/OrderingUtil.test.ts
@@ -5,6 +5,10 @@ import OrderingUtil from '../../src/subscribe/ordering/OrderingUtil'
 import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 import { shuffle } from 'lodash'
 
+const DEFAULT_GAP_FILL_TIMEOUT = 5000
+const DEFAULT_RETRY_RESEND_AFTER = 5000
+const DEFAULT_MAX_GAP_REQUESTS = 10
+
 const defaultPublisherId = toEthereumAddress('0x0000000000000000000000000000000000000001')
 const publisherId1 = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 const publisherId2 = toEthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
@@ -40,7 +44,7 @@ describe('OrderingUtil', () => {
             assert.deepStrictEqual(streamMessage.serialize(), msg.serialize())
             done()
         }
-        util = new OrderingUtil(handler, () => {})
+        util = new OrderingUtil(handler, () => {}, DEFAULT_GAP_FILL_TIMEOUT, DEFAULT_RETRY_RESEND_AFTER, DEFAULT_MAX_GAP_REQUESTS)
         util.add(msg)
     })
     it('calls the gap handler if a gap is detected', (done) => {
@@ -52,7 +56,7 @@ describe('OrderingUtil', () => {
             assert.equal(publisherId, defaultPublisherId)
             done()
         }
-        util = new OrderingUtil( () => {}, gapHandler, 50, 50)
+        util = new OrderingUtil( () => {}, gapHandler, 50, 50, DEFAULT_MAX_GAP_REQUESTS)
         const msg1 = msg
         const msg4 = createMsg(4, undefined, 3)
         util.add(msg1)
@@ -62,7 +66,7 @@ describe('OrderingUtil', () => {
         const gapHandler = () => {
             throw new Error('The gap handler should not be called.')
         }
-        util = new OrderingUtil(() => {}, gapHandler, 5000, 5000)
+        util = new OrderingUtil(() => {}, gapHandler, 5000, 5000, DEFAULT_MAX_GAP_REQUESTS)
         const msg1 = msg
         const msg2 = createMsg(2, undefined, 1)
         const msg3 = createMsg(3, undefined, 2)
@@ -103,7 +107,7 @@ describe('OrderingUtil', () => {
             } else if (m.getPublisherId() === publisherId3) {
                 received3.push(m)
             }
-        }, () => {}, 50)
+        }, () => {}, 50, DEFAULT_RETRY_RESEND_AFTER, DEFAULT_MAX_GAP_REQUESTS)
         util.add(msg1Pub1)
         util.add(msg1Pub2)
         util.add(msg1Pub3)


### PR DESCRIPTION
We always have values for `gapFillTimeout`, `retryResendAfter` and `maxGapRequests` as there are defaults in config.schema.json. Therefore there is no need to have defaults in `OrderedMsgChain`.

Also unified variable names to match the config options:
- `propagationTimeout` -> `gapFillTimeout`
- `resendTimeout` -> `retryResendAfter`