### PR TITLE
refactor(client): Simplify message cloning

### DIFF
--- a/packages/client/src/encryption/decrypt.ts
+++ b/packages/client/src/encryption/decrypt.ts
@@ -31,7 +31,7 @@ export const decrypt = async (
     if (destroySignal.isDestroyed()) {
         return streamMessage
     }
-    const clone = StreamMessage.deserialize(streamMessage.serialize())
+    const clone = streamMessage.clone()
     EncryptionUtil.decryptStreamMessage(clone, groupKey)
     if (streamMessage.newGroupKey) {
         // newGroupKey has been converted into GroupKey

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -47,10 +47,7 @@ export class FakeNetwork {
         * TODO: should we change the serialization or the test? Or keep this hack?
         */
         recipients.forEach((n) => {
-            n.messageListeners.forEach((listener) => {
-                // return a clone as client mutates message when it decrypts messages
-                listener(msg.clone())
-            })
+            n.messageListeners.forEach((listener) => listener(msg))
         })
         this.sends.push({
             message: msg,

--- a/packages/client/test/test-utils/fake/FakeNetwork.ts
+++ b/packages/client/test/test-utils/fake/FakeNetwork.ts
@@ -46,12 +46,10 @@ export class FakeNetwork {
         * as it expects that the EncryptedGroupKey format changes in the process.
         * TODO: should we change the serialization or the test? Or keep this hack?
         */
-        const serialized = msg.serialize()
         recipients.forEach((n) => {
             n.messageListeners.forEach((listener) => {
                 // return a clone as client mutates message when it decrypts messages
-                const deserialized = StreamMessage.deserialize(serialized)
-                listener(deserialized)
+                listener(msg.clone())
             })
         })
         this.sends.push({

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -92,10 +92,7 @@ export class FakeStorageNode extends FakeNetworkNode {
         if (messages !== undefined) {
             const firstIndex = Math.max(messages.length - count, 0)
             const lastIndex = Math.min(firstIndex + count, messages.length - 1)
-            return messages.slice(firstIndex, lastIndex + 1).map((msg: StreamMessage) => {
-                // return a clone as client mutates message when it decrypts messages
-                return msg.clone()
-            })
+            return messages.slice(firstIndex, lastIndex + 1)
         } else {
             // TODO throw an error if this storage node doesn't isn't configured to store the stream?
             return []

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -94,8 +94,7 @@ export class FakeStorageNode extends FakeNetworkNode {
             const lastIndex = Math.min(firstIndex + count, messages.length - 1)
             return messages.slice(firstIndex, lastIndex + 1).map((msg: StreamMessage) => {
                 // return a clone as client mutates message when it decrypts messages
-                const serialized = msg.serialize()
-                return StreamMessage.deserialize(serialized)
+                return msg.clone()
             })
         } else {
             // TODO throw an error if this storage node doesn't isn't configured to store the stream?


### PR DESCRIPTION
Use `StreamMessage#clone` instead of `StreamMessage.deserialize(streamMessage.serialize())`.

Also removed cloning from `FakeNetwork` and `FakeStorage` node as after PR #574 `decrypt()` no longer mutates `StreamMessage` instances.