### PR TITLE
trackerless-network: no longer delete autogenerated proto files in npm run clean

### DIFF
--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -16,7 +16,7 @@
     "build-browser": "webpack --mode=development --progress",
     "generate-protoc-code": "./proto.sh",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache src/proto || true",
+    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",


### PR DESCRIPTION
## Summary

Auto-generated files are no longer deleted after running `npm run clean` in the trackerless network package