### PR TITLE
refactor(client): `MessagePipelineFactory`

### DIFF
--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,8 +191,7 @@ export class Stream {
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 last: 1
-            },
-            (streamId: StreamID) => this._streamStorageRegistry.getStorageNodes(streamId)
+            }
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -191,7 +191,8 @@ export class Stream {
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
                 last: 1
-            }
+            },
+            (streamId: StreamID) => this._streamStorageRegistry.getStorageNodes(streamId)
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -187,12 +187,11 @@ export class Stream {
      */
     async detectFields(): Promise<void> {
         // Get last message of the stream to be used for field detecting
-        const sub = await this._resends.last(
+        const sub = await this._resends.resend(
             toStreamPartID(this.id, DEFAULT_PARTITION),
             {
-                count: 1,
-            },
-            false
+                last: 1
+            }
         )
 
         const receivedMsgs = await collect(sub)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -191,7 +191,6 @@ export class StreamrClient {
                 streamPartId,
                 options.resend,
                 this.resends,
-                this.streamStorageRegistry,
                 this.loggerFactory,
                 this.config
             )

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import './utils/PatchTsyringe'
 
-import { ProxyDirection, StreamID } from '@streamr/protocol'
+import { ProxyDirection } from '@streamr/protocol'
 import { EthereumAddress, TheGraphClient, toEthereumAddress } from '@streamr/utils'
 import merge from 'lodash/merge'
 import omit from 'lodash/omit'
@@ -249,11 +249,7 @@ export class StreamrClient {
         onMessage?: MessageListener
     ): Promise<MessageStream> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const messageStream = await this.resends.resend(
-            streamPartId,
-            options,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
-        )
+        const messageStream = await this.resends.resend(streamPartId, options)
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }
@@ -290,11 +286,7 @@ export class StreamrClient {
          */
         messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
     }): Promise<void> {
-        return this.resends.waitForStorage(
-            message,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId),
-            options
-        )
+        return this.resends.waitForStorage(message, options)
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -1,44 +1,43 @@
 import 'reflect-metadata'
 import './utils/PatchTsyringe'
 
+import { ProxyDirection, StreamID } from '@streamr/protocol'
+import { EthereumAddress, TheGraphClient, toEthereumAddress } from '@streamr/utils'
+import merge from 'lodash/merge'
+import omit from 'lodash/omit'
 import { container as rootContainer } from 'tsyringe'
-import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
-import { pOnce } from './utils/promises'
-import { StreamrClientConfig, createStrictConfig, redactConfig, StrictStreamrClientConfig, ConfigInjectionToken } from './Config'
-import { Publisher } from './publish/Publisher'
-import { Subscriber } from './subscribe/Subscriber'
-import { ResendOptions, Resends } from './subscribe/Resends'
-import { ResendSubscription } from './subscribe/ResendSubscription'
-import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
-import { DestroySignal } from './DestroySignal'
-import { LocalGroupKeyStore, UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'
-import { StorageNodeMetadata, StorageNodeRegistry } from './registry/StorageNodeRegistry'
-import { StreamRegistry } from './registry/StreamRegistry'
-import { StreamDefinition } from './types'
-import { Subscription } from './subscribe/Subscription'
-import { StreamIDBuilder } from './StreamIDBuilder'
-import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
-import { ProxyDirection } from '@streamr/protocol'
-import { MessageStream, MessageListener } from './subscribe/MessageStream'
-import { Stream, StreamMetadata } from './Stream'
-import { SearchStreamsPermissionFilter, SearchStreamsOrderBy } from './registry/searchStreams'
-import { PermissionAssignment, PermissionQuery } from './permission'
-import { MetricsPublisher } from './MetricsPublisher'
 import { PublishMetadata } from '../src/publish/Publisher'
 import { Authentication, AuthenticationInjectionToken, createAuthentication } from './Authentication'
-import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
-import { GroupKey } from './encryption/GroupKey'
-import { PublisherKeyExchange } from './encryption/PublisherKeyExchange'
-import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
-import { LoggerFactory } from './utils/LoggerFactory'
-import { convertStreamMessageToMessage, Message } from './Message'
+import { ConfigInjectionToken, StreamrClientConfig, StrictStreamrClientConfig, createStrictConfig, redactConfig } from './Config'
+import { DestroySignal } from './DestroySignal'
+import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
 import { ErrorCode } from './HttpUtil'
-import omit from 'lodash/omit'
-import merge from 'lodash/merge'
+import { Message, convertStreamMessageToMessage } from './Message'
+import { MetricsPublisher } from './MetricsPublisher'
+import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
+import { Stream, StreamMetadata } from './Stream'
+import { StreamIDBuilder } from './StreamIDBuilder'
 import { StreamrClientError } from './StreamrClientError'
-import { TheGraphClient } from '@streamr/utils'
-import { createTheGraphClient } from './utils/utils'
+import { GroupKey } from './encryption/GroupKey'
+import { LocalGroupKeyStore, UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'
+import { PublisherKeyExchange } from './encryption/PublisherKeyExchange'
+import { StreamrClientEventEmitter, StreamrClientEvents } from './events'
+import { PermissionAssignment, PermissionQuery } from './permission'
+import { Publisher } from './publish/Publisher'
+import { StorageNodeMetadata, StorageNodeRegistry } from './registry/StorageNodeRegistry'
+import { StreamRegistry } from './registry/StreamRegistry'
+import { StreamStorageRegistry } from './registry/StreamStorageRegistry'
+import { SearchStreamsOrderBy, SearchStreamsPermissionFilter } from './registry/searchStreams'
+import { MessageListener, MessageStream } from './subscribe/MessageStream'
+import { ResendSubscription } from './subscribe/ResendSubscription'
+import { ResendOptions, Resends } from './subscribe/Resends'
+import { Subscriber } from './subscribe/Subscriber'
+import { Subscription } from './subscribe/Subscription'
+import { StreamDefinition } from './types'
 import { HttpFetcher } from './utils/HttpFetcher'
+import { LoggerFactory } from './utils/LoggerFactory'
+import { pOnce } from './utils/promises'
+import { createTheGraphClient } from './utils/utils'
 
 // TODO: this type only exists to enable tsdoc to generate proper documentation
 export type SubscribeOptions = StreamDefinition & ExtraSubscribeOptions
@@ -250,7 +249,11 @@ export class StreamrClient {
         onMessage?: MessageListener
     ): Promise<MessageStream> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
-        const messageStream = await this.resends.resend(streamPartId, options)
+        const messageStream = await this.resends.resend(
+            streamPartId,
+            options,
+            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
+        )
         if (onMessage !== undefined) {
             messageStream.useLegacyOnMessageHandler(onMessage)
         }
@@ -287,7 +290,11 @@ export class StreamrClient {
          */
         messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
     }): Promise<void> {
-        return this.resends.waitForStorage(message, options)
+        return this.resends.waitForStorage(
+            message,
+            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId),
+            options
+        )
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -18,6 +18,7 @@ export class MessagePipelineFactory {
     private readonly destroySignal: DestroySignal
     private readonly config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 
+    /* eslint-disable indent */
     constructor(
         @inject(delay(() => Resends)) resends: Resends,
         groupKeyManager: GroupKeyManager,

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -19,31 +19,31 @@ export class MessagePipelineFactory {
     config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 
     constructor(
-        loggerFactory: LoggerFactory,
         resends: Resends,
         groupKeyManager: GroupKeyManager,
         streamRegistryCached: StreamRegistryCached,
         destroySignal: DestroySignal,
+        loggerFactory: LoggerFactory,
         // eslint-disable-next-line max-len
         @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
     ) {
-        this.loggerFactory = loggerFactory
         this.resends = resends
         this.groupKeyManager = groupKeyManager
         this.streamRegistryCached = streamRegistryCached
         this.destroySignal = destroySignal
+        this.loggerFactory = loggerFactory
         this.config = config
     }
 
     // eslint-disable-next-line max-len
-    createMessagePipeline(opts: Omit<MessagePipelineOptions, 'loggerFactory' | 'resends' | 'groupKeyManager' | 'streamRegistryCached' | 'destroySignal' | 'config'>): MessageStream {
+    createMessagePipeline(opts: Omit<MessagePipelineOptions, 'resends' | 'groupKeyManager' | 'streamRegistryCached' | 'destroySignal' | 'loggerFactory' | 'config'>): MessageStream {
         return _createMessagePipeline({
             ...opts,
-            loggerFactory: this.loggerFactory,
             resends: this.resends,
             groupKeyManager: this.groupKeyManager,
             streamRegistryCached: this.streamRegistryCached,
             destroySignal: this.destroySignal,
+            loggerFactory: this.loggerFactory,
             config: this.config
         })
     }

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -1,0 +1,50 @@
+import { Lifecycle, inject, scoped } from 'tsyringe'
+import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { DestroySignal } from '../DestroySignal'
+import { GroupKeyManager } from '../encryption/GroupKeyManager'
+import { StreamRegistryCached } from '../registry/StreamRegistryCached'
+import { LoggerFactory } from '../utils/LoggerFactory'
+import { MessageStream } from './MessageStream'
+import { Resends } from './Resends'
+import { MessagePipelineOptions, createMessagePipeline as _createMessagePipeline } from './messagePipeline'
+
+@scoped(Lifecycle.ContainerScoped)
+export class MessagePipelineFactory {
+
+    loggerFactory: LoggerFactory
+    resends: Resends
+    groupKeyManager: GroupKeyManager
+    streamRegistryCached: StreamRegistryCached
+    destroySignal: DestroySignal
+    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
+
+    constructor(
+        loggerFactory: LoggerFactory,
+        resends: Resends,
+        groupKeyManager: GroupKeyManager,
+        streamRegistryCached: StreamRegistryCached,
+        destroySignal: DestroySignal,
+        // eslint-disable-next-line max-len
+        @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
+    ) {
+        this.loggerFactory = loggerFactory
+        this.resends = resends
+        this.groupKeyManager = groupKeyManager
+        this.streamRegistryCached = streamRegistryCached
+        this.destroySignal = destroySignal
+        this.config = config
+    }
+
+    // eslint-disable-next-line max-len
+    createMessagePipeline(opts: Omit<MessagePipelineOptions, 'loggerFactory' | 'resends' | 'groupKeyManager' | 'streamRegistryCached' | 'destroySignal' | 'config'>): MessageStream {
+        return _createMessagePipeline({
+            ...opts,
+            loggerFactory: this.loggerFactory,
+            resends: this.resends,
+            groupKeyManager: this.groupKeyManager,
+            streamRegistryCached: this.streamRegistryCached,
+            destroySignal: this.destroySignal,
+            config: this.config
+        })
+    }
+}

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -33,7 +33,6 @@ export class MessagePipelineFactory {
         @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached,
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory,
-        // eslint-disable-next-line max-len
         @inject(ConfigInjectionToken) config: MessagePipelineOptions['config']
     ) {
         this.resends = resends

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -1,4 +1,4 @@
-import { Lifecycle, inject, scoped } from 'tsyringe'
+import { Lifecycle, inject, scoped, delay } from 'tsyringe'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import { DestroySignal } from '../DestroySignal'
 import { GroupKeyManager } from '../encryption/GroupKeyManager'
@@ -19,9 +19,9 @@ export class MessagePipelineFactory {
     private readonly config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 
     constructor(
-        resends: Resends,
+        @inject(delay(() => Resends)) resends: Resends,
         groupKeyManager: GroupKeyManager,
-        streamRegistryCached: StreamRegistryCached,
+        @inject(delay(() => StreamRegistryCached)) streamRegistryCached: StreamRegistryCached,
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory,
         // eslint-disable-next-line max-len

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -11,12 +11,12 @@ import { MessagePipelineOptions, createMessagePipeline as _createMessagePipeline
 @scoped(Lifecycle.ContainerScoped)
 export class MessagePipelineFactory {
 
-    loggerFactory: LoggerFactory
-    resends: Resends
-    groupKeyManager: GroupKeyManager
-    streamRegistryCached: StreamRegistryCached
-    destroySignal: DestroySignal
-    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
+    private readonly loggerFactory: LoggerFactory
+    private readonly resends: Resends
+    private readonly groupKeyManager: GroupKeyManager
+    private readonly streamRegistryCached: StreamRegistryCached
+    private readonly destroySignal: DestroySignal
+    private readonly config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 
     constructor(
         resends: Resends,

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -1,4 +1,5 @@
-import { Lifecycle, inject, scoped, delay } from 'tsyringe'
+import { MarkOptional } from 'ts-essentials'
+import { Lifecycle, delay, inject, scoped } from 'tsyringe'
 import { ConfigInjectionToken } from '../Config'
 import { DestroySignal } from '../DestroySignal'
 import { GroupKeyManager } from '../encryption/GroupKeyManager'
@@ -8,13 +9,13 @@ import { MessageStream } from './MessageStream'
 import { Resends } from './Resends'
 import { MessagePipelineOptions, createMessagePipeline as _createMessagePipeline } from './messagePipeline'
 
-type MessagePipelineFactoryOptions = Omit<MessagePipelineOptions,
+type MessagePipelineFactoryOptions = MarkOptional<Omit<MessagePipelineOptions,
     'resends' |
     'groupKeyManager' |
     'streamRegistryCached' |
     'destroySignal' |
-    'loggerFactory' |
-    'config'>
+    'loggerFactory'>,
+    'config'> 
 
 @scoped(Lifecycle.ContainerScoped)
 export class MessagePipelineFactory {
@@ -52,7 +53,7 @@ export class MessagePipelineFactory {
             streamRegistryCached: this.streamRegistryCached,
             destroySignal: this.destroySignal,
             loggerFactory: this.loggerFactory,
-            config: this.config
+            config: opts.config ?? this.config
         })
     }
 }

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -8,14 +8,22 @@ import { MessageStream } from './MessageStream'
 import { Resends } from './Resends'
 import { MessagePipelineOptions, createMessagePipeline as _createMessagePipeline } from './messagePipeline'
 
+type MessagePipelineFactoryOptions = Omit<MessagePipelineOptions,
+    'resends' |
+    'groupKeyManager' |
+    'streamRegistryCached' |
+    'destroySignal' |
+    'loggerFactory' |
+    'config'>
+
 @scoped(Lifecycle.ContainerScoped)
 export class MessagePipelineFactory {
 
-    private readonly loggerFactory: LoggerFactory
     private readonly resends: Resends
     private readonly groupKeyManager: GroupKeyManager
     private readonly streamRegistryCached: StreamRegistryCached
     private readonly destroySignal: DestroySignal
+    private readonly loggerFactory: LoggerFactory
     private readonly config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 
     /* eslint-disable indent */
@@ -37,7 +45,7 @@ export class MessagePipelineFactory {
     }
 
     // eslint-disable-next-line max-len
-    createMessagePipeline(opts: Omit<MessagePipelineOptions, 'resends' | 'groupKeyManager' | 'streamRegistryCached' | 'destroySignal' | 'loggerFactory' | 'config'>): MessageStream {
+    createMessagePipeline(opts: MessagePipelineFactoryOptions): MessageStream {
         return _createMessagePipeline({
             ...opts,
             resends: this.resends,

--- a/packages/client/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/client/src/subscribe/MessagePipelineFactory.ts
@@ -1,5 +1,5 @@
 import { Lifecycle, inject, scoped, delay } from 'tsyringe'
-import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
+import { ConfigInjectionToken } from '../Config'
 import { DestroySignal } from '../DestroySignal'
 import { GroupKeyManager } from '../encryption/GroupKeyManager'
 import { StreamRegistryCached } from '../registry/StreamRegistryCached'
@@ -24,7 +24,7 @@ export class MessagePipelineFactory {
     private readonly streamRegistryCached: StreamRegistryCached
     private readonly destroySignal: DestroySignal
     private readonly loggerFactory: LoggerFactory
-    private readonly config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
+    private readonly config: MessagePipelineOptions['config']
 
     /* eslint-disable indent */
     constructor(
@@ -34,7 +34,7 @@ export class MessagePipelineFactory {
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory,
         // eslint-disable-next-line max-len
-        @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
+        @inject(ConfigInjectionToken) config: MessagePipelineOptions['config']
     ) {
         this.resends = resends
         this.groupKeyManager = groupKeyManager

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -67,14 +67,13 @@ export class OrderMessages {
         let resendMessageStream!: MessageStream
 
         try {
-            resendMessageStream = await this.resends.range(this.streamPartId, {
-                fromTimestamp: from.timestamp,
-                toTimestamp: to.timestamp,
-                fromSequenceNumber: from.sequenceNumber,
-                toSequenceNumber: to.sequenceNumber,
+            resendMessageStream = await this.resends.resend(this.streamPartId, {
+                from,
+                to,
                 publisherId: context.publisherId,
                 msgChainId: context.msgChainId,
-            }, true)
+                raw: true
+            })
             resendMessageStream.onFinally.listen(() => {
                 this.resendStreams.delete(resendMessageStream)
             })

--- a/packages/client/src/subscribe/OrderMessages.ts
+++ b/packages/client/src/subscribe/OrderMessages.ts
@@ -26,14 +26,14 @@ export class OrderMessages {
     private readonly resends: Resends
     private readonly streamPartId: StreamPartID
     private readonly logger: Logger
-    private readonly getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
+    private readonly getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
 
     constructor(
         config: Pick<StrictStreamrClientConfig, 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>,
         resends: Resends,
         streamPartId: StreamPartID,
         loggerFactory: LoggerFactory,
-        getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
+        getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
     ) {
         this.resends = resends
         this.streamPartId = streamPartId

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -32,8 +32,7 @@ export class ResendSubscription extends Subscription {
                 config,
                 resends,
                 streamPartId,
-                loggerFactory,
-                (streamId: StreamID) => streamStorageRegistry.getStorageNodes(streamId)
+                loggerFactory
             )
             this.pipe(orderMessages.transform())
             this.onBeforeFinally.listen(() => orderMessages.stop())

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -1,7 +1,6 @@
-import { StreamID, StreamMessage, StreamPartID } from '@streamr/protocol'
+import { StreamMessage, StreamPartID } from '@streamr/protocol'
 import { inject } from 'tsyringe'
 import { ConfigInjectionToken } from '../Config'
-import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { StrictStreamrClientConfig } from './../Config'
 import { MessageStream } from './MessageStream'
@@ -19,7 +18,6 @@ export class ResendSubscription extends Subscription {
         streamPartId: StreamPartID,
         resendOptions: ResendOptions,
         resends: Resends,
-        streamStorageRegistry: StreamStorageRegistry,
         loggerFactory: LoggerFactory,
         @inject(ConfigInjectionToken) config: StrictStreamrClientConfig
     ) {

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -13,7 +13,6 @@ export class ResendSubscription extends Subscription {
 
     private resendOptions: ResendOptions
     private resends: Resends
-    private readonly streamStorageRegistry: StreamStorageRegistry
 
     /** @internal */
     constructor(
@@ -27,7 +26,6 @@ export class ResendSubscription extends Subscription {
         super(streamPartId, false, loggerFactory)
         this.resendOptions = resendOptions
         this.resends = resends
-        this.streamStorageRegistry = streamStorageRegistry
         this.pipe(this.resendThenRealtime.bind(this))
         if (config.orderMessages) {
             const orderMessages = new OrderMessages(

--- a/packages/client/src/subscribe/ResendSubscription.ts
+++ b/packages/client/src/subscribe/ResendSubscription.ts
@@ -43,11 +43,7 @@ export class ResendSubscription extends Subscription {
     }
 
     private async getResent(): Promise<MessageStream> {
-        const resentMsgs = await this.resends.resend(
-            this.streamPartId,
-            this.resendOptions,
-            (streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)
-        )
+        const resentMsgs = await this.resends.resend(this.streamPartId, this.resendOptions)
         this.onBeforeFinally.listen(async () => {
             resentMsgs.end()
             await resentMsgs.return()

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -102,11 +102,11 @@ export class Resends {
         this.logger = loggerFactory.createLogger(module)
     }
 
-    resend(streamPartId: StreamPartID, options: ResendOptions): Promise<MessageStream> {
+    resend(streamPartId: StreamPartID, options: ResendOptions & { raw?: boolean }): Promise<MessageStream> {
         if (isResendLast(options)) {
             return this.last(streamPartId, {
                 count: options.last,
-            }, false)
+            }, options.raw ?? false)
         }
 
         if (isResendRange(options)) {
@@ -117,7 +117,7 @@ export class Resends {
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
-            }, false)
+            }, options.raw ?? false)
         }
 
         if (isResendFrom(options)) {
@@ -125,7 +125,7 @@ export class Resends {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-            }, false)
+            }, options.raw ?? false)
         }
 
         throw new StreamrClientError(
@@ -173,7 +173,7 @@ export class Resends {
         return messageStream
     }
 
-    async last(streamPartId: StreamPartID, { count }: { count: number }, raw: boolean): Promise<MessageStream> {
+    private async last(streamPartId: StreamPartID, { count }: { count: number }, raw: boolean): Promise<MessageStream> {
         if (count <= 0) {
             const emptyStream = new MessageStream()
             emptyStream.endWrite()
@@ -201,7 +201,7 @@ export class Resends {
         }, raw)
     }
 
-    async range(streamPartId: StreamPartID, {
+    private async range(streamPartId: StreamPartID, {
         fromTimestamp,
         fromSequenceNumber = MIN_SEQUENCE_NUMBER_VALUE,
         toTimestamp,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -51,7 +51,7 @@ export interface ResendRangeOptions {
  */
 export type ResendOptions = ResendLastOptions | ResendFromOptions | ResendRangeOptions
 
-type ResendType = 'last' | 'from' | 'range' 
+type ResendType = 'last' | 'from' | 'range'
 
 function isResendLast<T extends ResendLastOptions>(options: any): options is T {
     return options && typeof options === 'object' && 'last' in options && options.last != null
@@ -102,8 +102,8 @@ export class Resends {
     }
 
     async resend(
-        streamPartId: StreamPartID, 
-        options: ResendOptions & { raw?: boolean }, 
+        streamPartId: StreamPartID,
+        options: ResendOptions & { raw?: boolean },
         getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
     ): Promise<MessageStream> {
         const raw = options.raw ?? false
@@ -166,12 +166,12 @@ export class Resends {
         const url = createUrl(nodeUrl, resendType, streamPartId, query)
         const messageStream = (raw === false) ? this.messagePipelineFactory.createMessagePipeline({
             streamPartId,
-            /* 
-             * We could disable ordering for every resend request because messages arrive in ascending 
-             * order from the storage node. But disable ordering would also disable gap filling.
-             * If there are no other storage nodes, we don't need gap filling, and can therefore we can
-             * disable both gap filling and message ordering (setting "disableMessageOrdering" to true 
-             * disables both of those).
+            /*
+             * Disable ordering if the source of this resend is the only storage node. In that case there is no
+             * another storage node from which we could fetch the gaps. When we set "disableMessageOrdering"
+             * to true, we disable both gap filling and message ordering. As resend messages always arrive 
+             * in ascending order, we don't need the ordering functionality. But as that flag controls also 
+             * gap filling, we can use it only if gap filling is not needed.
              */
             disableMessageOrdering: (nodeAddresses.length === 1),
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),
@@ -185,7 +185,7 @@ export class Resends {
     }
 
     async waitForStorage(
-        message: Message, 
+        message: Message,
         {
             // eslint-disable-next-line no-underscore-dangle
             interval = this.config._timeouts.storageNode.retryInterval,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -114,6 +114,7 @@ export class Resends {
         options: ResendOptions & { raw?: boolean }, 
         getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
     ): Promise<MessageStream> {
+        const raw = options.raw ?? false
         if (isResendLast(options)) {
             if (options.last <= 0) {
                 const emptyStream = new MessageStream()
@@ -122,7 +123,7 @@ export class Resends {
             }
             return this.fetchStream('last', streamPartId, {
                 count: options.last,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else if (isResendRange(options)) {
             return this.fetchStream('range',streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
@@ -131,13 +132,13 @@ export class Resends {
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-            }, options.raw ?? false, getStorageNodes)
+            }, raw, getStorageNodes)
         } else {
             throw new StreamrClientError(
                 `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -172,8 +172,8 @@ export class Resends {
              * to true, we disable both gap filling and message ordering. As resend messages always arrive 
              * in ascending order, we don't need the ordering functionality.
              */
-            disableMessageOrdering: (nodeAddresses.length === 1),
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),
+            config: (nodeAddresses.length > 1) ? this.config : { ...this.config, orderMessages: false }
         }) : new MessageStream()
 
         const dataStream = this.httpUtil.fetchHttpStream(url)

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -122,22 +122,22 @@ export class Resends {
                 return emptyStream
             }
             return this.fetchStream('last', streamPartId, {
-                count: options.last,
+                count: options.last
             }, raw, getStorageNodes)
         } else if (isResendRange(options)) {
-            return this.fetchStream('range',streamPartId, {
+            return this.fetchStream('range', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 toTimestamp: new Date(options.to.timestamp).getTime(),
                 toSequenceNumber: options.to.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
-                msgChainId: options.msgChainId,
+                msgChainId: options.msgChainId
             }, raw, getStorageNodes)
         } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
-                publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
+                publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined
             }, raw, getStorageNodes)
         } else {
             throw new StreamrClientError(

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -15,7 +15,7 @@ import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
 import { counting } from '../utils/GeneratorUtils'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { MessageStream } from './MessageStream'
-import { createSubscribePipeline } from './subscribePipeline'
+import { createMessagePipeline } from './messagePipeline'
 
 type QueryDict = Record<string, string | number | boolean | null | undefined>
 
@@ -176,7 +176,7 @@ export class Resends {
         const nodeUrl = (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).http
         const url = createUrl(nodeUrl, resendType, streamPartId, query)
         const config = (nodeAddresses.length > 1) ? this.config : { ...this.config, orderMessages: false }
-        const messageStream = (raw === false) ? createSubscribePipeline({
+        const messageStream = (raw === false) ? createMessagePipeline({
             streamPartId,
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),
             resends: this,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -166,9 +166,8 @@ export class Resends {
         })
         const streamId = StreamPartIDUtils.getStreamID(streamPartId)
         // eslint-disable-next-line no-underscore-dangle
-        const getStorageNodes_ = getStorageNodes ?? ((streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId))
-        // eslint-disable-next-line no-underscore-dangle
-        const nodeAddresses = await getStorageNodes_(streamId)
+        const _getStorageNodes = getStorageNodes ?? ((streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId))
+        const nodeAddresses = await _getStorageNodes(streamId)
         if (!nodeAddresses.length) {
             throw new StreamrClientError(`no storage assigned: ${streamId}`, 'NO_STORAGE_NODES')
         }

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -53,6 +53,8 @@ export interface ResendRangeOptions {
  */
 export type ResendOptions = ResendLastOptions | ResendFromOptions | ResendRangeOptions
 
+type ResendType = 'last' | 'from' | 'range' 
+
 function isResendLast<T extends ResendLastOptions>(options: any): options is T {
     return options && typeof options === 'object' && 'last' in options && options.last != null
 }
@@ -145,7 +147,7 @@ export class Resends {
     }
 
     private async fetchStream(
-        endpointSuffix: 'last' | 'range' | 'from',
+        resendType: ResendType,
         streamPartId: StreamPartID,
         query: QueryDict,
         raw: boolean,
@@ -154,7 +156,7 @@ export class Resends {
         const traceId = randomString(5)
         this.logger.debug('Fetch resend data', {
             loggerIdx: traceId,
-            resendType: endpointSuffix,
+            resendType,
             streamPartId,
             query
         })
@@ -166,7 +168,7 @@ export class Resends {
 
         const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]
         const nodeUrl = (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).http
-        const url = createUrl(nodeUrl, endpointSuffix, streamPartId, query)
+        const url = createUrl(nodeUrl, resendType, streamPartId, query)
         const config = (nodeAddresses.length > 1) ? this.config : { ...this.config, orderMessages: false }
         const messageStream = (raw === false) ? createSubscribePipeline({
             streamPartId,

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -168,10 +168,9 @@ export class Resends {
             streamPartId,
             /*
              * Disable ordering if the source of this resend is the only storage node. In that case there is no
-             * another storage node from which we could fetch the gaps. When we set "disableMessageOrdering"
+             * other storage node from which we could fetch the gaps. When we set "disableMessageOrdering"
              * to true, we disable both gap filling and message ordering. As resend messages always arrive 
-             * in ascending order, we don't need the ordering functionality. But as that flag controls also 
-             * gap filling, we can use it only if gap filling is not needed.
+             * in ascending order, we don't need the ordering functionality.
              */
             disableMessageOrdering: (nodeAddresses.length === 1),
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -121,8 +121,7 @@ export class Resends {
             return this.fetchStream('last', streamPartId, {
                 count: options.last,
             }, options.raw ?? false, getStorageNodes)
-        }
-        if (isResendRange(options)) {
+        } else if (isResendRange(options)) {
             return this.fetchStream('range',streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
@@ -131,18 +130,18 @@ export class Resends {
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
                 msgChainId: options.msgChainId,
             }, options.raw ?? false, getStorageNodes)
-        }
-        if (isResendFrom(options)) {
+        } else if (isResendFrom(options)) {
             return this.fetchStream('from', streamPartId, {
                 fromTimestamp: new Date(options.from.timestamp).getTime(),
                 fromSequenceNumber: options.from.sequenceNumber,
                 publisherId: options.publisherId !== undefined ? toEthereumAddress(options.publisherId) : undefined,
             }, options.raw ?? false, getStorageNodes)
+        } else {
+            throw new StreamrClientError(
+                `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,
+                'INVALID_ARGUMENT'
+            )
         }
-        throw new StreamrClientError(
-            `can not resend without valid resend options: ${JSON.stringify({ streamPartId, options })}`,
-            'INVALID_ARGUMENT'
-        )
     }
 
     private async fetchStream(

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -211,8 +211,7 @@ export class Resends {
             timeout?: number
             count?: number
             messageMatchFn?: (msgTarget: Message, msgGot: Message) => boolean
-        } = {},
-        getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
+        } = {}
     ): Promise<void> {
         if (!message) {
             throw new StreamrClientError('waitForStorage requires a Message', 'INVALID_ARGUMENT')
@@ -231,7 +230,7 @@ export class Resends {
                 throw new Error(`timed out after ${duration}ms waiting for message`)
             }
 
-            const resendStream = await this.resend(toStreamPartID(message.streamId, message.streamPartition), { last: count }, getStorageNodes)
+            const resendStream = await this.resend(toStreamPartID(message.streamId, message.streamPartition), { last: count })
             last = await collect(resendStream)
             for (const lastMsg of last) {
                 if (messageMatchFn(message, lastMsg)) {

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -2,8 +2,6 @@ import { StreamPartID } from '@streamr/protocol'
 import { Logger } from '@streamr/utils'
 import { Lifecycle, inject, scoped } from 'tsyringe'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
-import { StreamIDBuilder } from '../StreamIDBuilder'
-import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
 import { Subscription } from './Subscription'
@@ -14,19 +12,15 @@ export class Subscriber {
 
     private readonly subSessions: Map<StreamPartID, SubscriptionSession> = new Map()
     private readonly messagePipelineFactory: MessagePipelineFactory
-    private readonly streamStorageRegistry: StreamStorageRegistry
     private readonly node: NetworkNodeFacade
     private readonly logger: Logger
 
     constructor(
-        streamIdBuilder: StreamIDBuilder,
-        streamStorageRegistry: StreamStorageRegistry,
         messagePipelineFactory: MessagePipelineFactory,
         node: NetworkNodeFacade,
         @inject(LoggerFactory) loggerFactory: LoggerFactory,
     ) {
         this.messagePipelineFactory = messagePipelineFactory
-        this.streamStorageRegistry = streamStorageRegistry
         this.node = node
         this.logger = loggerFactory.createLogger(module)
     }
@@ -38,7 +32,6 @@ export class Subscriber {
         const subSession = new SubscriptionSession(
             streamPartId,
             this.messagePipelineFactory,
-            this.streamStorageRegistry,
             this.node
         )
 

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -12,7 +12,7 @@ import { Signal } from '../utils/Signal'
 import { MessageStream } from './MessageStream'
 import { Resends } from './Resends'
 import { Subscription } from './Subscription'
-import { createSubscribePipeline } from './subscribePipeline'
+import { createMessagePipeline } from './messagePipeline'
 
 /**
  * Manages adding & removing subscriptions to node as needed.
@@ -44,7 +44,7 @@ export class SubscriptionSession {
         this.distributeMessage = this.distributeMessage.bind(this)
         this.node = node
         this.onError = this.onError.bind(this)
-        this.pipeline = createSubscribePipeline({
+        this.pipeline = createMessagePipeline({
             streamPartId,
             getStorageNodes: (streamId: StreamID) => streamStorageRegistry.getStorageNodes(streamId),
             resends,

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -1,6 +1,5 @@
-import { StreamID, StreamMessage, StreamMessageType, StreamPartID } from '@streamr/protocol'
+import { StreamMessage, StreamMessageType, StreamPartID } from '@streamr/protocol'
 import { NetworkNodeFacade, NetworkNodeStub } from '../NetworkNodeFacade'
-import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
 import { Scaffold } from '../utils/Scaffold'
 import { Signal } from '../utils/Signal'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
@@ -26,7 +25,6 @@ export class SubscriptionSession {
     constructor(
         streamPartId: StreamPartID,
         messagePipelineFactory: MessagePipelineFactory,
-        streamStorageRegistry: StreamStorageRegistry,
         node: NetworkNodeFacade,
     ) {
         this.streamPartId = streamPartId
@@ -34,8 +32,7 @@ export class SubscriptionSession {
         this.node = node
         this.onError = this.onError.bind(this)
         this.pipeline = messagePipelineFactory.createMessagePipeline({
-            streamPartId,
-            getStorageNodes: (streamId: StreamID) => streamStorageRegistry.getStorageNodes(streamId)
+            streamPartId
         })
         this.pipeline.onError.listen(this.onError)
         this.pipeline

--- a/packages/client/src/subscribe/messagePipeline.ts
+++ b/packages/client/src/subscribe/messagePipeline.ts
@@ -20,7 +20,7 @@ import { MsgChainUtil } from './MsgChainUtil'
 import { OrderMessages } from './OrderMessages'
 import { Resends } from './Resends'
 
-export interface SubscriptionPipelineOptions {
+export interface MessagePipelineOptions {
     streamPartId: StreamPartID
     getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
     loggerFactory: LoggerFactory
@@ -31,7 +31,7 @@ export interface SubscriptionPipelineOptions {
     config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 }
 
-export const createSubscribePipeline = (opts: SubscriptionPipelineOptions): MessageStream => {
+export const createMessagePipeline = (opts: MessagePipelineOptions): MessageStream => {
 
     const logger = opts.loggerFactory.createLogger(module)
 

--- a/packages/client/src/subscribe/messagePipeline.ts
+++ b/packages/client/src/subscribe/messagePipeline.ts
@@ -23,7 +23,7 @@ import { Resends } from './Resends'
 export interface MessagePipelineOptions {
     streamPartId: StreamPartID
     disableMessageOrdering?: boolean
-    getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
+    getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
     resends: Resends
     groupKeyManager: GroupKeyManager
     streamRegistryCached: StreamRegistryCached

--- a/packages/client/src/subscribe/messagePipeline.ts
+++ b/packages/client/src/subscribe/messagePipeline.ts
@@ -22,7 +22,6 @@ import { Resends } from './Resends'
 
 export interface MessagePipelineOptions {
     streamPartId: StreamPartID
-    disableMessageOrdering?: boolean
     getStorageNodes?: (streamId: StreamID) => Promise<EthereumAddress[]>
     resends: Resends
     groupKeyManager: GroupKeyManager
@@ -73,7 +72,7 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): MessageStre
     // end up acting as gaps that we repeatedly try to fill.
     const ignoreMessages = new WeakSet()
     messageStream.onError.listen(onError)
-    if (opts.config.orderMessages && (opts.disableMessageOrdering !== true)) {
+    if (opts.config.orderMessages) {
         // order messages (fill gaps)
         const orderMessages = new OrderMessages(
             opts.config,

--- a/packages/client/src/subscribe/messagePipeline.ts
+++ b/packages/client/src/subscribe/messagePipeline.ts
@@ -22,12 +22,13 @@ import { Resends } from './Resends'
 
 export interface MessagePipelineOptions {
     streamPartId: StreamPartID
+    disableMessageOrdering?: boolean
     getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
-    loggerFactory: LoggerFactory
     resends: Resends
     groupKeyManager: GroupKeyManager
     streamRegistryCached: StreamRegistryCached
     destroySignal: DestroySignal
+    loggerFactory: LoggerFactory
     config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill'>
 }
 
@@ -72,7 +73,7 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): MessageStre
     // end up acting as gaps that we repeatedly try to fill.
     const ignoreMessages = new WeakSet()
     messageStream.onError.listen(onError)
-    if (opts.config.orderMessages) {
+    if (opts.config.orderMessages && (opts.disableMessageOrdering !== true)) {
         // order messages (fill gaps)
         const orderMessages = new OrderMessages(
             opts.config,

--- a/packages/client/src/utils/validateStreamMessage.ts
+++ b/packages/client/src/utils/validateStreamMessage.ts
@@ -13,7 +13,7 @@ export const validateStreamMessage = async (msg: StreamMessage, streamRegistry: 
     await doValidate(msg, streamRegistry).catch((err: any) => {
         // all StreamMessageError already have this streamMessage, maybe this is 
         // here if e.g. contract call fails? TODO is this really needed as
-        // the onError callback in subscribePipeline knows which message
+        // the onError callback in messagePipeline knows which message
         // it is handling?
         if (!err.streamMessage) {
             err.streamMessage = msg

--- a/packages/client/test/unit/OrderMessages.test.ts
+++ b/packages/client/test/unit/OrderMessages.test.ts
@@ -27,8 +27,7 @@ const createTransform = (resends: Pick<Resends, 'resend'>, config = CONFIG) => {
         config as any,
         resends as any,
         STREAM_PART_ID,
-        mockLoggerFactory(),
-        undefined as any
+        mockLoggerFactory()
     ).transform()
 }
 

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -33,7 +33,6 @@ describe('Resends', () => {
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
         return new Resends(
-            undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })
             } as any,
@@ -70,7 +69,7 @@ describe('Resends', () => {
         const resends = createResends({
             [storageNodeAddress]: [allMessages[0], allMessages[2]]
         })
-        const messageStream = await resends.last(STREAM_PART_ID, { count: 2 }, false, async () => [storageNodeAddress])
+        const messageStream = await resends.resend(STREAM_PART_ID, { last: 2 }, async () => [storageNodeAddress])
         const receivedMessages = await collect(messageStream)
         expect(receivedMessages.map((msg) => msg.content)).toEqual([
             { foo: 1 },
@@ -90,7 +89,7 @@ describe('Resends', () => {
             [storageNodeAddress1]: without(allMessages, msg2),
             [storageNodeAddress2]: without(allMessages, msg3)
         })
-        const messageStream = await resends.last(STREAM_PART_ID, { count: 4 }, false, async () => [storageNodeAddress1, storageNodeAddress2])
+        const messageStream = await resends.resend(STREAM_PART_ID, { last: 4 }, async () => [storageNodeAddress1, storageNodeAddress2])
         const receivedMessages = await collect(messageStream)
         expect(receivedMessages.map((msg) => msg.content)).toEqual([
             { foo: 1 },

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -9,7 +9,7 @@ import { DestroySignal } from '../../src/DestroySignal'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { MessageFactory } from '../../src/publish/MessageFactory'
 import { Resends } from '../../src/subscribe/Resends'
-import { MessagePipelineOptions, createMessagePipeline } from '../../src/subscribe/messagePipeline'
+import { MessagePipelineFactory } from '../../src/subscribe/MessagePipelineFactory'
 import { createGroupKeyQueue, createStreamRegistryCached, mockLoggerFactory } from '../test-utils/utils'
 
 const PUBLISHER_WALLET = fastWallet()
@@ -33,26 +33,24 @@ describe('Resends', () => {
     })
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
-        const resends: Resends = new Resends(
+        const messagePipelineFactory = new MessagePipelineFactory(
+            undefined as any, // set later in this method as we have a circular dependency
             {
-                createMessagePipeline: (opts: Partial<MessagePipelineOptions>) => createMessagePipeline({
-                    ...opts,
-                    resends,
-                    groupKeyManager: {
-                        fetchKey: async () => GROUP_KEY
-                    } as any,
-                    streamRegistryCached: createStreamRegistryCached(),
-                    destroySignal: new DestroySignal(),
-                    loggerFactory: mockLoggerFactory(),
-                    config: { 
-                        orderMessages: true,
-                        gapFill: true,
-                        maxGapRequests: 1,
-                        gapFillTimeout: 100,
-                        retryResendAfter: 100
-                    }
-                } as any)
+                fetchKey: async () => GROUP_KEY
             } as any,
+            createStreamRegistryCached(),
+            new DestroySignal(),
+            mockLoggerFactory(),
+            { 
+                orderMessages: true,
+                gapFill: true,
+                maxGapRequests: 1,
+                gapFillTimeout: 100,
+                retryResendAfter: 100
+            }
+        )
+        const resends: Resends = new Resends(
+            messagePipelineFactory,
             undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })
@@ -67,6 +65,8 @@ describe('Resends', () => {
             undefined as any,
             mockLoggerFactory()
         )
+        // @ts-expect-error set value for circular dependency
+        messagePipelineFactory.resends = resends
         return resends
     }
 

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -33,6 +33,7 @@ describe('Resends', () => {
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
         return new Resends(
+            undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })
             } as any,

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -9,7 +9,7 @@ import { DestroySignal } from '../../src/DestroySignal'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { MessageFactory } from '../../src/publish/MessageFactory'
 import { Resends } from '../../src/subscribe/Resends'
-import { MessagePipelineFactory } from '../../src/subscribe/MessagePipelineFactory'
+import { MessagePipelineOptions, createMessagePipeline } from '../../src/subscribe/messagePipeline'
 import { createGroupKeyQueue, createStreamRegistryCached, mockLoggerFactory } from '../test-utils/utils'
 
 const PUBLISHER_WALLET = fastWallet()
@@ -33,25 +33,26 @@ describe('Resends', () => {
     })
 
     const createResends = (messagesPerStorageNode: Record<EthereumAddress, StreamMessage[]>): Resends => {
-        let resends: Resends = undefined as any
-        const messagePipelineFactory = new MessagePipelineFactory(
-            resends,
+        const resends: Resends = new Resends(
             {
-                fetchKey: async () => GROUP_KEY
+                createMessagePipeline: (opts: Partial<MessagePipelineOptions>) => createMessagePipeline({
+                    ...opts,
+                    resends,
+                    groupKeyManager: {
+                        fetchKey: async () => GROUP_KEY
+                    } as any,
+                    streamRegistryCached: createStreamRegistryCached(),
+                    destroySignal: new DestroySignal(),
+                    loggerFactory: mockLoggerFactory(),
+                    config: { 
+                        orderMessages: true,
+                        gapFill: true,
+                        maxGapRequests: 1,
+                        gapFillTimeout: 100,
+                        retryResendAfter: 100
+                    }
+                } as any)
             } as any,
-            createStreamRegistryCached(),
-            new DestroySignal(),
-            mockLoggerFactory(),
-            { 
-                orderMessages: true,
-                gapFill: true,
-                maxGapRequests: 1,
-                gapFillTimeout: 100,
-                retryResendAfter: 100
-            }
-        )
-        resends = new Resends(
-            messagePipelineFactory,
             undefined as any,
             {
                 getStorageNodeMetadata: async (nodeAddress: EthereumAddress) => ({ http: `${URL_PREFIX}${nodeAddress}` })

--- a/packages/client/test/unit/messagePipeline.test.ts
+++ b/packages/client/test/unit/messagePipeline.test.ts
@@ -16,7 +16,7 @@ import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchang
 import { StreamrClientEventEmitter } from '../../src/events'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
-import { createSubscribePipeline } from "../../src/subscribe/subscribePipeline"
+import { createMessagePipeline } from "../../src/subscribe/messagePipeline"
 import { mockLoggerFactory } from '../test-utils/utils'
 import { GroupKey } from './../../src/encryption/GroupKey'
 import { MessageStream } from './../../src/subscribe/MessageStream'
@@ -25,7 +25,7 @@ const CONTENT = {
     foo: 'bar'
 }
 
-describe('subscribePipeline', () => {
+describe('messagePipeline', () => {
 
     let pipeline: MessageStream
     let streamRegistryCached: Partial<StreamRegistryCached>
@@ -88,7 +88,7 @@ describe('subscribePipeline', () => {
             isStreamPublisher: async () => true,
             clearStream: jest.fn()
         } 
-        pipeline = createSubscribePipeline({
+        pipeline = createMessagePipeline({
             streamPartId,
             getStorageNodes: undefined as any,
             loggerFactory: mockLoggerFactory(),


### PR DESCRIPTION
New factory class which provides an easy way to create message pipelines. There are multiple DI dependencies needed to create a pipeline, and therefore the factory can abstract out the dependency handling.