### PR TITLE
broker(feat): NET-999 add method `waitForReady` to `OperatorFleetState`

### DIFF
--- a/packages/broker/src/plugins/operator/AnnounceNodeService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeService.ts
@@ -4,7 +4,7 @@ import { StreamID, toStreamID } from '@streamr/protocol'
 
 const logger = new Logger(module)
 
-const DEFAULT_INTERVAL_IN_MS = 1000 * 10
+export const DEFAULT_INTERVAL_IN_MS = 1000 * 10
 
 export class AnnounceNodeService {
     private readonly abortController = new AbortController()

--- a/packages/broker/src/plugins/operator/OperatorFleetState.ts
+++ b/packages/broker/src/plugins/operator/OperatorFleetState.ts
@@ -26,11 +26,11 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
     private readonly timeProvider: () => number
     private readonly pruneAgeInMs: number
     private readonly pruneIntervalInMs: number
-    private readonly heartBeatIntervalInMs: number
+    private readonly heartbeatIntervalInMs: number
     private readonly latencyExtraInMs: number
     private readonly heartbeatTimestamps = new Map<NodeId, number>()
     private readonly abortController = new AbortController()
-    private ready = new Gate(false)
+    private readonly ready = new Gate(false)
     private subscription?: Subscription
 
     constructor(
@@ -39,7 +39,7 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
         timeProvider = Date.now,
         pruneAgeInMs = DEFAULT_PRUNE_AGE_IN_MS,
         pruneIntervalInMs = DEFAULT_PRUNE_INTERVAL_IN_MS,
-        heartBeatIntervalInMs = DEFAULT_INTERVAL_IN_MS,
+        heartbeatIntervalInMs = DEFAULT_INTERVAL_IN_MS,
         latencyExtraInMs = DEFAULT_LATENCY_EXTRA_MS
     ) {
         super()
@@ -48,7 +48,7 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
         this.timeProvider = timeProvider
         this.pruneAgeInMs = pruneAgeInMs
         this.pruneIntervalInMs = pruneIntervalInMs
-        this.heartBeatIntervalInMs = heartBeatIntervalInMs
+        this.heartbeatIntervalInMs = heartbeatIntervalInMs
         this.latencyExtraInMs = latencyExtraInMs
     }
 
@@ -98,7 +98,7 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
     private launchOpenReadyGateTimer = once(() => {
         setAbortableTimeout(() => {
             this.ready.open()
-        }, this.heartBeatIntervalInMs + this.latencyExtraInMs, this.abortController.signal)
+        }, this.heartbeatIntervalInMs + this.latencyExtraInMs, this.abortController.signal)
     })
 
     private pruneOfflineNodes(): void {

--- a/packages/broker/src/plugins/operator/OperatorFleetState.ts
+++ b/packages/broker/src/plugins/operator/OperatorFleetState.ts
@@ -1,15 +1,19 @@
 import { StreamrClient, Subscription } from 'streamr-client'
-import { Logger } from '@streamr/utils'
+import { Gate, Logger, setAbortableInterval, setAbortableTimeout } from '@streamr/utils'
 import { StreamID } from '@streamr/protocol'
 import { EventEmitter } from 'eventemitter3'
 import { NodeId } from '@streamr/trackerless-network'
 import min from 'lodash/min'
+import once from 'lodash/once'
+import { DEFAULT_INTERVAL_IN_MS } from './AnnounceNodeService'
 
 const logger = new Logger(module)
 
 const DEFAULT_PRUNE_AGE_IN_MS = 5 * 60 * 1000
 
 const DEFAULT_PRUNE_INTERVAL_IN_MS = 30 * 1000
+
+const DEFAULT_LATENCY_EXTRA_MS = 2000
 
 export interface OperatorFleetStateEvents {
     added: (nodeId: string) => void
@@ -22,16 +26,21 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
     private readonly timeProvider: () => number
     private readonly pruneAgeInMs: number
     private readonly pruneIntervalInMs: number
+    private readonly heartBeatIntervalInMs: number
+    private readonly latencyExtraInMs: number
     private readonly heartbeatTimestamps = new Map<NodeId, number>()
+    private readonly abortController = new AbortController()
+    private ready = new Gate(false)
     private subscription?: Subscription
-    private pruneNodesIntervalRef?: NodeJS.Timeout
 
     constructor(
         streamrClient: StreamrClient,
         coordinationStreamId: StreamID,
         timeProvider = Date.now,
         pruneAgeInMs = DEFAULT_PRUNE_AGE_IN_MS,
-        pruneIntervalInMs = DEFAULT_PRUNE_INTERVAL_IN_MS
+        pruneIntervalInMs = DEFAULT_PRUNE_INTERVAL_IN_MS,
+        heartBeatIntervalInMs = DEFAULT_INTERVAL_IN_MS,
+        latencyExtraInMs = DEFAULT_LATENCY_EXTRA_MS
     ) {
         super()
         this.streamrClient = streamrClient
@@ -39,6 +48,8 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
         this.timeProvider = timeProvider
         this.pruneAgeInMs = pruneAgeInMs
         this.pruneIntervalInMs = pruneIntervalInMs
+        this.heartBeatIntervalInMs = heartBeatIntervalInMs
+        this.latencyExtraInMs = latencyExtraInMs
     }
 
     async start(): Promise<void> {
@@ -59,13 +70,20 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
                 if (!exists) {
                     this.emit('added', nodeId)
                 }
+                if (!this.ready.isOpen()) {
+                    this.launchOpenReadyGateTimer()
+                }
             }
         })
-        this.pruneNodesIntervalRef = setInterval(() => this.pruneOfflineNodes(), this.pruneIntervalInMs)
+        setAbortableInterval(() => this.pruneOfflineNodes(), this.pruneIntervalInMs, this.abortController.signal)
+    }
+
+    async waitUntilReady(): Promise<void> {
+        return this.ready.waitUntilOpen()
     }
 
     async destroy(): Promise<void> {
-        clearInterval(this.pruneNodesIntervalRef)
+        this.abortController.abort()
         await this.subscription?.unsubscribe()
     }
 
@@ -76,6 +94,12 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
     getNodeIds(): string[] {
         return [...this.heartbeatTimestamps.keys()]
     }
+
+    private launchOpenReadyGateTimer = once(() => {
+        setAbortableTimeout(() => {
+            this.ready.open()
+        }, this.heartBeatIntervalInMs + this.latencyExtraInMs, this.abortController.signal)
+    })
 
     private pruneOfflineNodes(): void {
         const now = this.timeProvider()

--- a/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -8,6 +8,9 @@ import { eventsWithArgsToArray, randomEthereumAddress } from '@streamr/test-util
 const ADDRESS = randomEthereumAddress()
 const coordinationStreamId = toStreamID('/operator/coordination', ADDRESS)
 
+const READY_WAIT_MS = 500
+const JITTER = 100
+
 describe(OperatorFleetState, () => {
     let streamrClient: MockProxy<StreamrClient>
     let subscription: MockProxy<Subscription>
@@ -29,7 +32,7 @@ describe(OperatorFleetState, () => {
             return subscription
         })
         currentTime = 0
-        state = new OperatorFleetState(streamrClient, coordinationStreamId, () => currentTime, 10, 100)
+        state = new OperatorFleetState(streamrClient, coordinationStreamId, () => currentTime, 10, 100, READY_WAIT_MS, 0)
     })
 
     afterEach(() => {
@@ -139,5 +142,33 @@ describe(OperatorFleetState, () => {
         await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
 
         expect(state.getLeaderNodeId()).toEqual('a')
+    })
+
+    describe('waitUntilReady', () => {
+        let ready: boolean
+
+        beforeEach(() => {
+            ready = false
+            // eslint-disable-next-line promise/always-return,promise/catch-or-return
+            state.waitUntilReady().then(() => {
+                ready = true
+            })
+        })
+
+        it('does not become ready if no heartbeat arrives', async () => {
+            await state.start()
+            await wait(READY_WAIT_MS + JITTER)
+            expect(ready).toBeFalse()
+        })
+
+        it('eventually becomes ready if heartbeat arrives', async () => {
+            await state.start()
+            await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'a' })
+            await setTimeAndPublishMessage(5, { msgType: 'heartbeat', nodeId: 'b' })
+            await setTimeAndPublishMessage(10, { msgType: 'heartbeat', nodeId: 'c' })
+            expect(ready).toBeFalse()
+            await wait(READY_WAIT_MS + JITTER)
+            expect(ready).toBeTrue()
+        })
     })
 })


### PR DESCRIPTION
## Summary

Add method `waitForReady` to `OperatorFleetState`. It can be used to wait for a long enough time for the state to be considered stable.

## Limitations and future improvements

- Combine with `start` method? Not for now at least.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
