### PR TITLE
NET-846 fix flaky dht store tests

### DIFF
--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -93,7 +93,8 @@ export class RecursiveFinder implements IRecursiveFinder {
             rpcTransport: this.sessionTransport,
             kademliaIdToFind: idToFind,
             ownPeerID: this.ownPeerId!,
-            waitedRoutingPathCompletions: 1
+            waitedRoutingPathCompletions: this.connections.size > 1 ? 2 : 1,
+            mode: findMode
         })
         if (this.connections.size === 0) {
             const data = this.localDataStore.getEntry(PeerID.fromValue(idToFind))


### PR DESCRIPTION
## Summary

Fixed flaky dht store related tests. The RecursiveFindSession will now wait for data or both routing paths to send back noCloserNodesFound flags. This fixes race conditions related to finding data without requiring the timeout window to run out outside of rare cases.
