### PR TITLE
fix(client): Default value for resend range queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Fixed
 
+- Fix default value handling for resend range queries (https://github.com/streamr-dev/network/pull/1462)
+
 #### Security
 
 ### cli-tools

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -18,8 +18,6 @@ import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
 import { counting } from '../utils/GeneratorUtils'
 import { LoggerFactory } from '../utils/LoggerFactory'
 
-const MIN_SEQUENCE_NUMBER_VALUE = 0
-
 type QueryDict = Record<string, string | number | boolean | null | undefined>
 
 export interface ResendRef {
@@ -187,7 +185,7 @@ export class Resends {
 
     private async from(streamPartId: StreamPartID, {
         fromTimestamp,
-        fromSequenceNumber = MIN_SEQUENCE_NUMBER_VALUE,
+        fromSequenceNumber,
         publisherId
     }: {
         fromTimestamp: number
@@ -203,9 +201,9 @@ export class Resends {
 
     async range(streamPartId: StreamPartID, {
         fromTimestamp,
-        fromSequenceNumber = MIN_SEQUENCE_NUMBER_VALUE,
+        fromSequenceNumber,
         toTimestamp,
-        toSequenceNumber = MIN_SEQUENCE_NUMBER_VALUE,
+        toSequenceNumber,
         publisherId,
         msgChainId
     }: {


### PR DESCRIPTION
The default value of `toSequenceNumber` for resend range queries was incorrectly set to `0`.

Removed the default value handling of this query parameter, because the parameter is optional. The `storage` plugin applies the default value if we don't specify any query parameter value.

Removed also the default value of two other optional query parameters. That change doesn't change the functionality as the default is `0` in those cases.

### Related issue

Note that the default value which `storage` plugin uses is currently incorrect. PR https://github.com/streamr-dev/network/pull/1461 fixes that.