### PR TITLE
fix(client): Pipeline error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Fixed
 
+- Fix error handling in message pipeline (https://github.com/streamr-dev/network/pull/1479)
+
 #### Security
 
 ### cli-tools

--- a/packages/client/src/subscribe/MsgChainUtil.ts
+++ b/packages/client/src/subscribe/MsgChainUtil.ts
@@ -65,8 +65,8 @@ export class MsgChainUtil implements AsyncIterable<StreamMessage> {
         await Promise.all(Array.from(this.processors.values()).map((p) => p.busy.waitUntilOpen()))
     }
 
-    stop(): void {
-        this.outputBuffer.endWrite()
+    stop(err?: Error): void {
+        this.outputBuffer.endWrite(err)
     }
 
     [Symbol.asyncIterator](): AsyncIterator<StreamMessage> {

--- a/packages/client/src/subscribe/messagePipeline.ts
+++ b/packages/client/src/subscribe/messagePipeline.ts
@@ -61,7 +61,7 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): MessageStre
                 // clear cached permissions if cannot decrypt, likely permissions need updating
                 opts.streamRegistryCached.clearStream(msg.getStreamId())
                 throw err
-            }    
+            }
         } else {
             return msg
         }
@@ -90,11 +90,16 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): MessageStre
         // validate & decrypt
         .pipe(async function* (src: AsyncGenerator<StreamMessage>) {
             setImmediate(async () => {
-                for await (const msg of src) {
-                    msgChainUtil.addMessage(msg)
+                let err: Error | undefined = undefined
+                try {
+                    for await (const msg of src) {
+                        msgChainUtil.addMessage(msg)
+                    }
+                } catch (e) {
+                    err = e
                 }
                 await msgChainUtil.flush()
-                msgChainUtil.stop()
+                msgChainUtil.stop(err)
             })
             yield* msgChainUtil
         })

--- a/packages/client/test/unit/messagePipeline.test.ts
+++ b/packages/client/test/unit/messagePipeline.test.ts
@@ -87,7 +87,7 @@ describe('messagePipeline', () => {
             getStream: async () => stream,
             isStreamPublisher: async () => true,
             clearStream: jest.fn()
-        } 
+        }
         pipeline = createMessagePipeline({
             streamPartId,
             getStorageNodes: undefined as any,
@@ -165,5 +165,18 @@ describe('messagePipeline', () => {
         expect(output).toEqual([])
         expect(streamRegistryCached.clearStream).toBeCalledTimes(1)
         expect(streamRegistryCached.clearStream).toBeCalledWith(StreamPartIDUtils.getStreamID(streamPartId))
+    })
+
+    it('error: exception', async () => {
+        const err = new Error('mock-error')
+        const msg = await createMessage()
+        await pipeline.push(msg)
+        pipeline.endWrite(err)
+        const onError = jest.fn()
+        pipeline.onError.listen(onError)
+        const output = await collect(pipeline)
+        expect(output).toHaveLength(1)
+        expect(onError).toBeCalledTimes(1)
+        expect(onError).toBeCalledWith(err)
     })
 })


### PR DESCRIPTION
Added error handling  block to `messagePipeline.ts`. There was no `try-catch` in the outermost message iteration loop. If some component wrote an explicit error to a pipeline (with `pipeline.endWrite(err)`), the pipeline didn't handle that.

E.g. when we do a resend, `HttpUtils#fetchHttpStream` writes error to the pipeline if a `fetch` call throws:
- `fetchHttpStream` throws an error to the returned `AsyncIterable`
- `pull` function catches it in `PushBuffer.ts#265` 

Therefore it was possible that a network error during threw an unhandled promise rejection error which crashed the application process.