### PR TITLE
test(client): Test server utility

### DIFF
--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -5,10 +5,7 @@ import { MAX_PARTITION_COUNT, StreamMessage, StreamPartID, StreamPartIDUtils } f
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { EthereumAddress, Logger, merge, wait, waitForCondition } from '@streamr/utils'
 import crypto from 'crypto'
-import { once } from 'events'
-import express, { Request, Response } from 'express'
 import { mock } from 'jest-mock-extended'
-import { AddressInfo } from 'net'
 import { DependencyContainer } from 'tsyringe'
 import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
 import { StreamrClientConfig } from '../../src/Config'
@@ -225,24 +222,4 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
     await waitForCondition(() => mockFunction.mock.calls.length >= n, 1000, 10, undefined, () => {
         return `Timeout while waiting for calls: got ${mockFunction.mock.calls.length} out of ${n}`
     })
-}
-
-export const startTestServer = async (
-    endpoint: string,
-    onRequest: (req: Request, res: Response) => Promise<void>
-): Promise<{ url: string, stop: () => Promise<void> }> => {
-    const app = express()
-    app.get(endpoint, async (req, res) => {
-        await onRequest(req, res)
-    })
-    const server = app.listen()
-    await once(server, 'listening')
-    const port = (server.address() as AddressInfo).port
-    return {
-        url: `http://localhost:${port}`,
-        stop: async () => {
-            server.close()
-            await once(server, 'close')
-        }
-    }
 }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -1,31 +1,34 @@
-import crypto from 'crypto'
-import { DependencyContainer } from 'tsyringe'
-import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { EthereumAddress, Logger, wait } from '@streamr/utils'
+import 'reflect-metadata'
+
 import { Wallet } from '@ethersproject/wallet'
-import { StreamMessage, StreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } from '@streamr/protocol'
-import { StreamrClient } from '../../src/StreamrClient'
-import { counterId } from '../../src/utils/utils'
-import { Stream, StreamMetadata } from '../../src/Stream'
-import { CONFIG_TEST } from '../../src/ConfigTest'
-import { StreamrClientConfig } from '../../src/Config'
-import { GroupKey } from '../../src/encryption/GroupKey'
-import { addAfterFn } from './jest-utils'
-import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
-import { StreamrClientEventEmitter } from '../../src/events'
-import { MessageFactory } from '../../src/publish/MessageFactory'
-import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
-import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
-import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
-import { LoggerFactory } from '../../src/utils/LoggerFactory'
-import { waitForCondition } from '@streamr/utils'
-import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
+import { MAX_PARTITION_COUNT, StreamMessage, StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
+import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { EthereumAddress, Logger, merge, wait, waitForCondition } from '@streamr/utils'
+import crypto from 'crypto'
+import { once } from 'events'
+import express, { Request, Response } from 'express'
 import { mock } from 'jest-mock-extended'
-import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
-import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { AddressInfo } from 'net'
+import { DependencyContainer } from 'tsyringe'
+import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
+import { StreamrClientConfig } from '../../src/Config'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { DestroySignal } from '../../src/DestroySignal'
 import { PersistenceManager } from '../../src/PersistenceManager'
-import { merge } from '@streamr/utils'
+import { Stream, StreamMetadata } from '../../src/Stream'
+import { StreamrClient } from '../../src/StreamrClient'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
+import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
+import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
+import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { StreamrClientEventEmitter } from '../../src/events'
+import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
+import { MessageFactory } from '../../src/publish/MessageFactory'
+import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
+import { LoggerFactory } from '../../src/utils/LoggerFactory'
+import { counterId } from '../../src/utils/utils'
+import { addAfterFn } from './jest-utils'
 
 const logger = new Logger(module)
 
@@ -222,4 +225,24 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
     await waitForCondition(() => mockFunction.mock.calls.length >= n, 1000, 10, undefined, () => {
         return `Timeout while waiting for calls: got ${mockFunction.mock.calls.length} out of ${n}`
     })
+}
+
+export const startTestServer = async (
+    endpoint: string,
+    onRequest: (req: Request, res: Response) => Promise<void>
+): Promise<{ url: string, stop: () => Promise<void> }> => {
+    const app = express()
+    app.get(endpoint, async (req, res) => {
+        await onRequest(req, res)
+    })
+    const server = app.listen()
+    await once(server, 'listening')
+    const port = (server.address() as AddressInfo).port
+    return {
+        url: `http://localhost:${port}`,
+        stop: async () => {
+            server.close()
+            await once(server, 'close')
+        }
+    }
 }

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata'
 
 import { StreamPartIDUtils } from '@streamr/protocol'
-import { randomEthereumAddress } from '@streamr/test-utils'
+import { randomEthereumAddress, startTestServer } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Resends } from '../../src/subscribe/Resends'
-import { mockLoggerFactory, startTestServer } from '../test-utils/utils'
+import { mockLoggerFactory } from '../test-utils/utils'
 
 describe('Resends', () => {
 

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -3,37 +3,29 @@ import 'reflect-metadata'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
-import { once } from 'events'
-import express from 'express'
-import { AddressInfo } from 'net'
 import { Resends } from '../../src/subscribe/Resends'
-import { mockLoggerFactory } from '../test-utils/utils'
+import { mockLoggerFactory, startTestServer } from '../test-utils/utils'
 
 describe('Resends', () => {
 
     it('error handling', async () => {
-        const app = express()
-        app.get('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
+        const server = await startTestServer('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
             res.status(400).json({
                 error: 'Mock error'
             })
         })
-        const server = app.listen()
-        await once(server, 'listening')
-        const port = (server.address() as AddressInfo).port
-        const serverUrl = `http://localhost:${port}`
         const resends = new Resends(
             {
                 getStorageNodes: async () => [randomEthereumAddress()]
             } as any,
             {
-                getStorageNodeMetadata: async () => ({ http: serverUrl })
+                getStorageNodeMetadata: async () => ({ http: server.url })
             } as any,
             undefined as any,
             undefined as any,
             mockLoggerFactory()
         )
-        const requestUrl = `${serverUrl}/streams/stream/data/partitions/0/last?count=1&format=raw`
+        const requestUrl = `${server.url}/streams/stream/data/partitions/0/last?count=1&format=raw`
         await expect(async () => {
             const messages = await resends.resend(StreamPartIDUtils.parse('stream#0'), { last: 1, raw: true })
             await collect(messages)
@@ -41,6 +33,6 @@ describe('Resends', () => {
             message: `Storage node fetch failed: Mock error, httpStatus=400, url=${requestUrl}`,
             code: 'STORAGE_NODE_ERROR'
         })
-        server.close()
+        await server.stop()
     })
 })

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -1,10 +1,10 @@
 import { StreamPartIDUtils } from '@streamr/protocol'
-import { fastWallet } from '@streamr/test-utils'
+import { fastWallet, startTestServer } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Request, Response } from 'express'
 import range from 'lodash/range'
 import { createQueryString, fetchHttpStream, getEndpointUrl } from '../../src/utils/utils'
-import { createMockMessage, startTestServer } from '../test-utils/utils'
+import { createMockMessage } from '../test-utils/utils'
 
 describe('utils', () => {
 

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -1,11 +1,10 @@
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
-import { once } from 'events'
-import express from 'express'
+import { Request, Response } from 'express'
 import range from 'lodash/range'
 import { createQueryString, fetchHttpStream, getEndpointUrl } from '../../src/utils/utils'
-import { createMockMessage } from '../test-utils/utils'
+import { createMockMessage, startTestServer } from '../test-utils/utils'
 
 describe('utils', () => {
 
@@ -30,15 +29,13 @@ describe('utils', () => {
 
     it('fetchHttpStream', async () => {
         const MESSAGE_COUNT = 5
-        const MOCK_SERVER_PORT = 12345
-        const app = express()
-        app.get('/endpoint', async (_req, res) => {
+        const server = await startTestServer('/', async (_req: Request, res: Response) => {
             const publisher = fastWallet()
             for (const i of range(MESSAGE_COUNT)) {
                 const msg = await createMockMessage({
                     streamPartId: StreamPartIDUtils.parse('stream#0'),
                     publisher,
-                    content: {
+                    content: { 
                         mockId: i
                     }
                 })
@@ -46,10 +43,8 @@ describe('utils', () => {
             }
             res.end()
         })
-        const server = app.listen(MOCK_SERVER_PORT)
-        await once(server, 'listening')
-        const msgs = await collect(fetchHttpStream(`http://localhost:${MOCK_SERVER_PORT}/endpoint`, () => undefined as any))
-        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual([0, 1, 2, 3, 4])
-        server.close()
+        const msgs = await collect(fetchHttpStream(server.url, () => undefined as any))
+        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual(range(MESSAGE_COUNT))
+        await server.stop()
     })
 })


### PR DESCRIPTION
Create `startTestServer` utility for creating simple `expess` server. There were two tests which uses such test server, and now those tests cases create the server by calling the function. 

The shutdown logic has been improved: it now waits for the `close` event.