### PR TITLE
NET-846: fix memory leak in RecursiveFindSession

### DIFF
--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -66,7 +66,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         })
         if (this.noCloserNodesReceivedCounter >= 1 && unreportedHops.size == 0) {
             if (this.mode === FindMode.DATA 
-                && (this.foundData.size > 0 || this.noCloserNodesReceivedCounter > this.waitedRoutingPathCompletions)) {
+                && (this.foundData.size > 0 || this.noCloserNodesReceivedCounter >= this.waitedRoutingPathCompletions)) {
                 return true
             } else if (this.mode === FindMode.DATA) {
                 return false
@@ -113,6 +113,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
             if (!this.findCompletedEmitted && this.isFindCompleted()) {
                 if (this.reportFindCompletedTimeout) {
                     clearTimeout(this.reportFindCompletedTimeout)
+                    this.reportFindCompletedTimeout = undefined
                 }
                 this.emit('findCompleted', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
                 this.findCompletedEmitted = true
@@ -137,14 +138,17 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
             this.findCompletedEmitted = true
             if (this.reportFindCompletedTimeout) {
                 clearTimeout(this.reportFindCompletedTimeout)
+                this.reportFindCompletedTimeout = undefined
             }
         } else {
-            this.reportFindCompletedTimeout = setTimeout(() => {
-                if (!this.findCompletedEmitted) {
-                    this.emit('findCompleted', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
-                    this.findCompletedEmitted = true
-                }
-            }, 2500)
+            if (!this.reportFindCompletedTimeout && !this.findCompletedEmitted) {
+                this.reportFindCompletedTimeout = setTimeout(() => {
+                    if (!this.findCompletedEmitted) {
+                        this.emit('findCompleted', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
+                        this.findCompletedEmitted = true
+                    }
+                }, 2500)
+            }
         }
     }
 
@@ -160,6 +164,10 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
     })
 
     public stop(): void {
+        if (this.reportFindCompletedTimeout) {
+            clearTimeout(this.reportFindCompletedTimeout)
+            this.reportFindCompletedTimeout = undefined
+        }
         this.emit('findCompleted', [])
     }
 }

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -248,5 +248,6 @@ export class RecursiveFinder implements IRecursiveFinder {
         this.ongoingSessions.forEach((session, _id) => {
             session.stop()
         })
+        this.ongoingSessions.clear()
     }
 }


### PR DESCRIPTION
## Summary

Fixed memory leak in RecursiveFindSession related to timeouts not being handled properly.
