### PR TITLE
NET-986: trackerless side

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -164,6 +164,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     public connectionManager?: ConnectionManager
     private started = false
     private stopped = false
+    private joined = false
     private entryPointDisconnectTimeout?: NodeJS.Timeout
 
     public contactAddCounter = 0
@@ -617,6 +618,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
+        this.joined = true
         await this.peerDiscovery!.joinDht(entryPointDescriptor, doRandomJoin)
     }
 
@@ -698,6 +700,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.peerDiscovery!.isJoinOngoing()
     }
 
+    public hasJoined(): boolean {
+        return this.joined
+    }
+
     public getKnownEntryPoints(): PeerDescriptor[] {
         return this.config.entryPoints || []
     }
@@ -710,6 +716,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Err.CouldNotStop('Cannot not stop() before start()')
         }
+        this.joined = false
         this.stopped = true
 
         if (this.entryPointDisconnectTimeout) {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -386,6 +386,10 @@ export class StreamrNode extends EventEmitter<Events> {
         this.extraMetadata = metadata
     }
 
+    isJoinRequired(streamPartId: StreamPartID): boolean {
+        return !this.streams.has(streamPartId) && Array.from(this.streams.values()).every((stream) => stream.type === NodeType.PROXY)
+    }
+
 }
 
 [`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `unhandledRejection`, `SIGTERM`].forEach((term) => {

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -1,0 +1,107 @@
+import { NodeType, PeerDescriptor, PeerID } from "@streamr/dht"
+import { NetworkNode } from "../../src/NetworkNode"
+import { MessageID, MessageRef, StreamMessage, StreamMessageType, toStreamID, toStreamPartID } from "@streamr/protocol"
+import { EthereumAddress, waitForEvent3 } from "@streamr/utils"
+import { ProxyDirection } from "../../src/proto/packages/trackerless-network/protos/NetworkRpc"
+
+describe('proxy and full node', () => {
+
+    const proxyNodeDescriptor: PeerDescriptor = {
+        kademliaId: PeerID.fromString(`proxyNode`).value,
+        type: NodeType.NODEJS,
+        nodeName: 'proxyNode',
+        websocket: { ip: 'localhost', port: 23132 }
+    }
+    const proxiedNodeDescriptor: PeerDescriptor = {
+        kademliaId: PeerID.fromString(`proxiedNode`).value,
+        type: NodeType.NODEJS,
+    }
+
+    const proxyStreamId = toStreamPartID(toStreamID('proxy-stream'), 0)
+    const regularStreamId = toStreamPartID(toStreamID('regular-stream'), 0)
+
+    const proxiedMessage = new StreamMessage({
+        messageId: new MessageID(
+            toStreamID('proxy-stream'),
+            0,
+            666,
+            0,
+            'peer' as EthereumAddress,
+            'msgChainId'
+        ),
+        prevMsgRef: new MessageRef(665, 0),
+        content: {
+            hello: 'world'
+        },
+        messageType: StreamMessageType.MESSAGE,
+        signature: 'signature',
+    })
+
+    const regularMessage = new StreamMessage({
+        messageId: new MessageID(
+            toStreamID('regular-stream'),
+            0,
+            666,
+            0,
+            'peer' as EthereumAddress,
+            'msgChainId'
+        ),
+        prevMsgRef: new MessageRef(665, 0),
+        content: {
+            hello: 'world'
+        },
+        messageType: StreamMessageType.MESSAGE,
+        signature: 'signature',
+    })
+
+    let proxyNode: NetworkNode
+    let proxiedNode: NetworkNode
+
+    beforeEach(async () => {
+        proxyNode = new NetworkNode({
+            layer0: {
+                entryPoints: [proxyNodeDescriptor],
+                peerDescriptor: proxyNodeDescriptor,
+            },
+            networkNode: {
+                acceptProxyConnections: true
+            }
+        })
+        await proxyNode.start()
+        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId, [proxyNodeDescriptor])
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId, [proxyNodeDescriptor])
+
+        proxiedNode = new NetworkNode({
+            layer0: {
+                entryPoints: [proxyNodeDescriptor],
+                peerDescriptor: proxiedNodeDescriptor,
+            },
+            networkNode: {}
+        })
+        await proxiedNode.start(false)
+    })
+
+    afterEach(async () => {
+        await proxyNode.stop()
+        await proxiedNode.stop()
+    })
+
+    it('proxied node can act as full node on another stream', async () => {
+        await proxiedNode.setProxies(proxyStreamId, [proxyNodeDescriptor], ProxyDirection.PUBLISH, async () => 'proxiedNode', 1)
+        expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(false)
+
+        await Promise.all([
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            proxiedNode.publish(regularMessage, [proxyNodeDescriptor])
+        ])
+
+        expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(true)
+
+        await Promise.all([
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            proxiedNode.publish(proxiedMessage, [])
+        ])
+
+    })
+
+})

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -10,7 +10,7 @@ describe('proxy and full node', () => {
         kademliaId: PeerID.fromString(`proxyNode`).value,
         type: NodeType.NODEJS,
         nodeName: 'proxyNode',
-        websocket: { ip: 'localhost', port: 23132 }
+        websocket: { ip: 'localhost', port: 23135 }
     }
     const proxiedNodeDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString(`proxiedNode`).value,

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -79,7 +79,7 @@ describe('Proxy connections', () => {
             },
             networkNode: {}
         })
-        await proxiedNode.start()
+        await proxiedNode.start(false)
     }, 30000)
 
     afterEach(async () => {
@@ -210,7 +210,7 @@ describe('Proxy connections', () => {
             ProxyDirection.PUBLISH,
             async () => 'proxiedNode'
         )
-        expect(() => proxiedNode.subscribe(streamPartId, [])).toThrow('Cannot subscribe')
+        await expect(proxiedNode.subscribe(streamPartId, [])).rejects.toThrow('Cannot subscribe')
     })
 
     it('connect publish on proxy subscribe streams', async () => {
@@ -220,7 +220,7 @@ describe('Proxy connections', () => {
             ProxyDirection.SUBSCRIBE,
             async () => 'proxiedNode'
         )
-        expect(() => proxiedNode.publish(message, [])).toThrow('Cannot publish')
+        await expect(proxiedNode.publish(message, [])).rejects.toThrow('Cannot publish')
     })
 
 })

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -58,7 +58,7 @@ describe('proxy group key exchange', () => {
             },
             networkNode: {}
         })
-        await publisher.start()
+        await publisher.start(false)
 
         subscriber = new NetworkNode({
             layer0: {
@@ -67,7 +67,7 @@ describe('proxy group key exchange', () => {
             },
             networkNode: {}
         })
-        await subscriber.start()
+        await subscriber.start(false)
     })
 
     afterEach(async () => {

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -10,7 +10,7 @@ describe('random graph with real connections', () => {
     const epPeerDescriptor: PeerDescriptor = {
         kademliaId: Uint8Array.from([1, 2, 3]),
         type: NodeType.NODEJS,
-        websocket: { ip: 'localhost', port: 12225 }
+        websocket: { ip: 'localhost', port: 12221 }
     }
 
     const randomGraphId = 'random-graph'

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -10,7 +10,7 @@ describe('random graph with real connections', () => {
     const epPeerDescriptor: PeerDescriptor = {
         kademliaId: Uint8Array.from([1, 2, 3]),
         type: NodeType.NODEJS,
-        websocket: { ip: 'localhost', port: 12221 }
+        websocket: { ip: 'localhost', port: 12225 }
     }
 
     const randomGraphId = 'random-graph'


### PR DESCRIPTION
## Summary

Nodes can now avoid joining the layer0 during start, this is useful if the node is behind a proxy for a stream. When publish and subscribe are called for new streams the NetworkNode will join the DHT in cases where joining was skipped.
