### PR TITLE
fix(client): Active gap fill for encrypted streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Fixed
 
-- Gap fill for encrypted streams (https://github.com/streamr-dev/network/pull/1421)
+- Fix active gap fill for encrypted streams (https://github.com/streamr-dev/network/pull/1421)
 
 #### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Fixed
 
+- Gap fill for encrypted streams (https://github.com/streamr-dev/network/pull/1421)
+
 #### Security
 
 ### cli-tools

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,7 +191,8 @@ export class Stream {
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 count: 1,
-            }
+            },
+            false
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -74,7 +74,7 @@ export class OrderMessages {
                 toSequenceNumber: to.sequenceNumber,
                 publisherId: context.publisherId,
                 msgChainId: context.msgChainId,
-            })
+            }, true)
             resendMessageStream.onFinally.listen(() => {
                 this.resendStreams.delete(resendMessageStream)
             })

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -137,7 +137,7 @@ export class Resends {
     private async fetchStream(
         endpointSuffix: 'last' | 'range' | 'from',
         streamPartId: StreamPartID,
-        query: QueryDict = {},
+        query: QueryDict,
         raw: boolean
     ): Promise<MessageStream> {
         const traceId = randomString(5)

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -155,7 +155,7 @@ export const createRandomAuthentication = (): Authentication => {
     return createPrivateKeyAuthentication(`0x${fastPrivateKey()}`, undefined as any)
 }
 
-export const createStreamRegistryCached = (opts: {
+export const createStreamRegistryCached = (opts?: {
     partitionCount?: number
     isPublicStream?: boolean
     isStreamPublisher?: boolean
@@ -168,13 +168,13 @@ export const createStreamRegistryCached = (opts: {
             })
         }),
         isPublic: async () => {
-            return opts.isPublicStream ?? false
+            return opts?.isPublicStream ?? false
         },
         isStreamPublisher: async () => {
-            return opts.isStreamPublisher ?? true
+            return opts?.isStreamPublisher ?? true
         },
         isStreamSubscriber: async () => {
-            return opts.isStreamSubscriber ?? true
+            return opts?.isStreamSubscriber ?? true
         },
     } as any
 }

--- a/packages/client/test/unit/OrderMessages.test.ts
+++ b/packages/client/test/unit/OrderMessages.test.ts
@@ -81,7 +81,8 @@ describe('OrderMessages', () => {
                 toSequenceNumber: 0,
                 publisherId: PUBLISHER_ID,
                 msgChainId: MSG_CHAIN_ID
-            }
+            },
+            true
         )
     })
 
@@ -103,7 +104,8 @@ describe('OrderMessages', () => {
                 toSequenceNumber: 0,
                 publisherId: PUBLISHER_ID,
                 msgChainId: MSG_CHAIN_ID
-            }
+            },
+            true
         )
     })
 
@@ -128,7 +130,8 @@ describe('OrderMessages', () => {
                 toSequenceNumber: 0,
                 publisherId: PUBLISHER_ID,
                 msgChainId: MSG_CHAIN_ID
-            }
+            },
+            true
         )
         expect(resends.range).toHaveBeenNthCalledWith(2,
             STREAM_PART_ID,
@@ -139,7 +142,8 @@ describe('OrderMessages', () => {
                 toSequenceNumber: 0,
                 publisherId: PUBLISHER_ID,
                 msgChainId: MSG_CHAIN_ID
-            }
+            },
+            true
         )
     })
 


### PR DESCRIPTION
Gap fill didn't work for encrypted streams. It fetched the missing messages from a storage node, but each message failed in the subscribe pipeline validation step. Therefore instead of providing messages to the end-user, it emitted `Signature validation failed` error event for each message.

Also there was redundant pipeline work done for non-encrypted messages.

### Functionality before this PR

All gap filled messages are processed twice as there are two separate subscribe pipelines doing duplicate work. There is the main subscribe pipeline created for a subscription to handle all messages, and also a separate pipeline in `Resends#fetchStream` to transform message fetched from a storage node.

When `OrderMessages#transform` step in the main subscribe pipeline finds a gap, it calls `Resends#range` method. That method calls `Resends#fetchStream`, which initializes a temporary subscribe pipeline to transform the messages fetched from a storage node. In the temporary pipeline all normal subscribe pipeline steps are done: message ordering, decrypting and parsing the content. 

Therefore when a message fetched from a storage node is pushed to the main subscribe pipeline (in `OrderMessage#onGap`via the `orderingUtil.add` call), the message has already been processed once. 

The main subscribe pipeline starts to process the same messages again. The message is passed to the ordering util (redundant work, but doesn't affect the outcome), and then to the validator. The validation fails, because it receives a decrypted message. 

It would be ok to process a non-encrypted message. But the `StreamMessage` instance returned from  `EncryptionUtils#decryptStreamMessage` is actually a kind of a hybrid: it contains modified `serializedContent` (the decrypted content) field, but most of other fields, e.g. the `signature` field  has not been modified.

The `validateStreamMessage` step in the main subscribe pipeline throws an error because the signature and the hash calculated from messages's current `serializedContent`  don't match.

### Changes

As all `Resends#fetchStream` pipeline steps are redundant for gap filled messages, a new `raw`-parameter was added to the method. When the value is `true`, we don't do any pipeline processing in the method. In `OrderMessages#onGap` we use the flag to disable the extra processing of gap filled messages. 

For public API methods, e.g. `StreamrClient#resend`, the flag is set to `false` so the output of manual resend requests doesn't change.

The change also simplifies and optimizes message handling for non-encrypted streams: as there is no duplicate pipelines, the messages are no longer validated twice.

### Affected versions

This bug was maybe introduced in https://github.com/streamr-dev/network/commit/707df495d8689fc29e95b588da8c6b7ebf13d805.

### Test

Updated `gap-fill.test.ts` to use encrypted stream. It is notable that none of our existing test didn't catch this bug. 

To reproduce the bug:
- Create stream, add it to a storage node, and grant subscribe permissions to some users
- Start to publish content to the stream
- Start two nodes which subscribe to the stream
  - add `sub.on('error', () => {})` handler to subscriptions so that we can see when the error occurs
  - one instance should be e.g. in Firefox, so that we can easily disable network connectivity from the node
  - another instance, e.g. in Chrome, is needed so that all messages are propagated to two nodes (`minPropagationTargets`) and therefore are not kept in propagation buffers.
- Receive some messages in Firefox
- Switch Firefox to offline-mode
- Wait for some time so that at least one message has been published, and the storage node has stored it
- Switch Firefox back to online-mode
- Wait for Firefox node to receive the next published message
  - it finds a gap and fetches the missing messages from the storage node
  - it calls the error handler with `Signature validation failed` error

### Future improvements

- Maybe it is not optimal that `EncryptionUtils#decryptStreamMessage` returns this kind of hybrid message? Should we modify that function, or e.g. the validator function so that it can validate decrypted messages?
- The content parsing step in subscribe pipeline mutates the message object as it calls `message.getParsedContent()`. It is maybe ok as it is. But `StreamMessage` could be simpler if it contained just immutable fields?
- Currently we don't support raw resend subscriptions (see explicit check in `StreamrClient#186`). After this change it may be trivial to add that support?