### PR TITLE
Fix fatal bug if DhtNode's stop is called during start.

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -585,15 +585,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
     }
 
-    private async connectToEntryPoint(entryPoint: PeerDescriptor): Promise<void> {
+    private connectToEntryPoint(entryPoint: PeerDescriptor): void {
         this.connectionManager!.lockConnection(entryPoint, 'temporary-layer0-connection')
-        const target = new DhtPeer(
-            this.ownPeerDescriptor!,
-            entryPoint,
-            toProtoRpcClient(new DhtRpcServiceClient(this.rpcCommunicator!.getRpcClientTransport())),
-            this.config.serviceId
-        )
-        await target.getClosestPeers(this.ownPeerId!.value)
         this.entryPointDisconnectTimeout = setTimeout(() => {
             this.connectionManager!.unlockConnection(entryPoint, 'temporary-layer0-connection')
         }, 10 * 1000)


### PR DESCRIPTION
## Summary

Fixed fatal issue in cases where the DhtNode's stop() is called dirung start()

