### PR TITLE
DhtNode auto-generates UUID as kademliaId

### DIFF
--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -1,5 +1,4 @@
 import { toEthereumAddress } from '@streamr/utils'
-import { v4 as uuid } from 'uuid'
 import { StreamrClientConfig } from './Config'
 import { MIN_KEY_LENGTH } from './encryption/RSAKeyPair'
 
@@ -30,15 +29,8 @@ export const CONFIG_TEST: StreamrClientConfig = {
                     port: 40401
                 }
             }],
-            peerDescriptor: {
-                kademliaId: uuid(),
-                type: 0
-            },
             iceServers: [],
             webrtcDisallowPrivateAddresses: false
-        },
-        networkNode: {
-            firstConnectionTimeout: 15 * 1000
         }
     },
     contracts: {

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -28,8 +28,8 @@ async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID)
         ...CONFIG_TEST.network as any,
         layer0: {
             entryPoints,
-            stringKademliaId: 'node'
-        }
+        },
+        networkNode: {} 
     })
 
     try {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -40,6 +40,7 @@ import { LocalDataStore } from './store/LocalDataStore'
 import { IceServer } from '../connection/WebRTC/WebRtcConnector'
 import { ExternalApi } from './ExternalApi'
 import { RemoteExternalApi } from './RemoteExternalApi'
+import { UUID } from '../exports'
 
 export interface DhtNodeEvents {
     newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
@@ -96,13 +97,13 @@ export class DhtNodeConfig {
     storeMaxTtl = 60000
     storeNumberOfCopies = 5
     metricsContext = new MetricsContext()
+    peerIdString = new UUID().toString()
 
     transportLayer?: ITransport
     peerDescriptor?: PeerDescriptor
     entryPoints?: PeerDescriptor[]
     webSocketHost?: string
     webSocketPort?: number
-    peerIdString?: string
     nodeName?: string
     rpcRequestTimeout?: number
     iceServers?: IceServer[]


### PR DESCRIPTION
## Summary

It is no longer required to externally give a kademliaId for the DhtNode.

In the future the id will be generated using the region / IP address of the node