### PR TITLE
Broker(test): no longer explicitly create a kademliaId for non-entrypoint peers in tests

### DIFF
--- a/packages/broker/test/integration/createMessagingPluginTest.ts
+++ b/packages/broker/test/integration/createMessagingPluginTest.ts
@@ -99,10 +99,6 @@ export const createMessagingPluginTest = <T>(
             streamrClient = await createClient(brokerUser.privateKey, {
                 network: {
                     layer0: {
-                        peerDescriptor: {
-                            kademliaId: 'client',
-                            type: 0
-                        },
                         entryPoints: [{
                             kademliaId: (await broker.getAddress()),
                             type: 0,

--- a/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/integration/plugins/mqtt/Bridge.test.ts
@@ -59,10 +59,6 @@ describe('MQTT Bridge', () => {
         streamrClient = await createClient(brokerUser.privateKey, {
             network: {
                 layer0: {
-                    peerDescriptor: {
-                        kademliaId: 'Bridge-client',
-                        type: 0
-                    },
                     entryPoints: [{
                         kademliaId: toEthereumAddress(await brokerUser.getAddress()),
                         type: 0,

--- a/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
+++ b/packages/broker/test/integration/plugins/storage/StorageConfig.test.ts
@@ -57,11 +57,7 @@ describe('StorageConfig', () => {
         client = await createClient(publisherAccount.privateKey, {
             network: {
                 layer0: {
-                    entryPoints,
-                    peerDescriptor: {
-                        kademliaId: 'StorageConfig-client',
-                        type: 0
-                    }
+                    entryPoints
                 }
             }
         })

--- a/packages/broker/test/integration/plugins/storage/dataMetadataEndpoint.test.ts
+++ b/packages/broker/test/integration/plugins/storage/dataMetadataEndpoint.test.ts
@@ -46,10 +46,6 @@ describe('DataMetadataEndpoints', () => {
         client1 = await createClient(await fetchPrivateKeyWithGas(), {
             network: {
                 layer0: {
-                    peerDescriptor: {
-                        kademliaId: 'DataMetadataEndpoints-client',
-                        type: 0
-                    },
                     entryPoints
                 }
             }

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -1,6 +1,6 @@
 import { createClient } from '../../../utils'
 import { SubscriberPlugin } from '../../../../src/plugins/subscriber/SubscriberPlugin'
-import StreamrClient, { CONFIG_TEST } from 'streamr-client'
+import StreamrClient from 'streamr-client'
 import { fastWallet } from '@streamr/test-utils'
 import { waitForCondition } from '@streamr/utils'
 
@@ -11,12 +11,6 @@ const createMockPlugin = async (streamrClient: StreamrClient) => {
         client: {
             auth: {
                 privateKey: wallet.privateKey
-            },
-            network: {
-                layer0: {
-                    ...CONFIG_TEST.network!.layer0,
-                    stringKademliaId: 'subscriber-plugin'
-                }
             }
         },
         plugins: {


### PR DESCRIPTION
## Summary

Use the client's `CONFIG_TEST` auto-generation for kademliaIds.