### PR TITLE
fix(broker): Default value for resend range queries

### DIFF
--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix default value handling for resend range queries (https://github.com/streamr-dev/network/pull/1461)
+- Fix `storage` plugin default value handling for resend range queries (https://github.com/streamr-dev/network/pull/1461)
 
 ### Security
 

--- a/packages/broker/CHANGELOG.md
+++ b/packages/broker/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix default value handling for resend range queries (https://github.com/streamr-dev/network/pull/1461)
+
 ### Security
 
 ## [33.3.0] - 2023-05-10

--- a/packages/broker/src/plugins/storage/dataQueryEndpoint.ts
+++ b/packages/broker/src/plugins/storage/dataQueryEndpoint.ts
@@ -146,7 +146,7 @@ const handleFrom = (
 ) => {
     metrics.resendFromQueriesPerSecond.record(1)
     const fromTimestamp = parseIntIfExists(req.query.fromTimestamp)
-    const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) || MIN_SEQUENCE_NUMBER_VALUE
+    const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) ?? MIN_SEQUENCE_NUMBER_VALUE
     const { publisherId } = req.query
     if (fromTimestamp === undefined) {
         sendError('Query parameter "fromTimestamp" required.', res)
@@ -179,8 +179,8 @@ const handleRange = (
     metrics.resendRangeQueriesPerSecond.record(1)
     const fromTimestamp = parseIntIfExists(req.query.fromTimestamp)
     const toTimestamp = parseIntIfExists(req.query.toTimestamp)
-    const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) || MIN_SEQUENCE_NUMBER_VALUE
-    const toSequenceNumber = parseIntIfExists(req.query.toSequenceNumber) || MAX_SEQUENCE_NUMBER_VALUE
+    const fromSequenceNumber = parseIntIfExists(req.query.fromSequenceNumber) ?? MIN_SEQUENCE_NUMBER_VALUE
+    const toSequenceNumber = parseIntIfExists(req.query.toSequenceNumber) ?? MAX_SEQUENCE_NUMBER_VALUE
     const { publisherId, msgChainId } = req.query
     if (req.query.fromOffset !== undefined || req.query.toOffset !== undefined) {
         sendError('Query parameters "fromOffset" and "toOffset" are no longer supported. Please use "fromTimestamp" and "toTimestamp".', res)


### PR DESCRIPTION
Fixed default value handling of `toSequenceNumber` in the `storage` plugin resend range handler. 

The previously used `||` operator handled 0 value incorrectly. As value `0` is one of the _falsy_ values in JavaScript, if we provided explicit value of `0`, it used the default of `MAX_SEQUENCE_NUMBER_VALUE` instead.

Changed also two other use cases of `|| `operator in `dataQueryEndpoints`. That change doesn't change the functionality as the default is `0` in those cases.

### Related issue

Also note a related client fix of another bug https://github.com/streamr-dev/network/pull/1462. When we deploy this fix to storage node, the resend range functionality in old clients break because the clients have a bug.