### PR TITLE
NET-846: Handle cases where NetworkStack is stopped during start

### DIFF
--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -15,6 +15,7 @@ export class NetworkStack {
     private streamrNode?: StreamrNode
     private readonly metricsContext: MetricsContext
     private readonly options: NetworkOptions
+    private stopped = false
 
     constructor(options: NetworkOptions) {
         this.options = options
@@ -34,12 +35,12 @@ export class NetworkStack {
         this.connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
         const entryPoint = this.options.layer0.entryPoints![0]
         if (isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())) {
-            this.layer0DhtNode!.joinDht(entryPoint)
-            await this.streamrNode!.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
+            await this.layer0DhtNode?.joinDht(entryPoint)
+            await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
         } else {
-            setImmediate(() => this.layer0DhtNode!.joinDht(this.options.layer0.entryPoints![0])) 
-            await waitForCondition(() => this.layer0DhtNode!.getNumberOfConnections() > 0)
-            await this.streamrNode!.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
+            setImmediate(() => this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints![0])) 
+            await waitForCondition(() => this.stopped || this.layer0DhtNode!.getNumberOfConnections() > 0)
+            await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
         }
         
     }
@@ -61,6 +62,7 @@ export class NetworkStack {
     }
 
     async stop(): Promise<void> {
+        this.stopped = true
         await this.streamrNode!.destroy()
         this.streamrNode = undefined
         this.layer0DhtNode = undefined

--- a/packages/trackerless-network/test/integration/NetworkStackStoppedDuringStart.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStackStoppedDuringStart.test.ts
@@ -1,0 +1,45 @@
+import { PeerID } from "@streamr/dht"
+import { NetworkStack } from "../../src/NetworkStack"
+import { NodeType } from "../../src/proto/packages/dht/protos/DhtRpc"
+
+describe('NetworkStack can be stopped during start', () => {
+    
+    const epDescriptor = {
+        kademliaId: PeerID.fromString('entrypoint').value,
+        type: NodeType.NODEJS,
+        websocket: { ip: 'localhost', port: 32224 },
+    }
+    let entryPoint: NetworkStack
+    let peer: NetworkStack
+
+    beforeEach(async () => {
+        entryPoint = new NetworkStack({
+            layer0: {
+                peerDescriptor: epDescriptor,
+                entryPoints: [epDescriptor]
+            },
+            networkNode: {}
+        })
+        peer = new NetworkStack({
+            layer0: {
+                peerDescriptor: {
+                    kademliaId: PeerID.fromString('peer').value,
+                    type: NodeType.NODEJS
+                },
+                entryPoints: [epDescriptor]
+            },
+            networkNode: {}
+        })
+        await entryPoint.start()
+    })
+    
+    afterEach(async () => {
+        await entryPoint.stop()
+    })
+
+    it('Can be stopped during start', async () => {
+        setImmediate(() => peer.stop())
+        await peer.start()
+    })
+
+})


### PR DESCRIPTION
## Summary

The NetworkStack class can now be stopped without uncaught rejections during start