### PR TITLE
Proxied node as regular node on multiple other streams

### DIFF
--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -29,7 +29,7 @@ import { IStreamNode } from './IStreamNode'
 import { ProxyStreamConnectionClient } from './proxy/ProxyStreamConnectionClient'
 import { PeerIDKey } from '@streamr/dht/src/exports'
 
-enum NodeType {
+export enum StreamNodeType {
     RANDOM_GRAPH = 'random-graph',
     PROXY = 'proxy'
 }
@@ -67,7 +67,7 @@ class NeighborCounter {
 export interface StreamObject {
     layer1?: DhtNode
     layer2: IStreamNode
-    type: NodeType
+    type: StreamNodeType
 }
 
 export interface Events {
@@ -222,7 +222,7 @@ export class StreamrNode extends EventEmitter<Events> {
         const layer1 = this.createLayer1Node(streamPartID, entryPoints)
         const layer2 = this.createRandomGraphNode(streamPartID, layer1)
         this.streams.set(streamPartID, {
-            type: NodeType.RANDOM_GRAPH,
+            type: StreamNodeType.RANDOM_GRAPH,
             layer1,
             layer2
         })
@@ -267,7 +267,7 @@ export class StreamrNode extends EventEmitter<Events> {
         msg: StreamMessage,
         timeout?: number
     ): Promise<number> {
-        if (this.getStream(streamPartId)?.type === NodeType.PROXY) {
+        if (this.getStream(streamPartId)?.type === StreamNodeType.PROXY) {
             return 0
         }
         await this.joinStream(streamPartId, knownEntryPointDescriptors)
@@ -285,7 +285,7 @@ export class StreamrNode extends EventEmitter<Events> {
         timeout?: number,
         expectedNeighbors = 1
     ): Promise<number> {
-        if (this.getStream(streamPartId)?.type === NodeType.PROXY) {
+        if (this.getStream(streamPartId)?.type === StreamNodeType.PROXY) {
             return 0
         }
         await this.joinStream(streamPartId, knownEntryPointDescriptors)
@@ -305,10 +305,10 @@ export class StreamrNode extends EventEmitter<Events> {
         connectionCount?: number
     ): Promise<void> {
         const userId = await getUserId()
-        if (this.streams.get(streamPartId)?.type === NodeType.PROXY && contactPeerDescriptors.length > 0) {
+        if (this.streams.get(streamPartId)?.type === StreamNodeType.PROXY && contactPeerDescriptors.length > 0) {
             const proxyClient = this.streams.get(streamPartId)!.layer2 as ProxyStreamConnectionClient
             await proxyClient.setProxies(streamPartId, contactPeerDescriptors, direction, userId, connectionCount)
-        } else if (this.streams.get(streamPartId)?.type === NodeType.PROXY && contactPeerDescriptors.length === 0) {
+        } else if (this.streams.get(streamPartId)?.type === StreamNodeType.PROXY && contactPeerDescriptors.length === 0) {
             this.streams.get(streamPartId)!.layer2.stop()
             this.streams.delete(streamPartId)
         } else {
@@ -321,7 +321,7 @@ export class StreamrNode extends EventEmitter<Events> {
     private createProxyStream(streamPartId: string, userId: string): ProxyStreamConnectionClient {
         const layer2 = this.createProxyStreamConnectionClient(streamPartId, userId)
         this.streams.set(streamPartId, {
-            type: NodeType.PROXY,
+            type: StreamNodeType.PROXY,
             layer2
         })
         layer2.on('message', (message: StreamMessage) => {
@@ -342,7 +342,7 @@ export class StreamrNode extends EventEmitter<Events> {
     }
 
     isProxiedStreamPart(streamId: string, direction: ProxyDirection): boolean {
-        return this.streams.get(streamId)?.type === NodeType.PROXY 
+        return this.streams.get(streamId)?.type === StreamNodeType.PROXY 
             && (this.streams.get(streamId)!.layer2 as ProxyStreamConnectionClient).getDirection() === direction
     }
 
@@ -387,7 +387,7 @@ export class StreamrNode extends EventEmitter<Events> {
     }
 
     isJoinRequired(streamPartId: StreamPartID): boolean {
-        return !this.streams.has(streamPartId) && Array.from(this.streams.values()).every((stream) => stream.type === NodeType.PROXY)
+        return !this.streams.has(streamPartId) && Array.from(this.streams.values()).every((stream) => stream.type === StreamNodeType.PROXY)
     }
 
 }

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -1,8 +1,28 @@
 import { NodeType, PeerDescriptor, PeerID } from "@streamr/dht"
 import { NetworkNode } from "../../src/NetworkNode"
-import { MessageID, MessageRef, StreamMessage, StreamMessageType, toStreamID, toStreamPartID } from "@streamr/protocol"
+import { MessageID, MessageRef, StreamID, StreamMessage, StreamMessageType, toStreamID, toStreamPartID } from "@streamr/protocol"
 import { EthereumAddress, waitForEvent3 } from "@streamr/utils"
-import { ProxyDirection } from "../../src/proto/packages/trackerless-network/protos/NetworkRpc"
+import { ProxyDirection, StreamMessage as InternalStreamMessage } from "../../src/proto/packages/trackerless-network/protos/NetworkRpc"
+import { StreamNodeType } from "../../src/logic/StreamrNode"
+
+const createMessage = (streamId: StreamID): StreamMessage => {
+    return new StreamMessage({ 
+        messageId: new MessageID(
+            streamId,
+            0,
+            666,
+            0,
+            'peer' as EthereumAddress,
+            'msgChainId'
+        ),
+        prevMsgRef: new MessageRef(665, 0),
+        content: {
+            hello: 'world'
+        },
+        messageType: StreamMessageType.MESSAGE,
+        signature: 'signature',
+    })
+}
 
 describe('proxy and full node', () => {
 
@@ -18,41 +38,16 @@ describe('proxy and full node', () => {
     }
 
     const proxyStreamId = toStreamPartID(toStreamID('proxy-stream'), 0)
-    const regularStreamId = toStreamPartID(toStreamID('regular-stream'), 0)
+    const regularStreamId1 = toStreamPartID(toStreamID('regular-stream1'), 0)
+    const regularStreamId2 = toStreamPartID(toStreamID('regular-stream2'), 0)
+    const regularStreamId3 = toStreamPartID(toStreamID('regular-stream3'), 0)
+    const regularStreamId4 = toStreamPartID(toStreamID('regular-stream4'), 0)
 
-    const proxiedMessage = new StreamMessage({
-        messageId: new MessageID(
-            toStreamID('proxy-stream'),
-            0,
-            666,
-            0,
-            'peer' as EthereumAddress,
-            'msgChainId'
-        ),
-        prevMsgRef: new MessageRef(665, 0),
-        content: {
-            hello: 'world'
-        },
-        messageType: StreamMessageType.MESSAGE,
-        signature: 'signature',
-    })
-
-    const regularMessage = new StreamMessage({
-        messageId: new MessageID(
-            toStreamID('regular-stream'),
-            0,
-            666,
-            0,
-            'peer' as EthereumAddress,
-            'msgChainId'
-        ),
-        prevMsgRef: new MessageRef(665, 0),
-        content: {
-            hello: 'world'
-        },
-        messageType: StreamMessageType.MESSAGE,
-        signature: 'signature',
-    })
+    const proxiedMessage = createMessage(toStreamID('proxy-stream'))
+    const regularMessage1 = createMessage(toStreamID('regular-stream1'))
+    const regularMessage2 = createMessage(toStreamID('regular-stream2'))
+    const regularMessage3 = createMessage(toStreamID('regular-stream3'))
+    const regularMessage4 = createMessage(toStreamID('regular-stream4'))
 
     let proxyNode: NetworkNode
     let proxiedNode: NetworkNode
@@ -68,8 +63,11 @@ describe('proxy and full node', () => {
             }
         })
         await proxyNode.start()
-        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId, [proxyNodeDescriptor])
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId, [proxyNodeDescriptor])
+        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId, [])
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId1, [])
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId2, [])
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId3, [])
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId4, [])
 
         proxiedNode = new NetworkNode({
             layer0: {
@@ -92,7 +90,7 @@ describe('proxy and full node', () => {
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
-            proxiedNode.publish(regularMessage, [proxyNodeDescriptor])
+            proxiedNode.publish(regularMessage1, [])
         ])
 
         expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(true)
@@ -102,6 +100,41 @@ describe('proxy and full node', () => {
             proxiedNode.publish(proxiedMessage, [])
         ])
 
+        expect(proxiedNode.stack.getStreamrNode().getStream(proxyStreamId)!.type).toBe(StreamNodeType.PROXY)
+        expect(proxiedNode.stack.getStreamrNode().getStream(regularStreamId1)!.type).toBe(StreamNodeType.RANDOM_GRAPH)
+    })
+
+    it('proxied node can act as full node on multiple streams', async () => {
+        await proxiedNode.setProxies(proxyStreamId, [proxyNodeDescriptor], ProxyDirection.PUBLISH, async () => 'proxiedNode', 1)
+        expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(false)
+
+        await Promise.all([
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+                (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream1'),
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+                (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream2'),
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+                (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream3'),
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+                (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream4'),
+            proxiedNode.publish(regularMessage1, []),
+            proxiedNode.publish(regularMessage2, []),
+            proxiedNode.publish(regularMessage3, []),
+            proxiedNode.publish(regularMessage4, [])
+        ])
+
+        expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(true)
+
+        await Promise.all([
+            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            proxiedNode.publish(proxiedMessage, [])
+        ])
+
+        expect(proxiedNode.stack.getStreamrNode().getStream(proxyStreamId)!.type).toBe(StreamNodeType.PROXY)
+        expect(proxiedNode.stack.getStreamrNode().getStream(regularStreamId1)!.type).toBe(StreamNodeType.RANDOM_GRAPH)
+        expect(proxiedNode.stack.getStreamrNode().getStream(regularStreamId2)!.type).toBe(StreamNodeType.RANDOM_GRAPH)
+        expect(proxiedNode.stack.getStreamrNode().getStream(regularStreamId3)!.type).toBe(StreamNodeType.RANDOM_GRAPH)
+        expect(proxiedNode.stack.getStreamrNode().getStream(regularStreamId4)!.type).toBe(StreamNodeType.RANDOM_GRAPH)
     })
 
 })


### PR DESCRIPTION
## Summary

Added a test case for nodes joining as regular nodes on multiple streams after setting proxies for another stream.

Added support for setting predicates in waitForEvent3