### PR TITLE
client: fix ts-essentials skipLibCheck issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23046,7 +23046,6 @@
             "version": "9.3.2",
             "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.2.tgz",
             "integrity": "sha512-JxKJzuWqH1MmH4ZFHtJzGEhkfN3QvVR3C3w+4BIoWeoY68UVVoA2Np/Bca9z0IPSErVCWhv439aT0We4Dks8kQ==",
-            "dev": true,
             "peerDependencies": {
                 "typescript": ">=4.1.0"
             }
@@ -24867,6 +24866,7 @@
                 "split2": "^4.2.0",
                 "sqlite": "^4.0.23",
                 "sqlite3": "^5.0.3",
+                "ts-essentials": "^9.3.0",
                 "ts-toolbelt": "^9.6.0",
                 "tsyringe": "^4.6.0",
                 "uuid": "^9.0.0"
@@ -24904,7 +24904,6 @@
                 "nightwatch": "^2.6.20",
                 "node-polyfill-webpack-plugin": "^2.0.1",
                 "terser-webpack-plugin": "^5.2.5",
-                "ts-essentials": "^9.3.0",
                 "ts-loader": "^9.3.1",
                 "typedoc": "^0.24.4",
                 "util": "^0.12.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -71,7 +71,6 @@
     "nightwatch": "^2.6.20",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "terser-webpack-plugin": "^5.2.5",
-    "ts-essentials": "^9.3.0",
     "ts-loader": "^9.3.1",
     "typedoc": "^0.24.4",
     "util": "^0.12.4",
@@ -122,6 +121,7 @@
     "split2": "^4.2.0",
     "sqlite": "^4.0.23",
     "sqlite3": "^5.0.3",
+    "ts-essentials": "^9.3.0",
     "ts-toolbelt": "^9.6.0",
     "tsyringe": "^4.6.0",
     "uuid": "^9.0.0"

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import Ajv, { ErrorObject } from 'ajv'
 import addFormats from 'ajv-formats'
 import type { ExternalProvider } from '@ethersproject/providers'
-import type { MarkOptional, DeepRequired } from 'ts-essentials'
+import { MarkOptional, DeepRequired } from 'ts-essentials'
 
 import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import Ajv, { ErrorObject } from 'ajv'
 import addFormats from 'ajv-formats'
 import type { ExternalProvider } from '@ethersproject/providers'
-import { MarkOptional, DeepRequired } from 'ts-essentials'
+import type { MarkOptional, DeepRequired } from 'ts-essentials'
 
 import CONFIG_SCHEMA from './config.schema.json'
 import { TrackerRegistryRecord } from '@streamr/protocol'


### PR DESCRIPTION
Fix issue in `streamr-client` type declarations. If a TypeScript project with setting `skipLibCheck: false` uses `streamr-client` it will not build due to error caused by streamr-client type declarations.

### Further improvements
Any other solution that avoids having to include `ts-essentials` as a dependency?