### PR TITLE
NET-977: routing session partialSuccess event

### DIFF
--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -125,7 +125,7 @@ export class Router implements IRouter {
         try {
             // eslint-disable-next-line promise/catch-or-return
             logger.trace('starting to raceEvents from routingSession: ' + session.sessionId)
-            raceEvents3<RoutingSessionEvents>(session, ['routingSucceeded', 'routingFailed', 'stopped', 'noCandidatesFound'], 10000)
+            raceEvents3<RoutingSessionEvents>(session, ['routingSucceeded', 'partialSuccess', 'routingFailed', 'stopped', 'noCandidatesFound'], 10000)
                 .then(() => {
                     logger.trace('raceEvents ended from routingSession: ' + session.sessionId)
                     this.removeRoutingSession(session.sessionId)


### PR DESCRIPTION
## Summary

The routing session will now wait for as many successful routing attempts as the `parallelism` configuration asks for.

Additionally, the routing session will now emit a `partialSuccess` event instead of a `failed` event if there is atleast a single successful routing path.