### PR TITLE
NET-846: Fix flakyness in finding data under churn

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -76,6 +76,7 @@ message DataEntry {
   google.protobuf.Any data = 3;
   google.protobuf.Timestamp storedAt = 4; 
   uint32 ttl = 5;   // milliseconds
+  bool stale = 6;
 }
 
 message ClosestPeersRequest {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -273,7 +273,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         })
         this.dataStore = new DataStore({
             rpcCommunicator: this.rpcCommunicator!,
-            router: this.router!,
             recursiveFinder: this.recursiveFinder,
             ownPeerDescriptor: this.ownPeerDescriptor!,
             serviceId: this.config.serviceId,

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -66,7 +66,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         })
         if (this.noCloserNodesReceivedCounter >= 1 && unreportedHops.size === 0) {
             if (this.mode === FindMode.DATA 
-                && (this.foundData.size > 0 || this.noCloserNodesReceivedCounter >= this.waitedRoutingPathCompletions)) {
+                && (this.hasNonStaleData() || this.noCloserNodesReceivedCounter >= this.waitedRoutingPathCompletions)) {
                 return true
             } else if (this.mode === FindMode.DATA) {
                 return false
@@ -74,6 +74,10 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
             return true
         }
         return false
+    }
+
+    private hasNonStaleData(): boolean {
+        return Array.from(this.foundData.values()).some((entry) => entry.stale === false)
     }
 
     public doReportRecursiveFindResult(

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -67,6 +67,20 @@ export class LocalDataStore {
         return dataEntries
     }
 
+    public setStale(key: PeerID, storer: PeerDescriptor, stale: boolean): void {
+        const storerKey = keyFromPeerDescriptor(storer)
+        const storedEntry = this.store.get(key.toKey())?.get(storerKey)
+        if (storedEntry) {
+            storedEntry.dataEntry.stale = stale
+        }
+    }
+
+    public setAllEntriesAsStale(key: PeerID): void {
+        this.store.get(key.toKey())?.forEach((value) => {
+            value.dataEntry.stale = true
+        })
+    }
+
     public deleteEntry(key: PeerID, storer: PeerDescriptor): void {
         const storerKey = keyFromPeerDescriptor(storer)
         const storedEntry = this.store.get(key.toKey())?.get(storerKey)

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -77,6 +77,10 @@ export interface DataEntry {
      * @generated from protobuf field: uint32 ttl = 5;
      */
     ttl: number; // milliseconds
+    /**
+     * @generated from protobuf field: bool stale = 6;
+     */
+    stale: boolean;
 }
 /**
  * @generated from protobuf message dht.ClosestPeersRequest
@@ -824,7 +828,8 @@ class DataEntry$Type extends MessageType$<DataEntry> {
             { no: 2, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "data", kind: "message", T: () => Any },
             { no: 4, name: "storedAt", kind: "message", T: () => Timestamp },
-            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -32,7 +32,7 @@ describe('LocalDataStore', () => {
 
     it('can store', () => {
         const dataKey = peerIdFromPeerDescriptor(storer1)
-        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000 })
+        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000, stale: false })
         const fetchedData = localDataStore.getEntry(dataKey)
         fetchedData!.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
@@ -42,8 +42,8 @@ describe('LocalDataStore', () => {
 
     it('multiple storers behind one key', () => {
         const dataKey = peerIdFromPeerDescriptor(storer1)
-        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000 })
-        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data1, ttl: 10000 })
+        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000, stale: false })
+        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data1, ttl: 10000, stale: false })
         const fetchedData = localDataStore.getEntry(dataKey)
         fetchedData!.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
@@ -53,8 +53,8 @@ describe('LocalDataStore', () => {
 
     it('can remove data entries', () => {
         const dataKey = peerIdFromPeerDescriptor(storer1)
-        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000 })
-        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data2, ttl: 10000 })
+        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000, stale: false })
+        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data2, ttl: 10000, stale: false })
         localDataStore.deleteEntry(dataKey, storer1)
         const fetchedData = localDataStore.getEntry(dataKey)
         fetchedData!.forEach((entry) => {
@@ -65,8 +65,8 @@ describe('LocalDataStore', () => {
 
     it('can remove all data entries', () => {
         const dataKey = peerIdFromPeerDescriptor(storer1)
-        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000 })
-        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data2, ttl: 10000 })
+        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 10000, stale: false })
+        localDataStore.storeEntry({ storer: storer2, kademliaId: dataKey.value, data: data2, ttl: 10000, stale: false })
         localDataStore.deleteEntry(dataKey, storer1)
         localDataStore.deleteEntry(dataKey, storer2)
         const fetchedData = localDataStore.getEntry(dataKey)
@@ -75,7 +75,7 @@ describe('LocalDataStore', () => {
 
     it('data is deleted after TTL', async () => {
         const dataKey = peerIdFromPeerDescriptor(storer1)
-        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 1000 })
+        localDataStore.storeEntry({ storer: storer1, kademliaId: dataKey.value, data: data1, ttl: 1000, stale: false })
         const intitialStore = localDataStore.getEntry(dataKey)
         expect(intitialStore.size).toBe(1)
         await wait(1100)

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -77,6 +77,10 @@ export interface DataEntry {
      * @generated from protobuf field: uint32 ttl = 5;
      */
     ttl: number; // milliseconds
+    /**
+     * @generated from protobuf field: bool stale = 6;
+     */
+    stale: boolean;
 }
 /**
  * @generated from protobuf message dht.ClosestPeersRequest
@@ -824,7 +828,8 @@ class DataEntry$Type extends MessageType$<DataEntry> {
             { no: 2, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "data", kind: "message", T: () => Any },
             { no: 4, name: "storedAt", kind: "message", T: () => Timestamp },
-            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
+++ b/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
@@ -22,7 +22,8 @@ describe('StreamEntryPointDiscovery', () => {
         data: Any.pack(peerDescriptor, PeerDescriptor),
         ttl: 1000,
         storer: peerDescriptor,
-        kademliaId: Uint8Array.from([1, 2, 3])
+        kademliaId: Uint8Array.from([1, 2, 3]),
+        stale: false
     }
 
     const stream = 'stream#0'


### PR DESCRIPTION
## Summary

Data can now be found more reliably from the DHT store if churn is present. The recursive finds with data-mode on will traverse to the closest peers in all cases. Additionally data that is stored on nodes that are too far to the closest peers to it is marked as stale.