### PR TITLE
NET-977: FindRecursiveSession wait for a single noClosestPeersFound flag

### DIFF
--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -23,7 +23,7 @@ export interface RecursiveFindSessionConfig {
     rpcTransport: ITransport
     kademliaIdToFind: Uint8Array
     ownPeerID: PeerID
-    routingPaths: number
+    waitedRoutingPathCompletions: number
 }
 
 export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvents> implements IRecursiveFindSessionService {
@@ -31,7 +31,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
     private readonly rpcTransport: ITransport
     private readonly kademliaIdToFind: Uint8Array
     private readonly ownPeerID: PeerID
-    private readonly routingPaths: number
+    private readonly waitedRoutingPathCompletions: number
     private readonly rpcCommunicator: ListeningRpcCommunicator
     private results: SortedContactList<Contact>
     private foundData: Map<string, DataEntry> = new Map()
@@ -47,7 +47,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         this.rpcTransport = config.rpcTransport
         this.kademliaIdToFind = config.kademliaIdToFind
         this.ownPeerID = config.ownPeerID
-        this.routingPaths = config.routingPaths
+        this.waitedRoutingPathCompletions = config.waitedRoutingPathCompletions
         this.results = new SortedContactList(PeerID.fromValue(this.kademliaIdToFind), 10)
         this.rpcCommunicator = new ListeningRpcCommunicator(this.serviceId, this.rpcTransport, {
             rpcRequestTimeout: 15000
@@ -61,7 +61,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         this.reportedHops.forEach((id) => {
             unreportedHops.delete(id)
         })
-        if (this.noCloserNodesReceivedCounter >= this.routingPaths && unreportedHops.size == 0) {
+        if (this.noCloserNodesReceivedCounter >= this.waitedRoutingPathCompletions && unreportedHops.size == 0) {
             return true
         }
         return false

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -89,7 +89,7 @@ export class RecursiveFinder implements IRecursiveFinder {
             rpcTransport: this.sessionTransport,
             kademliaIdToFind: idToFind,
             ownPeerID: this.ownPeerId!,
-            routingPaths: this.connections.size > 1 ? 2 : 1
+            waitedRoutingPathCompletions: 1
         })
         if (this.connections.size === 0) {
             const data = this.localDataStore.getEntry(PeerID.fromValue(idToFind))


### PR DESCRIPTION
## Summary

The FindRecursiveSession will now complete once all the hops are reported and a single noClosestPeersFound is set.
