### PR TITLE
fix(client): Error handling of `fetchHttpStream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ found [here](packages/broker/CHANGELOG.md).
 #### Fixed
 
 - Fix error handling in message pipeline (https://github.com/streamr-dev/network/pull/1479)
+- Fix resend freeze issue (https://github.com/streamr-dev/network/pull/1554)
 
 #### Security
 

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -91,9 +91,7 @@ const getHttpErrorTransform = (): (error: any) => Promise<StreamrClientError> =>
         } else {
             message = err?.message ?? 'Unknown error'
         }
-        return new StreamrClientError(
-            message, 'STORAGE_NODE_ERROR'
-        )
+        return new StreamrClientError(message, 'STORAGE_NODE_ERROR')
     }
 }
 

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -2,16 +2,15 @@ import { StreamID, StreamMessage, StreamPartID, StreamPartIDUtils } from '@strea
 import { EthereumAddress, Logger, randomString, toEthereumAddress } from '@streamr/utils'
 import random from 'lodash/random'
 import without from 'lodash/without'
-import { Response } from 'node-fetch'
 import { Lifecycle, delay, inject, scoped } from 'tsyringe'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import { StreamrClientError } from '../StreamrClientError'
 import { StorageNodeRegistry } from '../registry/StorageNodeRegistry'
 import { StreamStorageRegistry } from '../registry/StreamStorageRegistry'
-import { forEach, map } from '../utils/GeneratorUtils'
+import { forEach, map, transformError } from '../utils/GeneratorUtils'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { PushPipeline } from '../utils/PushPipeline'
-import { createQueryString, fetchHttpStream } from '../utils/utils'
+import { FetchHttpStreamResponseError, createQueryString, fetchHttpStream } from '../utils/utils'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
 
 type QueryDict = Record<string, string | number | boolean | null | undefined>
@@ -75,19 +74,26 @@ const createUrl = (baseUrl: string, endpointSuffix: string, streamPartId: Stream
     return `${baseUrl}/streams/${encodeURIComponent(streamId)}/data/partitions/${streamPartition}/${endpointSuffix}?${queryString}`
 }
 
-const parseHttpError = async (response: Response): Promise<Error> => {
-    const body = await response.text()
-    let descriptionSnippet
-    try {
-        const json = JSON.parse(body)
-        descriptionSnippet = `: ${json.error}`
-    } catch (err) {
-        descriptionSnippet = ''
+const getHttpErrorTransform = (): (error: any) => Promise<StreamrClientError> => {
+    return async (err: any) => {
+        let message
+        if (err instanceof FetchHttpStreamResponseError) {
+            const body = await err.response.text()
+            let descriptionSnippet
+            try {
+                const json = JSON.parse(body)
+                descriptionSnippet = `: ${json.error}`
+            } catch (err) {
+                descriptionSnippet = ''
+            }
+            message = `Storage node fetch failed${descriptionSnippet}, httpStatus=${err.response.status}, url=${err.response.url}`
+        } else {
+            message = err?.message ?? 'Unknown error'
+        }
+        return new StreamrClientError(
+            message, 'STORAGE_NODE_ERROR'
+        )
     }
-    throw new StreamrClientError(
-        `Storage node fetch failed${descriptionSnippet}, httpStatus=${response.status}, url=${response.url}`,
-        'STORAGE_NODE_ERROR'
-    )
 }
 
 @scoped(Lifecycle.ContainerScoped)
@@ -186,7 +192,7 @@ export class Resends {
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),
             config: (nodeAddresses.length === 1) ? { ...this.config, orderMessages: false } : this.config
         })
-        const lines = fetchHttpStream(url, parseHttpError)
+        const lines = transformError(fetchHttpStream(url), getHttpErrorTransform())
         setImmediate(async () => {
             let count = 0
             const messages = map(lines, (line: string) => StreamMessage.deserialize(line))

--- a/packages/client/src/utils/GeneratorUtils.ts
+++ b/packages/client/src/utils/GeneratorUtils.ts
@@ -126,3 +126,13 @@ export const fromArray = async function* <T>(items: T[]): AsyncGenerator<T> {
         yield item
     }
 }
+
+export const transformError = async function* <T>(src: AsyncGenerator<T>, transformFn: (err: any) => any): AsyncGenerator<T> {
+    try {
+        for await (const item of src) {
+            yield item
+        }
+    } catch (err: any) {
+        throw await transformFn(err)
+    }
+}

--- a/packages/client/src/utils/GeneratorUtils.ts
+++ b/packages/client/src/utils/GeneratorUtils.ts
@@ -126,15 +126,3 @@ export const fromArray = async function* <T>(items: T[]): AsyncGenerator<T> {
         yield item
     }
 }
-
-export const counting = async function*<T>(items: AsyncIterable<T>, onFinally: (count: number) => void): AsyncGenerator<T> {
-    let count = 0
-    try {
-        for await (const item of items) {
-            yield item
-            count++
-        }
-    } finally {
-        onFinally(count)
-    }
-}

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -148,9 +148,18 @@ export const createQueryString = (query: Record<string, any>): string => {
     return new URLSearchParams(withoutEmpty).toString()
 }
 
+export class FetchHttpStreamResponseError extends Error {
+
+    response: Response
+
+    constructor(response: Response) {
+        super(`Fetch error, url=${response.url}`)
+        this.response = response
+    }
+}
+
 export const fetchHttpStream = async function*(
     url: string,
-    parseError: (response: Response) => Promise<Error>,
     abortController = new AbortController()
 ): AsyncGenerator<string, void, undefined> {
     logger.debug('Send HTTP request', { url })
@@ -163,7 +172,7 @@ export const fetchHttpStream = async function*(
         status: response.status,
     })
     if (!response.ok) {
-        throw await parseError(response)
+        throw new FetchHttpStreamResponseError(response)
     }
     if (!response.body) {
         throw new Error('No Response Body')

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -173,13 +173,11 @@ export const fetchHttpStream = async function*(
     try {
         // in the browser, response.body will be a web stream. Convert this into a node stream.
         const source: Readable = WebStreamToNodeStream(response.body as unknown as (ReadableStream | Readable))
-
         stream = source.pipe(split2())
-
+        source.on('error', (err: Error) => stream?.destroy(err))
         stream.once('close', () => {
             abortController.abort()
         })
-
         yield* stream
     } catch (err) {
         abortController.abort()

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -174,7 +174,7 @@ export const fetchHttpStream = async function*(
         // in the browser, response.body will be a web stream. Convert this into a node stream.
         const source: Readable = WebStreamToNodeStream(response.body as unknown as (ReadableStream | Readable))
         stream = source.pipe(split2())
-        source.on('error', (err: Error) => stream?.destroy(err))
+        source.on('error', (err: Error) => stream!.destroy(err))
         stream.once('close', () => {
             abortController.abort()
         })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -1,31 +1,34 @@
-import crypto from 'crypto'
-import { DependencyContainer } from 'tsyringe'
-import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { EthereumAddress, Logger, wait } from '@streamr/utils'
+import 'reflect-metadata'
+
 import { Wallet } from '@ethersproject/wallet'
-import { StreamMessage, StreamPartID, StreamPartIDUtils, MAX_PARTITION_COUNT } from '@streamr/protocol'
-import { StreamrClient } from '../../src/StreamrClient'
-import { counterId } from '../../src/utils/utils'
-import { Stream, StreamMetadata } from '../../src/Stream'
-import { CONFIG_TEST } from '../../src/ConfigTest'
-import { StreamrClientConfig } from '../../src/Config'
-import { GroupKey } from '../../src/encryption/GroupKey'
-import { addAfterFn } from './jest-utils'
-import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
-import { StreamrClientEventEmitter } from '../../src/events'
-import { MessageFactory } from '../../src/publish/MessageFactory'
-import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
-import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
-import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
-import { LoggerFactory } from '../../src/utils/LoggerFactory'
-import { waitForCondition } from '@streamr/utils'
-import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
+import { MAX_PARTITION_COUNT, StreamMessage, StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
+import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import { EthereumAddress, Logger, merge, wait, waitForCondition } from '@streamr/utils'
+import crypto from 'crypto'
+import { once } from 'events'
+import express, { Request, Response } from 'express'
 import { mock } from 'jest-mock-extended'
-import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
-import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { AddressInfo } from 'net'
+import { DependencyContainer } from 'tsyringe'
+import { Authentication, createPrivateKeyAuthentication } from '../../src/Authentication'
+import { StreamrClientConfig } from '../../src/Config'
+import { CONFIG_TEST } from '../../src/ConfigTest'
 import { DestroySignal } from '../../src/DestroySignal'
 import { PersistenceManager } from '../../src/PersistenceManager'
-import { merge } from '@streamr/utils'
+import { Stream, StreamMetadata } from '../../src/Stream'
+import { StreamrClient } from '../../src/StreamrClient'
+import { GroupKey } from '../../src/encryption/GroupKey'
+import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
+import { LitProtocolFacade } from '../../src/encryption/LitProtocolFacade'
+import { LocalGroupKeyStore } from '../../src/encryption/LocalGroupKeyStore'
+import { SubscriberKeyExchange } from '../../src/encryption/SubscriberKeyExchange'
+import { StreamrClientEventEmitter } from '../../src/events'
+import { GroupKeyQueue } from '../../src/publish/GroupKeyQueue'
+import { MessageFactory } from '../../src/publish/MessageFactory'
+import { StreamRegistryCached } from '../../src/registry/StreamRegistryCached'
+import { LoggerFactory } from '../../src/utils/LoggerFactory'
+import { counterId } from '../../src/utils/utils'
+import { addAfterFn } from './jest-utils'
 
 const logger = new Logger(module)
 
@@ -222,4 +225,24 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
     await waitForCondition(() => mockFunction.mock.calls.length >= n, 1000, 10, undefined, () => {
         return `Timeout while waiting for calls: got ${mockFunction.mock.calls.length} out of ${n}`
     })
+}
+
+export const startTestServer = async (
+    endpoint: string,
+    onRequest: (req: Request, res: Response) => Promise<void>
+): Promise<{ url: string, stop: () => Promise<void> }> => {
+    const app = express()
+    app.get(endpoint, async (req, res) => {
+        await onRequest(req, res)
+    })
+    const server = app.listen()
+    await once(server, 'listening')
+    const port = (server.address() as AddressInfo).port
+    return {
+        url: `http://localhost:${port}`,
+        stop: async () => {
+            server.close()
+            await once(server, 'close')
+        }
+    }
 }

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -23,7 +23,7 @@ const createResends = (serverUrl: string) => {
 
 describe('Resends', () => {
 
-    it('error handling', async () => {
+    it('error response', async () => {
         const server = await startTestServer('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
             res.status(400).json({
                 error: 'Mock error'
@@ -39,6 +39,18 @@ describe('Resends', () => {
             code: 'STORAGE_NODE_ERROR'
         })
         await server.stop()
+    })
+
+    it('invalid server url', async () => {
+        const resends = createResends('http://mock.test')
+        await expect(async () => {
+            const messages = await resends.resend(StreamPartIDUtils.parse('stream#0'), { last: 1, raw: true })
+            await collect(messages)
+        }).rejects.toThrowStreamrError({
+            // eslint-disable-next-line max-len
+            message: `request to http://mock.test/streams/stream/data/partitions/0/last?count=1&format=raw failed, reason: getaddrinfo ENOTFOUND mock.test`,
+            code: 'STORAGE_NODE_ERROR'
+        })
     })
 
     it('large response', async () => {

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -3,37 +3,29 @@ import 'reflect-metadata'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
-import { once } from 'events'
-import express from 'express'
-import { AddressInfo } from 'net'
 import { Resends } from '../../src/subscribe/Resends'
-import { mockLoggerFactory } from '../test-utils/utils'
+import { mockLoggerFactory, startTestServer } from '../test-utils/utils'
 
 describe('Resends', () => {
 
     it('error handling', async () => {
-        const app = express()
-        app.get('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
+        const server = await startTestServer('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
             res.status(400).json({
                 error: 'Mock error'
             })
         })
-        const server = app.listen()
-        await once(server, 'listening')
-        const port = (server.address() as AddressInfo).port
-        const serverUrl = `http://localhost:${port}`
         const resends = new Resends(
             {
                 getStorageNodes: async () => [randomEthereumAddress()]
             } as any,
             {
-                getStorageNodeMetadata: async () => ({ http: serverUrl })
+                getStorageNodeMetadata: async () => ({ http: server.url })
             } as any,
             undefined as any,
             undefined as any,
             mockLoggerFactory()
         )
-        const requestUrl = `${serverUrl}/streams/stream/data/partitions/0/last?count=1&format=raw`
+        const requestUrl = `${server.url}/streams/stream/data/partitions/0/last?count=1&format=raw`
         await expect(async () => {
             const messages = await resends.resend(StreamPartIDUtils.parse('stream#0'), { last: 1, raw: true })
             await collect(messages)
@@ -41,6 +33,6 @@ describe('Resends', () => {
             message: `Storage node fetch failed: Mock error, httpStatus=400, url=${requestUrl}`,
             code: 'STORAGE_NODE_ERROR'
         })
-        server.close()
+        await server.stop()
     })
 })

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -1,10 +1,25 @@
 import 'reflect-metadata'
 
-import { StreamPartIDUtils } from '@streamr/protocol'
+import { MessageID, StreamMessage, StreamPartIDUtils, toStreamID } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
+import range from 'lodash/range'
 import { Resends } from '../../src/subscribe/Resends'
 import { mockLoggerFactory, startTestServer } from '../test-utils/utils'
+
+const createResends = (serverUrl: string) => {
+    return new Resends(
+        {
+            getStorageNodes: async () => [randomEthereumAddress()]
+        } as any,
+        {
+            getStorageNodeMetadata: async () => ({ http: serverUrl })
+        } as any,
+        undefined as any,
+        undefined as any,
+        mockLoggerFactory()
+    )
+}
 
 describe('Resends', () => {
 
@@ -14,17 +29,7 @@ describe('Resends', () => {
                 error: 'Mock error'
             })
         })
-        const resends = new Resends(
-            {
-                getStorageNodes: async () => [randomEthereumAddress()]
-            } as any,
-            {
-                getStorageNodeMetadata: async () => ({ http: server.url })
-            } as any,
-            undefined as any,
-            undefined as any,
-            mockLoggerFactory()
-        )
+        const resends = createResends(server.url)
         const requestUrl = `${server.url}/streams/stream/data/partitions/0/last?count=1&format=raw`
         await expect(async () => {
             const messages = await resends.resend(StreamPartIDUtils.parse('stream#0'), { last: 1, raw: true })
@@ -33,6 +38,29 @@ describe('Resends', () => {
             message: `Storage node fetch failed: Mock error, httpStatus=400, url=${requestUrl}`,
             code: 'STORAGE_NODE_ERROR'
         })
+        await server.stop()
+    })
+
+    it('large response', async () => {
+        // larger than PuhsBuffer DEFAULT_BUFFER_SIZE
+        const MESSAGE_COUNT = 257
+        const streamPartId = StreamPartIDUtils.parse('stream#0')
+        const server = await startTestServer('/streams/:streamId/data/partitions/:partition/:resendType', async (_req, res) => {
+            const publisherId = randomEthereumAddress()
+            for (const _ of range(MESSAGE_COUNT)) {
+                const msg = new StreamMessage({
+                    messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisherId, ''),
+                    content: {},
+                    signature: 'signature'
+                })
+                res.write(`${msg.serialize()}\n`)
+            }
+            res.end()
+        })
+        const resends = createResends(server.url)
+        const response = await resends.resend(streamPartId, { last: MESSAGE_COUNT, raw: true })
+        const messages = await collect(response)
+        expect(messages.length).toBe(MESSAGE_COUNT)
         await server.stop()
     })
 })

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -1,10 +1,8 @@
-import { StreamPartIDUtils } from '@streamr/protocol'
-import { fastWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Request, Response } from 'express'
 import range from 'lodash/range'
 import { createQueryString, fetchHttpStream, getEndpointUrl } from '../../src/utils/utils'
-import { createMockMessage, startTestServer } from '../test-utils/utils'
+import { startTestServer } from '../test-utils/utils'
 
 describe('utils', () => {
 
@@ -28,23 +26,15 @@ describe('utils', () => {
     })
 
     it('fetchHttpStream', async () => {
-        const MESSAGE_COUNT = 5
+        const LINE_COUNT = 5
         const server = await startTestServer('/', async (_req: Request, res: Response) => {
-            const publisher = fastWallet()
-            for (const i of range(MESSAGE_COUNT)) {
-                const msg = await createMockMessage({
-                    streamPartId: StreamPartIDUtils.parse('stream#0'),
-                    publisher,
-                    content: { 
-                        mockId: i
-                    }
-                })
-                res.write(`${msg.serialize()}\n`)
+            for (const i of range(LINE_COUNT)) {
+                res.write(`${i}\n`)
             }
             res.end()
         })
-        const msgs = await collect(fetchHttpStream(server.url, () => undefined as any))
-        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual(range(MESSAGE_COUNT))
+        const lines = await collect(fetchHttpStream(server.url, () => undefined as any))
+        expect(lines.map((line) => parseInt(line))).toEqual(range(LINE_COUNT))
         await server.stop()
     })
 })

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -1,11 +1,10 @@
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
-import { once } from 'events'
-import express from 'express'
+import { Request, Response } from 'express'
 import range from 'lodash/range'
 import { createQueryString, fetchHttpStream, getEndpointUrl } from '../../src/utils/utils'
-import { createMockMessage } from '../test-utils/utils'
+import { createMockMessage, startTestServer } from '../test-utils/utils'
 
 describe('utils', () => {
 
@@ -30,15 +29,13 @@ describe('utils', () => {
 
     it('fetchHttpStream', async () => {
         const MESSAGE_COUNT = 5
-        const MOCK_SERVER_PORT = 12345
-        const app = express()
-        app.get('/endpoint', async (_req, res) => {
+        const server = await startTestServer('/', async (_req: Request, res: Response) => {
             const publisher = fastWallet()
             for (const i of range(MESSAGE_COUNT)) {
                 const msg = await createMockMessage({
                     streamPartId: StreamPartIDUtils.parse('stream#0'),
                     publisher,
-                    content: {
+                    content: { 
                         mockId: i
                     }
                 })
@@ -46,10 +43,8 @@ describe('utils', () => {
             }
             res.end()
         })
-        const server = app.listen(MOCK_SERVER_PORT)
-        await once(server, 'listening')
-        const msgs = await collect(fetchHttpStream(`http://localhost:${MOCK_SERVER_PORT}/endpoint`, () => undefined as any))
-        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual([0, 1, 2, 3, 4])
-        server.close()
+        const msgs = await collect(fetchHttpStream(server.url, () => undefined as any))
+        expect(msgs.map((m) => (m.getParsedContent() as any).mockId)).toEqual(range(MESSAGE_COUNT))
+        await server.stop()
     })
 })

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -1,8 +1,9 @@
-import { collect } from '@streamr/utils'
+import { collect, waitForCondition } from '@streamr/utils'
 import { Request, Response } from 'express'
 import range from 'lodash/range'
 import { createQueryString, fetchHttpStream, getEndpointUrl } from '../../src/utils/utils'
 import { startTestServer } from '../test-utils/utils'
+import { nextValue } from './../../src/utils/iterators'
 
 describe('utils', () => {
 
@@ -25,16 +26,37 @@ describe('utils', () => {
         expect(actual).toBe('a=foo&d=123&e=x%2Cy')
     })
 
-    it('fetchHttpStream', async () => {
-        const LINE_COUNT = 5
-        const server = await startTestServer('/', async (_req: Request, res: Response) => {
-            for (const i of range(LINE_COUNT)) {
-                res.write(`${i}\n`)
-            }
-            res.end()
+    describe('fetchHttpStream', () => {
+
+        it('happy path', async () => {
+            const LINE_COUNT = 5
+            const server = await startTestServer('/', async (_req: Request, res: Response) => {
+                for (const i of range(LINE_COUNT)) {
+                    res.write(`${i}\n`)
+                }
+                res.end()
+            })
+            const lines = await collect(fetchHttpStream(server.url, () => undefined as any))
+            expect(lines.map((line) => parseInt(line))).toEqual(range(LINE_COUNT))
+            await server.stop()
         })
-        const lines = await collect(fetchHttpStream(server.url, () => undefined as any))
-        expect(lines.map((line) => parseInt(line))).toEqual(range(LINE_COUNT))
-        await server.stop()
+
+        it('abort', async () => {
+            let serverResponseClosed = false
+            const server = await startTestServer('/', async (_req: Request, res: Response) => {
+                res.on('close', () => {
+                    serverResponseClosed = true
+                })
+                res.write(`foobar\n`)
+            })
+            const abortController = new AbortController()
+            const iterator = fetchHttpStream(server.url, () => undefined as any, abortController)[Symbol.asyncIterator]()
+            const line = await nextValue(iterator)
+            expect(line).toBe('foobar')
+            abortController.abort()
+            await waitForCondition(() => serverResponseClosed === true)
+            await expect(() => nextValue(iterator)).rejects.toThrow(/aborted/)
+            await server.stop()
+        })
     })
 })

--- a/packages/client/test/unit/utils.test.ts
+++ b/packages/client/test/unit/utils.test.ts
@@ -62,9 +62,9 @@ describe('utils', () => {
 
         it('error code from response', async () => {
             const server = await startTestServer('/foo', async () => {})
-            const parseError = async (response: FetchResponse) => new Error(`foo=${response.status}`)
+            const parseError = async (response: FetchResponse) => new Error(`status=${response.status}`)
             const iterator = fetchHttpStream(`${server.url}/bar`, parseError)[Symbol.asyncIterator]()
-            await expect(() => nextValue(iterator)).rejects.toThrow('foo=404')
+            await expect(() => nextValue(iterator)).rejects.toThrow('status=404')
             await server.stop()
         })
 


### PR DESCRIPTION
If the HTTP `fetch` stream fails, it now propagates the error to the piped stream (the stream which transforms chunks of texts to lines). The underlying stream throws an error e.g. if we call `AbortController#abort()`. 

Before this PR the error in the underlying stream would just stop the output of that stream, but the transform stream didn't stop as it was not notified by the error. The `AsyncGenerator` never completed in that case.

Also replaced `parseError` functionality: the `fetchHttpStream` now throws an explicit `FetchHttpStreamResponseError` if the response is not ok (i.e. HTTP 200) instead of calling `parseError` to form the error.