### PR TITLE
fix(network): fix duplicate detection bug

### DIFF
--- a/packages/trackerless-network/src/logic/utils.ts
+++ b/packages/trackerless-network/src/logic/utils.ts
@@ -6,11 +6,12 @@ export const markAndCheckDuplicate = (
     currentMessageRef: MessageRef, 
     previousMessageRef?: MessageRef
 ): boolean => {
+    const detectorKey = `${currentMessageRef.publisherId}-${currentMessageRef.messageChainId}`
     const previousNumberPair = previousMessageRef ?
         new NumberPair(Number(previousMessageRef!.timestamp), previousMessageRef!.sequenceNumber) : null
     const currentNumberPair = new NumberPair(Number(currentMessageRef.timestamp), currentMessageRef.sequenceNumber)
-    if (!duplicateDetectors.has(currentMessageRef.messageChainId)) {
-        duplicateDetectors.set(currentMessageRef.messageChainId, new DuplicateMessageDetector())
+    if (!duplicateDetectors.has(detectorKey)) {
+        duplicateDetectors.set(detectorKey, new DuplicateMessageDetector())
     }
-    return duplicateDetectors.get(currentMessageRef.messageChainId)!.markAndCheck(previousNumberPair, currentNumberPair)
+    return duplicateDetectors.get(detectorKey)!.markAndCheck(previousNumberPair, currentNumberPair)
 }


### PR DESCRIPTION
## Summary

Fixed bug related to the generating keys for maps used to store duplicate detectors. The keys were only using the messageChainId of messages. The keys now include both the publisherId and messageChainId.