### PR TITLE
test(cli-tools): Improve matcher of `storage-node list` test

### DIFF
--- a/packages/cli-tools/test/storage-node.test.ts
+++ b/packages/cli-tools/test/storage-node.test.ts
@@ -27,6 +27,6 @@ describe('storage node', () => {
 
     it('list nodes', async () => {
         const outputLines = await runCommand('storage-node list')
-        expect(outputLines[2]).toEqual(DOCKER_DEV_STORAGE_NODE.toLowerCase())
+        expect(outputLines.join()).toMatch(DOCKER_DEV_STORAGE_NODE.toLowerCase())
     })
 })


### PR DESCRIPTION
The dev environment storage node must be one of the items, but there can be additional storage nodes.