### PR TITLE
refactor(client): [NET-1003] Use `@streamr/config` package in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,28 +1970,6 @@
                 "node": ">=0.1.90"
             }
         },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
-        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -4721,76 +4699,6 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
             "dev": true
         },
-        "node_modules/@protobuf-ts/plugin": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.0.tgz",
-            "integrity": "sha512-SYHWyvobfYcm1tq5O9DVU0vPYLhm66l83ImGLZBME1bjtyVSZ06aVrAXr6mJrwAjmVBDN9TeoPqstk48zpMHjA==",
-            "dependencies": {
-                "@protobuf-ts/plugin-framework": "^2.9.0",
-                "@protobuf-ts/protoc": "^2.9.0",
-                "@protobuf-ts/runtime": "^2.9.0",
-                "@protobuf-ts/runtime-rpc": "^2.9.0",
-                "typescript": "^3.9"
-            },
-            "bin": {
-                "protoc-gen-dump": "bin/protoc-gen-dump",
-                "protoc-gen-ts": "bin/protoc-gen-ts"
-            }
-        },
-        "node_modules/@protobuf-ts/plugin-framework": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.0.tgz",
-            "integrity": "sha512-/fgpwEgYeiazEpkp9S+iaxVXd6LCkfd2iCfsvHiiSz94DatwZGkhv/85ciq2vcZVwSeEagKoSKeinnQWYvTnxw==",
-            "dependencies": {
-                "@protobuf-ts/runtime": "^2.9.0",
-                "typescript": "^3.9"
-            }
-        },
-        "node_modules/@protobuf-ts/plugin-framework/node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/@protobuf-ts/plugin/node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/@protobuf-ts/protoc": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.0.tgz",
-            "integrity": "sha512-8mQmw+OVqrpaHgmErle8heE5Z1ktX2vmWJmvFORSTcHxMfqHLv8RKTRroC9pkBQRgUaSGSXmy7n4ItdZnz41dw==",
-            "bin": {
-                "protoc": "protoc.js"
-            }
-        },
-        "node_modules/@protobuf-ts/runtime": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.0.tgz",
-            "integrity": "sha512-DnJtLZFMglADv9jiawBmg0RaET4a6fNSAaAHuU6Ovw2ZhJ23ehIY0NrlYLS0Lc8HRH0S5rkLI1QF1A1h8uKUnA=="
-        },
-        "node_modules/@protobuf-ts/runtime-rpc": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.0.tgz",
-            "integrity": "sha512-h2S86+u2cNJACjzbBubbjKmNrnXkTmJ9yJHW4t7ZVS9xdV1C68blsVIh3Su4ghR8Nlj0459FuIUTsjWR8hA/7g==",
-            "dependencies": {
-                "@protobuf-ts/runtime": "^2.9.0"
-            }
-        },
         "node_modules/@sigstore/protobuf-specs": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.1.0.tgz",
@@ -5005,9 +4913,10 @@
             "resolved": "packages/cli-tools",
             "link": true
         },
-        "node_modules/@streamr/dht": {
-            "resolved": "packages/dht",
-            "link": true
+        "node_modules/@streamr/config": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-3.1.1.tgz",
+            "integrity": "sha512-qH9cyyWYBgCUfBKOWXNwOuE7Wh+zWnDG8TSwdS/HZNyIbl9o2i/w/fOqAL3d9g7wPYAfUqLRjiBOlKUlRphfrQ=="
         },
         "node_modules/@streamr/network-node": {
             "resolved": "packages/network",
@@ -5015,10 +4924,6 @@
         },
         "node_modules/@streamr/network-tracker": {
             "resolved": "packages/network-tracker",
-            "link": true
-        },
-        "node_modules/@streamr/proto-rpc": {
-            "resolved": "packages/proto-rpc",
             "link": true
         },
         "node_modules/@streamr/protocol": {
@@ -5057,24 +4962,6 @@
             "engines": {
                 "node": ">= 10"
             }
-        },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true
         },
         "node_modules/@tsconfig/node16": {
             "version": "16.1.0",
@@ -5159,12 +5046,6 @@
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
-        },
-        "node_modules/@types/bloomfilter": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@types/bloomfilter/-/bloomfilter-0.0.0.tgz",
-            "integrity": "sha512-bZhGgidbIsN1sgI3tLwyxTpSa9Dkd9V5MrDU/O92OiqqEN+CNOxbyzPYAFOoBFw4VAh2EdzqT4XucKZEkrI0JQ==",
-            "dev": true
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.2",
@@ -5379,15 +5260,6 @@
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
             "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/k-bucket": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/k-bucket/-/k-bucket-5.0.1.tgz",
-            "integrity": "sha512-HjWSV4fBIRlZNbp7e+IQlHOY9MZhBcY+9Jf8vhZv5qGHJMlkCQQBKiX/n69/3YvTF34jsm+WKmro7eyG6FbYww==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -6563,12 +6435,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -6770,15 +6636,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
@@ -7089,11 +6946,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/bloomfilter": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/bloomfilter/-/bloomfilter-0.0.18.tgz",
-            "integrity": "sha512-CbnyHE78gY1tpXS/Ap+B0RJxKdRWCDzjBnX97UJSG8rdLv1PK8GiTWc/CCQyWu6PWVD4lUceeFrqC6Mf3nMgOA=="
         },
         "node_modules/bn.js": {
             "version": "5.2.1",
@@ -8726,12 +8578,6 @@
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
             }
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
         },
         "node_modules/cross-fetch": {
             "version": "3.1.6",
@@ -10800,15 +10646,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/find-yarn-workspace-root": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-            "dev": true,
-            "dependencies": {
-                "micromatch": "^4.0.2"
-            }
-        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -10952,21 +10789,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-        },
-        "node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/fs-minipass": {
             "version": "3.0.2",
@@ -13713,18 +13535,6 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "node_modules/json-stable-stringify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-            "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
-            "dev": true,
-            "dependencies": {
-                "jsonify": "^0.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -13765,15 +13575,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsonparse": {
@@ -13833,14 +13634,6 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
-            }
-        },
-        "node_modules/k-bucket": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
-            "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/karma": {
@@ -14047,15 +13840,6 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/klaw-sync": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kleur": {
@@ -18615,82 +18399,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/patch-package": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-            "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
-            "dev": true,
-            "dependencies": {
-                "@yarnpkg/lockfile": "^1.1.0",
-                "chalk": "^4.1.2",
-                "ci-info": "^3.7.0",
-                "cross-spawn": "^7.0.3",
-                "find-yarn-workspace-root": "^2.0.0",
-                "fs-extra": "^9.0.0",
-                "json-stable-stringify": "^1.0.2",
-                "klaw-sync": "^6.0.0",
-                "minimist": "^1.2.6",
-                "open": "^7.4.2",
-                "rimraf": "^2.6.3",
-                "semver": "^7.5.3",
-                "slash": "^2.0.0",
-                "tmp": "^0.0.33",
-                "yaml": "^2.2.2"
-            },
-            "bin": {
-                "patch-package": "index.js"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">5"
-            }
-        },
-        "node_modules/patch-package/node_modules/open": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-            "dev": true,
-            "dependencies": {
-                "is-docker": "^2.0.0",
-                "is-wsl": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/patch-package/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/patch-package/node_modules/slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/patch-package/node_modules/yaml": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -19397,6 +19105,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -22396,64 +22105,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-support": "^0.8.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "v8-compile-cache-lib": "^3.0.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-esm": "dist/bin-esm.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ts-node/node_modules/@tsconfig/node16": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true
-        },
-        "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/ts-toolbelt": {
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
@@ -22989,12 +22640,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
-        },
-        "node_modules/v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",
@@ -23811,15 +23456,6 @@
                 "fd-slicer": "~1.1.0"
             }
         },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -24143,6 +23779,7 @@
                 "@ethersproject/web": "^5.5.0",
                 "@lit-protocol/core": "^2.2.5",
                 "@lit-protocol/uint8arrays": "^2.2.47",
+                "@streamr/config": "^3.1.1",
                 "@streamr/network-node": "8.5.5",
                 "@streamr/protocol": "8.5.5",
                 "@streamr/utils": "8.5.5",
@@ -24272,6 +23909,7 @@
         "packages/dht": {
             "name": "@streamr/dht",
             "version": "8.5.5",
+            "extraneous": true,
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
                 "@protobuf-ts/plugin": "^2.8.0",
@@ -24302,30 +23940,6 @@
             "optionalDependencies": {
                 "bufferutil": "^4.0.5",
                 "utf-8-validate": "^6.0.3"
-            }
-        },
-        "packages/dht/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-        },
-        "packages/dht/node_modules/p-queue": {
-            "version": "6.3.0",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^4.0.0",
-                "p-timeout": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "packages/dht/node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "packages/network": {
@@ -24446,6 +24060,7 @@
         "packages/proto-rpc": {
             "name": "@streamr/proto-rpc",
             "version": "8.5.5",
+            "extraneous": true,
             "license": "(Apache-2.0 AND BSD-3-Clause)",
             "dependencies": {
                 "@protobuf-ts/plugin": "^2.8.0",
@@ -24467,14 +24082,6 @@
             "optionalDependencies": {
                 "bufferutil": "^4.0.5",
                 "utf-8-validate": "^6.0.3"
-            }
-        },
-        "packages/proto-rpc/node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "packages/protocol": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4914,9 +4914,9 @@
             "link": true
         },
         "node_modules/@streamr/config": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-3.1.1.tgz",
-            "integrity": "sha512-qH9cyyWYBgCUfBKOWXNwOuE7Wh+zWnDG8TSwdS/HZNyIbl9o2i/w/fOqAL3d9g7wPYAfUqLRjiBOlKUlRphfrQ=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-4.0.0.tgz",
+            "integrity": "sha512-+mbLgOcmuos9GSdC5nRCNe5K8Km+y47l9Oif4Uhj7ro+1XPoJM13PNOqeLP8xqeNNEylsqbBQltz0exqYfyp6A=="
         },
         "node_modules/@streamr/network-node": {
             "resolved": "packages/network",
@@ -16236,6 +16236,7 @@
         },
         "node_modules/node-datachannel/node_modules/ansi-regex": {
             "version": "2.1.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16244,11 +16245,13 @@
         },
         "node_modules/node-datachannel/node_modules/aproba": {
             "version": "1.2.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/base64-js": {
             "version": "1.5.1",
+            "extraneous": true,
             "funding": [
                 {
                     "type": "github",
@@ -16268,6 +16271,7 @@
         },
         "node_modules/node-datachannel/node_modules/buffer": {
             "version": "5.7.1",
+            "extraneous": true,
             "funding": [
                 {
                     "type": "github",
@@ -16291,11 +16295,13 @@
         },
         "node_modules/node-datachannel/node_modules/chownr": {
             "version": "1.1.4",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/code-point-at": {
             "version": "1.1.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16304,16 +16310,19 @@
         },
         "node_modules/node-datachannel/node_modules/console-control-strings": {
             "version": "1.1.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/core-util-is": {
             "version": "1.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/decompress-response": {
             "version": "6.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16328,6 +16337,7 @@
         },
         "node_modules/node-datachannel/node_modules/deep-extend": {
             "version": "0.6.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16336,11 +16346,13 @@
         },
         "node_modules/node-datachannel/node_modules/delegates": {
             "version": "1.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/detect-libc": {
             "version": "2.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -16349,6 +16361,7 @@
         },
         "node_modules/node-datachannel/node_modules/end-of-stream": {
             "version": "1.4.4",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16357,6 +16370,7 @@
         },
         "node_modules/node-datachannel/node_modules/expand-template": {
             "version": "2.0.3",
+            "extraneous": true,
             "inBundle": true,
             "license": "(MIT OR WTFPL)",
             "engines": {
@@ -16365,21 +16379,25 @@
         },
         "node_modules/node-datachannel/node_modules/fs-constants": {
             "version": "1.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/github-from-package": {
             "version": "0.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/has-unicode": {
             "version": "2.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/ieee754": {
             "version": "1.2.1",
+            "extraneous": true,
             "funding": [
                 {
                     "type": "github",
@@ -16399,16 +16417,19 @@
         },
         "node_modules/node-datachannel/node_modules/inherits": {
             "version": "2.0.4",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/ini": {
             "version": "1.3.8",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16420,11 +16441,13 @@
         },
         "node_modules/node-datachannel/node_modules/isarray": {
             "version": "1.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/lru-cache": {
             "version": "6.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16436,11 +16459,13 @@
         },
         "node_modules/node-datachannel/node_modules/lru-cache/node_modules/yallist": {
             "version": "4.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/mimic-response": {
             "version": "3.1.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16452,21 +16477,25 @@
         },
         "node_modules/node-datachannel/node_modules/minimist": {
             "version": "1.2.6",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/mkdirp-classic": {
             "version": "0.5.3",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/napi-build-utils": {
             "version": "1.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/node-abi": {
             "version": "3.8.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16478,6 +16507,7 @@
         },
         "node_modules/node-datachannel/node_modules/node-abi/node_modules/semver": {
             "version": "7.3.7",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16492,6 +16522,7 @@
         },
         "node_modules/node-datachannel/node_modules/npmlog": {
             "version": "4.1.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16503,6 +16534,7 @@
         },
         "node_modules/node-datachannel/node_modules/npmlog/node_modules/are-we-there-yet": {
             "version": "1.1.7",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16512,6 +16544,7 @@
         },
         "node_modules/node-datachannel/node_modules/npmlog/node_modules/gauge": {
             "version": "2.7.4",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16527,6 +16560,7 @@
         },
         "node_modules/node-datachannel/node_modules/number-is-nan": {
             "version": "1.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16535,6 +16569,7 @@
         },
         "node_modules/node-datachannel/node_modules/object-assign": {
             "version": "4.1.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16543,6 +16578,7 @@
         },
         "node_modules/node-datachannel/node_modules/once": {
             "version": "1.4.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16551,6 +16587,7 @@
         },
         "node_modules/node-datachannel/node_modules/prebuild-install": {
             "version": "7.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16577,11 +16614,13 @@
         },
         "node_modules/node-datachannel/node_modules/process-nextick-args": {
             "version": "2.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/pump": {
             "version": "3.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16591,6 +16630,7 @@
         },
         "node_modules/node-datachannel/node_modules/rc": {
             "version": "1.2.8",
+            "extraneous": true,
             "inBundle": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
@@ -16605,6 +16645,7 @@
         },
         "node_modules/node-datachannel/node_modules/readable-stream": {
             "version": "2.3.7",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16619,21 +16660,25 @@
         },
         "node_modules/node-datachannel/node_modules/safe-buffer": {
             "version": "5.1.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/set-blocking": {
             "version": "2.0.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/signal-exit": {
             "version": "3.0.3",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/node-datachannel/node_modules/simple-concat": {
             "version": "1.0.1",
+            "extraneous": true,
             "funding": [
                 {
                     "type": "github",
@@ -16653,6 +16698,7 @@
         },
         "node_modules/node-datachannel/node_modules/simple-get": {
             "version": "4.0.1",
+            "extraneous": true,
             "funding": [
                 {
                     "type": "github",
@@ -16677,6 +16723,7 @@
         },
         "node_modules/node-datachannel/node_modules/string_decoder": {
             "version": "1.1.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16685,6 +16732,7 @@
         },
         "node_modules/node-datachannel/node_modules/string-width": {
             "version": "1.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16698,6 +16746,7 @@
         },
         "node_modules/node-datachannel/node_modules/strip-ansi": {
             "version": "3.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16709,6 +16758,7 @@
         },
         "node_modules/node-datachannel/node_modules/strip-json-comments": {
             "version": "2.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -16717,6 +16767,7 @@
         },
         "node_modules/node-datachannel/node_modules/tar-fs": {
             "version": "2.1.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16728,6 +16779,7 @@
         },
         "node_modules/node-datachannel/node_modules/tar-stream": {
             "version": "2.1.4",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16743,6 +16795,7 @@
         },
         "node_modules/node-datachannel/node_modules/tar-stream/node_modules/bl": {
             "version": "4.1.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16753,6 +16806,7 @@
         },
         "node_modules/node-datachannel/node_modules/tar-stream/node_modules/readable-stream": {
             "version": "3.6.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -16766,6 +16820,7 @@
         },
         "node_modules/node-datachannel/node_modules/tunnel-agent": {
             "version": "0.6.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -16777,11 +16832,13 @@
         },
         "node_modules/node-datachannel/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/node-datachannel/node_modules/wide-align": {
             "version": "1.1.5",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -16790,6 +16847,7 @@
         },
         "node_modules/node-datachannel/node_modules/wrappy": {
             "version": "1.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
@@ -23779,7 +23837,7 @@
                 "@ethersproject/web": "^5.5.0",
                 "@lit-protocol/core": "^2.2.5",
                 "@lit-protocol/uint8arrays": "^2.2.47",
-                "@streamr/config": "^3.1.1",
+                "@streamr/config": "^4.0.0",
                 "@streamr/network-node": "8.5.5",
                 "@streamr/protocol": "8.5.5",
                 "@streamr/utils": "8.5.5",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -99,6 +99,7 @@
     "@ethersproject/web": "^5.5.0",
     "@lit-protocol/core": "^2.2.5",
     "@lit-protocol/uint8arrays": "^2.2.47",
+    "@streamr/config": "^3.1.1",
     "@streamr/network-node": "8.5.5",
     "@streamr/protocol": "8.5.5",
     "@streamr/utils": "8.5.5",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -99,7 +99,7 @@
     "@ethersproject/web": "^5.5.0",
     "@lit-protocol/core": "^2.2.5",
     "@lit-protocol/uint8arrays": "^2.2.47",
-    "@streamr/config": "^3.1.1",
+    "@streamr/config": "^4.0.0",
     "@streamr/network-node": "8.5.5",
     "@streamr/protocol": "8.5.5",
     "@streamr/utils": "8.5.5",

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -16,8 +16,7 @@ const sideChainConfig = {
     name: SIDE_CHAIN_NAME,
     chainId: SIDE_CHAIN_CONFIG.id,
     rpcs: [{
-        // TODO do we need "process.env.SIDECHAIN_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?
-        url: process.env.SIDECHAIN_URL || SIDE_CHAIN_CONFIG.rpcEndpoints[0].url,
+        url: SIDE_CHAIN_CONFIG.rpcEndpoints[0].url,
         timeout: toNumber(process.env.TEST_TIMEOUT) ?? 30 * 1000,
     }]
 }
@@ -53,8 +52,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
             name: MAIN_CHAIN_NAME,
             chainId: MAIN_CHAIN_CONFIG.id,
             rpcs: [{
-                // TODO do we need "process.env.ETHEREUM_SERVER_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?
-                url: process.env.ETHEREUM_SERVER_URL || MAIN_CHAIN_CONFIG.rpcEndpoints[0].url,
+                url: MAIN_CHAIN_CONFIG.rpcEndpoints[0].url,
                 timeout: toNumber(process.env.TEST_TIMEOUT) ?? 30 * 1000
             }]
         },

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -1,16 +1,21 @@
 import { toEthereumAddress } from '@streamr/utils'
 import { StreamrClientConfig } from './Config'
 import { MIN_KEY_LENGTH } from './encryption/RSAKeyPair'
+import { Chains } from '@streamr/config'
+
+const MAIN_CHAIN_CONFIG = Chains.load()['dev0']
+const SIDE_CHAIN_CONFIG = Chains.load()['dev1']
 
 function toNumber(value: any): number | undefined {
     return (value !== undefined) ? Number(value) : undefined
 }
 
 const sideChainConfig = {
-    name: 'streamr',
-    chainId: 8997,
+    name: 'streamr', // TODO from config?
+    chainId: SIDE_CHAIN_CONFIG.id,
     rpcs: [{
-        url: process.env.SIDECHAIN_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'}:8546`,
+        // TODO do we need "process.env.SIDECHAIN_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?
+        url: process.env.SIDECHAIN_URL || SIDE_CHAIN_CONFIG.rpcEndpoints[0].url,
         timeout: toNumber(process.env.TEST_TIMEOUT) ?? 30 * 1000,
     }]
 }
@@ -39,14 +44,15 @@ export const CONFIG_TEST: StreamrClientConfig = {
         iceServers: []
     },
     contracts: {
-        streamRegistryChainAddress: '0x6cCdd5d866ea766f6DF5965aA98DeCCD629ff222',
-        streamStorageRegistryChainAddress: '0xd04af489677001444280366Dd0885B03dAaDe71D',
-        storageNodeRegistryChainAddress: '0x231b810D98702782963472e1D60a25496999E75D',    
+        streamRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StreamRegistry,
+        streamStorageRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StreamStorageRegistry,
+        storageNodeRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StorageNodeRegistry,
         mainChainRPCs: {
-            name: 'dev_ethereum',
-            chainId: 8995,
+            name: 'dev_ethereum',  // TODO from config?
+            chainId: MAIN_CHAIN_CONFIG.id,
             rpcs: [{
-                url: process.env.ETHEREUM_SERVER_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'}:8545`,
+                // TODO do we need "process.env.ETHEREUM_SERVER_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?
+                url: process.env.ETHEREUM_SERVER_URL || MAIN_CHAIN_CONFIG.rpcEndpoints[0].url,
                 timeout: toNumber(process.env.TEST_TIMEOUT) ?? 30 * 1000
             }]
         },

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -1,19 +1,17 @@
 import { toEthereumAddress } from '@streamr/utils'
 import { StreamrClientConfig } from './Config'
 import { MIN_KEY_LENGTH } from './encryption/RSAKeyPair'
-import { Chains } from '@streamr/config'
+import { config as CHAIN_CONFIG } from '@streamr/config'
 
-const MAIN_CHAIN_NAME = 'dev0'
-const SIDE_CHAIN_NAME = 'dev1'
-const MAIN_CHAIN_CONFIG = Chains.load()[MAIN_CHAIN_NAME]
-const SIDE_CHAIN_CONFIG = Chains.load()[SIDE_CHAIN_NAME]
+const MAIN_CHAIN_CONFIG = CHAIN_CONFIG['dev0']
+const SIDE_CHAIN_CONFIG = CHAIN_CONFIG['dev1']
 
 function toNumber(value: any): number | undefined {
     return (value !== undefined) ? Number(value) : undefined
 }
 
 const sideChainConfig = {
-    name: SIDE_CHAIN_NAME,
+    name: SIDE_CHAIN_CONFIG.name,
     chainId: SIDE_CHAIN_CONFIG.id,
     rpcs: [{
         url: SIDE_CHAIN_CONFIG.rpcEndpoints[0].url,
@@ -49,7 +47,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
         streamStorageRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StreamStorageRegistry,
         storageNodeRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StorageNodeRegistry,
         mainChainRPCs: {
-            name: MAIN_CHAIN_NAME,
+            name: MAIN_CHAIN_CONFIG.name,
             chainId: MAIN_CHAIN_CONFIG.id,
             rpcs: [{
                 url: MAIN_CHAIN_CONFIG.rpcEndpoints[0].url,

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -3,15 +3,17 @@ import { StreamrClientConfig } from './Config'
 import { MIN_KEY_LENGTH } from './encryption/RSAKeyPair'
 import { Chains } from '@streamr/config'
 
-const MAIN_CHAIN_CONFIG = Chains.load()['dev0']
-const SIDE_CHAIN_CONFIG = Chains.load()['dev1']
+const MAIN_CHAIN_NAME = 'dev0'
+const SIDE_CHAIN_NAME = 'dev1'
+const MAIN_CHAIN_CONFIG = Chains.load()[MAIN_CHAIN_NAME]
+const SIDE_CHAIN_CONFIG = Chains.load()[SIDE_CHAIN_NAME]
 
 function toNumber(value: any): number | undefined {
     return (value !== undefined) ? Number(value) : undefined
 }
 
 const sideChainConfig = {
-    name: 'streamr', // TODO from config?
+    name: SIDE_CHAIN_NAME,
     chainId: SIDE_CHAIN_CONFIG.id,
     rpcs: [{
         // TODO do we need "process.env.SIDECHAIN_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?
@@ -48,7 +50,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
         streamStorageRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StreamStorageRegistry,
         storageNodeRegistryChainAddress: SIDE_CHAIN_CONFIG.contracts.StorageNodeRegistry,
         mainChainRPCs: {
-            name: 'dev_ethereum',  // TODO from config?
+            name: MAIN_CHAIN_NAME,
             chainId: MAIN_CHAIN_CONFIG.id,
             rpcs: [{
                 // TODO do we need "process.env.ETHEREUM_SERVER_URL || `http://${process.env.STREAMR_DOCKER_DEV_HOST" support?


### PR DESCRIPTION
Updated client's test config to use `@streamr/config` package. The chain names changed (from `dev_ethereum`/`streamr` to `dev0`/`dev1`), no other changes in the values.

## Future improvements
- read production config values from the `@streamr/config` package, i.e. update config.schema.json values (NET-1004)