### PR TITLE
refactor(client): Refactor `waitForAssignmentsToPropagate`

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -228,8 +228,8 @@ export class Stream {
      */
     async addToStorageNode(storageNodeAddress: string, waitOptions: { timeout?: number } = {}): Promise<void> {
         const normalizedNodeAddress = toEthereumAddress(storageNodeAddress)
-        // check whether the stream is already stored: the assignment event listener logic requires that 
-        // there must not be an existing assignment (it timeouts if there is an existing assignment as the 
+        // check whether the stream is already stored: the assignment event listener logic requires that
+        // there must not be an existing assignment (it timeouts if there is an existing assignment as the
         // storage node doesn't send an assignment event in that case)
         const isAlreadyStored = await this._streamStorageRegistry.isStoredStream(this.id, normalizedNodeAddress)
         if (isAlreadyStored) {
@@ -240,7 +240,7 @@ export class Stream {
             const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
             assignmentSubscription = new Subscription(streamPartId, false, this._loggerFactory)
             await this._subscriber.add(assignmentSubscription)
-            const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
+            const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription.getStreamMessages(), {
                 id: this.id,
                 partitions: this.getMetadata().partitions
             })

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -243,7 +243,7 @@ export class Stream {
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription.getStreamMessages(), {
                 id: this.id,
                 partitions: this.getMetadata().partitions
-            })
+            }, this._loggerFactory)
             await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(
                 propagationPromise,

--- a/packages/client/src/utils/waitForAssignmentsToPropagate.ts
+++ b/packages/client/src/utils/waitForAssignmentsToPropagate.ts
@@ -1,31 +1,24 @@
 import { StreamID, StreamMessage, StreamPartIDUtils } from '@streamr/protocol'
-import { collect } from '@streamr/utils'
-import identity from 'lodash/identity'
-import { MessageStream } from '../subscribe/MessageStream'
-import { unique } from './GeneratorUtils'
 
-export function waitForAssignmentsToPropagate(
-    messageStream: MessageStream,
+export async function waitForAssignmentsToPropagate(
+    messages: AsyncIterable<StreamMessage>,
     targetStream: {
         id: StreamID
         partitions: number
     }
-): Promise<string[]> {
-    return collect(
-        unique<string>(
-            messageStream
-                .map((msg: StreamMessage) => (msg.getParsedContent() as any).streamPart)
-                .filter((input: any) => {
-                    try {
-                        const streamPartId = StreamPartIDUtils.parse(input)
-                        const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
-                        return streamId === targetStream.id && partition < targetStream.partitions
-                    } catch {
-                        return false
-                    }
-                }),
-            identity
-        ),
-        targetStream.partitions
-    )
+): Promise<void> {
+    const foundPartitions = new Set<number>
+    for await (const msg of messages) {
+        const streamPart = (msg.getParsedContent() as any).streamPart
+        try {
+            const streamPartId = StreamPartIDUtils.parse(streamPart)
+            const [streamId, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
+            if ((streamId === targetStream.id) && (partition < targetStream.partitions)) {
+                foundPartitions.add(partition)
+                if (foundPartitions.size === targetStream.partitions) {
+                    return
+                }
+            }
+        } catch {} // TODO logging?
+    }
 }

--- a/packages/client/src/utils/waitForAssignmentsToPropagate.ts
+++ b/packages/client/src/utils/waitForAssignmentsToPropagate.ts
@@ -1,11 +1,13 @@
 import { StreamID, StreamMessage, StreamPartIDUtils } from '@streamr/protocol'
+import { LoggerFactory } from './LoggerFactory'
 
 export async function waitForAssignmentsToPropagate(
     messages: AsyncIterable<StreamMessage>,
     targetStream: {
         id: StreamID
         partitions: number
-    }
+    },
+    loggerFactory: LoggerFactory
 ): Promise<void> {
     const foundPartitions = new Set<number>
     for await (const msg of messages) {
@@ -19,6 +21,8 @@ export async function waitForAssignmentsToPropagate(
                     return
                 }
             }
-        } catch {} // TODO logging?
+        } catch {
+            loggerFactory.createLogger(module).debug('Ignore malformed content')
+        }
     }
 }

--- a/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -50,7 +50,7 @@ describe(waitForAssignmentsToPropagate, () => {
     beforeEach(() => {
         messageStream = new MessageStream()
         propagatePromiseState = 'pending'
-        propagatePromise = waitForAssignmentsToPropagate(messageStream, TARGET_STREAM)
+        propagatePromise = waitForAssignmentsToPropagate(messageStream.getStreamMessages(), TARGET_STREAM)
             .then((retValue) => {
                 propagatePromiseState = 'resolved'
                 return retValue

--- a/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -11,7 +11,7 @@ import range from 'lodash/range'
 import shuffle from 'lodash/shuffle'
 import { wait } from '@streamr/utils'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
-import { createRandomAuthentication } from '../test-utils/utils'
+import { createRandomAuthentication, mockLoggerFactory } from '../test-utils/utils'
 import { MessageStream } from '../../src/subscribe/MessageStream'
 
 const authentication = createRandomAuthentication()
@@ -50,7 +50,7 @@ describe(waitForAssignmentsToPropagate, () => {
     beforeEach(() => {
         messageStream = new MessageStream()
         propagatePromiseState = 'pending'
-        propagatePromise = waitForAssignmentsToPropagate(messageStream.getStreamMessages(), TARGET_STREAM)
+        propagatePromise = waitForAssignmentsToPropagate(messageStream.getStreamMessages(), TARGET_STREAM, mockLoggerFactory())
             .then((retValue) => {
                 propagatePromiseState = 'resolved'
                 return retValue


### PR DESCRIPTION
Refactor waitForAssignmentsToPropagate so that it receives the input as `AsyncIterable<StreamMessage>` instead of `MessageStream`. The filtering and mapping logic is implemented more straightforwardly without using `GeneratorUtils` utility functions.

Also added logging of messages which contain malformed content.