### PR TITLE
refactor(client): rename layer0 kademliaId to id in client config

### DIFF
--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "peerDescriptor": {
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 },
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 }],
                 "peerDescriptor": {
-                    "kademliaId": "dev-broker-2",
+                    "id": "dev-broker-2",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 }],
                 "peerDescriptor": {
-                    "kademliaId": "dev-broker-3",
+                    "id": "dev-broker-3",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "peerDescriptor": {
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 },
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 }],
                 "peerDescriptor": {
-                    "kademliaId": "dev-broker-2",
+                    "id": "dev-broker-2",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -7,7 +7,7 @@
         "network": {
             "layer0": {
                 "entryPoints": [{
-                    "kademliaId": "entryPointBroker",
+                    "id": "entryPointBroker",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",
@@ -15,7 +15,7 @@
                     }
                 }],
                 "peerDescriptor": {
-                    "kademliaId": "dev-broker-3",
+                    "id": "dev-broker-3",
                     "type": 0,
                     "websocket": {
                         "ip": "127.0.0.1",

--- a/packages/broker/test/unit/authentication.test.ts
+++ b/packages/broker/test/unit/authentication.test.ts
@@ -10,11 +10,11 @@ const formConfig = (auth: StreamrClientConfig['auth']): Config => {
             network: {
                 layer0: {
                     peerDescriptor: {
-                        kademliaId: 'broker',
+                        id: 'broker',
                         type: 0
                     },
                     entryPoints: [{
-                        kademliaId: 'broker',
+                        id: 'broker',
                         type: 0
                     }]
                 }

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -28,7 +28,7 @@ interface TestConfig {
 }
 
 const DEFAULT_ENTRYPOINTS = [{
-    kademliaId: "entryPointBroker",
+    id: "entryPointBroker",
     type: 0,
     websocket: {
         ip: "127.0.0.1",
@@ -64,14 +64,14 @@ export const formConfig = ({
         }
     }
     const peerDescriptor = networkLayerWsServerPort ? {
-        kademliaId: uuid(),
+        id: uuid(),
         type: 0,
         websocket: {
             ip: '127.0.0.1',
             port: networkLayerWsServerPort
         }
     } : {
-        kademliaId: uuid(),
+        id: uuid(),
         type: 0,
     }
 
@@ -121,11 +121,7 @@ export const createClient = async (
             },
             network: {
                 layer0: {
-                    ...CONFIG_TEST.network!.layer0!,
-                    peerDescriptor: {
-                        kademliaId: uuid(),
-                        type: 0
-                    }
+                    ...CONFIG_TEST.network!.layer0!
                 },
                 networkNode:
                     merge(

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -18,7 +18,7 @@ import { DhtNodeOptions } from '@streamr/dht'
 export interface layer0Config extends Omit<DhtNodeOptions, 'entryPoints' | 'peerDescriptor' | 'stringId'> {
     entryPoints?: JsonPeerDescriptor[]
     peerDescriptor?: JsonPeerDescriptor
-    stringKademliaId?: string
+    id?: string
 }
 
 export interface NetworkConfig {
@@ -39,7 +39,7 @@ export interface PrivateKeyAuthConfig {
 }
 
 export interface JsonPeerDescriptor {
-    kademliaId: string
+    id: string
     type: number
     websocket?: ConnectivityMethod
     openInternet?: boolean

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -22,7 +22,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
     network: {
         layer0: {
             entryPoints: [{
-                kademliaId: 'entryPointBroker',
+                id: 'entryPointBroker',
                 type: 0,
                 websocket: {
                     ip: '127.0.0.1',

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -133,8 +133,8 @@ export class NetworkNodeFacade {
         return {
             ...jsonPeerDescriptor,
             websocket: jsonPeerDescriptor.websocket,
-            kademliaId: PeerID.fromString(jsonPeerDescriptor!.kademliaId).value,
-            nodeName: jsonPeerDescriptor!.kademliaId,
+            kademliaId: PeerID.fromString(jsonPeerDescriptor!.id).value,
+            nodeName: jsonPeerDescriptor!.id,
         }
     }
 

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -73,7 +73,7 @@
                                 "$ref": "#/definitions/peerDescriptor"
                             },
                             "default": [{
-                                "kademliaId": "productionEntryPoint1",
+                                "id": "productionEntryPoint1",
                                 "type": 0,
                                 "websocket": {
                                     "ip": "127.0.0.1",
@@ -81,7 +81,7 @@
                                 }
                             }]
                         },
-                        "stringKademliaId": {
+                        "id": {
                             "type": "string",
                             "description": "TODO: remove later"
                         },
@@ -464,11 +464,11 @@
             "type": "object",
             "additionalProperties": false,
             "required": [
-                "kademliaId",
+                "id",
                 "type"
             ],
             "properties": {
-                "kademliaId": {
+                "id": {
                     "type": "string"
                 },
                 "type": {

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -115,7 +115,7 @@ export class MaxSizedSet<T> {
 export function entryPointTranslator(json: JsonPeerDescriptor[]): PeerDescriptor[] {
     return json.map((ep: JsonPeerDescriptor) => {
         const peerDescriptor: PeerDescriptor = {
-            kademliaId: PeerID.fromString(ep.kademliaId).value,
+            kademliaId: PeerID.fromString(ep.id).value,
             type: ep.type,
             openInternet: ep.openInternet,
             websocket: ep.websocket

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -32,8 +32,7 @@ describe('NodeMetrics', () => {
             },
             network: {
                 layer0: {
-                    ...CONFIG_TEST.network!.layer0,
-                    stringKademliaId: 'generator'
+                    ...CONFIG_TEST.network!.layer0
                 }
             }
         })

--- a/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
+++ b/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
@@ -29,7 +29,7 @@ describe('PubSub with proxy connections', () => {
     const proxyNodePort2 = 14232
 
     const proxyNodeDescriptor1: JsonPeerDescriptor = {
-        kademliaId: proxyNodeId1,
+        id: proxyNodeId1,
         type: 0,
         websocket: {
             ip: 'localhost',
@@ -37,7 +37,7 @@ describe('PubSub with proxy connections', () => {
         }
     }
     const proxyNodeDescriptor2: JsonPeerDescriptor = {
-        kademliaId: proxyNodeId2,
+        id: proxyNodeId2,
         type: 0,
         websocket: {
             ip: 'localhost',

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -19,7 +19,7 @@ const ENCRYPTED_MESSSAGE_FORMAT = /^[0-9A-Fa-f]+$/
 async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID): Promise<unknown[]> {
     const entryPoints = CONFIG_TEST.network!.layer0!.entryPoints!.map((ep) => {
         return {
-            kademliaId: PeerID.fromString(ep.kademliaId).value,
+            kademliaId: PeerID.fromString(ep.id).value,
             type: ep.type,
             websocket: ep.websocket
         }

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -229,7 +229,7 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
     })
 }
 
-export const createTestClient = (privateKey: string, stringKademliaId: string, wsPort?: number, acceptProxyConnections = false): StreamrClient => {
+export const createTestClient = (privateKey: string, id: string, wsPort?: number, acceptProxyConnections = false): StreamrClient => {
     return new StreamrClient({
         ...CONFIG_TEST,
         auth: {
@@ -239,7 +239,7 @@ export const createTestClient = (privateKey: string, stringKademliaId: string, w
             layer0: {
                 ...CONFIG_TEST.network!.layer0,
                 peerDescriptor: {
-                    kademliaId: stringKademliaId,
+                    id,
                     type: 0,
                     websocket: wsPort ? {
                         ip: 'localhost',

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -22,7 +22,7 @@ describe('Config', () => {
                     network: {
                         layer0: {
                             entryPoints: [{
-                                kademliaId: 'test'
+                                id: 'test'
                             }]
                         }
                     }
@@ -115,12 +115,12 @@ describe('Config', () => {
                 network: {}
             })
             expect(clientOverrides.network).toEqual(clientDefaults.network)
-            expect(clientOverrides.network.layer0!.entryPoints![0].kademliaId).toEqual('productionEntryPoint1')
+            expect(clientOverrides.network.layer0!.entryPoints![0].id).toEqual('productionEntryPoint1')
         })
 
         it('can override entryPoints', () => {
             const entryPoints = [{
-                kademliaId: '0xFBB6066c44bc8132bA794C73f58F391273E3bdA1',
+                id: '0xFBB6066c44bc8132bA794C73f58F391273E3bdA1',
                 type: 0,
                 websocket: {
                     ip: 'brubeck3.streamr.network',

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -84,6 +84,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
         this.connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
         const entryPoint = this.options.layer0.entryPoints![0]
         if (isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())) {
+            this.dhtJoinRequired = false
             await this.layer0DhtNode?.joinDht(entryPoint)
             await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
         } else {


### PR DESCRIPTION
## Summary

Rename layer0 kademliaId to id in the client's network layer0 configuration
