### PR TITLE
feat(broker): [NET-978] Support `partitionKey` and `partitionKeyField` in MQTT plugin

### DIFF
--- a/packages/broker/plugins.md
+++ b/packages/broker/plugins.md
@@ -236,6 +236,9 @@ By default the plugin publishes and subscribes to partition `0`. If you want to 
 await client.publish('/foobar?partition=5', ...)
 ```
 
+For publishing, it is also possible select the partition using `partitionKey`/`partitionKeyField` query parameter in the topic. See [above](#partitions) how the partition is calculated in that case.
+
+
 ## HTTP
 
 At the moment, only publishing is supported over HTTP. To subscribe, use one of the other protocol plugins as they allow a continuous streaming connection.

--- a/packages/broker/src/helpers/partitions.ts
+++ b/packages/broker/src/helpers/partitions.ts
@@ -1,0 +1,31 @@
+import { ParsedQs } from 'qs'
+import { parsePositiveInteger, parseQueryParameter } from './parser'
+
+export class PublishPartitionDefinition {
+    partition?: number
+    partitionKey?: string
+    partitionKeyField?: string
+}
+
+export const parsePublishPartitionDefinition = (queryParams: ParsedQs): PublishPartitionDefinition => {
+    const partition = parseQueryParameter<number>('partition', queryParams, parsePositiveInteger)
+    const partitionKey = queryParams['partitionKey'] as string | undefined
+    const partitionKeyField = queryParams['partitionKeyField'] as string | undefined
+    const partitionDefinitions = [partition, partitionKey, partitionKeyField].filter((d) => d !== undefined)
+    if (partitionDefinitions.length > 1) {
+        throw new Error('Invalid combination of "partition", "partitionKey" and "partitionKeyField"')
+    }
+    return {
+        partition,
+        partitionKey,
+        partitionKeyField
+    }
+}
+
+export const getPartitionKey = (content: Record<string, unknown>, definition: PublishPartitionDefinition): string | undefined => {
+    return definition.partitionKey ?? (
+        definition.partitionKeyField 
+            ? (content[definition.partitionKeyField] as string) 
+            : undefined
+    )
+}

--- a/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
+++ b/packages/broker/test/unit/plugins/mqtt/Bridge.test.ts
@@ -48,7 +48,11 @@ describe('MQTT Bridge', () => {
 
         it('onMessageReceived', async () => {
             await bridge.onMessageReceived(topic, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
-            expect(streamrClient.publish).toBeCalledWith(`${MOCK_STREAM_ID}#0`, MOCK_CONTENT, { msgChainId: expect.any(String) })
+            expect(streamrClient.publish).toBeCalledWith(
+                { id: MOCK_STREAM_ID, partition: undefined },
+                MOCK_CONTENT,
+                { msgChainId: expect.any(String) }
+            )
         })
 
         it('onSubscribed', async () => {
@@ -98,12 +102,47 @@ describe('MQTT Bridge', () => {
             bridge = new Bridge(streamrClient as any, undefined as any, new PlainPayloadFormat(), undefined)
         })
     
-        it('publish', async () => {
+        it('publish with partition', async () => {
             await bridge.onMessageReceived(`${MOCK_TOPIC}?partition=5`, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
             expect(streamrClient.publish).toBeCalledWith(
-                `${MOCK_TOPIC}#5`,
+                {
+                    id: MOCK_TOPIC,
+                    partition: 5
+                }, 
                 MOCK_CONTENT,
                 {
+                    msgChainId: MOCK_CLIENT_ID,
+                    timestamp: undefined
+                }
+            )
+        })
+
+        it('publish with partition key', async () => {
+            await bridge.onMessageReceived(`${MOCK_TOPIC}?partitionKey=mock-key`, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            expect(streamrClient.publish).toBeCalledWith(
+                {
+                    id: MOCK_TOPIC,
+                    partition: undefined
+                }, 
+                MOCK_CONTENT,
+                {
+                    partitionKey: 'mock-key',
+                    msgChainId: MOCK_CLIENT_ID,
+                    timestamp: undefined
+                }
+            )
+        })
+
+        it('publish with partition key field', async () => {
+            await bridge.onMessageReceived(`${MOCK_TOPIC}?partitionKeyField=foo`, JSON.stringify(MOCK_CONTENT), MOCK_CLIENT_ID)
+            expect(streamrClient.publish).toBeCalledWith(
+                {
+                    id: MOCK_TOPIC,
+                    partition: undefined
+                }, 
+                MOCK_CONTENT,
+                {
+                    partitionKey: MOCK_CONTENT.foo,
                     msgChainId: MOCK_CLIENT_ID,
                     timestamp: undefined
                 }


### PR DESCRIPTION
It is now possible to define partition using `partitionKey` or `partitionKeyField` for MQTT publishing. 

These parameters are not supports for MQTT subscribing (i.e. the behavior is similar to `websocket` plugin).

### Refactoring

Extracted partition handling logic to helper functions so that `websocket` and `mqtt` plugin can use the same utilities.