### PR TITLE
test(client): Unit test for resend functionality

### DIFF
--- a/packages/client/src/HttpUtil.ts
+++ b/packages/client/src/HttpUtil.ts
@@ -51,6 +51,11 @@ ERROR_TYPES.set(ErrorCode.VALIDATION_ERROR, ValidationError)
 ERROR_TYPES.set(ErrorCode.NOT_FOUND, NotFoundError)
 ERROR_TYPES.set(ErrorCode.UNKNOWN, HttpError)
 
+export const createQueryString = (query: Record<string, any>): string => {
+    const withoutEmpty = Object.fromEntries(Object.entries(query).filter(([_k, v]) => v != null))
+    return new URLSearchParams(withoutEmpty).toString()
+}
+
 const parseErrorCode = (body: string) => {
     let json
     try {
@@ -101,12 +106,6 @@ export class HttpUtil {
         } finally {
             stream?.destroy()
         }
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    createQueryString(query: Record<string, any>): string {
-        const withoutEmpty = Object.fromEntries(Object.entries(query).filter(([_k, v]) => v != null))
-        return new URLSearchParams(withoutEmpty).toString()
     }
 }
 

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -28,7 +28,7 @@ export class OrderMessages {
     private readonly logger: Logger
 
     constructor(
-        config: StrictStreamrClientConfig,
+        config: Pick<StrictStreamrClientConfig, 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>,
         resends: Resends,
         streamPartId: StreamPartID,
         loggerFactory: LoggerFactory

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -23,7 +23,6 @@ export class OrderMessages {
     private readonly resendStreams = new Set<MessageStream>() // holds outstanding resends for cleanup
     private readonly outBuffer = new PushBuffer<StreamMessage>()
     private readonly orderingUtil: OrderingUtil
-    private readonly config: StrictStreamrClientConfig
     private readonly resends: Resends
     private readonly streamPartId: StreamPartID
     private readonly logger: Logger
@@ -34,14 +33,13 @@ export class OrderMessages {
         streamPartId: StreamPartID,
         loggerFactory: LoggerFactory
     ) {
-        this.config = config
         this.resends = resends
         this.streamPartId = streamPartId
         this.logger = loggerFactory.createLogger(module)
         this.onOrdered = this.onOrdered.bind(this)
         this.onGap = this.onGap.bind(this)
         this.maybeClose = this.maybeClose.bind(this)
-        const { gapFillTimeout, retryResendAfter, maxGapRequests, gapFill } = this.config
+        const { gapFillTimeout, retryResendAfter, maxGapRequests, gapFill } = config
         this.enabled = gapFill && (maxGapRequests > 0)
         this.orderingUtil = new OrderingUtil(
             this.streamPartId,

--- a/packages/client/src/subscribe/subscribePipeline.ts
+++ b/packages/client/src/subscribe/subscribePipeline.ts
@@ -25,7 +25,7 @@ export interface SubscriptionPipelineOptions {
     groupKeyManager: GroupKeyManager
     streamRegistryCached: StreamRegistryCached
     destroySignal: DestroySignal
-    config: StrictStreamrClientConfig
+    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 }
 
 export const createSubscribePipeline = (opts: SubscriptionPipelineOptions): MessageStream => {

--- a/packages/client/test/test-utils/fake/FakeHttpUtil.ts
+++ b/packages/client/test/test-utils/fake/FakeHttpUtil.ts
@@ -17,13 +17,12 @@ interface ResendRequest {
 }
 
 export class FakeHttpUtil extends HttpUtil {
+
     private readonly network: FakeNetwork
-    private readonly realHttpUtil: HttpUtil
 
     constructor(network: FakeNetwork) {
         super(mockLoggerFactory())
         this.network = network
-        this.realHttpUtil = new HttpUtil(mockLoggerFactory())
     }
 
     override async* fetchHttpStream(url: string): AsyncIterable<StreamMessage> {
@@ -64,10 +63,6 @@ export class FakeHttpUtil extends HttpUtil {
         } else {
             throw new Error(`not implemented: ${url}`)
         }
-    }
-
-    override createQueryString(query: Record<string, any>): string {
-        return this.realHttpUtil.createQueryString(query)
     }
 
     private static getResendRequest(url: string): ResendRequest | undefined {

--- a/packages/client/test/unit/HttpUtil.test.ts
+++ b/packages/client/test/unit/HttpUtil.test.ts
@@ -6,7 +6,7 @@ import { collect } from '@streamr/utils'
 import { once } from 'events'
 import express from 'express'
 import range from 'lodash/range'
-import { HttpUtil } from '../../src/HttpUtil'
+import { HttpUtil, createQueryString } from '../../src/HttpUtil'
 import { createMockMessage, mockLoggerFactory } from '../test-utils/utils'
 
 const MOCK_SERVER_PORT = 12345
@@ -39,8 +39,7 @@ describe('HttpUtil', () => {
     })
 
     it('query parameters with null/undefined', () => {
-        const httpUtil = new HttpUtil(mockLoggerFactory())
-        const actual = httpUtil.createQueryString({
+        const actual = createQueryString({
             a: 'foo',
             b: undefined,
             c: null,

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata'
+
+import { StreamMessage, StreamPartIDUtils } from '@streamr/protocol'
+import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { collect } from '@streamr/utils'
+import { createPrivateKeyAuthentication } from '../../src/Authentication'
+import { DestroySignal } from '../../src/DestroySignal'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { MessageFactory } from '../../src/publish/MessageFactory'
+import { Resends } from '../../src/subscribe/Resends'
+import { createGroupKeyQueue, createStreamRegistryCached, mockLoggerFactory } from '../test-utils/utils'
+
+const PUBLISHER_WALLET = fastWallet()
+const STREAM_PART_ID = StreamPartIDUtils.parse(`${PUBLISHER_WALLET.address}/path#0`)
+const STORAGE_NODE_ADDRESS = randomEthereumAddress()
+const STORAGE_NODE_URL = 'mock.test/foobar'
+const GROUP_KEY = GroupKey.generate()
+
+describe('Resends', () => {
+
+    let messageFactory: MessageFactory
+
+    beforeEach(async () => {
+        const authentication = createPrivateKeyAuthentication(PUBLISHER_WALLET.privateKey, undefined as any)
+        messageFactory = new MessageFactory({
+            authentication,
+            streamId: StreamPartIDUtils.getStreamID(STREAM_PART_ID),
+            streamRegistry: createStreamRegistryCached(),
+            groupKeyQueue: await createGroupKeyQueue(authentication, GROUP_KEY)
+        })
+    })
+
+    const createResends = (messages: StreamMessage[]): Resends => {
+        return new Resends(
+            {
+                getStorageNodes: async () => [STORAGE_NODE_ADDRESS]
+            } as any,
+            {
+                getStorageNodeMetadata: async () => ({ http: STORAGE_NODE_URL })
+            } as any,
+            createStreamRegistryCached(),
+            {
+                fetchHttpStream: async function*() {
+                    yield* messages
+                }
+            } as any,
+            {
+                fetchKey: async () => GROUP_KEY
+            } as any,
+            new DestroySignal(),
+            { 
+                orderMessages: true,
+                gapFill: true,
+                maxGapRequests: 5,
+                gapFillTimeout: 5000,
+                retryResendAfter: 5000
+            } as any,
+            mockLoggerFactory()
+        )
+    }
+
+    it('last', async () => {
+        const storageNodeMessages = [
+            await messageFactory.createMessage({ foo: 1 }, { timestamp: 1000 }),
+            await messageFactory.createMessage({ foo: 2 }, { timestamp: 2000 })
+        ]
+        const resends = createResends(storageNodeMessages)
+        const messageStream = await resends.last(STREAM_PART_ID, { count: 2 }, false)
+        const receivedMessages = await collect(messageStream)
+        expect(receivedMessages.map((msg) => msg.content)).toEqual([
+            { foo: 1 },
+            { foo: 2 }
+        ])
+    })
+})


### PR DESCRIPTION
Added unit test for `Resends`. 

Also small refactoring:
- removed obsolete field from `OrderMessages`
- added type annotations for config object in  `OrderMessages`
- converted `HttpUtils#createQueryString` and `Resends#createUrl` methods to utility functions