### PR TITLE
feat(broker): MQTT plugin partition support

### DIFF
--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -229,6 +229,13 @@ This way you can publish and subscribe to a stream by using only the path part o
 await client.publish('path-part', ...)  // publishes to a stream "0x1234567890123456789012345678901234567890/path-part"
 ```
 
+#### Partition
+
+By default the plugin publishes and subscribes to partition `0`. If you want to specify other partition, you can encode the information into the topic string, e.g.:
+```
+await client.publish('/foobar?partition=5', ...)
+```
+
 ## HTTP
 
 At the moment, only publishing is supported over HTTP. To subscribe, use one of the other protocol plugins as they allow a continuous streaming connection.

--- a/packages/broker/src/helpers/parser.ts
+++ b/packages/broker/src/helpers/parser.ts
@@ -1,4 +1,4 @@
-import { ParsedQs } from 'qs'
+import { ParsedQs, parse } from 'qs'
 
 export const parsePositiveInteger = (n: string): number | never => {
     const parsed = parseInt(n)
@@ -36,4 +36,19 @@ export const parseQueryParameter = <T>(name: string, query: ParsedQs, parser: (i
 
 export const parseQueryParameterArray = <T>(name: string, query: ParsedQs, parser: (input: string) => T): T[] | undefined => {
     return parseQueryParameter(name, query, (input) => input.split(',').map((part) => parser(part)))
+}
+
+export const parseQueryAndBase = (str: string): { base: string, query: ParsedQs } => {
+    const queryParameterStartPos = str.lastIndexOf('?')
+    if (queryParameterStartPos !== -1) {
+        return {
+            base: str.substring(0, queryParameterStartPos),
+            query: parse(str.substring(queryParameterStartPos + 1))
+        }
+    } else {
+        return {
+            base: str,
+            query: {}
+        }
+    }
 }

--- a/packages/broker/src/plugins/mqtt/Bridge.ts
+++ b/packages/broker/src/plugins/mqtt/Bridge.ts
@@ -60,10 +60,10 @@ export class Bridge implements MqttServerListener {
 
     async onSubscribed(topic: string, clientId: string): Promise<void> {
         logger.info('Handle client subscribe', { clientId, topic })
-        const streamId = this.getStreamPartition(topic)
-        const existingSubscription = this.getSubscription(streamId)
+        const streamPart = this.getStreamPartition(topic)
+        const existingSubscription = this.getSubscription(streamPart)
         if (existingSubscription === undefined) {
-            const streamrClientSubscription = await this.streamrClient.subscribe(streamId, (content: any, metadata: MessageMetadata) => {
+            const streamrClientSubscription = await this.streamrClient.subscribe(streamPart, (content: any, metadata: MessageMetadata) => {
                 if (!this.isSelfPublishedMessage(metadata)) {
                     const payload = this.payloadFormat.createPayload(content, metadata)
                     this.mqttServer.publish(topic, payload)

--- a/packages/broker/test/unit/helpers/parser.test.ts
+++ b/packages/broker/test/unit/helpers/parser.test.ts
@@ -31,5 +31,10 @@ describe('parse', () => {
             expect(base).toBe('foobar')
             expect(query).toEqual({})
         })
+        it('empty query', () => {
+            const { base, query } = parseQueryAndBase('foobar?')
+            expect(base).toBe('foobar')
+            expect(query).toEqual({})
+        })
     })
 })

--- a/packages/broker/test/unit/helpers/parser.test.ts
+++ b/packages/broker/test/unit/helpers/parser.test.ts
@@ -1,0 +1,35 @@
+import { parse } from 'qs'
+import { parsePositiveInteger, parseQueryAndBase, parseQueryParameter } from '../../../src/helpers/parser'
+
+describe('parse', () => {
+
+    describe('parseQueryParameter', () => {
+        it('happy path', () => {
+            const query = parse('x=3')
+            const value = parseQueryParameter('x', query, parsePositiveInteger)
+            expect(value).toBe(3)
+        })
+        it('no value', () => {
+            const query = parse('')
+            const value = parseQueryParameter('x', query, parsePositiveInteger)
+            expect(value).toBe(undefined)
+        })
+        it('parse error', () => {
+            const query = parse('x=foo')
+            expect(() => parseQueryParameter('x', query, parsePositiveInteger)).toThrow()
+        })
+    })
+
+    describe('parseQueryAndBase', () => {
+        it('with parameters', () => {
+            const { base, query } = parseQueryAndBase('foobar?lorem=ipsum')
+            expect(base).toBe('foobar')
+            expect(query['lorem']).toBe('ipsum')
+        })
+        it('without parameters', () => {
+            const { base, query } = parseQueryAndBase('foobar')
+            expect(base).toBe('foobar')
+            expect(query).toEqual({})
+        })
+    })
+})

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -58,7 +58,7 @@ describe('MQTT Bridge', () => {
 
         it('onUnsubscribed', async () => {
             await bridge.onSubscribed(topic, MOCK_CLIENT_ID)
-            await bridge.onUnsubscribed(topic, MOCK_CLIENT_ID)
+            bridge.onUnsubscribed(topic, MOCK_CLIENT_ID)
             expect(subscription.unsubscribe).toBeCalled()
         })
     

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -48,12 +48,12 @@ describe('MQTT Bridge', () => {
 
         it('onMessageReceived', async () => {
             await bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
-            expect(streamrClient.publish).toBeCalledWith(MOCK_STREAM_ID, MOCK_CONTENT, { msgChainId: expect.any(String) })
+            expect(streamrClient.publish).toBeCalledWith(`${MOCK_STREAM_ID}#0`, MOCK_CONTENT, { msgChainId: expect.any(String) })
         })
 
         it('onSubscribed', async () => {
             await bridge.onSubscribed(topic, MOCK_CLIENT_ID)
-            expect(streamrClient.subscribe).toBeCalledWith(MOCK_STREAM_ID, expect.anything())
+            expect(streamrClient.subscribe).toBeCalledWith(`${MOCK_STREAM_ID}#0`, expect.anything())
         })
 
         it('onUnsubscribed', async () => {
@@ -88,5 +88,34 @@ describe('MQTT Bridge', () => {
             expect(firstMessageMsgChainId).not.toBe(secondMessageMsgChainId)
         })
 
+    })
+
+    describe('partition', () => {
+
+        let bridge: Bridge
+
+        beforeEach(() => {
+            bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), undefined)
+        })
+    
+        it('publish', async () => {
+            await bridge.onMessageReceived(`${MOCK_TOPIC}?partition=5`, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            expect(streamrClient.publish).toBeCalledWith(
+                `${MOCK_TOPIC}#5`,
+                MOCK_CONTENT,
+                {
+                    msgChainId: MOCK_CLIENT_ID,
+                    timestamp: undefined
+                }
+            )
+        })
+
+        it('subscribe', async () => {
+            await bridge.onSubscribed(`${MOCK_TOPIC}?partition=5`, MOCK_CLIENT_ID)
+            expect(streamrClient.subscribe).toBeCalledWith(
+                `${MOCK_TOPIC}#5`,
+                expect.anything()
+            )
+        })
     })
 })


### PR DESCRIPTION
MQTT plugin can publish and subscribe to specific partition. The information can be encoded into the topic string, e.g. 
```
await client.publish('/foobar?partition=5', ...)
```