### PR TITLE
fix(client): Gap fill drain

### DIFF
--- a/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
+++ b/packages/client/src/subscribe/ordering/OrderedMsgChain.ts
@@ -294,13 +294,9 @@ export class OrderedMsgChain {
             return
         }
 
-        // emit drain after clearing a block. If only a single item was in the
-        // queue, the queue was never blocked, so it doesn't need to 'drain'.
-        if (processedMessages > 1) {
-            logger.trace('Drained queue', { processedMessages, lastMsgRef: this.lastOrderedMsgRef })
-            this.clearGap()
-            this.onDrain(processedMessages)
-        }
+        logger.trace('Drained queue', { processedMessages, lastMsgRef: this.lastOrderedMsgRef })
+        this.clearGap()
+        this.onDrain(processedMessages)
     }
 
     /**


### PR DESCRIPTION
WIP: maybe not a good fix as breaks some tests

Made a small change to the logic when the drain event is emitted. Before the change these `OrderMessages.test.ts` test failed:
- "ignore missing messages if no data in storage node"
- "ignore missing messages if no storage node assigned"

There was a comment in the code which stated that drain event is not needed if only one message was processed. 

After the fix several other tests fail on `OrderedMsgChain.test.ts`
