### PR TITLE
feat(trackerless-network): Nodes will delete themselves as entry points when leaving streams

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -633,7 +633,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public async deleteDataFromDht(idToDelete: Uint8Array): Promise<void> {
-        return this.dataStore!.deleteDataFromDht(idToDelete)
+        if (!this.stopped) {
+            return this.dataStore!.deleteDataFromDht(idToDelete)
+        }
     }
 
     public async findDataViaPeer(idToFind: Uint8Array, peer: PeerDescriptor): Promise<DataEntry[]> {

--- a/packages/dht/src/dht/store/DataStore.ts
+++ b/packages/dht/src/dht/store/DataStore.ts
@@ -221,7 +221,7 @@ export class DataStore implements IStoreService {
                 }
                 successfulNodes.push(closestNodes[i])
             } catch (e) {
-                logger.warn('remoteStore.deleteData() threw an exception ' + e)
+                logger.debug('remoteStore.deleteData() threw an exception ' + e)
             }
         }
     }

--- a/packages/trackerless-network/src/logic/ILayer0.ts
+++ b/packages/trackerless-network/src/logic/ILayer0.ts
@@ -7,6 +7,7 @@ export interface ILayer0 extends ITransport {
     getDataFromDht(key: Uint8Array): Promise<RecursiveFindResult>
     findDataViaPeer(key: Uint8Array, peer: PeerDescriptor): Promise<DataEntry[]>
     storeDataToDht(key: Uint8Array, data: Any): Promise<PeerDescriptor[]>
+    deleteDataFromDht(key: Uint8Array): Promise<void>
     getKnownEntryPoints(): PeerDescriptor[]
     isJoinOngoing(): boolean
     stop(): Promise<void>

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -133,7 +133,8 @@ export class StreamrNode extends EventEmitter<Events> {
             streams: this.streams,
             getEntryPointData: (key) => this.layer0!.getDataFromDht(key),
             getEntryPointDataViaPeer: (peerDescriptor, key) => this.layer0!.findDataViaPeer(peerDescriptor, key),
-            storeEntryPointData: (key, data) => this.layer0!.storeDataToDht(key, data)
+            storeEntryPointData: (key, data) => this.layer0!.storeDataToDht(key, data),
+            deleteEntryPointData: (key) => this.layer0!.deleteDataFromDht(key)
         })
         cleanUp = () => this.destroy()
     }
@@ -148,11 +149,11 @@ export class StreamrNode extends EventEmitter<Events> {
             stream.layer2.stop()
             stream.layer1?.stop()
         })
+        await this.streamEntryPointDiscovery!.destroy()
         this.streams.clear()
         this.removeAllListeners()
         await this.layer0!.stop()
         await this.P2PTransport!.stop()
-        await this.streamEntryPointDiscovery!.destroy()
         this.layer0 = undefined
         this.P2PTransport = undefined
         this.streamEntryPointDiscovery = undefined
@@ -191,7 +192,7 @@ export class StreamrNode extends EventEmitter<Events> {
             stream.layer1?.stop()
             this.streams.delete(streamPartID)
         }
-        this.streamEntryPointDiscovery!.stopRecaching(streamPartID)
+        this.streamEntryPointDiscovery!.removeSelfAsEntryPoint(streamPartID)
     }
 
     async joinStream(streamPartID: string, knownEntryPointDescriptors: PeerDescriptor[]): Promise<void> {

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -138,13 +138,4 @@ describe('StreamrNode', () => {
         await waitForCondition(() => node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 0)
     })
 
-    // TODO: make this work
-    // it('Publishing and subscribing to streams without join awaits', async () => {
-    //     node1.subscribeToStream(STREAM_ID, peer1)
-    //     await Promise.all([
-    //         waitForEvent3<Events>(node1, 'newMessage'),
-    //         node2.publishToStream(STREAM_ID, peer1, msg)
-    //     ])
-    // })
-
 })

--- a/packages/trackerless-network/test/utils/mock/MockLayer0.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer0.ts
@@ -34,6 +34,11 @@ export class MockLayer0 extends EventEmitter implements ILayer0 {
     }
 
     // eslint-disable-next-line class-methods-use-this
+    async deleteDataFromDht(_key: Uint8Array): Promise<void> {
+        
+    }
+
+    // eslint-disable-next-line class-methods-use-this
     async storeDataToDht(_key: Uint8Array, _data: Any): Promise<PeerDescriptor[]> {
         return []
     }


### PR DESCRIPTION
## Summary

Nodes that leave streams will now mark themselves as deleted in the entry point store. Additionally the EntryPointDiscovery-class now ignores DataEntries that are marked as deleted.