### PR TITLE
refactor(network): Remove unused fields in HandshakeRequest

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -95,8 +95,7 @@ message StreamHandshakeRequest {
   repeated string neighbors = 5;
   repeated string peerView = 6;
   dht.PeerDescriptor senderDescriptor = 7;
-  bool interleaving = 8;
-  optional string interleavingFrom = 9;
+  optional string interleavingFrom = 8;
 }
 
 message StreamHandshakeResponse {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -93,9 +93,8 @@ message StreamHandshakeRequest {
   string requestId = 3;
   optional string concurrentHandshakeTargetId = 4;
   repeated string neighbors = 5;
-  repeated string peerView = 6;
-  dht.PeerDescriptor senderDescriptor = 7;
-  optional string interleavingFrom = 8;
+  dht.PeerDescriptor senderDescriptor = 6;
+  optional string interleavingFrom = 7;
 }
 
 message StreamHandshakeResponse {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -154,7 +154,6 @@ export class Handshaker implements IHandshaker {
             this.config.targetNeighbors.getStringIds(),
             this.config.nearbyContactPool.getStringIds(),
             undefined,
-            true,
             interleavingFrom
         )
         if (result.accepted) {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -127,7 +127,6 @@ export class Handshaker implements IHandshaker {
         const result = await targetNeighbor.handshake(
             this.config.ownPeerDescriptor,
             this.config.targetNeighbors.getStringIds(),
-            this.config.nearbyContactPool.getStringIds(),
             concurrentStringId
         )
         if (result.accepted) {
@@ -152,7 +151,6 @@ export class Handshaker implements IHandshaker {
         const result = await targetNeighbor.handshake(
             this.config.ownPeerDescriptor,
             this.config.targetNeighbors.getStringIds(),
-            this.config.nearbyContactPool.getStringIds(),
             undefined,
             interleavingFrom
         )

--- a/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
@@ -18,7 +18,6 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
         neighbors: string[],
         peerView: string[],
         concurrentHandshakeTargetId?: string,
-        interleaving = false,
         interleavingFrom?: string
     ): Promise<HandshakeResponse> {
         const request: StreamHandshakeRequest = {
@@ -28,7 +27,6 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
             neighbors,
             peerView,
             concurrentHandshakeTargetId,
-            interleaving,
             interleavingFrom,
             senderDescriptor: ownPeerDescriptor
         }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
@@ -16,7 +16,6 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
     async handshake(
         ownPeerDescriptor: PeerDescriptor,
         neighbors: string[],
-        peerView: string[],
         concurrentHandshakeTargetId?: string,
         interleavingFrom?: string
     ): Promise<HandshakeResponse> {
@@ -25,7 +24,6 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
             requestId: new UUID().toString(),
             senderId: keyFromPeerDescriptor(ownPeerDescriptor),
             neighbors,
-            peerView,
             concurrentHandshakeTargetId,
             interleavingFrom,
             senderDescriptor: ownPeerDescriptor

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -177,11 +177,7 @@ export interface StreamHandshakeRequest {
      */
     senderDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: bool interleaving = 8;
-     */
-    interleaving: boolean;
-    /**
-     * @generated from protobuf field: optional string interleavingFrom = 9;
+     * @generated from protobuf field: optional string interleavingFrom = 8;
      */
     interleavingFrom?: string;
 }
@@ -490,8 +486,7 @@ class StreamHandshakeRequest$Type extends MessageType<StreamHandshakeRequest> {
             { no: 5, name: "neighbors", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "peerView", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 7, name: "senderDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 8, name: "interleaving", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 9, name: "interleavingFrom", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 8, name: "interleavingFrom", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -169,15 +169,11 @@ export interface StreamHandshakeRequest {
      */
     neighbors: string[];
     /**
-     * @generated from protobuf field: repeated string peerView = 6;
-     */
-    peerView: string[];
-    /**
-     * @generated from protobuf field: dht.PeerDescriptor senderDescriptor = 7;
+     * @generated from protobuf field: dht.PeerDescriptor senderDescriptor = 6;
      */
     senderDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: optional string interleavingFrom = 8;
+     * @generated from protobuf field: optional string interleavingFrom = 7;
      */
     interleavingFrom?: string;
 }
@@ -484,9 +480,8 @@ class StreamHandshakeRequest$Type extends MessageType<StreamHandshakeRequest> {
             { no: 3, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "concurrentHandshakeTargetId", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "neighbors", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 6, name: "peerView", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 7, name: "senderDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 8, name: "interleavingFrom", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 6, name: "senderDescriptor", kind: "message", T: () => PeerDescriptor },
+            { no: 7, name: "interleavingFrom", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/integration/RemoteHandshaker.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteHandshaker.test.ts
@@ -72,7 +72,7 @@ describe('RemoteHandshaker', () => {
     })
 
     it('handshake', async () => {
-        const result = await remoteHandshaker.handshake(clientPeer, [], [])
+        const result = await remoteHandshaker.handshake(clientPeer, [])
         expect(result.accepted).toEqual(true)
     })
 })


### PR DESCRIPTION
## Summary

Remove unused fields `interleaving` and `peerView` from HandshakeRequest