### PR TITLE
ci: Add the trackerless network to the labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,9 @@ broker:
 browser-test-runner:
   - 'package/browser-test-runner/*'
   - 'package/browser-test-runner/**/*'
+trackerless-network:
+  - 'packages/trackerless-network/*'
+  - 'packages/trackerless-network/**/*'
 dht:
   - 'packages/dht/*'
   - 'packages/dht/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ broker:
 browser-test-runner:
   - 'package/browser-test-runner/*'
   - 'package/browser-test-runner/**/*'
-trackerless-network:
+network:
   - 'packages/trackerless-network/*'
   - 'packages/trackerless-network/**/*'
 dht:


### PR DESCRIPTION
## Summary

Add the trackerless-network package to the CI labeler.
