### PR TITLE
feat(broker): NET-996 getLeaderNodeId

### DIFF
--- a/packages/broker/src/plugins/operator/OperatorFleetState.ts
+++ b/packages/broker/src/plugins/operator/OperatorFleetState.ts
@@ -3,6 +3,7 @@ import { Logger } from '@streamr/utils'
 import { StreamID } from '@streamr/protocol'
 import { EventEmitter } from 'eventemitter3'
 import { NodeId } from '@streamr/trackerless-network'
+import min from 'lodash/min'
 
 const logger = new Logger(module)
 
@@ -69,7 +70,7 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
     }
 
     getLeaderNodeId(): string | undefined {
-        return this.getNodeIds().sort()[0]
+        return min(this.getNodeIds()) // we just need the leader to be consistent
     }
 
     getNodeIds(): string[] {

--- a/packages/broker/src/plugins/operator/OperatorFleetState.ts
+++ b/packages/broker/src/plugins/operator/OperatorFleetState.ts
@@ -68,6 +68,10 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
         await this.subscription?.unsubscribe()
     }
 
+    getLeaderNodeId(): string | undefined {
+        return this.getNodeIds().sort()[0]
+    }
+
     getNodeIds(): string[] {
         return [...this.heartbeatTimestamps.keys()]
     }

--- a/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -133,10 +133,10 @@ describe(OperatorFleetState, () => {
 
     it('getLeaderNodeId returns leader node when nodes', async () => {
         await state.start()
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
-        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'c' })
         await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'd' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'c' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
 
         expect(state.getLeaderNodeId()).toEqual('a')
     })

--- a/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -125,4 +125,19 @@ describe(OperatorFleetState, () => {
         await waitForEvent(state as any, 'removed')
         expect(state.getNodeIds()).toEqual([])
     })
+
+    it('getLeaderNodeId returns undefined when no nodes', async () => {
+        await state.start()
+        expect(state.getLeaderNodeId()).toBeUndefined()
+    })
+
+    it('getLeaderNodeId returns leader node when nodes', async () => {
+        await state.start()
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'c' })
+        await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'd' })
+
+        expect(state.getLeaderNodeId()).toEqual('a')
+    })
 })


### PR DESCRIPTION
## Summary

Add method `getLeaderNodeId()` to class `OperatorFleetState` for determining leader node of operator fleet.

## Limitations and future improvements

- Array sorted on each invocation of method. Most likely acceptable since method should be called fairly rarely. If we need to call it often, we should cache the result.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
