### PR TITLE
refactor(client): Throw `StreamrClientError` if stream not found from registry 

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -12,7 +12,6 @@ import { Authentication, AuthenticationInjectionToken, createAuthentication } fr
 import { ConfigInjectionToken, StreamrClientConfig, StrictStreamrClientConfig, createStrictConfig, redactConfig } from './Config'
 import { DestroySignal } from './DestroySignal'
 import { generateEthereumAccount as _generateEthereumAccount } from './Ethereum'
-import { ErrorCode } from './HttpUtil'
 import { Message, convertStreamMessageToMessage } from './Message'
 import { MetricsPublisher } from './MetricsPublisher'
 import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
@@ -354,7 +353,7 @@ export class StreamrClient {
         try {
             return await this.getStream(props.id)
         } catch (err: any) {
-            if (err.errorCode === ErrorCode.NOT_FOUND) {
+            if (err.errorCode === 'STREAM_NOT_FOUND') {
                 return this.createStream(props)
             }
             throw err

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -353,7 +353,7 @@ export class StreamrClient {
         try {
             return await this.getStream(props.id)
         } catch (err: any) {
-            if (err.errorCode === 'STREAM_NOT_FOUND') {
+            if (err.code === 'STREAM_NOT_FOUND') {
                 return this.createStream(props)
             }
             throw err

--- a/packages/client/src/StreamrClientError.ts
+++ b/packages/client/src/StreamrClientError.ts
@@ -1,8 +1,9 @@
-export type StreamrClientErrorCode = 
-    'MISSING_PERMISSION' | 
-    'NO_STORAGE_NODES' | 
-    'INVALID_ARGUMENT' | 
-    'CLIENT_DESTROYED' | 
+export type StreamrClientErrorCode =
+    'STREAM_NOT_FOUND' |
+    'MISSING_PERMISSION' |
+    'NO_STORAGE_NODES' |
+    'INVALID_ARGUMENT' |
+    'CLIENT_DESTROYED' |
     'PIPELINE_ERROR' |
     'UNSUPPORTED_OPERATION' |
     'INVALID_STREAM_METADATA' |

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -8,9 +8,9 @@ import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import { ContractFactory } from '../ContractFactory'
 import { getStreamRegistryChainProviders, getStreamRegistryOverrides } from '../Ethereum'
-import { NotFoundError } from '../HttpUtil'
 import { Stream, StreamMetadata } from '../Stream'
 import { StreamIDBuilder } from '../StreamIDBuilder'
+import { StreamrClientError } from '../StreamrClientError'
 import type { StreamRegistryV4 as StreamRegistryContract } from '../ethereumArtifacts/StreamRegistryV4'
 import StreamRegistryArtifact from '../ethereumArtifacts/StreamRegistryV4Abi.json'
 import { StreamrClientEventEmitter } from '../events'
@@ -59,7 +59,7 @@ export interface StreamCreationEvent {
 
 const streamContractErrorProcessor = (err: any, streamId: StreamID, registry: string): never => {
     if (err.reason?.code === 'CALL_EXCEPTION') {
-        throw new NotFoundError('Stream not found: id=' + streamId)
+        throw new StreamrClientError('Stream not found: id=' + streamId, 'STREAM_NOT_FOUND')
     } else {
         throw new Error(`Could not reach the ${registry} Smart Contract: ${err.message}`)
     }
@@ -340,7 +340,7 @@ export class StreamRegistry {
                 if (response.stream !== null) {
                     return response.stream.permissions
                 } else {
-                    throw new NotFoundError('stream not found: id: ' + streamId)
+                    throw new StreamrClientError('Stream not found: id=' + streamId, 'STREAM_NOT_FOUND')
                 }
             }
         ))

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -278,7 +278,7 @@ describe('StreamRegistry', () => {
                     await client.getStream(stream.id)
                     return false
                 } catch (err: any) {
-                    return err.errorCode === 'STREAM_NOT_FOUND'
+                    return err.code === 'STREAM_NOT_FOUND'
                 }
             }, 100000, 1000)
             return expect(client.getStream(stream.id)).rejects.toThrow()

--- a/packages/client/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/client/test/end-to-end/StreamRegistry.test.ts
@@ -5,7 +5,6 @@ import { toStreamID } from '@streamr/protocol'
 import { fetchPrivateKeyWithGas, randomEthereumAddress } from '@streamr/test-utils'
 import { EthereumAddress, collect, toEthereumAddress, waitForCondition } from '@streamr/utils'
 import { CONFIG_TEST } from '../../src/ConfigTest'
-import { NotFoundError } from '../../src/HttpUtil'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { until } from '../../src/utils/promises'
@@ -156,7 +155,9 @@ describe('StreamRegistry', () => {
 
         it('get a non-existing Stream', async () => {
             const streamId = `${publicAddress}/StreamRegistry-nonexisting-${Date.now()}`
-            return expect(() => client.getStream(streamId)).rejects.toThrow(NotFoundError)
+            return expect(() => client.getStream(streamId)).rejects.toThrowStreamrError({
+                code: 'STREAM_NOT_FOUND'
+            })
         })
     })
 
@@ -277,7 +278,7 @@ describe('StreamRegistry', () => {
                     await client.getStream(stream.id)
                     return false
                 } catch (err: any) {
-                    return err.errorCode === 'NOT_FOUND'
+                    return err.errorCode === 'STREAM_NOT_FOUND'
                 }
             }, 100000, 1000)
             return expect(client.getStream(stream.id)).rejects.toThrow()

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -2,10 +2,10 @@ import { StreamID } from '@streamr/protocol'
 import { EthereumAddress, Multimap, toEthereumAddress } from '@streamr/utils'
 import { Lifecycle, inject, scoped } from 'tsyringe'
 import { Authentication, AuthenticationInjectionToken } from '../../../src/Authentication'
-import { NotFoundError } from '../../../src/HttpUtil'
 import { Stream, StreamMetadata } from '../../../src/Stream'
 import { StreamFactory } from '../../../src/StreamFactory'
 import { StreamIDBuilder } from '../../../src/StreamIDBuilder'
+import { StreamrClientError } from '../../../src/StreamrClientError'
 import {
     PermissionAssignment,
     PermissionQuery, StreamPermission,
@@ -61,7 +61,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         if (registryItem !== undefined) {
             return this.streamFactory.createStream(id, registryItem.metadata)
         } else {
-            throw new NotFoundError('Stream not found: id=' + id)
+            throw new StreamrClientError('Stream not found: id=' + id, 'STREAM_NOT_FOUND')
         }
     }
 


### PR DESCRIPTION
Throw `StreamrClientError(..., 'STREAM_NOT_FOUND')` if we query a stream from registry, which does not exists. 

Before this PR an error was throw, but it was not an instance of `StreamrClientError`, but a `HttpUtils.NotFound` error. It is preferred that all errors generated by the client are instances of `StreamrClientError`.

This changes also the the content of `error.code` field from `NOT_FOUND` to `STREAM_NOT_FOUND` (and removes the fallback field `error.errorCode`). Therefore this could be a breaking change. But error codes are not documented in the public API, and therefore this can also be considered as internal refactoring. There can be applications which assume this undocumented behavior.

### Future improvements

- `HttpUtils.ERROR_CODES` are specific to the storage node implementation, not generic HTTP error codes. We should move the logic to `Resends` and use standard `StreamrClientError` instead of custom error class.
- Specify to TSDocs of `getStream` (and maybe other places) which error is thrown. Could also document other `StreamrClientError` throws for other methods similarly.