### PR TITLE
NET-975: stored data can be marked as  deleted in the dht

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -23,6 +23,7 @@ service RoutingService {
 service StoreService {
   rpc storeData (StoreDataRequest) returns (StoreDataResponse);
   rpc migrateData (MigrateDataRequest) returns (MigrateDataResponse);
+  rpc deleteData (DeleteDataRequest) returns (DeleteDataResponse);
 }
 
 service RecursiveFindSessionService {
@@ -56,6 +57,7 @@ message StoreDataRequest {
   bytes kademliaId = 1;
   google.protobuf.Any data = 2;
   uint32 ttl = 3;
+  google.protobuf.Timestamp storerTime = 4;
 }
 
 message StoreDataResponse {
@@ -70,6 +72,14 @@ message MigrateDataResponse {
   string error = 1;
 }
 
+message DeleteDataRequest {
+  bytes kademliaId = 1;
+}
+
+message DeleteDataResponse {
+  bool deleted = 1;
+}
+
 message DataEntry {
   PeerDescriptor storer = 1;
   bytes kademliaId = 2;
@@ -77,6 +87,8 @@ message DataEntry {
   google.protobuf.Timestamp storedAt = 4; 
   uint32 ttl = 5;   // milliseconds
   bool stale = 6;
+  bool deleted = 7;
+  google.protobuf.Timestamp storerTime = 8;
 }
 
 message ClosestPeersRequest {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -632,6 +632,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.recursiveFinder!.startRecursiveFind(idToFind, FindMode.DATA)
     }
 
+    public async deleteDataFromDht(idToDelete: Uint8Array): Promise<void> {
+        return this.dataStore!.deleteDataFromDht(idToDelete)
+    }
+
     public async findDataViaPeer(idToFind: Uint8Array, peer: PeerDescriptor): Promise<DataEntry[]> {
         const target = new RemoteExternalApi(
             this.ownPeerDescriptor!,

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -129,7 +129,8 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         dataEntries.forEach((entry) => {
             const storerKey = keyFromPeerDescriptor(entry.storer!)
             const existingEntry = this.foundData.get(storerKey)
-            if (!existingEntry || existingEntry.storedAt! < entry.storedAt!) {
+            if (!existingEntry || existingEntry.storerTime! < entry.storerTime! 
+                || (existingEntry.storerTime! <= entry.storerTime! && entry.deleted)) {
                 this.foundData.set(storerKey, entry)
             }
         })

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -35,9 +35,9 @@ export class LocalDataStore {
         }
 
         if (this.store.get(dataKey)!.has(publisherKey)) {
-            const storedMillis = (dataEntry.storedAt!.seconds * 1000) + (dataEntry.storedAt!.nanos / 1000000)
+            const storedMillis = (dataEntry.storerTime!.seconds * 1000) + (dataEntry.storerTime!.nanos / 1000000)
             const oldLocalEntry = this.store.get(dataKey)!.get(publisherKey)!
-            const oldStoredMillis = (oldLocalEntry.dataEntry.storedAt!.seconds * 1000) + (oldLocalEntry.dataEntry.storedAt!.nanos / 1000000)
+            const oldStoredMillis = (oldLocalEntry.dataEntry.storerTime!.seconds * 1000) + (oldLocalEntry.dataEntry.storerTime!.nanos / 1000000)
         
             // do nothing if old entry is newer than the one being migrated
             if (oldStoredMillis >= storedMillis) {
@@ -52,6 +52,16 @@ export class LocalDataStore {
                 this.deleteEntry(PeerID.fromValue(dataEntry.kademliaId), dataEntry.storer!)
             }, createTtlValue(dataEntry.ttl))
         })
+        return true
+    }
+
+    public markAsDeleted(id: Uint8Array, storer: PeerID): boolean {
+        const dataKey = PeerID.fromValue(id).toKey()
+        if (!this.store.get(dataKey)?.has(storer.toKey())) {
+            return false
+        }
+        const storedEntry = this.store.get(dataKey)!.get(storer.toKey())
+        storedEntry!.dataEntry.deleted = true
         return true
     }
 

--- a/packages/dht/src/dht/store/RemoteStore.ts
+++ b/packages/dht/src/dht/store/RemoteStore.ts
@@ -1,6 +1,13 @@
 import { Remote } from '../contact/Remote'
 import { IStoreServiceClient } from '../../proto/packages/dht/protos/DhtRpc.client'
-import { MigrateDataRequest, MigrateDataResponse, StoreDataRequest, StoreDataResponse } from '../../proto/packages/dht/protos/DhtRpc'
+import { 
+    DeleteDataRequest,
+    DeleteDataResponse,
+    MigrateDataRequest,
+    MigrateDataResponse,
+    StoreDataRequest,
+    StoreDataResponse
+} from '../../proto/packages/dht/protos/DhtRpc'
 import { DhtRpcOptions } from '../../rpc-protocol/DhtRpcOptions'
 import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 
@@ -17,6 +24,21 @@ export class RemoteStore extends Remote<IStoreServiceClient> {
         } catch (err) {
             throw Error(
                 `Could not store data to ${keyFromPeerDescriptor(this.peerDescriptor)} from ${keyFromPeerDescriptor(this.ownPeerDescriptor)} ${err}`
+            )
+        }
+    }
+
+    async deleteData(request: DeleteDataRequest): Promise<DeleteDataResponse> {
+        const options: DhtRpcOptions = {
+            sourceDescriptor: this.ownPeerDescriptor,
+            targetDescriptor: this.peerDescriptor,
+            timeout: 10000
+        }
+        try {
+            return await this.client.deleteData(request, options)
+        } catch (err) {
+            throw Error(
+                `Could not call delete data to ${keyFromPeerDescriptor(this.peerDescriptor)} ${err}`
             )
         }
     }

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -21,6 +21,8 @@ import type { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindSessionService } from "./DhtRpc";
 import type { RecursiveFindReport } from "./DhtRpc";
 import { StoreService } from "./DhtRpc";
+import type { DeleteDataResponse } from "./DhtRpc";
+import type { DeleteDataRequest } from "./DhtRpc";
 import type { MigrateDataResponse } from "./DhtRpc";
 import type { MigrateDataRequest } from "./DhtRpc";
 import type { StoreDataResponse } from "./DhtRpc";
@@ -148,6 +150,10 @@ export interface IStoreServiceClient {
      * @generated from protobuf rpc: migrateData(dht.MigrateDataRequest) returns (dht.MigrateDataResponse);
      */
     migrateData(input: MigrateDataRequest, options?: RpcOptions): UnaryCall<MigrateDataRequest, MigrateDataResponse>;
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(input: DeleteDataRequest, options?: RpcOptions): UnaryCall<DeleteDataRequest, DeleteDataResponse>;
 }
 /**
  * @generated from protobuf service dht.StoreService
@@ -171,6 +177,13 @@ export class StoreServiceClient implements IStoreServiceClient, ServiceInfo {
     migrateData(input: MigrateDataRequest, options?: RpcOptions): UnaryCall<MigrateDataRequest, MigrateDataResponse> {
         const method = this.methods[1], opt = this._transport.mergeOptions(options);
         return stackIntercept<MigrateDataRequest, MigrateDataResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(input: DeleteDataRequest, options?: RpcOptions): UnaryCall<DeleteDataRequest, DeleteDataResponse> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<DeleteDataRequest, DeleteDataResponse>("unary", this._transport, method, opt, input);
     }
 }
 /**

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -15,6 +15,8 @@ import { WebRtcConnectionRequest } from "./DhtRpc";
 import { WebSocketConnectionResponse } from "./DhtRpc";
 import { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindReport } from "./DhtRpc";
+import { DeleteDataResponse } from "./DhtRpc";
+import { DeleteDataRequest } from "./DhtRpc";
 import { MigrateDataResponse } from "./DhtRpc";
 import { MigrateDataRequest } from "./DhtRpc";
 import { StoreDataResponse } from "./DhtRpc";
@@ -74,6 +76,10 @@ export interface IStoreService<T = ServerCallContext> {
      * @generated from protobuf rpc: migrateData(dht.MigrateDataRequest) returns (dht.MigrateDataResponse);
      */
     migrateData(request: MigrateDataRequest, context: T): Promise<MigrateDataResponse>;
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(request: DeleteDataRequest, context: T): Promise<DeleteDataResponse>;
 }
 /**
  * @generated from protobuf service dht.RecursiveFindSessionService

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -25,6 +25,10 @@ export interface StoreDataRequest {
      * @generated from protobuf field: uint32 ttl = 3;
      */
     ttl: number;
+    /**
+     * @generated from protobuf field: google.protobuf.Timestamp storerTime = 4;
+     */
+    storerTime?: Timestamp;
 }
 /**
  * @generated from protobuf message dht.StoreDataResponse
@@ -54,6 +58,24 @@ export interface MigrateDataResponse {
     error: string;
 }
 /**
+ * @generated from protobuf message dht.DeleteDataRequest
+ */
+export interface DeleteDataRequest {
+    /**
+     * @generated from protobuf field: bytes kademliaId = 1;
+     */
+    kademliaId: Uint8Array;
+}
+/**
+ * @generated from protobuf message dht.DeleteDataResponse
+ */
+export interface DeleteDataResponse {
+    /**
+     * @generated from protobuf field: bool deleted = 1;
+     */
+    deleted: boolean;
+}
+/**
  * @generated from protobuf message dht.DataEntry
  */
 export interface DataEntry {
@@ -81,6 +103,14 @@ export interface DataEntry {
      * @generated from protobuf field: bool stale = 6;
      */
     stale: boolean;
+    /**
+     * @generated from protobuf field: bool deleted = 7;
+     */
+    deleted: boolean;
+    /**
+     * @generated from protobuf field: google.protobuf.Timestamp storerTime = 8;
+     */
+    storerTime?: Timestamp;
 }
 /**
  * @generated from protobuf message dht.ClosestPeersRequest
@@ -776,7 +806,8 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
         super("dht.StoreDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "data", kind: "message", T: () => Any },
-            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp }
         ]);
     }
 }
@@ -821,6 +852,30 @@ class MigrateDataResponse$Type extends MessageType$<MigrateDataResponse> {
  */
 export const MigrateDataResponse = new MigrateDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class DeleteDataRequest$Type extends MessageType$<DeleteDataRequest> {
+    constructor() {
+        super("dht.DeleteDataRequest", [
+            { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.DeleteDataRequest
+ */
+export const DeleteDataRequest = new DeleteDataRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DeleteDataResponse$Type extends MessageType$<DeleteDataResponse> {
+    constructor() {
+        super("dht.DeleteDataResponse", [
+            { no: 1, name: "deleted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.DeleteDataResponse
+ */
+export const DeleteDataResponse = new DeleteDataResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class DataEntry$Type extends MessageType$<DataEntry> {
     constructor() {
         super("dht.DataEntry", [
@@ -829,7 +884,9 @@ class DataEntry$Type extends MessageType$<DataEntry> {
             { no: 3, name: "data", kind: "message", T: () => Any },
             { no: 4, name: "storedAt", kind: "message", T: () => Timestamp },
             { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 7, name: "deleted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 8, name: "storerTime", kind: "message", T: () => Timestamp }
         ]);
     }
 }
@@ -1302,7 +1359,8 @@ export const RoutingService = new ServiceType("dht.RoutingService", [
  */
 export const StoreService = new ServiceType("dht.StoreService", [
     { name: "storeData", options: {}, I: StoreDataRequest, O: StoreDataResponse },
-    { name: "migrateData", options: {}, I: MigrateDataRequest, O: MigrateDataResponse }
+    { name: "migrateData", options: {}, I: MigrateDataRequest, O: MigrateDataResponse },
+    { name: "deleteData", options: {}, I: DeleteDataRequest, O: DeleteDataResponse }
 ]);
 /**
  * @generated ServiceType for protobuf service dht.RecursiveFindSessionService

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -1,0 +1,93 @@
+import { LatencyType, Simulator } from '../../src/connection/Simulator/Simulator'
+import { DhtNode } from '../../src/dht/DhtNode'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
+import { isSamePeerDescriptor, PeerID } from '../../src/exports'
+import { Any } from '../../src/proto/google/protobuf/any'
+
+describe('Storing data in DHT', () => {
+    let entryPoint: DhtNode
+    let nodes: DhtNode[]
+    let entrypointDescriptor: PeerDescriptor
+    const simulator = new Simulator(LatencyType.RANDOM)
+    const NUM_NODES = 5
+    const MAX_CONNECTIONS = 5
+    const K = 4
+    const nodeIndicesById: Record<string, number> = {}
+
+    const getRandomNode = () => {
+        return nodes[Math.floor(Math.random() * nodes.length)]
+    }
+
+    beforeEach(async () => {
+        nodes = []
+        const entryPointId = '0'
+        entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
+            undefined, K, entryPointId, MAX_CONNECTIONS)
+        nodes.push(entryPoint)
+        nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
+        entrypointDescriptor = {
+            kademliaId: entryPoint.getNodeId().value,
+            type: NodeType.NODEJS,
+            nodeName: entryPointId
+        }
+        nodes.push(entryPoint)
+        for (let i = 1; i < NUM_NODES; i++) {
+            const nodeId = `${i}`
+            const node = await createMockConnectionDhtNode(nodeId, simulator, 
+                undefined, K, nodeId, MAX_CONNECTIONS, 60000)
+            nodeIndicesById[node.getNodeId().toKey()] = i
+            nodes.push(node)
+        }
+        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await waitConnectionManagersReadyForTesting(nodes.map((node) => node.connectionManager!), MAX_CONNECTIONS)
+    }, 90000)
+
+    afterEach(async () => {
+        await Promise.all(nodes.map((node) => node.stop()))
+    })
+
+    it('Data can be deleted', async () => {
+        const storingNode = getRandomNode()
+        const dataKey = PeerID.fromString('3232323e12r31r3')
+        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const successfulStorers = await storingNode.storeDataToDht(dataKey.value, data)
+        expect(successfulStorers.length).toBeGreaterThan(4)
+        await storingNode.deleteDataFromDht(dataKey.value)
+
+        const fetchingNode = getRandomNode()
+        const results = await fetchingNode.getDataFromDht(dataKey.value)
+        results.dataEntries!.forEach((entry) => {
+            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
+            expect(entry.deleted).toBeTrue()
+            expect(isSamePeerDescriptor(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+        })
+    }, 90000)
+
+    it('Data can be deleted and re-stored', async () => {
+        const storingNode = getRandomNode()
+        const dataKey = PeerID.fromString('3232323e12r31r3')
+        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const successfulStorers1 = await storingNode.storeDataToDht(dataKey.value, data)
+        expect(successfulStorers1.length).toBeGreaterThan(4)
+        await storingNode.deleteDataFromDht(dataKey.value)
+
+        const fetchingNode = getRandomNode()
+        const results1 = await fetchingNode.getDataFromDht(dataKey.value)
+        results1.dataEntries!.forEach((entry) => {
+            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
+            expect(entry.deleted).toBeTrue()
+            expect(isSamePeerDescriptor(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+        })
+
+        const successfulStorers2 = await storingNode.storeDataToDht(dataKey.value, data)
+        expect(successfulStorers2.length).toBeGreaterThan(4)
+
+        const results2 = await fetchingNode.getDataFromDht(dataKey.value)
+        results2.dataEntries!.forEach((entry) => {
+            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
+            expect(entry.deleted).toBeFalse()
+            expect(isSamePeerDescriptor(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+        })
+    }, 90000)
+})

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -16,7 +16,9 @@ import {
     WebSocketConnectionRequest,
     WebSocketConnectionResponse,
     RecursiveFindRequest, 
-    FindMode
+    FindMode,
+    DeleteDataRequest,
+    DeleteDataResponse
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { PeerID } from '../../src/helpers/PeerID'
@@ -225,6 +227,9 @@ export const MockStoreService: IStoreServiceWithError = {
     },
     async migrateData(_request: MigrateDataRequest, _context: ServerCallContext): Promise<MigrateDataResponse> {
         return MigrateDataResponse.create()
+    },
+    async deleteData(_request: DeleteDataRequest, _context: ServerCallContext): Promise<DeleteDataResponse> {
+        return DeleteDataResponse.create()
     }
 }
 

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -21,6 +21,8 @@ import type { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindSessionService } from "./DhtRpc";
 import type { RecursiveFindReport } from "./DhtRpc";
 import { StoreService } from "./DhtRpc";
+import type { DeleteDataResponse } from "./DhtRpc";
+import type { DeleteDataRequest } from "./DhtRpc";
 import type { MigrateDataResponse } from "./DhtRpc";
 import type { MigrateDataRequest } from "./DhtRpc";
 import type { StoreDataResponse } from "./DhtRpc";
@@ -148,6 +150,10 @@ export interface IStoreServiceClient {
      * @generated from protobuf rpc: migrateData(dht.MigrateDataRequest) returns (dht.MigrateDataResponse);
      */
     migrateData(input: MigrateDataRequest, options?: RpcOptions): UnaryCall<MigrateDataRequest, MigrateDataResponse>;
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(input: DeleteDataRequest, options?: RpcOptions): UnaryCall<DeleteDataRequest, DeleteDataResponse>;
 }
 /**
  * @generated from protobuf service dht.StoreService
@@ -171,6 +177,13 @@ export class StoreServiceClient implements IStoreServiceClient, ServiceInfo {
     migrateData(input: MigrateDataRequest, options?: RpcOptions): UnaryCall<MigrateDataRequest, MigrateDataResponse> {
         const method = this.methods[1], opt = this._transport.mergeOptions(options);
         return stackIntercept<MigrateDataRequest, MigrateDataResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(input: DeleteDataRequest, options?: RpcOptions): UnaryCall<DeleteDataRequest, DeleteDataResponse> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<DeleteDataRequest, DeleteDataResponse>("unary", this._transport, method, opt, input);
     }
 }
 /**

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -15,6 +15,8 @@ import { WebRtcConnectionRequest } from "./DhtRpc";
 import { WebSocketConnectionResponse } from "./DhtRpc";
 import { WebSocketConnectionRequest } from "./DhtRpc";
 import { RecursiveFindReport } from "./DhtRpc";
+import { DeleteDataResponse } from "./DhtRpc";
+import { DeleteDataRequest } from "./DhtRpc";
 import { MigrateDataResponse } from "./DhtRpc";
 import { MigrateDataRequest } from "./DhtRpc";
 import { StoreDataResponse } from "./DhtRpc";
@@ -74,6 +76,10 @@ export interface IStoreService<T = ServerCallContext> {
      * @generated from protobuf rpc: migrateData(dht.MigrateDataRequest) returns (dht.MigrateDataResponse);
      */
     migrateData(request: MigrateDataRequest, context: T): Promise<MigrateDataResponse>;
+    /**
+     * @generated from protobuf rpc: deleteData(dht.DeleteDataRequest) returns (dht.DeleteDataResponse);
+     */
+    deleteData(request: DeleteDataRequest, context: T): Promise<DeleteDataResponse>;
 }
 /**
  * @generated from protobuf service dht.RecursiveFindSessionService

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -25,6 +25,10 @@ export interface StoreDataRequest {
      * @generated from protobuf field: uint32 ttl = 3;
      */
     ttl: number;
+    /**
+     * @generated from protobuf field: google.protobuf.Timestamp storerTime = 4;
+     */
+    storerTime?: Timestamp;
 }
 /**
  * @generated from protobuf message dht.StoreDataResponse
@@ -54,6 +58,24 @@ export interface MigrateDataResponse {
     error: string;
 }
 /**
+ * @generated from protobuf message dht.DeleteDataRequest
+ */
+export interface DeleteDataRequest {
+    /**
+     * @generated from protobuf field: bytes kademliaId = 1;
+     */
+    kademliaId: Uint8Array;
+}
+/**
+ * @generated from protobuf message dht.DeleteDataResponse
+ */
+export interface DeleteDataResponse {
+    /**
+     * @generated from protobuf field: bool deleted = 1;
+     */
+    deleted: boolean;
+}
+/**
  * @generated from protobuf message dht.DataEntry
  */
 export interface DataEntry {
@@ -81,6 +103,14 @@ export interface DataEntry {
      * @generated from protobuf field: bool stale = 6;
      */
     stale: boolean;
+    /**
+     * @generated from protobuf field: bool deleted = 7;
+     */
+    deleted: boolean;
+    /**
+     * @generated from protobuf field: google.protobuf.Timestamp storerTime = 8;
+     */
+    storerTime?: Timestamp;
 }
 /**
  * @generated from protobuf message dht.ClosestPeersRequest
@@ -776,7 +806,8 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
         super("dht.StoreDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "data", kind: "message", T: () => Any },
-            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp }
         ]);
     }
 }
@@ -821,6 +852,30 @@ class MigrateDataResponse$Type extends MessageType$<MigrateDataResponse> {
  */
 export const MigrateDataResponse = new MigrateDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class DeleteDataRequest$Type extends MessageType$<DeleteDataRequest> {
+    constructor() {
+        super("dht.DeleteDataRequest", [
+            { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.DeleteDataRequest
+ */
+export const DeleteDataRequest = new DeleteDataRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class DeleteDataResponse$Type extends MessageType$<DeleteDataResponse> {
+    constructor() {
+        super("dht.DeleteDataResponse", [
+            { no: 1, name: "deleted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.DeleteDataResponse
+ */
+export const DeleteDataResponse = new DeleteDataResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class DataEntry$Type extends MessageType$<DataEntry> {
     constructor() {
         super("dht.DataEntry", [
@@ -829,7 +884,9 @@ class DataEntry$Type extends MessageType$<DataEntry> {
             { no: 3, name: "data", kind: "message", T: () => Any },
             { no: 4, name: "storedAt", kind: "message", T: () => Timestamp },
             { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 6, name: "stale", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 7, name: "deleted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 8, name: "storerTime", kind: "message", T: () => Timestamp }
         ]);
     }
 }
@@ -1302,7 +1359,8 @@ export const RoutingService = new ServiceType("dht.RoutingService", [
  */
 export const StoreService = new ServiceType("dht.StoreService", [
     { name: "storeData", options: {}, I: StoreDataRequest, O: StoreDataResponse },
-    { name: "migrateData", options: {}, I: MigrateDataRequest, O: MigrateDataResponse }
+    { name: "migrateData", options: {}, I: MigrateDataRequest, O: MigrateDataResponse },
+    { name: "deleteData", options: {}, I: DeleteDataRequest, O: DeleteDataResponse }
 ]);
 /**
  * @generated ServiceType for protobuf service dht.RecursiveFindSessionService

--- a/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
+++ b/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
@@ -23,7 +23,8 @@ describe('StreamEntryPointDiscovery', () => {
         ttl: 1000,
         storer: peerDescriptor,
         kademliaId: Uint8Array.from([1, 2, 3]),
-        stale: false
+        stale: false,
+        deleted: false
     }
 
     const stream = 'stream#0'


### PR DESCRIPTION
## Summary

Stored data can now be marked as deleted in by its original storer in the DHT. The RecursiveFindSession will now check if the latest stored data has been marked as deleted before passing it on to the requestor.

The stored data's storer's timestamp has been included to the dataEntry-objects and is used when handling the data. This ensures that the latest data sent by the storer will be kept in storage.