### PR TITLE
refactor: make knownEntryPoints optional in NetworkNode

### DIFF
--- a/packages/broker/src/plugins/storage/StoragePlugin.ts
+++ b/packages/broker/src/plugins/storage/StoragePlugin.ts
@@ -52,7 +52,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
             }
         }
         const node = await this.streamrClient.getNode()
-        await node.subscribeAndWaitForJoin(toStreamPartID(assignmentStream.id, 0), [])
+        await node.subscribeAndWaitForJoin(toStreamPartID(assignmentStream.id, 0))
         node.addMessageListener(this.messageListener)
         this.addHttpServerEndpoint(createDataQueryEndpoint(this.cassandra, metricsContext))
         this.addHttpServerEndpoint(createDataMetadataEndpoint(this.cassandra))
@@ -100,7 +100,7 @@ export class StoragePlugin extends Plugin<StoragePluginConfig> {
             {
                 onStreamPartAdded: async (streamPart) => {
                     try {
-                        await node.subscribeAndWaitForJoin(streamPart, []) // best-effort, can time out
+                        await node.subscribeAndWaitForJoin(streamPart) // best-effort, can time out
                     } catch (_e) {
                         // no-op
                     }

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -20,11 +20,11 @@ export interface NetworkNodeStub {
     getNodeId: () => string
     addMessageListener: (listener: (msg: StreamMessage) => void) => void
     removeMessageListener: (listener: (msg: StreamMessage) => void) => void
-    subscribe: (streamPartId: StreamPartID, entryPointDescriptors: PeerDescriptor[]) => Promise<void>
-    subscribeAndWaitForJoin: (streamPart: StreamPartID, entryPointDescriptors: PeerDescriptor[], timeout?: number) => Promise<number>
-    waitForJoinAndPublish: (msg: StreamMessage, entryPointDescriptors: PeerDescriptor[], timeout?: number) => Promise<number>
+    subscribe: (streamPartId: StreamPartID, entryPointDescriptors?: PeerDescriptor[]) => Promise<void>
+    subscribeAndWaitForJoin: (streamPart: StreamPartID, entryPointDescriptors?: PeerDescriptor[], timeout?: number) => Promise<number>
+    waitForJoinAndPublish: (msg: StreamMessage, entryPointDescriptors?: PeerDescriptor[], timeout?: number) => Promise<number>
     unsubscribe: (streamPartId: StreamPartID) => void
-    publish: (streamMessage: StreamMessage, entryPointDescriptors: PeerDescriptor[]) => Promise<void>
+    publish: (streamMessage: StreamMessage, entryPointDescriptors?: PeerDescriptor[]) => Promise<void>
     getStreamParts: () => StreamPartID[]
     getNeighbors: () => string[]
     getNeighborsForStreamPart: (streamPartId: StreamPartID) => ReadonlyArray<string>

--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -75,7 +75,7 @@ export class PublisherKeyExchange {
                             request.getPublisherId(),
                             requestId)
                         const node = await this.networkNodeFacade.getNode()
-                        node.publish(response, [])
+                        node.publish(response)
                         this.logger.debug('Handled group key request (found keys)', {
                             groupKeyIds: keys.map((k) => k.id).join(),
                             recipient: request.getPublisherId()

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -80,7 +80,7 @@ export class SubscriberKeyExchange {
             this.rsaKeyPair!.getPublicKey(),
             requestId)
         const node = await this.networkNodeFacade.getNode()
-        node.publish(request, [])
+        node.publish(request)
         this.pendingRequests.add(requestId)
         this.logger.debug('Sent group key request (waiting for response)', {
             groupKeyId,

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -40,12 +40,12 @@ export class FakeNetworkNode implements NetworkNodeStub {
         this.subscriptions.delete(streamPartId)
     }
 
-    async subscribeAndWaitForJoin(streamPartId: StreamPartID, _entryPointDescriptors: PeerDescriptor[], _timeout?: number): Promise<number> {
+    async subscribeAndWaitForJoin(streamPartId: StreamPartID, _entryPointDescriptors?: PeerDescriptor[], _timeout?: number): Promise<number> {
         this.subscriptions.add(streamPartId)
         return this.getNeighborsForStreamPart(streamPartId).length
     }
 
-    async waitForJoinAndPublish(msg: StreamMessage, _entryPointDescriptors: PeerDescriptor[], _timeout?: number): Promise<number> {
+    async waitForJoinAndPublish(msg: StreamMessage, _entryPointDescriptors?: PeerDescriptor[], _timeout?: number): Promise<number> {
         const streamPartID = msg.getStreamPartID()
         this.subscriptions.add(streamPartID)
         this.publish(msg)

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -151,7 +151,7 @@ export const startPublisherKeyExchangeSubscription = async (
     publisherClient: StreamrClient,
     streamPartId: StreamPartID): Promise<void> => {
     const node = await publisherClient.getNode()
-    node.subscribe(streamPartId, [])
+    node.subscribe(streamPartId)
 }
 
 export const createRandomAuthentication = (): Authentication => {

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -27,7 +27,7 @@ export class NetworkNode {
         this.stack.getStreamrNode().setExtraMetadata(metadata)
     }
 
-    async publish(streamMessage: StreamMessage, knownEntrypointDescriptors: PeerDescriptor[]): Promise<void> {
+    async publish(streamMessage: StreamMessage, knownEntrypointDescriptors: PeerDescriptor[] = []): Promise<void> {
         const streamPartId = streamMessage.getStreamPartID()
         if (this.stack.getStreamrNode().isProxiedStreamPart(streamPartId, ProxyDirection.SUBSCRIBE) 
             && streamMessage.messageType === StreamMessageType.MESSAGE) {
@@ -39,7 +39,7 @@ export class NetworkNode {
         this.stack.getStreamrNode().publishToStream(streamPartId, knownEntrypointDescriptors, msg)
     }
 
-    async subscribe(streamPartId: StreamPartID, knownEntrypointDescriptors: PeerDescriptor[]): Promise<void> {
+    async subscribe(streamPartId: StreamPartID, knownEntrypointDescriptors: PeerDescriptor[] = []): Promise<void> {
         if (this.stack.getStreamrNode().isProxiedStreamPart(streamPartId, ProxyDirection.PUBLISH)) {
             throw new Error(`Cannot subscribe to ${streamPartId} as proxy publish connections have been set`)
         }
@@ -79,7 +79,7 @@ export class NetworkNode {
 
     async subscribeAndWaitForJoin(
         streamPartId: StreamPartID,
-        knownEntrypointDescriptors: PeerDescriptor[],
+        knownEntrypointDescriptors: PeerDescriptor[] = [],
         timeout?: number,
         expectedNeighbors?: number
     ): Promise<number> {
@@ -89,7 +89,7 @@ export class NetworkNode {
         return this.stack.getStreamrNode().waitForJoinAndSubscribe(streamPartId, knownEntrypointDescriptors, timeout, expectedNeighbors)
     }
 
-    async waitForJoinAndPublish(streamMessage: StreamMessage, knownEntrypointDescriptors: PeerDescriptor[], timeout?: number): Promise<number> {
+    async waitForJoinAndPublish(streamMessage: StreamMessage, knownEntrypointDescriptors: PeerDescriptor[] = [], timeout?: number): Promise<number> {
         const streamPartId = streamMessage.getStreamPartID()
         const msg = StreamMessageTranslator.toProtobuf(streamMessage)
 

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -51,7 +51,7 @@ const prepareStream = async (streamId: string) => {
     const streamPartId = toStreamPartID(toStreamID(streamId), 0)
     const streamPublisher = createNetworkNodeWithSimulator(peerDescriptor, simulator, [layer0Ep])
     await streamPublisher.start()
-    streamPublisher.subscribe(streamPartId, [])
+    streamPublisher.subscribe(streamPartId)
     nodes.push(streamPublisher)
     streams.set(streamPartId, streamPublisher)
 }
@@ -106,7 +106,7 @@ const measureJoiningTime = async (count: number) => {
 
     await Promise.all([
         waitForEvent3(streamSubscriber.stack.getStreamrNode() as any, 'newMessage', 60000),
-        streamSubscriber.subscribe(stream, [])
+        streamSubscriber.subscribe(stream)
     ])
 
     const end = performance.now()

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -90,14 +90,14 @@ describe('proxy and full node', () => {
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
-            proxiedNode.publish(regularMessage1, [])
+            proxiedNode.publish(regularMessage1)
         ])
 
         expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(true)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
-            proxiedNode.publish(proxiedMessage, [])
+            proxiedNode.publish(proxiedMessage)
         ])
 
         expect(proxiedNode.stack.getStreamrNode().getStream(proxyStreamId)!.type).toBe(StreamNodeType.PROXY)
@@ -117,17 +117,17 @@ describe('proxy and full node', () => {
                 (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream3'),
             waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
                 (streamMessage: InternalStreamMessage) => streamMessage.messageRef!.streamId === 'regular-stream4'),
-            proxiedNode.publish(regularMessage1, []),
-            proxiedNode.publish(regularMessage2, []),
-            proxiedNode.publish(regularMessage3, []),
-            proxiedNode.publish(regularMessage4, [])
+            proxiedNode.publish(regularMessage1),
+            proxiedNode.publish(regularMessage2),
+            proxiedNode.publish(regularMessage3),
+            proxiedNode.publish(regularMessage4)
         ])
 
         expect(proxiedNode.stack.getLayer0DhtNode().hasJoined()).toBe(true)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
-            proxiedNode.publish(proxiedMessage, [])
+            proxiedNode.publish(proxiedMessage)
         ])
 
         expect(proxiedNode.stack.getStreamrNode().getStream(proxyStreamId)!.type).toBe(StreamNodeType.PROXY)

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -93,16 +93,16 @@ describe('Proxy connections', () => {
 
         await Promise.all([
             waitForEvent3(proxyNode1.stack.getStreamrNode()! as any, 'newMessage'),
-            proxiedNode.publish(message, [])
+            proxiedNode.publish(message)
         ])
     })
 
     it('happy path subscribing', async () => {
         await proxiedNode.setProxies(streamPartId, [proxyNodeDescriptor1], ProxyDirection.SUBSCRIBE, async () => 'proxiedNode', 1)
-        proxiedNode.subscribe(streamPartId, [])
+        proxiedNode.subscribe(streamPartId)
         await Promise.all([
             waitForEvent3(proxiedNode.stack.getStreamrNode()! as any, 'newMessage'),
-            proxyNode1.publish(message, [])
+            proxyNode1.publish(message)
         ])
     })
 
@@ -210,7 +210,7 @@ describe('Proxy connections', () => {
             ProxyDirection.PUBLISH,
             async () => 'proxiedNode'
         )
-        await expect(proxiedNode.subscribe(streamPartId, [])).rejects.toThrow('Cannot subscribe')
+        await expect(proxiedNode.subscribe(streamPartId)).rejects.toThrow('Cannot subscribe')
     })
 
     it('connect publish on proxy subscribe streams', async () => {
@@ -220,7 +220,7 @@ describe('Proxy connections', () => {
             ProxyDirection.SUBSCRIBE,
             async () => 'proxiedNode'
         )
-        await expect(proxiedNode.publish(message, [])).rejects.toThrow('Cannot publish')
+        await expect(proxiedNode.publish(message)).rejects.toThrow('Cannot publish')
     })
 
 })

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -83,13 +83,13 @@ describe('stream without default entrypoints', () => {
     })
 
     it('can join stream without configured entrypoints one by one', async () => {
-        await nodes[0].subscribeAndWaitForJoin(STREAM_ID, [])
+        await nodes[0].subscribeAndWaitForJoin(STREAM_ID)
         nodes[0].addMessageListener((_msg) => {
             numOfReceivedMessages += 1
         })
         await Promise.all([
             waitForCondition(() => numOfReceivedMessages === 1, 10000),
-            nodes[1].publish(streamMessage, [])
+            nodes[1].publish(streamMessage)
         ])
     })
 
@@ -99,8 +99,8 @@ describe('stream without default entrypoints', () => {
         })
         await Promise.all([
             waitForCondition(() => numOfReceivedMessages === 1, 15000),
-            nodes[0].subscribe(STREAM_ID, []),
-            nodes[1].publish(streamMessage, []),
+            nodes[0].subscribe(STREAM_ID),
+            nodes[1].publish(streamMessage),
         ])
     })
 
@@ -114,13 +114,13 @@ describe('stream without default entrypoints', () => {
         }))
         await Promise.all([
             waitForCondition(() => numOfReceivedMessages === numOfSubscribers, 15000),
-            nodes[9].publish(streamMessage, [])
+            nodes[9].publish(streamMessage)
         ])
     }, 45000)
 
     it('nodes store themselves as entrypoints on streamPart if number of entrypoints is low', async () => {
         for (let i = 0; i < 10; i++) {
-            await nodes[i].subscribeAndWaitForJoin(STREAM_ID, [])
+            await nodes[i].subscribeAndWaitForJoin(STREAM_ID)
         }
         await waitForCondition(async () => {
             const entryPointData = await nodes[15].stack.getLayer0DhtNode().getDataFromDht(streamPartIdToDataKey(STREAM_ID))


### PR DESCRIPTION
## Summary

Made knownEntryPoints for streams optional in `subscribe`, `publish`, `subscribeAndWaitForJoin` and `waitForJoinAndPublish` in the NetworkNode and client's NetworkNodeStub.
