### PR TITLE
refactor(client): `MsgChainContext`

### DIFF
--- a/packages/client/src/subscribe/ordering/GapFillFailedError.ts
+++ b/packages/client/src/subscribe/ordering/GapFillFailedError.ts
@@ -1,19 +1,17 @@
-import { MessageRef } from "@streamr/protocol"
-import { EthereumAddress } from '@streamr/utils'
+import { MessageRef } from '@streamr/protocol'
+import { MsgChainContext } from './OrderedMsgChain'
 
 export default class GapFillFailedError extends Error {
 
     from: MessageRef
     to: MessageRef
-    publisherId: EthereumAddress
-    msgChainId: string
+    context: MsgChainContext
 
-    constructor(from: MessageRef, to: MessageRef, publisherId: EthereumAddress, msgChainId: string, nbTrials: number) {
-        super(`Failed to fill gap between ${from.serialize()} and ${to.serialize()}`
-            + ` for ${publisherId}-${msgChainId} after ${nbTrials} trials`)
+    constructor(from: MessageRef, to: MessageRef, context: MsgChainContext, nbTrials: number) {
+        // eslint-disable-next-line max-len
+        super(`Failed to fill gap between ${from.serialize()} and ${to.serialize()} for ${context.streamPartId} ${context.publisherId}-${context.msgChainId} after ${nbTrials} trials`)
         this.from = from
         this.to = to
-        this.publisherId = publisherId
-        this.msgChainId = msgChainId
+        this.context = context
     }
 }

--- a/packages/client/src/subscribe/ordering/OrderingUtil.ts
+++ b/packages/client/src/subscribe/ordering/OrderingUtil.ts
@@ -1,4 +1,4 @@
-import { StreamMessage } from '@streamr/protocol'
+import { StreamMessage, StreamPartID } from '@streamr/protocol'
 import { EthereumAddress } from '@streamr/utils'
 import { GapHandler, MessageHandler, OnDrain, OnError, OrderedMsgChain } from './OrderedMsgChain'
 
@@ -6,6 +6,7 @@ export default class OrderingUtil {
 
     private maxGapRequests: number
     private readonly orderedChains: Record<string, OrderedMsgChain>
+    private readonly streamPartId: StreamPartID
     private readonly inOrderHandler: MessageHandler
     private readonly gapHandler: GapHandler
     private readonly onDrain: OnDrain
@@ -14,6 +15,7 @@ export default class OrderingUtil {
     private readonly retryResendAfter: number
 
     constructor(
+        streamPartId: StreamPartID,
         inOrderHandler: MessageHandler,
         gapHandler: GapHandler,
         onDrain: OnDrain,
@@ -22,6 +24,7 @@ export default class OrderingUtil {
         retryResendAfter: number,
         maxGapRequests: number
     ) {
+        this.streamPartId = streamPartId
         this.inOrderHandler = inOrderHandler
         this.gapHandler = gapHandler
         this.onDrain = onDrain
@@ -41,7 +44,7 @@ export default class OrderingUtil {
         const key = publisherId + msgChainId
         if (!this.orderedChains[key]) {
             const chain = new OrderedMsgChain(
-                publisherId, msgChainId, this.inOrderHandler, this.gapHandler, this.onDrain, this.onError,
+                { streamPartId: this.streamPartId, publisherId, msgChainId }, this.inOrderHandler, this.gapHandler, this.onDrain, this.onError,
                 this.gapFillTimeout, this.retryResendAfter, this.maxGapRequests
             )
             this.orderedChains[key] = chain

--- a/packages/client/test/unit/OrderingUtil.test.ts
+++ b/packages/client/test/unit/OrderingUtil.test.ts
@@ -1,14 +1,15 @@
+import { MessageID, MessageRef, StreamMessage, StreamPartIDUtils, toStreamID } from '@streamr/protocol'
+import { toEthereumAddress } from '@streamr/utils'
 import assert from 'assert'
-
-import { MessageID, MessageRef, StreamMessage, toStreamID } from '@streamr/protocol'
-import OrderingUtil from '../../src/subscribe/ordering/OrderingUtil'
-import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
 import { shuffle } from 'lodash'
+import { MsgChainContext } from '../../src/subscribe/ordering/OrderedMsgChain'
+import OrderingUtil from '../../src/subscribe/ordering/OrderingUtil'
 
 const DEFAULT_GAP_FILL_TIMEOUT = 5000
 const DEFAULT_RETRY_RESEND_AFTER = 5000
 const DEFAULT_MAX_GAP_REQUESTS = 10
 
+const STREAM_PART_ID = StreamPartIDUtils.parse('stream#0')
 const defaultPublisherId = toEthereumAddress('0x0000000000000000000000000000000000000001')
 const publisherId1 = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 const publisherId2 = toEthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
@@ -44,19 +45,20 @@ describe('OrderingUtil', () => {
             assert.deepStrictEqual(streamMessage.serialize(), msg.serialize())
             done()
         }
-        util = new OrderingUtil(handler, () => {}, () => {}, () => {}, DEFAULT_GAP_FILL_TIMEOUT, DEFAULT_RETRY_RESEND_AFTER, DEFAULT_MAX_GAP_REQUESTS)
+        // eslint-disable-next-line max-len
+        util = new OrderingUtil(STREAM_PART_ID, handler, () => {}, () => {}, () => {}, DEFAULT_GAP_FILL_TIMEOUT, DEFAULT_RETRY_RESEND_AFTER, DEFAULT_MAX_GAP_REQUESTS)
         util.add(msg)
     })
     it('calls the gap handler if a gap is detected', (done) => {
-        const gapHandler = (from: MessageRef, to: MessageRef, publisherId: EthereumAddress) => {
+        const gapHandler = (from: MessageRef, to: MessageRef, context: MsgChainContext) => {
             assert.equal(from.timestamp, 1)
             assert.equal(from.sequenceNumber, 1)
             assert.equal(to.timestamp, 3)
             assert.equal(to.sequenceNumber, 0)
-            assert.equal(publisherId, defaultPublisherId)
+            assert.equal(context.publisherId, defaultPublisherId)
             done()
         }
-        util = new OrderingUtil( () => {}, gapHandler, () => {}, () => {}, 50, 50, DEFAULT_MAX_GAP_REQUESTS)
+        util = new OrderingUtil(STREAM_PART_ID, () => {}, gapHandler, () => {}, () => {}, 50, 50, DEFAULT_MAX_GAP_REQUESTS)
         const msg1 = msg
         const msg4 = createMsg(4, undefined, 3)
         util.add(msg1)
@@ -66,7 +68,7 @@ describe('OrderingUtil', () => {
         const gapHandler = () => {
             throw new Error('The gap handler should not be called.')
         }
-        util = new OrderingUtil(() => {}, gapHandler, () => {}, () => {}, 5000, 5000, DEFAULT_MAX_GAP_REQUESTS)
+        util = new OrderingUtil(STREAM_PART_ID, () => {}, gapHandler, () => {}, () => {}, 5000, 5000, DEFAULT_MAX_GAP_REQUESTS)
         const msg1 = msg
         const msg2 = createMsg(2, undefined, 1)
         const msg3 = createMsg(3, undefined, 2)
@@ -99,7 +101,7 @@ describe('OrderingUtil', () => {
         const received1: StreamMessage[] = []
         const received2: StreamMessage[] = []
         const received3: StreamMessage[] = []
-        util = new OrderingUtil((m) => {
+        util = new OrderingUtil(STREAM_PART_ID, (m) => {
             if (m.getPublisherId() === publisherId1) {
                 received1.push(m)
             } else if (m.getPublisherId() === publisherId2) {

--- a/packages/client/test/unit/OrderingUtil2.test.ts
+++ b/packages/client/test/unit/OrderingUtil2.test.ts
@@ -2,11 +2,13 @@ import {
     MessageID,
     MessageRef,
     StreamMessage,
+    StreamPartIDUtils,
     toStreamID
 } from '@streamr/protocol'
 import { EthereumAddress, toEthereumAddress, wait, waitForCondition } from '@streamr/utils'
-import OrderingUtil from '../../src/subscribe/ordering/OrderingUtil'
 import { shuffle } from 'lodash'
+import { MsgChainContext } from '../../src/subscribe/ordering/OrderedMsgChain'
+import OrderingUtil from '../../src/subscribe/ordering/OrderingUtil'
 
 const MESSAGES_PER_PUBLISHER = 1000
 const NUM_OF_DUPLICATE_MESSAGES = 500
@@ -125,8 +127,8 @@ describe.skip(OrderingUtil, () => {
             actual[msg.getPublisherId()].push(msg.getTimestamp())
         }
 
-        const gapHandler = async (from: MessageRef, to: MessageRef, publisherId: EthereumAddress) => {
-            const requestedMessages = groundTruthMessages[publisherId].filter(({ delivery, timestamp }) => {
+        const gapHandler = async (from: MessageRef, to: MessageRef, context: MsgChainContext) => {
+            const requestedMessages = groundTruthMessages[context.publisherId].filter(({ delivery, timestamp }) => {
                 return delivery === Delivery.GAP_FILL && (timestamp > from.timestamp && timestamp <= to.timestamp)
             })
             for (const msgInfo of requestedMessages) {
@@ -136,7 +138,8 @@ describe.skip(OrderingUtil, () => {
         }
 
         const errorHandler = jest.fn()
-        const util = new OrderingUtil(inOrderHandler, gapHandler, () => {}, errorHandler, PROPAGATION_TIMEOUT, RESEND_TIMEOUT, MAX_GAP_REQUESTS)
+        // eslint-disable-next-line max-len
+        const util = new OrderingUtil(StreamPartIDUtils.parse('stream#0'), inOrderHandler, gapHandler, () => {}, errorHandler, PROPAGATION_TIMEOUT, RESEND_TIMEOUT, MAX_GAP_REQUESTS)
 
         // supply 1st message of chain always to set gap detection to work from 1st message onwards
         for (const publisherId of PUBLISHER_IDS) {


### PR DESCRIPTION
`OrderedMsgChain` and related class wrap the context information (`streamPartId`+`publisherId`+`msgChainId`) to a simple  object. This allows us to pass the context easily between components. 

Improved also `GapFillFailedError` error to contain information about stream part.