### PR TITLE
use NodeType to configure the PeerDescriptors type

### DIFF
--- a/packages/broker/test/unit/authentication.test.ts
+++ b/packages/broker/test/unit/authentication.test.ts
@@ -1,5 +1,5 @@
 import { fastWallet } from '@streamr/test-utils'
-import { ExternalProvider, StreamrClientConfig } from 'streamr-client'
+import { ExternalProvider, StreamrClientConfig, NodeType } from 'streamr-client'
 import { createBroker } from '../../src/broker'
 import { Config } from '../../src/config/config'
 
@@ -11,11 +11,11 @@ const formConfig = (auth: StreamrClientConfig['auth']): Config => {
                 layer0: {
                     peerDescriptor: {
                         id: 'broker',
-                        type: 0
+                        type: NodeType.NODEJS,
                     },
                     entryPoints: [{
                         id: 'broker',
-                        type: 0
+                        type: NodeType.NODEJS,
                     }]
                 }
             }

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -12,6 +12,7 @@ import { Broker, createBroker } from '../src/broker'
 import { Config } from '../src/config/config'
 import { StreamPartID } from '@streamr/protocol'
 import { EthereumAddress, toEthereumAddress, merge } from '@streamr/utils'
+import { NodeType } from 'streamr-client'
 import { v4 as uuid } from 'uuid'
 
 export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
@@ -29,7 +30,7 @@ interface TestConfig {
 
 const DEFAULT_ENTRYPOINTS = [{
     id: "entryPointBroker",
-    type: 0,
+    type: NodeType.NODEJS,
     websocket: {
         ip: "127.0.0.1",
         port: 40401
@@ -65,14 +66,14 @@ export const formConfig = ({
     }
     const peerDescriptor = networkLayerWsServerPort ? {
         id: uuid(),
-        type: 0,
+        type: NodeType.NODEJS,
         websocket: {
             ip: '127.0.0.1',
             port: networkLayerWsServerPort
         }
     } : {
         id: uuid(),
-        type: 0,
+        type: NodeType.NODEJS,
     }
 
     return {

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -8,7 +8,7 @@ import { MarkOptional, DeepRequired } from 'ts-essentials'
 
 import CONFIG_SCHEMA from './config.schema.json'
 import { LogLevel } from '@streamr/utils'
-import { IceServer } from '@streamr/dht'
+import { IceServer, NodeType } from '@streamr/dht'
 
 import type { ConnectionInfo } from '@ethersproject/web'
 import { generateClientId } from './utils/utils'
@@ -123,7 +123,7 @@ export interface NetworkConfig {
 
 export interface JsonPeerDescriptor {
     id: string
-    type: number
+    type: NodeType
     websocket?: ConnectivityMethod
     openInternet?: boolean
     region?: number

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -1,3 +1,4 @@
+import { NodeType } from '@streamr/dht'
 import { toEthereumAddress } from '@streamr/utils'
 import { StreamrClientConfig } from './Config'
 import { MIN_KEY_LENGTH } from './encryption/RSAKeyPair'
@@ -23,7 +24,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
         layer0: {
             entryPoints: [{
                 id: 'entryPointBroker',
-                type: 0,
+                type: NodeType.NODEJS,
                 websocket: {
                     ip: '127.0.0.1',
                     port: 40401

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -63,6 +63,7 @@ export {
     StreamMessageType
 } from '@streamr/protocol'
 
+export { NodeType } from '@streamr/dht'
 export type { IceServer, PeerDescriptor } from '@streamr/dht' 
 export type { ConnectionInfo } from '@ethersproject/web'
 export type { ExternalProvider } from '@ethersproject/providers'

--- a/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
+++ b/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
@@ -2,6 +2,7 @@ import { createTestStream, createTestClient } from '../test-utils/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { Stream } from '../../src/Stream'
 import { StreamPermission } from '../../src/permission'
+import { NodeType } from '@streamr/dht'
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { wait } from '@streamr/utils'
 import { toStreamPartID } from '@streamr/protocol'
@@ -30,7 +31,7 @@ describe('PubSub with proxy connections', () => {
 
     const proxyNodeDescriptor1: JsonPeerDescriptor = {
         id: proxyNodeId1,
-        type: 0,
+        type: NodeType.NODEJS,
         websocket: {
             ip: 'localhost',
             port: proxyNodePort1
@@ -38,7 +39,7 @@ describe('PubSub with proxy connections', () => {
     }
     const proxyNodeDescriptor2: JsonPeerDescriptor = {
         id: proxyNodeId2,
-        type: 0,
+        type: NodeType.NODEJS,
         websocket: {
             ip: 'localhost',
             port: proxyNodePort2

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 
 import { Wallet } from '@ethersproject/wallet'
+import { NodeType } from '@streamr/dht'
 import { MAX_PARTITION_COUNT, StreamMessage, StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
 import { fastPrivateKey, fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { EthereumAddress, Logger, merge, wait, waitForCondition } from '@streamr/utils'
@@ -240,7 +241,7 @@ export const createTestClient = (privateKey: string, id: string, wsPort?: number
                 ...CONFIG_TEST.network!.layer0,
                 peerDescriptor: {
                     id,
-                    type: 0,
+                    type: NodeType.NODEJS,
                     websocket: wsPort ? {
                         ip: 'localhost',
                         port: wsPort

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,3 +1,4 @@
+import { NodeType } from '@streamr/dht'
 import { createStrictConfig, JsonPeerDescriptor, redactConfig } from '../../src/Config'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
@@ -121,7 +122,7 @@ describe('Config', () => {
         it('can override entryPoints', () => {
             const entryPoints = [{
                 id: '0xFBB6066c44bc8132bA794C73f58F391273E3bdA1',
-                type: 0,
+                type: NodeType.NODEJS,
                 websocket: {
                     ip: 'brubeck3.streamr.network',
                     port: 30401


### PR DESCRIPTION
## Summary

Use the DHT's NodeType to configure the PeerDescriptors type in the client and broker
