### PR TITLE
feat(client): Informative error messages for contract call errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ found [here](packages/broker/CHANGELOG.md).
 
 #### Changed
 
+- Improve error messages for contract call errors (https://github.com/streamr-dev/network/pull/1558)
+
 #### Deprecated
 
 #### Removed

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -93,7 +93,7 @@ const createWrappedContractMethod = (
             const tx = returnValue
             const originalWaitMethod = tx.wait
             tx.wait = async (confirmations?: number): Promise<ContractReceipt> => {
-                const receipt = await withErrorHandling(() => originalWaitMethod(confirmations), `${methodName}.wait`, 'waiting transaction for')
+                const receipt = await withErrorHandling(() => originalWaitMethod(confirmations), methodName, 'waiting transaction for')
                 eventEmitter.emit('onTransactionConfirm', methodName, tx, receipt)
                 return receipt
             }

--- a/packages/client/src/utils/contract.ts
+++ b/packages/client/src/utils/contract.ts
@@ -65,8 +65,13 @@ const withErrorHandling = async <T>(
     try {
         return await execute()
     } catch (e: any) {
-        const suffixes = without(['reason', 'code'].map(field => (e[field] !== undefined ? `${field}=${e[field]}` : undefined)), undefined)
-        const wrappedError = new Error(`Error while ${action} contract call "${methodName}"${(suffixes.length > 0) ? ', ' + suffixes.join(', ') : ''}`)
+        const suffixes = without(
+            ['reason', 'code'].map((field) => (e[field] !== undefined ? `${field}=${e[field]}` : undefined)),
+            undefined
+        )
+        const wrappedError = new Error(
+            `Error while ${action} contract call "${methodName}"${(suffixes.length > 0) ? ', ' + suffixes.join(', ') : ''}`
+        )
         // @ts-expect-error unknown property
         wrappedError.reason = e
         throw wrappedError

--- a/packages/client/test/end-to-end/contract-call-error.test.ts
+++ b/packages/client/test/end-to-end/contract-call-error.test.ts
@@ -1,0 +1,36 @@
+import { CONFIG_TEST } from '../../src/ConfigTest'
+import { StreamrClient } from '../../src/StreamrClient'
+import { fastWallet } from '@streamr/test-utils'
+
+describe('contract call error', () => {
+    
+    it('insufficient funds', async () => {
+        const client = new StreamrClient({
+            ...CONFIG_TEST,
+            auth: {
+                privateKey: fastWallet().privateKey
+            }
+        })
+        await expect(() => client.createStream('/path')).rejects.toThrow(
+            'Error in contract call "streamRegistry.createStream", reason=insufficient funds for intrinsic transaction cost, code=INSUFFICIENT_FUNDS'
+        )
+    })
+
+    it('invalid chain RPC url', async () => {
+        const client = new StreamrClient({
+            ...CONFIG_TEST,
+            contracts: {
+                streamRegistryChainRPCs: {
+                    name: 'streamr',
+                    chainId: 8997,
+                    rpcs: [{
+                        url: 'http://mock.test'
+                    }]
+                }
+            }
+        })
+        await expect(() => client.createStream('/path')).rejects.toThrow(
+            'Error in contract call \"streamRegistry.createStream\", reason=could not detect network, code=NETWORK_ERROR'
+        )
+    })
+})

--- a/packages/client/test/end-to-end/contract-call-error.test.ts
+++ b/packages/client/test/end-to-end/contract-call-error.test.ts
@@ -12,7 +12,7 @@ describe('contract call error', () => {
             }
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
-            'Error in contract call "streamRegistry.createStream", reason=insufficient funds for intrinsic transaction cost, code=INSUFFICIENT_FUNDS'
+            'Error while executing contract call "streamRegistry.createStream", reason=insufficient funds for intrinsic transaction cost, code=INSUFFICIENT_FUNDS'
         )
     })
 
@@ -30,7 +30,7 @@ describe('contract call error', () => {
             }
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
-            'Error in contract call \"streamRegistry.createStream\", reason=could not detect network, code=NETWORK_ERROR'
+            'Error while executing contract call \"streamRegistry.createStream\", reason=could not detect network, code=NETWORK_ERROR'
         )
     })
 })

--- a/packages/client/test/end-to-end/contract-call-error.test.ts
+++ b/packages/client/test/end-to-end/contract-call-error.test.ts
@@ -1,5 +1,4 @@
 import { fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import range from 'lodash/range'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { StreamrClient } from '../../src/StreamrClient'
 
@@ -49,21 +48,5 @@ describe('contract call error', () => {
             client.createStream('/path2' + Date.now())
             // eslint-disable-next-line max-len
         ])).rejects.toThrow('Error while executing contract call "streamRegistry.createStream", reason=replacement fee too low, code=REPLACEMENT_UNDERPRICED')
-    })
-
-    it('concurrent transactions with different clients', async () => {
-        const privateKey = await fetchPrivateKeyWithGas()
-        await expect(() => Promise.all(range(2).map((i) => {
-            const client = new StreamrClient({
-                ...CONFIG_TEST,
-                auth: {
-                    privateKey
-                }
-            })
-            return client.createStream(`/path${i}`)
-        }))).rejects.toThrow(
-            // eslint-disable-next-line max-len
-            'Error while executing contract call "streamRegistry.createStream", reason=cannot estimate gas; transaction may fail or may require manual gas limit, code=UNPREDICTABLE_GAS_LIMIT'
-        )
     })
 })

--- a/packages/client/test/end-to-end/contract-call-error.test.ts
+++ b/packages/client/test/end-to-end/contract-call-error.test.ts
@@ -1,6 +1,7 @@
+import { fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
+import range from 'lodash/range'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { StreamrClient } from '../../src/StreamrClient'
-import { fastWallet } from '@streamr/test-utils'
 
 describe('contract call error', () => {
     
@@ -32,6 +33,37 @@ describe('contract call error', () => {
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
             'Error while executing contract call "streamRegistry.createStream", reason=could not detect network, code=NETWORK_ERROR'
+        )
+    })
+
+    it('concurrent transactions', async () => {
+        const privateKey = await fetchPrivateKeyWithGas()
+        const client = new StreamrClient({
+            ...CONFIG_TEST,
+            auth: {
+                privateKey
+            }
+        })
+        await expect(() => Promise.all([
+            client.createStream('/path1' + Date.now()),
+            client.createStream('/path2' + Date.now())
+            // eslint-disable-next-line max-len
+        ])).rejects.toThrow('Error while executing contract call "streamRegistry.createStream", reason=replacement fee too low, code=REPLACEMENT_UNDERPRICED')
+    })
+
+    it('concurrent transactions with different clients', async () => {
+        const privateKey = await fetchPrivateKeyWithGas()
+        await expect(() => Promise.all(range(2).map((i) => {
+            const client = new StreamrClient({
+                ...CONFIG_TEST,
+                auth: {
+                    privateKey
+                }
+            })
+            return client.createStream(`/path${i}`)
+        }))).rejects.toThrow(
+            // eslint-disable-next-line max-len
+            'Error while executing contract call "streamRegistry.createStream", reason=cannot estimate gas; transaction may fail or may require manual gas limit, code=UNPREDICTABLE_GAS_LIMIT'
         )
     })
 })

--- a/packages/client/test/end-to-end/contract-call-error.test.ts
+++ b/packages/client/test/end-to-end/contract-call-error.test.ts
@@ -12,6 +12,7 @@ describe('contract call error', () => {
             }
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
+            // eslint-disable-next-line max-len
             'Error while executing contract call "streamRegistry.createStream", reason=insufficient funds for intrinsic transaction cost, code=INSUFFICIENT_FUNDS'
         )
     })
@@ -30,7 +31,7 @@ describe('contract call error', () => {
             }
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
-            'Error while executing contract call \"streamRegistry.createStream\", reason=could not detect network, code=NETWORK_ERROR'
+            'Error while executing contract call "streamRegistry.createStream", reason=could not detect network, code=NETWORK_ERROR'
         )
     })
 })


### PR DESCRIPTION
If there is a contract call error, the reason and error code are included to the `Error` throw from the client. The message also includes information about the context: whether the error occurred while executing the contract call, or while waiting the transaction.

Example errors:
```
Error while executing contract call "streamRegistry.createStream", reason=insufficient funds for intrinsic transaction cost, code=INSUFFICIENT_FUNDS
Error while executing contract call "streamRegistry.createStream", reason=user rejected transaction, code=ACTION_REJECTED
Error while waiting transaction for contract call "streamRegistry.createStream", reason=could not detect network, code=NETWORK_ERROR
```