### PR TITLE
reduce client test timeouts

### DIFF
--- a/packages/client/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/client/test/end-to-end/MemoryLeaks.test.ts
@@ -147,7 +147,7 @@ describe('MemoryLeaks', () => {
                 const client = await createClient()
                 await client.connect()
                 await client.destroy()
-                leaksDetector.addAll(instanceId(client), client) // Should this be moved up by catch leaks?
+                leaksDetector.addAll(instanceId(client), client)
             })
         })
 

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -68,7 +68,7 @@ describe('NodeMetrics', () => {
         const dummyStream = await generatorClient.createStream(`/${Date.now()}`)
         await generatorClient.subscribe(dummyStream, () => {})
 
-        await waitForCondition(() => report !== undefined, 15000)
+        await waitForCondition(() => report !== undefined, 10000)
         expect(report!).toMatchObject({
             node: {
                 publishMessagesPerSecond: expect.any(Number),

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -7,7 +7,7 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { until } from '../../src/utils/promises'
 import { createTestStream, createTestClient } from '../test-utils/utils'
 
-const TEST_TIMEOUT = 60 * 1000
+const TEST_TIMEOUT = 30 * 1000
 
 describe('StorageNodeRegistry', () => {
     let creatorWallet: Wallet

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -10,7 +10,7 @@ import { waitForCondition } from '@streamr/utils'
 import { NetworkNode } from '@streamr/trackerless-network'
 import { PeerID } from '@streamr/dht'
 
-const TIMEOUT = 60 * 1000
+const TIMEOUT = 30 * 1000
 
 const PAYLOAD = { hello: 'world' }
 
@@ -107,10 +107,10 @@ describe('publish-subscribe', () => {
 
         it('subscriber is able to receive and decrypt messages', async () => {
             const messages: any[] = []
-            await publisherClient.publish(stream.id, PAYLOAD)
             await subscriberClient.subscribe(stream.id, (msg: any) => {
                 messages.push(msg)
             })
+            await publisherClient.publish(stream.id, PAYLOAD)
             await waitForCondition(() => messages.length > 0, 15000)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)
@@ -134,10 +134,10 @@ describe('publish-subscribe', () => {
 
         it('subscriber is able to receive messages', async () => {
             const messages: unknown[] = []
-            await publisherClient.publish(stream.id, PAYLOAD)
             await subscriberClient.subscribe(stream.id, (msg: any) => {
                 messages.push(msg)
             })
+            await publisherClient.publish(stream.id, PAYLOAD)
             await waitForCondition(() => messages.length > 0)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -107,10 +107,10 @@ describe('publish-subscribe', () => {
 
         it('subscriber is able to receive and decrypt messages', async () => {
             const messages: any[] = []
+            await publisherClient.publish(stream.id, PAYLOAD)
             await subscriberClient.subscribe(stream.id, (msg: any) => {
                 messages.push(msg)
             })
-            await publisherClient.publish(stream.id, PAYLOAD)
             await waitForCondition(() => messages.length > 0, 15000)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)

--- a/packages/client/test/end-to-end/resend.test.ts
+++ b/packages/client/test/end-to-end/resend.test.ts
@@ -46,7 +46,7 @@ describe('resend', () => {
                 })
             }
             await wait(MESSAGE_STORE_TIMEOUT)
-        }, TIMEOUT * 2)
+        }, TIMEOUT)
 
         it('can request resend for all messages', async () => {
             const messages: unknown[] = []

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -152,7 +152,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
                         this.emit('findCompleted', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
                         this.findCompletedEmitted = true
                     }
-                }, 5000)
+                }, 4000)
             }
         }
     }

--- a/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
@@ -30,8 +30,8 @@ const exponentialRunOff = async (
     task: () => Promise<void>,
     description: string,
     abortSignal: AbortSignal,
-    baseDelay = 1000,
-    maxAttempts = 5
+    baseDelay = 500,
+    maxAttempts = 6
 ): Promise<void> => {
     for (let i = 1; i <= maxAttempts; i++) {
         if (abortSignal.aborted) {


### PR DESCRIPTION
## Summary

Reduce client test timeouts by reduce timeoutes related to stream split recovery in DHT and Trackerless Network