### PR TITLE
NET-846 : reduce stream-without-default-entrypoints test flakyness

### DIFF
--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -70,11 +70,16 @@ export class NetworkNode {
         })
     }
 
-    async subscribeAndWaitForJoin(streamPartId: StreamPartID, knownEntrypointDescriptors: PeerDescriptor[], _timeout?: number): Promise<number> {
+    async subscribeAndWaitForJoin(
+        streamPartId: StreamPartID,
+        knownEntrypointDescriptors: PeerDescriptor[],
+        timeout?: number,
+        expectedNeighbors?: number
+    ): Promise<number> {
         // if (this.isProxiedStreamPart(streamPartId, ProxyDirection.PUBLISH)) {
         //     throw new Error(`Cannot subscribe to ${streamPartId} as proxy publish connections have been set`)
         // }
-        return this.stack.getStreamrNode().waitForJoinAndSubscribe(streamPartId, knownEntrypointDescriptors)
+        return this.stack.getStreamrNode().waitForJoinAndSubscribe(streamPartId, knownEntrypointDescriptors, timeout, expectedNeighbors)
     }
 
     async waitForJoinAndPublish(streamMessage: StreamMessage, knownEntrypointDescriptors: PeerDescriptor[], timeout?: number): Promise<number> {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -230,10 +230,15 @@ export class StreamrNode extends EventEmitter<Events> {
         return this.getStream(streamPartId)?.layer2.getTargetNeighborStringIds().length || 0
     }
 
-    async waitForJoinAndSubscribe(streamPartId: string, knownEntryPointDescriptors: PeerDescriptor[], timeout?: number): Promise<number> {
+    async waitForJoinAndSubscribe(
+        streamPartId: string,
+        knownEntryPointDescriptors: PeerDescriptor[],
+        timeout?: number,
+        expectedNeighbors = 1
+    ): Promise<number> {
         await this.joinStream(streamPartId, knownEntryPointDescriptors)
         if (this.getStream(streamPartId)!.layer1.getBucketSize() > 0) {
-            await waitForCondition(() => this.getStream(streamPartId)!.layer2.getTargetNeighborStringIds().length > 0, timeout)
+            await waitForCondition(() => this.getStream(streamPartId)!.layer2.getTargetNeighborStringIds().length >= expectedNeighbors, timeout)
         }
         this.subscribeToStream(streamPartId, knownEntryPointDescriptors)
         return this.getStream(streamPartId)?.layer2.getTargetNeighborStringIds().length || 0

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -105,7 +105,7 @@ describe('stream without default entrypoints', () => {
     it('multiple nodes can join without configured entrypoints simultaneously', async () => {
         const numOfSubscribers = 8
         await Promise.all(range(numOfSubscribers).map(async (i) => {
-            await nodes[i].subscribeAndWaitForJoin(STREAM_ID, [])
+            await nodes[i].subscribeAndWaitForJoin(STREAM_ID, [], undefined, 4)
             nodes[i].addMessageListener((_msg) => {
                 numOfReceivedMessages += 1
             })
@@ -120,7 +120,10 @@ describe('stream without default entrypoints', () => {
         for (let i = 0; i < 10; i++) {
             await nodes[i].subscribeAndWaitForJoin(STREAM_ID, [])
         }
-        const entryPointData = await nodes[15].stack.getLayer0DhtNode().getDataFromDht(streamPartIdToDataKey(STREAM_ID))
-        expect(entryPointData.dataEntries!.length).toBeGreaterThanOrEqual(7)
+        await waitForCondition(async () => {
+            const entryPointData = await nodes[15].stack.getLayer0DhtNode().getDataFromDht(streamPartIdToDataKey(STREAM_ID))
+            return entryPointData.dataEntries!.length >= 7
+        }, 15000)
+        
     }, 90000)
 })


### PR DESCRIPTION
## Summary
Fixed flakyness in the stream-without-default-entrypoints test cases.
