### PR TITLE
refactor(network, client): setStreamEntryPoints

### DIFF
--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -52,12 +52,6 @@ export interface ExtraSubscribeOptions {
      * and decryption _disabled_.
      */
     raw?: boolean
-
-    /**
-     * Configure known entry points to the stream 
-     * (e.g. for private streams, or if you want to avoid DHT lookups).
-     */
-    entryPoints?: JsonPeerDescriptor[]
 }
 
 /**
@@ -566,7 +560,6 @@ export class StreamrClient {
         return this.node.getEntryPoints()
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async setProxies(
         streamDefinition: StreamDefinition,
         nodeDescriptors: JsonPeerDescriptor[],
@@ -575,6 +568,15 @@ export class StreamrClient {
     ): Promise<void> {
         const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
         await this.node.setProxies(streamPartId, nodeDescriptors, direction, connectionCount)
+    }
+
+    /**
+     * Used to set known entry points for a stream. If known are not set they 
+     * will be automatically discovered from the Streamr Network.
+    */
+    async setStreamEntryPoints(streamDefinition: StreamDefinition, nodeDescriptors: JsonPeerDescriptor[]): Promise<void> {
+        const streamPartId = await this.streamIdBuilder.toStreamPartID(streamDefinition)
+        await this.node.setStreamEntryPoints(streamPartId, nodeDescriptors)
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -3,7 +3,6 @@ import isString from 'lodash/isString'
 import pLimit from 'p-limit'
 import { Lifecycle, inject, scoped } from 'tsyringe'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
-import { JsonPeerDescriptor } from '../Config'
 import { MessageFactory } from './MessageFactory'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { StreamIDBuilder } from '../StreamIDBuilder'
@@ -13,13 +12,11 @@ import { StreamRegistry } from '../registry/StreamRegistry'
 import { StreamDefinition } from '../types'
 import { GroupKeyQueue } from './GroupKeyQueue'
 import { Mapping } from '../utils/Mapping'
-import { entryPointTranslator } from '../utils/utils'
 
 export interface PublishMetadata {
     timestamp?: string | number | Date
     partitionKey?: string | number
     msgChainId?: string
-    knownEntryPoints?: JsonPeerDescriptor[]
 }
 
 const parseTimestamp = (metadata?: PublishMetadata): number => {
@@ -70,7 +67,6 @@ export class Publisher {
         metadata?: PublishMetadata
     ): Promise<StreamMessage<T>> {
         const timestamp = parseTimestamp(metadata)
-        const entryPoints = metadata?.knownEntryPoints ? entryPointTranslator(metadata.knownEntryPoints) : []  
         /*
          * There are some steps in the publish process which need to be done sequentially:
          * - message chaining
@@ -98,7 +94,7 @@ export class Publisher {
                     },
                     partition
                 )
-                await this.node.publishToNode(message, entryPoints)
+                await this.node.publishToNode(message)
                 return message
             } catch (e) {
                 const errorCode = (e instanceof StreamrClientError) ? e.code : 'UNKNOWN_ERROR'

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -1,7 +1,6 @@
 import { StreamPartID } from '@streamr/protocol'
 import { Logger } from '@streamr/utils'
 import { Lifecycle, scoped } from 'tsyringe'
-import { JsonPeerDescriptor } from '../Config'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
@@ -26,15 +25,14 @@ export class Subscriber {
         this.logger = loggerFactory.createLogger(module)
     }
 
-    getOrCreateSubscriptionSession(streamPartId: StreamPartID, knownEntryPoints?: JsonPeerDescriptor[]): SubscriptionSession {
+    getOrCreateSubscriptionSession(streamPartId: StreamPartID): SubscriptionSession {
         if (this.subSessions.has(streamPartId)) {
             return this.getSubscriptionSession(streamPartId)!
         }
         const subSession = new SubscriptionSession(
             streamPartId,
             this.messagePipelineFactory,
-            this.node,
-            knownEntryPoints
+            this.node
         )
 
         this.subSessions.set(streamPartId, subSession)
@@ -45,8 +43,8 @@ export class Subscriber {
         return subSession
     }
 
-    async add(sub: Subscription, knownEntryPoints?: JsonPeerDescriptor[]): Promise<void> {
-        const subSession = this.getOrCreateSubscriptionSession(sub.streamPartId, knownEntryPoints)
+    async add(sub: Subscription): Promise<void> {
+        const subSession = this.getOrCreateSubscriptionSession(sub.streamPartId)
 
         // add subscription to subSession
         try {

--- a/packages/client/src/subscribe/SubscriptionSession.ts
+++ b/packages/client/src/subscribe/SubscriptionSession.ts
@@ -1,13 +1,10 @@
 import { StreamMessage, StreamMessageType, StreamPartID } from '@streamr/protocol'
-import { JsonPeerDescriptor } from '../Config'
 import { NetworkNodeFacade, NetworkNodeStub } from '../NetworkNodeFacade'
 import { PushPipeline } from '../utils/PushPipeline'
 import { Scaffold } from '../utils/Scaffold'
 import { Signal } from '../utils/Signal'
-import { entryPointTranslator } from '../utils/utils'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
 import { Subscription } from './Subscription'
-import { PeerDescriptor } from '@streamr/dht'
 
 /**
  * Manages adding & removing subscriptions to node as needed.
@@ -24,12 +21,10 @@ export class SubscriptionSession {
     private readonly pendingRemoval: WeakSet<Subscription> = new WeakSet()
     private readonly pipeline: PushPipeline<StreamMessage, StreamMessage>
     private readonly node: NetworkNodeFacade
-    private readonly knownEntryPoints: PeerDescriptor[]
     constructor(
         streamPartId: StreamPartID,
         messagePipelineFactory: MessagePipelineFactory,
-        node: NetworkNodeFacade,
-        knownEntryPoints?: JsonPeerDescriptor[]
+        node: NetworkNodeFacade
     ) {
         this.streamPartId = streamPartId
         this.distributeMessage = this.distributeMessage.bind(this)
@@ -47,7 +42,6 @@ export class SubscriptionSession {
                 }
             })
         this.pipeline.flow()
-        this.knownEntryPoints = knownEntryPoints ? entryPointTranslator(knownEntryPoints) : []
     }
 
     private async retire(): Promise<void> {
@@ -106,7 +100,7 @@ export class SubscriptionSession {
     private async subscribe(): Promise<NetworkNodeStub> {
         const node = await this.node.getNode()
         node.addMessageListener(this.onMessageInput)
-        await node.subscribe(this.streamPartId, this.knownEntryPoints)
+        await node.subscribe(this.streamPartId)
         return node
     }
 

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -34,7 +34,7 @@ async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID)
 
     try {
         await networkNode.start()
-        networkNode.subscribe(toStreamPartID(streamId, 0), [])
+        networkNode.subscribe(toStreamPartID(streamId, 0))
         const messages: unknown[] = []
         networkNode.addMessageListener((msg) => {
             messages.push(msg.getContent())

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -40,12 +40,12 @@ export class FakeNetworkNode implements NetworkNodeStub {
         this.subscriptions.delete(streamPartId)
     }
 
-    async subscribeAndWaitForJoin(streamPartId: StreamPartID, _entryPointDescriptors?: PeerDescriptor[], _timeout?: number): Promise<number> {
+    async subscribeAndWaitForJoin(streamPartId: StreamPartID, _timeout?: number): Promise<number> {
         this.subscriptions.add(streamPartId)
         return this.getNeighborsForStreamPart(streamPartId).length
     }
 
-    async waitForJoinAndPublish(msg: StreamMessage, _entryPointDescriptors?: PeerDescriptor[], _timeout?: number): Promise<number> {
+    async waitForJoinAndPublish(msg: StreamMessage, _timeout?: number): Promise<number> {
         const streamPartID = msg.getStreamPartID()
         this.subscriptions.add(streamPartID)
         this.publish(msg)
@@ -75,6 +75,11 @@ export class FakeNetworkNode implements NetworkNodeStub {
             .filter((node) => (node.id !== this.id))
             .filter((node) => node.subscriptions.has(streamPartId))
             .map((node) => node.id)
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    setStreamEntryPoints(_streamPartId: StreamPartID, _peerDescriptors: PeerDescriptor[]): void {
+        return
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -102,6 +102,7 @@ export class StreamrNode extends EventEmitter<Events> {
     private readonly metrics: Metrics
     public config: StreamrNodeConfig
     private readonly streams: Map<string, StreamObject>
+    private readonly knownStreamEntryPoints: Map<string, PeerDescriptor[]> = new Map()
     protected extraMetadata: Record<string, unknown> = {}
     private started = false
     private destroyed = false
@@ -159,20 +160,20 @@ export class StreamrNode extends EventEmitter<Events> {
         this.connectionLocker = undefined
     }
 
-    subscribeToStream(streamPartID: string, knownEntryPointDescriptors: PeerDescriptor[]): void {
+    subscribeToStream(streamPartID: string): void {
         if (!this.streams.has(streamPartID)) {
-            this.joinStream(streamPartID, knownEntryPointDescriptors)
+            this.joinStream(streamPartID)
                 .catch((err) => {
                     logger.warn(`Failed to subscribe to stream ${streamPartID} with error: ${err}`)
                 })
         }
     }
 
-    publishToStream(streamPartID: string, knownEntryPointDescriptors: PeerDescriptor[], msg: StreamMessage): void {
+    publishToStream(streamPartID: string, msg: StreamMessage): void {
         if (this.streams.has(streamPartID)) {
             this.streams.get(streamPartID)!.layer2.broadcast(msg)
         } else {
-            this.joinStream(streamPartID, knownEntryPointDescriptors)
+            this.joinStream(streamPartID)
                 .catch((err) => {
                     logger.warn(`Failed to publish to stream ${streamPartID} with error: ${err}`)
                 })
@@ -194,24 +195,26 @@ export class StreamrNode extends EventEmitter<Events> {
         this.streamEntryPointDiscovery!.removeSelfAsEntryPoint(streamPartID)
     }
 
-    async joinStream(streamPartID: string, knownEntryPointDescriptors: PeerDescriptor[]): Promise<void> {
-        if (this.streams.has(streamPartID)) {
+    async joinStream(streamPartId: string): Promise<void> {
+        if (this.streams.has(streamPartId)) {
             return
         }
-        logger.info(`Joining stream ${streamPartID}`)
-        const [layer1, layer2] = this.createStream(streamPartID, knownEntryPointDescriptors)
+        logger.info(`Joining stream ${streamPartId}`)
+        const knownEntryPoints = this.knownStreamEntryPoints.get(streamPartId) ?? []
+        let entryPoints = knownEntryPoints.concat(knownEntryPoints)
+        const [layer1, layer2] = this.createStream(streamPartId, knownEntryPoints)
         await layer1.start()
         await layer2.start()
         const forwardingPeer = this.layer0!.isJoinOngoing() ? this.layer0!.getKnownEntryPoints()[0] : undefined
         const discoveryResult = await this.streamEntryPointDiscovery!.discoverEntryPointsFromDht(
-            streamPartID,
-            knownEntryPointDescriptors.length,
+            streamPartId,
+            knownEntryPoints.length,
             forwardingPeer
         )
-        const entryPoints = knownEntryPointDescriptors.concat(discoveryResult.discoveredEntryPoints)
+        entryPoints = knownEntryPoints.concat(discoveryResult.discoveredEntryPoints)
         await Promise.all(sampleSize(entryPoints, 4).map((entryPoint) => layer1.joinDht(entryPoint)))
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
-            streamPartID,
+            streamPartId,
             discoveryResult.joiningEmptyStream,
             discoveryResult.entryPointsFromDht,
             entryPoints.length
@@ -262,37 +265,35 @@ export class StreamrNode extends EventEmitter<Events> {
 
     async waitForJoinAndPublish(
         streamPartId: string,
-        knownEntryPointDescriptors: PeerDescriptor[],
         msg: StreamMessage,
         timeout?: number
     ): Promise<number> {
         if (this.getStream(streamPartId)?.type === StreamNodeType.PROXY) {
             return 0
         }
-        await this.joinStream(streamPartId, knownEntryPointDescriptors)
+        await this.joinStream(streamPartId)
         if (this.getStream(streamPartId)!.layer1!.getBucketSize() > 0) {
             const neighborCounter = new NeighborCounter(this.getStream(streamPartId)!.layer2 as RandomGraphNode, 1)
             await neighborCounter.waitForTargetReached(timeout || 5001)
         }
-        this.publishToStream(streamPartId, knownEntryPointDescriptors, msg)
+        this.publishToStream(streamPartId, msg)
         return this.getStream(streamPartId)?.layer2.getTargetNeighborStringIds().length || 0
     }
 
     async waitForJoinAndSubscribe(
         streamPartId: string,
-        knownEntryPointDescriptors: PeerDescriptor[],
         timeout?: number,
         expectedNeighbors = 1
     ): Promise<number> {
         if (this.getStream(streamPartId)?.type === StreamNodeType.PROXY) {
             return 0
         }
-        await this.joinStream(streamPartId, knownEntryPointDescriptors)
+        await this.joinStream(streamPartId)
         if (this.getStream(streamPartId)!.layer1!.getBucketSize() > 0) {
             const neighborCounter = new NeighborCounter(this.getStream(streamPartId)!.layer2 as RandomGraphNode, expectedNeighbors)
             await neighborCounter.waitForTargetReached(timeout || 5002)
         }
-        this.subscribeToStream(streamPartId, knownEntryPointDescriptors)
+        this.subscribeToStream(streamPartId)
         return this.getStream(streamPartId)?.layer2.getTargetNeighborStringIds().length || 0
     }
 
@@ -338,6 +339,10 @@ export class StreamrNode extends EventEmitter<Events> {
             nodeName: this.config.nodeName,
             userId: userId
         })
+    }
+
+    setStreamEntryPoints(streamPartId: string, entryPoints: PeerDescriptor[]): void {
+        this.knownStreamEntryPoints.set(streamPartId, entryPoints)
     }
 
     isProxiedStreamPart(streamId: string, direction: ProxyDirection): boolean {

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -95,7 +95,7 @@ const measureJoiningTime = async (count: number) => {
             messageType: StreamMessageType.MESSAGE,
             signature: 'signature',
         })
-        streams.get(stream)!.publish(streamMessage, [])
+        streams.get(stream)!.publish(streamMessage)
     }, 1000)
     // get random node from network to use as entrypoint
     const randomNode = nodes[Math.floor(Math.random() * nodes.length)]

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -63,11 +63,11 @@ describe('proxy and full node', () => {
             }
         })
         await proxyNode.start()
-        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId, [])
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId1, [])
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId2, [])
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId3, [])
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId4, [])
+        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId)
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId1)
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId2)
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId3)
+        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId4)
 
         proxiedNode = new NetworkNode({
             layer0: {

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -58,7 +58,8 @@ describe('Proxy connections', () => {
             }
         })
         await proxyNode1.start()
-        await proxyNode1.stack.getStreamrNode()!.joinStream(streamPartId, [proxyNodeDescriptor1])
+        await proxyNode1.setStreamEntryPoints(streamPartId, [proxyNodeDescriptor1])
+        await proxyNode1.stack.getStreamrNode()!.joinStream(streamPartId)
        
         proxyNode2 = new NetworkNode({
             layer0: {
@@ -70,7 +71,8 @@ describe('Proxy connections', () => {
             }
         })
         await proxyNode2.start()
-        await proxyNode2.stack.getStreamrNode()!.joinStream(streamPartId, [proxyNodeDescriptor1])
+        proxyNode2.setStreamEntryPoints(streamPartId, [proxyNodeDescriptor1])
+        await proxyNode2.stack.getStreamrNode()!.joinStream(streamPartId)
 
         proxiedNode = new NetworkNode({
             layer0: {
@@ -195,7 +197,7 @@ describe('Proxy connections', () => {
             proxiedNode.hasProxyConnection(streamPartId, keyFromPeerDescriptor(proxyNodeDescriptor1), ProxyDirection.SUBSCRIBE))
         expect(proxyNode1.hasProxyConnection(streamPartId, proxiedPeerId.toKey(), ProxyDirection.SUBSCRIBE)).toBe(false)
     
-        await proxyNode1.stack.getStreamrNode()!.joinStream(streamPartId, [proxyNodeDescriptor1])
+        await proxyNode1.stack.getStreamrNode()!.joinStream(streamPartId)
         await waitForCondition(() => 
             proxiedNode.hasProxyConnection(streamPartId, keyFromPeerDescriptor(proxyNodeDescriptor1), ProxyDirection.SUBSCRIBE)
         , 25000)

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -50,7 +50,8 @@ describe('proxy group key exchange', () => {
             }
         })
         await proxyNode.start()
-        await proxyNode.stack.getStreamrNode()!.joinStream(streamPartId, [proxyNodeDescriptor])
+        proxyNode.setStreamEntryPoints(streamPartId, [proxyNodeDescriptor])
+        await proxyNode.stack.getStreamrNode()!.joinStream(streamPartId)
         publisher = new NetworkNode({
             layer0: {
                 entryPoints: [publisherDescriptor],
@@ -105,7 +106,7 @@ describe('proxy group key exchange', () => {
 
         await Promise.all([
             waitForEvent3(publisher.stack.getStreamrNode()! as any, 'newMessage'),
-            subscriber.publish(request, [proxyNodeDescriptor])
+            subscriber.publish(request)
         ])
     })
 
@@ -135,7 +136,7 @@ describe('proxy group key exchange', () => {
 
         await Promise.all([
             waitForEvent3(subscriber.stack.getStreamrNode()! as any, 'newMessage'),
-            publisher.publish(response, [proxyNodeDescriptor])
+            publisher.publish(response)
         ])
     })
 })

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -35,7 +35,8 @@ describe('Full node network with WebRTC connections', () => {
             networkNode: {}
         })
         await entryPoint.start()
-        await entryPoint.getStreamrNode()!.joinStream(randomGraphId, [epPeerDescriptor])
+        entryPoint.getStreamrNode()!.setStreamEntryPoints(randomGraphId, [epPeerDescriptor])
+        await entryPoint.getStreamrNode()!.joinStream(randomGraphId)
 
         await Promise.all(range(NUM_OF_NODES).map(async (i) => {
             const peerId = PeerID.fromString(`${i}`)
@@ -52,8 +53,9 @@ describe('Full node network with WebRTC connections', () => {
             })
             nodes.push(node)
             await node.start()
-            await node.getStreamrNode().joinStream(randomGraphId, [epPeerDescriptor])
-            node.getStreamrNode!().subscribeToStream(randomGraphId, [epPeerDescriptor])
+            node.getStreamrNode().setStreamEntryPoints(randomGraphId, [epPeerDescriptor])
+            await node.getStreamrNode().joinStream(randomGraphId)
+            node.getStreamrNode!().subscribeToStream(randomGraphId)
         }))
 
     }, 90000)
@@ -88,7 +90,7 @@ describe('Full node network with WebRTC connections', () => {
             randomGraphId,
             peerIdFromPeerDescriptor(epPeerDescriptor).toString()
         )
-        entryPoint.getStreamrNode()!.publishToStream(randomGraphId, [epPeerDescriptor], msg)
+        entryPoint.getStreamrNode()!.publishToStream(randomGraphId, msg)
         await waitForCondition(() => numOfMessagesReceived === NUM_OF_NODES)
     }, 120000)
 

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -32,7 +32,8 @@ describe('Full node network with WebSocket connections only', () => {
             networkNode: {}
         })
         await entryPoint.start()
-        await entryPoint.getStreamrNode()!.joinStream(randomGraphId, [epPeerDescriptor])
+        entryPoint.getStreamrNode()!.setStreamEntryPoints(randomGraphId, [epPeerDescriptor])
+        await entryPoint.getStreamrNode()!.joinStream(randomGraphId)
 
         await Promise.all(range(NUM_OF_NODES).map(async (i) => {
             const node = new NetworkStack({
@@ -48,8 +49,9 @@ describe('Full node network with WebSocket connections only', () => {
             })
             nodes.push(node)
             await node.start()
-            await node.getStreamrNode().joinStream(randomGraphId, [epPeerDescriptor])
-            node.getStreamrNode!().subscribeToStream(randomGraphId, [epPeerDescriptor])
+            node.getStreamrNode!().setStreamEntryPoints(randomGraphId, [epPeerDescriptor])
+            await node.getStreamrNode().joinStream(randomGraphId)
+            node.getStreamrNode!().subscribeToStream(randomGraphId)
         }))
 
     }, 120000)
@@ -84,7 +86,7 @@ describe('Full node network with WebSocket connections only', () => {
             randomGraphId,
             peerIdFromPeerDescriptor(epPeerDescriptor).toString()
         )
-        entryPoint.getStreamrNode()!.publishToStream(randomGraphId, [epPeerDescriptor], msg)
+        entryPoint.getStreamrNode()!.publishToStream(randomGraphId, msg)
         await waitForCondition(() => numOfMessagesReceived === NUM_OF_NODES)
     }, 220000)
 

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -54,7 +54,9 @@ describe('NetworkNode', () => {
         })
 
         await node1.start()
+        node1.setStreamEntryPoints(STREAM_ID, [pd1])
         await node2.start()
+        node2.setStreamEntryPoints(STREAM_ID, [pd1])
     })
 
     afterEach(async () => {
@@ -84,13 +86,13 @@ describe('NetworkNode', () => {
         })
 
         let msgCount = 0
-        await node1.subscribeAndWaitForJoin(STREAM_ID, [pd1])
+        await node1.subscribeAndWaitForJoin(STREAM_ID)
         node1.addMessageListener((msg) => {
             expect(msg.messageId.timestamp).toEqual(666)
             expect(msg.getSequenceNumber()).toEqual(0)
             msgCount += 1
         })
-        await node2.waitForJoinAndPublish(streamMessage, [pd1])
+        await node2.waitForJoinAndPublish(streamMessage)
         await waitForCondition(() => msgCount === 1)
     })
 

--- a/packages/trackerless-network/test/integration/NetworkStack.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStack.test.ts
@@ -12,6 +12,7 @@ describe('NetworkStack', () => {
 
     let stack1: NetworkStack
     let stack2: NetworkStack
+    const streamPartId = StreamPartIDUtils.parse('stream1#0')
 
     const epDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString('entrypoint').value,
@@ -40,7 +41,9 @@ describe('NetworkStack', () => {
         })
 
         await stack1.start()
+        stack1.getStreamrNode()!.setStreamEntryPoints(streamPartId, [epDescriptor])
         await stack2.start()
+        stack2.getStreamrNode()!.setStreamEntryPoints(streamPartId, [epDescriptor])
     })
 
     afterEach(async () => {
@@ -52,8 +55,7 @@ describe('NetworkStack', () => {
 
     it('Can use NetworkNode pub/sub via NetworkStack', async () => {
         let receivedMessages = 0
-        const streamPartId = StreamPartIDUtils.parse('stream1#0')
-        await stack1.getStreamrNode().waitForJoinAndSubscribe(streamPartId, [epDescriptor])
+        await stack1.getStreamrNode().waitForJoinAndSubscribe(streamPartId)
         stack1.getStreamrNode().on('newMessage', () => {
             receivedMessages += 1
         })
@@ -65,7 +67,7 @@ describe('NetworkStack', () => {
             toStreamID(streamPartId),
             PeerID.fromString('network-stack').toKey()
         )
-        await stack2.getStreamrNode().waitForJoinAndPublish(streamPartId, [epDescriptor], msg)
+        await stack2.getStreamrNode().waitForJoinAndPublish(streamPartId, msg)
         await waitForCondition(() => receivedMessages === 1)
     })
 

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -72,7 +72,9 @@ describe('StreamrNode', () => {
         node1 = new StreamrNode({})
         node2 = new StreamrNode({})
         await node1.start(layer01, transport1, transport1)
+        node1.setStreamEntryPoints(STREAM_ID, [peer1])
         await node2.start(layer02, transport2, transport2)
+        node2.setStreamEntryPoints(STREAM_ID, [peer1])
     })
 
     it('starts', async () => {
@@ -81,8 +83,8 @@ describe('StreamrNode', () => {
     })
 
     it('Joining stream', async () => {
-        await node1.joinStream(STREAM_ID, [peer1])
-        await node2.joinStream(STREAM_ID, [peer1])
+        await node1.joinStream(STREAM_ID)
+        await node2.joinStream(STREAM_ID)
         await waitForCondition(() => node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1)
         await waitForCondition(() => node2.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1)
         expect(node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length).toEqual(1)
@@ -90,24 +92,26 @@ describe('StreamrNode', () => {
     })
 
     it('Publishing after joining and waiting for neighbors', async () => {
-        node1.subscribeToStream(STREAM_ID, [peer1])
-        await node2.joinStream(STREAM_ID, [peer1])
+        node1.subscribeToStream(STREAM_ID)
+        await node2.joinStream(STREAM_ID)
         await waitForCondition(() => node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1)
         await waitForCondition(() => node2.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1)
         await Promise.all([
             waitForEvent3<Events>(node1, 'newMessage'),
-            node2.publishToStream(STREAM_ID, [peer1], msg)
+            node2.publishToStream(STREAM_ID, msg)
         ])
     })
 
     it('multi-stream pub/sub', async () => {
         const stream2 = 'test2'
-        await node1.joinStream(STREAM_ID, [peer1])
-        await node1.joinStream(stream2, [peer1])
-        await node2.joinStream(STREAM_ID, [peer1])
-        await node2.joinStream(stream2, [peer1])
-        node1.subscribeToStream(STREAM_ID, [peer1])
-        node2.subscribeToStream(stream2, [peer1])
+        node1.setStreamEntryPoints(stream2, [peer1])
+        node2.setStreamEntryPoints(stream2, [peer1])
+        await node1.joinStream(STREAM_ID)
+        await node1.joinStream(stream2)
+        await node2.joinStream(STREAM_ID)
+        await node2.joinStream(stream2)
+        node1.subscribeToStream(STREAM_ID)
+        node2.subscribeToStream(stream2)
         await Promise.all([
             waitForCondition(() => node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1),
             waitForCondition(() => node2.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1),
@@ -122,14 +126,14 @@ describe('StreamrNode', () => {
         await Promise.all([
             waitForEvent3<Events>(node1, 'newMessage'),
             waitForEvent3<Events>(node2, 'newMessage'),
-            node1.publishToStream(stream2, [peer1], msg2),
-            node2.publishToStream(STREAM_ID, [peer1], msg)
+            node1.publishToStream(stream2, msg2),
+            node2.publishToStream(STREAM_ID, msg)
         ])
     })
 
     it('leaving streams', async () => {
-        await node1.joinStream(STREAM_ID, [peer1])
-        await node2.joinStream(STREAM_ID, [peer1])
+        await node1.joinStream(STREAM_ID)
+        await node2.joinStream(STREAM_ID)
         await Promise.all([
             waitForCondition(() => node1.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1),
             waitForCondition(() => node2.getStream(STREAM_ID)!.layer2.getTargetNeighborStringIds().length === 1)

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -107,7 +107,7 @@ describe('stream without default entrypoints', () => {
     it('multiple nodes can join without configured entrypoints simultaneously', async () => {
         const numOfSubscribers = 8
         await Promise.all(range(numOfSubscribers).map(async (i) => {
-            await nodes[i].subscribeAndWaitForJoin(STREAM_ID, [], undefined, 4)
+            await nodes[i].subscribeAndWaitForJoin(STREAM_ID, undefined, 4)
             nodes[i].addMessageListener((_msg) => {
                 numOfReceivedMessages += 1
             })

--- a/packages/trackerless-network/test/unit/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/unit/StreamrNode.test.ts
@@ -23,6 +23,7 @@ describe('StreamrNode', () => {
         node = new StreamrNode({})
         const mockLayer0 = new MockLayer0(peerDescriptor)
         await node.start(mockLayer0, new MockTransport(), mockConnectionLocker)
+        node.setStreamEntryPoints(stream, [peerDescriptor])
     })
 
     afterEach(async () => {
@@ -34,39 +35,39 @@ describe('StreamrNode', () => {
     })
 
     it('can join streams', async () => {
-        await node.joinStream(stream, [peerDescriptor])
+        await node.joinStream(stream)
         expect(node.hasStream(stream)).toEqual(true)
     })
 
     it('can leave streams', async () => {
-        await node.joinStream(stream, [peerDescriptor])
+        await node.joinStream(stream)
         expect(node.hasStream(stream)).toEqual(true)
         node.leaveStream(stream)
         expect(node.hasStream(stream)).toEqual(false)
     })
 
     it('subscribe and wait for join', async () => {
-        await node.waitForJoinAndSubscribe(stream, [peerDescriptor])
+        await node.waitForJoinAndSubscribe(stream)
         expect(node.hasStream(stream)).toEqual(true)
     })
 
     it('publish and wait for join', async () => {
-        await node.waitForJoinAndPublish(stream, [peerDescriptor], message)
+        await node.waitForJoinAndPublish(stream, message)
         expect(node.hasStream(stream)).toEqual(true)
     })
 
     it('subscribe joins stream', async () => {
-        node.subscribeToStream(stream, [peerDescriptor])
+        node.subscribeToStream(stream)
         await waitForCondition(() => node.hasStream(stream))
     })
 
     it('publish joins stream', async () => {
-        await node.publishToStream(stream, [peerDescriptor], message)
+        await node.publishToStream(stream, message)
         await waitForCondition(() => node.hasStream(stream))
     })
 
     it('can unsubscribe', async () => {
-        await node.joinStream(stream, [peerDescriptor])
+        await node.joinStream(stream)
         await node.unsubscribeFromStream(stream)
     })
 


### PR DESCRIPTION
## Summary

Known entry points for streams are now set separately with the setStreamEntryPoints() call instead of passing them as arguments for the publish and subscribe options.

