### PR TITLE
Only call the layer0 dht join once when joining as a regular node on streams after setting proxies

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -164,7 +164,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     public connectionManager?: ConnectionManager
     private started = false
     private stopped = false
-    private joined = false
     private entryPointDisconnectTimeout?: NodeJS.Timeout
 
     public contactAddCounter = 0
@@ -618,7 +617,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
-        this.joined = true
         await this.peerDiscovery!.joinDht(entryPointDescriptor, doRandomJoin)
     }
 
@@ -701,7 +699,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public hasJoined(): boolean {
-        return this.joined
+        return this.peerDiscovery!.isJoinCalled()
     }
 
     public getKnownEntryPoints(): PeerDescriptor[] {
@@ -716,7 +714,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Err.CouldNotStop('Cannot not stop() before start()')
         }
-        this.joined = false
         this.stopped = true
 
         if (this.entryPointDisconnectTimeout) {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -144,6 +144,10 @@ export class PeerDiscovery {
         return !this.joinCalled ? true : this.ongoingDiscoverySessions.size > 0
     }
 
+    public isJoinCalled(): boolean {
+        return this.joinCalled
+    }
+
     public stop(): void {
         this.stopped = true
         this.abortController.abort()


### PR DESCRIPTION
## Summary

Fixed a bug where the layer0 joinDht() would be called multiple times after a node had set proxies on one stream and then joined as a regular node on other streams simultaneously.