### PR TITLE
refactor(client): Simplify `Resends`

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,8 +191,7 @@ export class Stream {
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 last: 1
-            },
-            (streamId: StreamID) => this._streamStorageRegistry.getStorageNodes(streamId)
+            }
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,7 +191,8 @@ export class Stream {
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 last: 1
-            }
+            },
+            (streamId: StreamID) => this._streamStorageRegistry.getStorageNodes(streamId)
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -187,12 +187,11 @@ export class Stream {
      */
     async detectFields(): Promise<void> {
         // Get last message of the stream to be used for field detecting
-        const sub = await this._resends.last(
+        const sub = await this._resends.resend(
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
-                count: 1,
-            },
-            false
+                last: 1
+            }
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import './utils/PatchTsyringe'
 
-import { ProxyDirection, StreamID } from '@streamr/protocol'
+import { ProxyDirection } from '@streamr/protocol'
 import { EthereumAddress, TheGraphClient, toEthereumAddress } from '@streamr/utils'
 import merge from 'lodash/merge'
 import omit from 'lodash/omit'
@@ -249,11 +249,7 @@ export class StreamrClient {
         onMessage?: MessageListener
     ): Promise<MessageStream> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const messageStream = await this.resends.resend(
-            streamPartId,
-            options,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
-        )
+        const messageStream = await this.resends.resend(streamPartId, options)
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }
@@ -290,11 +286,7 @@ export class StreamrClient {
          */
         messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
     }): Promise<void> {
-        return this.resends.waitForStorage(
-            message,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId),
-            options
-        )
+        return this.resends.waitForStorage(message, options)
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,44 +1,43 @@
 import 'reflect-metadata'
 import './utils/PatchTsyringe'
 
+import { ProxyDirection, StreamID } from '@streamr/protocol'
+import { EthereumAddress, TheGraphClient, toEthereumAddress } from '@streamr/utils'
+import merge from 'lodash/merge'
+import omit from 'lodash/omit'
 import { container as rootContainer } from 'tsyringe'
-import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
-import { pOnce } from './utils/promises'
-import { StreamrClientConfig, createStrictConfig, redactConfig, StrictStreamrClientConfig, ConfigInjectionToken } from './Config'
-import { Publisher } from './publish/Publisher'
-import { Subscriber } from './subscribe/Subscriber'
-import { ResendOptions, Resends } from './subscribe/Resends'
-import { ResendSubscription } from './subscribe/ResendSubscription'
-import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
-import { DestroySignal } from './DestroySignal'
-import { LocalGroupKeyStore, UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'
-import { StorageNodeMetadata, StorageNodeRegistry } from './registry/StorageNodeRegistry'
-import { StreamRegistry } from './registry/StreamRegistry'
-import { StreamDefinition } from './types'
-import { Subscription } from './subscribe/Subscription'
-import { StreamIDBuilder } from './StreamIDBuilder'
-import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
-import { ProxyDirection } from '@streamr/protocol'
-import { MessageStream, MessageListener } from './subscribe/MessageStream'
-import { Stream, StreamMetadata } from './Stream'
-import { SearchStreamsPermissionFilter, SearchStreamsOrderBy } from './registry/searchStreams'
-import { PermissionAssignment, PermissionQuery } from './permission'
-import { MetricsPublisher } from './MetricsPublisher'
 import { PublishMetadata } from '../src/publish/Publisher'
 import { Authentication, AuthenticationInjectionToken, createAuthentication } from './Authentication'
-import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
-import { GroupKey } from './encryption/GroupKey'
-import { PublisherKeyExchange } from './encryption/PublisherKeyExchange'
-import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
-import { LoggerFactory } from './utils/LoggerFactory'
-import { convertStreamMessageToMessage, Message } from './Message'
+import { ConfigInjectionToken, StreamrClientConfig, StrictStreamrClientConfig, createStrictConfig, redactConfig } from './Config'
+import { DestroySignal } from './DestroySignal'
+import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
 import { ErrorCode } from './HttpUtil'
-import omit from 'lodash/omit'
-import merge from 'lodash/merge'
+import { Message, convertStreamMessageToMessage } from './Message'
+import { MetricsPublisher } from './MetricsPublisher'
+import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
+import { Stream, StreamMetadata } from './Stream'
+import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientError } from './StreamrClientError'
-import { TheGraphClient } from '@streamr/utils'
-import { createTheGraphClient } from './utils/utils'
+import { GroupKey } from './encryption/GroupKey'
+import { LocalGroupKeyStore, UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'
+import { PublisherKeyExchange } from './encryption/PublisherKeyExchange'
+import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
+import { PermissionAssignment, PermissionQuery } from './permission'
+import { Publisher } from './publish/Publisher'
+import { StorageNodeMetadata, StorageNodeRegistry } from './registry/StorageNodeRegistry'
+import { StreamRegistry } from './registry/StreamRegistry'
+import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
+import { SearchStreamsOrderBy, SearchStreamsPermissionFilter } from './registry/searchStreams'
+import { MessageListener, MessageStream } from './subscribe/MessageStream'
+import { ResendSubscription } from './subscribe/ResendSubscription'
+import { ResendOptions, Resends } from './subscribe/Resends'
+import { Subscriber } from './subscribe/Subscriber'
+import { Subscription } from './subscribe/Subscription'
+import { StreamDefinition } from './types'
 import { HttpFetcher } from './utils/HttpFetcher'
+import { LoggerFactory } from './utils/LoggerFactory'
+import { pOnce } from './utils/promises'
+import { createTheGraphClient } from './utils/utils'
 
 // TODO: this type only exists to enable tsdoc to generate proper documentation
 export type SubscribeOptions = StreamDefinition & ExtraSubscribeOptions
@@ -250,7 +249,11 @@ export class StreamrClient {
         onMessage?: MessageListener
     ): Promise<MessageStream> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const messageStream = await this.resends.resend(streamPartId, options)
+        const messageStream = await this.resends.resend(
+            streamPartId,
+            options,
+            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
+        )
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }
@@ -287,7 +290,11 @@ export class StreamrClient {
          */
         messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
     }): Promise<void> {
-        return this.resends.waitForStorage(message, options)
+        return this.resends.waitForStorage(
+            message,
+            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId),
+            options
+        )
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -67,14 +67,13 @@ export class OrderMessages {
         let resendMessageStream!: MessageStream
 
         try {
-            resendMessageStream = await this.resends.range(this.streamPartId, {
-                fromTimestamp: from.timestamp,
-                toTimestamp: to.timestamp,
-                fromSequenceNumber: from.sequenceNumber,
-                toSequenceNumber: to.sequenceNumber,
+            resendMessageStream = await this.resends.resend(this.streamPartId, {
+                from,
+                to,
                 publisherId: context.publisherId,
                 msgChainId: context.msgChainId,
-            }, true)
+                raw: true
+            })
             resendMessageStream.onFinally.listen(() => {
                 this.resendStreams.delete(resendMessageStream)
             })

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -13,7 +13,6 @@ export class ResendSubscription extends Subscription {
 
     private resendOptions: ResendOptions
     private resends: Resends
-    private readonly streamStorageRegistry: StreamStorageRegistry
 
     /** @internal */
     constructor(
@@ -27,7 +26,6 @@ export class ResendSubscription extends Subscription {
         super(streamPartId, false, loggerFactory)
         this.resendOptions = resendOptions
         this.resends = resends
-        this.streamStorageRegistry = streamStorageRegistry
         this.pipe(this.resendThenRealtime.bind(this))
         if (config.orderMessages) {
             const orderMessages = new OrderMessages(

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -43,11 +43,7 @@ export class ResendSubscription extends Subscription {
     }
 
     private async getResent(): Promise<MessageStream> {
-        const resentMsgs = await this.resends.resend(
-            this.streamPartId,
-            this.resendOptions,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
-        )
+        const resentMsgs = await this.resends.resend(this.streamPartId, this.resendOptions)
         this.onBeforeFinally.listen(async () => {
             resentMsgs.end()
             await resentMsgs.return()

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -102,11 +102,11 @@ export class Resends {
         this.logger = loggerFactory.createLogger(module)
     }
 
-    resend(streamPartId: StreamPartID, options: ResendOptions): Promise<MessageStream> {
+    resend(streamPartId: StreamPartID, options: ResendOptions & { raw?: boolean }): Promise<MessageStream> {
         if (isResendLast(options)) {
             return this.last(streamPartId, {
                 count: options.last,
-            }, false)
+            }, options.raw ?? false)
         }
 
         if (isResendRange(options)) {
@@ -117,7 +117,7 @@ export class Resends {
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
-            }, false)
+            }, options.raw ?? false)
         }
 
         if (isResendFrom(options)) {
@@ -125,7 +125,7 @@ export class Resends {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-            }, false)
+            }, options.raw ?? false)
         }
 
         throw new StreamrClientError(
@@ -173,7 +173,7 @@ export class Resends {
         return messageStream
     }
 
-    async last(streamPartId: StreamPartID, { count }: { count: number }, raw: boolean): Promise<MessageStream> {
+    private async last(streamPartId: StreamPartID, { count }: { count: number }, raw: boolean): Promise<MessageStream> {
         if (count <= 0) {
             const emptyStream = new MessageStream()
             emptyStream.endWrite()
@@ -201,7 +201,7 @@ export class Resends {
         }, raw)
     }
 
-    async range(streamPartId: StreamPartID, {
+    private async range(streamPartId: StreamPartID, {
         fromTimestamp,
         fromSequenceNumber = MIN_SEQUENCE_NUMBER_VALUE,
         toTimestamp,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -114,6 +114,7 @@ export class Resends {
         options: ResendOptions & { raw?: boolean }, 
         getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
     ): Promise<MessageStream> {
+        const raw = options.raw ?? false
         if (isResendLast(options)) {
             if (options.last <= 0) {
                 const emptyStream = new MessageStream()
@@ -122,7 +123,7 @@ export class Resends {
             }
             return this.fetchStream('last', streamPartId, {
                 count: options.last,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else if (isResendRange(options)) {
             return this.fetchStream('range',streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
@@ -131,13 +132,13 @@ export class Resends {
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else {
             throw new StreamrClientError(
                 `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -122,22 +122,22 @@ export class Resends {
                 return emptyStream
             }
             return this.fetchStream('last', streamPartId, {
-                count: options.last,
+                count: options.last
             }, raw, getStorageNodes)
         } else if (isResendRange(options)) {
-            return this.fetchStream('range',streamPartId, {
+            return this.fetchStream('range', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 toTimestamp: new Date(options.to.timestamp).getTime(),
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-                msgChainId: options.msgChainId,
+                msgChainId: options.msgChainId
             }, raw, getStorageNodes)
         } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
-                publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
+                publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined
             }, raw, getStorageNodes)
         } else {
             throw new StreamrClientError(

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -166,9 +166,8 @@ export class Resends {
         })
         const streamId = StreamPartIDUtils.getStreamID(streamPartId)
         // eslint-disable-next-line no-underscore-dangle
-        const getStorageNodes_ = getStorageNodes ?? ((streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId))
-        // eslint-disable-next-line no-underscore-dangle
-        const nodeAddresses = await getStorageNodes_(streamId)
+        const _getStorageNodes = getStorageNodes ?? ((streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId))
+        const nodeAddresses = await _getStorageNodes(streamId)
         if (!nodeAddresses.length) {
             throw new StreamrClientError(`no storage assigned: ${streamId}`, 'NO_STORAGE_NODES')
         }

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -53,6 +53,8 @@ export interface ResendRangeOptions {
  */
 export type ResendOptions = ResendLastOptions | ResendFromOptions | ResendRangeOptions
 
+type ResendType = 'last' | 'from' | 'range' 
+
 function isResendLast<T extends ResendLastOptions>(options: any): options is T {
     return options && typeof options === 'object' && 'last' in options && options.last != null
 }
@@ -145,7 +147,7 @@ export class Resends {
     }
 
     private async fetchStream(
-        endpointSuffix: 'last' | 'range' | 'from',
+        resendType: ResendType,
         streamPartId: StreamPartID,
         query: QueryDict,
         raw: boolean,
@@ -154,7 +156,7 @@ export class Resends {
         const traceId = randomString(5)
         this.logger.debug('Fetch resend data', {
             loggerIdx: traceId,
-            resendType: endpointSuffix,
+            resendType,
             streamPartId,
             query
         })
@@ -166,7 +168,7 @@ export class Resends {
 
         const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]
         const nodeUrl = (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).http
-        const url = createUrl(nodeUrl, endpointSuffix, streamPartId, query)
+        const url = createUrl(nodeUrl, resendType, streamPartId, query)
         const config = (nodeAddresses.length > 1) ? this.config : { ...this.config, orderMessages: false }
         const messageStream = (raw === false) ? createSubscribePipeline({
             streamPartId,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -121,8 +121,7 @@ export class Resends {
             return this.fetchStream('last', streamPartId, {
                 count: options.last,
             }, options.raw ?? false, getStorageNodes)
-        }
-        if (isResendRange(options)) {
+        } else if (isResendRange(options)) {
             return this.fetchStream('range',streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
@@ -131,18 +130,18 @@ export class Resends {
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
             }, options.raw ?? false, getStorageNodes)
-        }
-        if (isResendFrom(options)) {
+        } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
             }, options.raw ?? false, getStorageNodes)
+        } else {
+            throw new StreamrClientError(
+                `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,
+                'INVALID_ARGUMENT'
+            )
         }
-        throw new StreamrClientError(
-            `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,
-            'INVALID_ARGUMENT'
-        )
     }
 
     private async fetchStream(

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -211,8 +211,7 @@ export class Resends {
             timeout?: number
             count?: number
             messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
-        } = {},
-        getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
+        } = {}
     ): Promise<void> {
         if (!message) {
             throw new StreamrClientError('waitForStorage requires a Message', 'INVALID_ARGUMENT')
@@ -231,7 +230,7 @@ export class Resends {
                 throw new Error(`timed out after ${duration}ms waiting for message`)
             }
 
-            const resendStream = await this.resend(toStreamPartID(message.streamId, message.streamPartition), { last: count }, getStorageNodes)
+            const resendStream = await this.resend(toStreamPartID(message.streamId, message.streamPartition), { last: count })
             last = await collect(resendStream)
             for (const lastMsg of last) {
                 if (messageMatchFn(message, lastMsg)) {

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -33,7 +33,6 @@ describe('Resends', () => {
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
         return new Resends(
-            undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })
             } as any,
@@ -70,7 +69,7 @@ describe('Resends', () => {
         const resends = createResends({
             [storageNodeAddress]: [allMessages[0], allMessages[2]]
         })
-        const messageStream = await resends.last(STREAM_PART_ID, { count: 2 }, false, async () => [storageNodeAddress])
+        const messageStream = await resends.resend(STREAM_PART_ID, { last: 2 }, async () => [storageNodeAddress])
         const receivedMessages = await collect(messageStream)
         expect(receivedMessages.map((msg) => msg.content)).toEqual([
             { foo: 1 },
@@ -90,7 +89,7 @@ describe('Resends', () => {
             [storageNodeAddress1]: without(allMessages, msg2),
             [storageNodeAddress2]: without(allMessages, msg3)
         })
-        const messageStream = await resends.last(STREAM_PART_ID, { count: 4 }, false, async () => [storageNodeAddress1, storageNodeAddress2])
+        const messageStream = await resends.resend(STREAM_PART_ID, { last: 4 }, async () => [storageNodeAddress1, storageNodeAddress2])
         const receivedMessages = await collect(messageStream)
         expect(receivedMessages.map((msg) => msg.content)).toEqual([
             { foo: 1 },

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -33,6 +33,7 @@ describe('Resends', () => {
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
         return new Resends(
+            undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })
             } as any,


### PR DESCRIPTION
Refactor `Resends` class:
- components uses `resend()` instead of `last()` and `range()` 
- removed `last()`, `from()` and `range()` methods, which just delegated calls from `resend()` to `fetchStream()`

### Future improvements

- Convert `Resends` class to utility function: `resend()` and `waitForStorage()`. Maybe we could need e.g. `MessagePipelineFactory` class instead?