### PR TITLE
chore(client): reduce webpack size by aliasing unused modules

### DIFF
--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -119,6 +119,18 @@ module.exports = (env, argv) => {
                 [path.resolve('./src/utils/persistence/ServerPersistence.ts')]: (
                     path.resolve('./src/utils/persistence/BrowserPersistence.ts')
                 ),
+                '@walletconnect/ethereum-provider': false, // This and below brought in by @litprotocol/client-node but not actually used by our use case...
+                '@walletconnect/universal-provider': false,
+                '@walletconnect/core': false,
+                '@walletconnect/sign-client': false,
+                '@walletconnect/logger': false,
+                '@walletconnect/utils': false,
+                '@walletconnect/time': false,
+                '@walletconnect/keyvaluestorage': false,
+                '@walletconnect/heartbeat': false,
+                '@walletconnect/environment': false,
+                'ipfs-http-client': false,
+                'jszip': false,
             },
             fallback: {
                 module: false,


### PR DESCRIPTION
## Summary

Exclude some packages brought in by  `@lit-protocol/lit-node-client` that we don't  (indirectly) use due to us using only a specific portion of the public API of  `@lit-protocol/lit-node-client` .

Tested by hand using the HTML templates we built earlier.

## Limitations and future improvements

Obviously this can break very easily in the future if the authors of `@lit-protocol/lit-node-client` decide to use these modules in their public API code that our code interacts with. I see this as further argument to get the lit-protocol integration under automated testing.
