### PR TITLE
test(client): Skip invalid messages

### DIFF
--- a/packages/client/src/subscribe/MessageStream.ts
+++ b/packages/client/src/subscribe/MessageStream.ts
@@ -6,7 +6,6 @@
 import { Pipeline, PipelineTransform } from '../utils/Pipeline'
 import { PushPipeline } from '../utils/PushPipeline'
 import { StreamMessage } from '@streamr/protocol'
-import * as G from '../utils/GeneratorUtils'
 import { convertStreamMessageToMessage, Message, MessageMetadata } from './../Message'
 import omit from 'lodash/omit'
 
@@ -86,11 +85,6 @@ export class MessageStream implements AsyncIterable<Message> {
     /** @internal */
     pipe<NewOutType>(fn: PipelineTransform<StreamMessage, NewOutType>): Pipeline<StreamMessage, NewOutType> {
         return this.pipeline.pipe(fn)
-    }
-
-    /** @internal */
-    forEach(fn: G.GeneratorForEach<StreamMessage>): Pipeline<StreamMessage, StreamMessage> {
-        return this.pipeline.forEach(fn)
     }
 
     /** @internal */

--- a/packages/client/test/integration/Subscriber2.test.ts
+++ b/packages/client/test/integration/Subscriber2.test.ts
@@ -1,13 +1,15 @@
 import 'reflect-metadata'
 
-import { StreamID, StreamMessage } from '@streamr/protocol'
+import { MessageID, StreamID, StreamMessage } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { Defer, collect, waitForCondition } from '@streamr/utils'
-import shuffle from 'lodash/shuffle'
 import sample from 'lodash/sample'
+import shuffle from 'lodash/shuffle'
+import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
 import { Message, MessageMetadata } from '../../src/Message'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'
+import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { Subscription } from '../../src/subscribe/Subscription'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { getPublishTestStreamMessages } from '../test-utils/publish'
@@ -38,11 +40,20 @@ describe('Subscriber', () => {
     let streamId: StreamID
     let publishTestMessages: ReturnType<typeof getPublishTestStreamMessages>
     let publisher: StreamrClient
+    let publisherAuthentication: Authentication
     let environment: FakeEnvironment
 
     const getSubscriptionCount = async (def?: StreamID) => {
         const subcriptions = await client.getSubscriptions(def !== undefined ? { id: def } : undefined)
         return subcriptions.length
+    }
+
+    const createMockMessage = async (serializedContent: string, timestamp: number) => {
+        return await createSignedMessage({
+            messageId: new MessageID(streamId, 0, timestamp, 0, await publisher.getAddress(), 'msgChainId'),
+            serializedContent,
+            authentication: publisherAuthentication
+        })
     }
 
     beforeAll(async () => {
@@ -53,6 +64,7 @@ describe('Subscriber', () => {
                 privateKey: publisherWallet.privateKey
             }
         })
+        publisherAuthentication = createPrivateKeyAuthentication(publisherWallet.privateKey, undefined as any)
     })
 
     beforeEach(async () => {
@@ -314,21 +326,19 @@ describe('Subscriber', () => {
             })
 
             it('will skip bad message if error handler attached', async () => {
-                const err = new Error('expected')
-
                 const sub = await client.subscribe(streamId)
-                sub.forEach((_item, index) => {
-                    if (index === MAX_ITEMS) {
-                        throw err
-                    }
-                })
-
                 const onSubscriptionError = jest.fn()
                 sub.onError.listen(onSubscriptionError)
 
-                const published = await publishTestMessages(NUM_MESSAGES, {
-                    timestamp: 111111,
-                })
+                const published = []
+                const nodeId = (await publisher.getNode()).getNodeId()
+                const node = environment.getNetwork().getNode(nodeId)!
+                for (let i = 0; i < NUM_MESSAGES; i++) {
+                    const serializedContent = (i === MAX_ITEMS) ? 'invalid-json' : JSON.stringify({ foo: i })
+                    const msg = await createMockMessage(serializedContent, i)
+                    node.publish(msg)
+                    published.push(msg)
+                }
 
                 const received: Message[] = []
                 let t!: ReturnType<typeof setTimeout>
@@ -354,26 +364,22 @@ describe('Subscriber', () => {
             })
 
             it('will not skip bad message if error handler attached & throws', async () => {
-                const err = new Error('expected')
-
                 const sub = await client.subscribe(streamId)
-
-                sub.forEach((_item, index) => {
-                    if (index === MAX_ITEMS) {
-                        throw err
-                    }
-                })
-
                 const received: Message[] = []
                 const onSubscriptionError = jest.fn((error: Error) => {
                     throw error
                 })
-
                 sub.onError.listen(onSubscriptionError)
 
-                const published = await publishTestMessages(NUM_MESSAGES, {
-                    timestamp: 111111,
-                })
+                const published = []
+                const nodeId = (await publisher.getNode()).getNodeId()
+                const node = environment.getNetwork().getNode(nodeId)!
+                for (let i = 0; i < NUM_MESSAGES; i++) {
+                    const serializedContent = (i === MAX_ITEMS) ? 'invalid-json' : JSON.stringify({ foo: i })
+                    const msg = await createMockMessage(serializedContent, i)
+                    node.publish(msg)
+                    published.push(msg)
+                }
 
                 await expect(async () => {
                     for await (const m of sub) {


### PR DESCRIPTION
Update two `Subscriber` test cases which tested handling of invalid messages.

The test implementations didn't actually produce invalid messages, but instead threw errors in `forEach` handler. Therefore it tested also the `forEach` functionality, which was previously part of public API. But as we've removed `forEach` from public API, it is now better to implement the tests by producing invalid content to `Subscriber`.

Also removed the internal `MessageStream#forEach` method as it is no longer used anywhere.