### PR TITLE
docs: do not add generated files to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ lerna-debug.log
 *.heapprofile
 *.heapsnapshot
 oldsrc
-docs/docs/usage
+docs/docs/usage/streamr-js-client/api

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ lerna-debug.log
 *.heapprofile
 *.heapsnapshot
 oldsrc
-docs/docs/usage/streamr-js-client/api

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lerna-debug.log
 *.heapprofile
 *.heapsnapshot
 oldsrc
+docs/docs/usage

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,7 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
-/docs/api
+/docs/usage/streamr-js-client/api
 
 # Misc
 .DS_Store

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Please feel very welcome to submit content suggestions!
 For ease of use, small changes can be suggested by editing the markdown file on GitHub. Every content page has an "Edit this page" link at the bottom- Simply edit the text contents and submit a pull request to have the change reviewed before it is implemented.
 
 ### Run it locally
-Simply, `npm i` & `npm start`
+Simply, `npm ci` & `npm start`
 
 ## Streamr core devs
 Deployments are automatically made after every commit to `main`, therefore editing markdown files directly on `main` will be reflected in production within a minute or two.


### PR DESCRIPTION
Added a .gitignore so that generated API docs are ignored.

Also changed README to use `npm ci` instead of `npm i` so that uses consistent versions (and doesn't update the local `package-lock.json`)