### PR TITLE
chore: fix `restrict-plus-operands` eslint rule issues 

### DIFF
--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -309,6 +309,6 @@ export const start = async (
         logger.info('You can start the broker now with')
         logger.info(`streamr-broker ${storagePath}`)
     } catch (e: any) {
-        logger.error("Broker Config Wizard encountered an error:\n" + e.message)
+        logger.error(`Broker Config Wizard encountered an error:\n${e.message}`)
     }
 }

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -13,7 +13,7 @@ const TRACKER_PORT = 12471
 jest.setTimeout(30000)
 
 const createMqttClient = () => {
-    return mqtt.connectAsync('mqtt://localhost:' + MQTT_PLUGIN_PORT)
+    return mqtt.connectAsync(`mqtt://localhost:${MQTT_PLUGIN_PORT}`)
 }
 
 describe('MQTT Bridge', () => {

--- a/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/MqttPlugin.test.ts
@@ -16,7 +16,7 @@ createMessagingPluginTest('mqtt',
                 username: '',
                 password: apiKey
             } : undefined
-            return mqtt.connectAsync('mqtt://localhost:' + MQTT_PORT, opts)
+            return mqtt.connectAsync(`mqtt://localhost:${MQTT_PORT}`, opts)
         },
         closeClient: async (client: AsyncMqttClient): Promise<void> => {
             await client.end(true)

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -11,7 +11,7 @@ const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 
-const MOCK_STREAM_ID = 'mock-stream-id-' + Date.now()
+const MOCK_STREAM_ID = `mock-stream-id-${Date.now()}`
 const MOCK_PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 const MOCK_MSG_CHAIN_ID = 'msgChainId'
 const createMockMessage = (i: number) => {
@@ -25,7 +25,7 @@ const createMockMessage = (i: number) => {
 }
 const MOCK_MESSAGES = [1, 2, 3].map((contentValue: number) => createMockMessage(contentValue))
 
-const EMPTY_STREAM_ID = 'empty-stream-id' + Date.now()
+const EMPTY_STREAM_ID = `empty-stream-id-${Date.now()}`
 
 const REQUEST_TYPE_FROM = 'requestFrom'
 const REQUEST_TYPE_RANGE = 'requestRange'

--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -52,7 +52,7 @@ describe('Storage: lots of data', () => {
                 bucketKeepAliveSeconds: 1
             }
         })
-        streamId = getTestName(module) + Date.now()
+        streamId = `${getTestName(module)}-${Date.now()}`
     })
 
     afterAll(async () => {

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -143,7 +143,7 @@ export const createTestStream = async (
     module: NodeModule,
     props?: Partial<StreamMetadata>
 ): Promise<Stream> => {
-    const id = (await streamrClient.getAddress()) + '/test/' + getTestName(module) + '/' + Date.now()
+    const id = `${await streamrClient.getAddress()}/test/${getTestName(module)}/${Date.now()}`
     const stream = await streamrClient.createStream({
         id,
         ...props

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -83,7 +83,7 @@ export class EncryptionUtil {
             }
         } catch (err) {
             streamMessage.encryptionType = EncryptionType.AES
-            throw new DecryptError(streamMessage, 'Could not decrypt new group key: ' + err.stack)
+            throw new DecryptError(streamMessage, `Could not decrypt new group key: ${err.stack}`)
         }
         /* eslint-enable no-param-reassign */
     }

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -117,7 +117,7 @@ describe('StreamRegistry', () => {
         describe('ENS', () => {
 
             it('domain owned by user', async () => {
-                const streamId = 'testdomain1.eth/foobar/' + Date.now()
+                const streamId = `testdomain1.eth/foobar/${Date.now()}`
                 const ensOwnerClient = new StreamrClient({
                     ...CONFIG_TEST,
                     auth: {


### PR DESCRIPTION
Some fixes related to [restrict-plus-operands](https://typescript-eslint.io/rules/restrict-plus-operands) eslint rule. The rule is not yet in our eslint rule set, but we may add it in PR https://github.com/streamr-dev/network/pull/1171.