### PR TITLE
feat: Method `getPeerDescriptor` to client and `NetworkNode` 

### DIFF
--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -29,6 +29,7 @@ export interface NetworkNodeStub {
     getNeighbors: () => string[]
     getNeighborsForStreamPart: (streamPartId: StreamPartID) => ReadonlyArray<string>
     setExtraMetadata: (metadata: Record<string, unknown>) => void
+    getPeerDescriptor: () => PeerDescriptor
     getMetricsContext: () => MetricsContext
     getDiagnosticInfo: () => Record<string, unknown>
     hasStreamPart: (streamPartId: StreamPartID) => boolean

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -45,7 +45,7 @@ import { waitForStorage } from './subscribe/waitForStorage'
 import { StreamDefinition } from './types'
 import { LoggerFactory } from './utils/LoggerFactory'
 import { pOnce } from './utils/promises'
-import { createTheGraphClient } from './utils/utils'
+import { convertPeerDescriptorToNetworkPeerDescriptor, createTheGraphClient } from './utils/utils'
 
 // TODO: this type only exists to enable tsdoc to generate proper documentation
 export type SubscribeOptions = StreamDefinition & ExtraSubscribeOptions
@@ -625,6 +625,10 @@ export class StreamrClient {
         await Promise.allSettled(tasks)
         await Promise.all(tasks)
     })
+
+    async getPeerDescriptor(): Promise<NetworkPeerDescriptor> {
+        return convertPeerDescriptorToNetworkPeerDescriptor((await this.node.getNode()).getPeerDescriptor())
+    }
 
     /**
      * Get diagnostic info about the underlying network. Useful for debugging issues.

--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -1,17 +1,18 @@
 import { ContractReceipt } from '@ethersproject/contracts'
 import { StreamID, toStreamID } from '@streamr/protocol'
-import { Logger, TheGraphClient, composeAbortSignals, merge, randomString, toEthereumAddress } from '@streamr/utils'
+import { composeAbortSignals, Logger, merge, randomString, TheGraphClient, toEthereumAddress } from '@streamr/utils'
 import compact from 'lodash/compact'
 import fetch, { Response } from 'node-fetch'
 import { AbortSignal as FetchAbortSignal } from 'node-fetch/externals'
 import split2 from 'split2'
 import { Readable } from 'stream'
 import LRU from '../../vendor/quick-lru'
-import { StrictStreamrClientConfig, NetworkPeerDescriptor, NetworkNodeType } from '../Config'
+import { NetworkNodeType, NetworkPeerDescriptor, StrictStreamrClientConfig } from '../Config'
 import { StreamrClientEventEmitter } from '../events'
 import { WebStreamToNodeStream } from './WebStreamToNodeStream'
 import { SEPARATOR } from './uuid'
-import { PeerDescriptor, PeerID, NodeType } from '@streamr/dht'
+import { NodeType, PeerDescriptor, PeerID } from '@streamr/dht'
+import omit from 'lodash/omit'
 
 const logger = new Logger(module)
 
@@ -112,6 +113,7 @@ export class MaxSizedSet<T> {
     }
 }
 
+// TODO: rename to convertNetworkPeerDescriptorToPeerDescriptor
 export function peerDescriptorTranslator(json: NetworkPeerDescriptor): PeerDescriptor {
     const type = json.type === NetworkNodeType.BROWSER ? NodeType.BROWSER : NodeType.NODEJS
     const peerDescriptor: PeerDescriptor = {
@@ -121,6 +123,17 @@ export function peerDescriptorTranslator(json: NetworkPeerDescriptor): PeerDescr
         websocket: json.websocket
     }
     return peerDescriptor
+}
+
+export function convertPeerDescriptorToNetworkPeerDescriptor(descriptor: PeerDescriptor): NetworkPeerDescriptor {
+    if (descriptor.type === NodeType.VIRTUAL) {
+        throw new Error('nodeType "virtual" not supported')
+    }
+    return {
+        ...omit(descriptor, 'kademliaId'),
+        id: PeerID.fromValue(descriptor.kademliaId).toString(),
+        type: descriptor.type === NodeType.NODEJS ? NetworkNodeType.NODEJS : NetworkNodeType.BROWSER
+    }
 }
 
 export function generateClientId(): string {

--- a/packages/client/test/end-to-end/StreamrClient.test.ts
+++ b/packages/client/test/end-to-end/StreamrClient.test.ts
@@ -1,0 +1,30 @@
+import { fastPrivateKey } from '@streamr/test-utils'
+import { CONFIG_TEST, StreamrClient } from '../../src'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+describe('StreamrClient', () => {
+    let client: StreamrClient
+
+    beforeEach(async () => {
+        client = new StreamrClient({
+            ...CONFIG_TEST,
+            auth: {
+                privateKey: fastPrivateKey(),
+            }
+        })
+    }, 30 * 1000)
+
+    afterEach(async () => {
+        await client.destroy()
+    })
+
+    it('getPeerDescriptor', async () => {
+        await client.subscribe('foobar')
+        const descriptor = await client.getPeerDescriptor()
+        expect(descriptor).toMatchObject({
+            id: expect.stringMatching(UUID_REGEX),
+            type: 'nodejs',
+        })
+    }, 30 * 1000)
+})

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -97,6 +97,11 @@ export class FakeNetworkNode implements NetworkNodeStub {
         throw new Error('not implemented')
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    getPeerDescriptor(): PeerDescriptor {
+        throw new Error('not implemented')
+    }
+
     hasStreamPart(streamPartId: StreamPartID): boolean {
         return this.subscriptions.has(streamPartId)
     }

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -134,6 +134,10 @@ export class NetworkNode {
         await this.stack.stop()
     }
 
+    getPeerDescriptor(): PeerDescriptor {
+        return this.stack.getLayer0DhtNode().getPeerDescriptor()
+    }
+
     getMetricsContext(): MetricsContext {
         return this.stack.getMetricsContext()
     }


### PR DESCRIPTION
## Summary

Add method `getPeerDescriptor` to client (and `NetworkNode`).

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
