### PR TITLE
refactor(client): Use mono subgraph

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,7 +72,7 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: client
-      docker-services: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph ens-sync-script
+      docker-services: cassandra init-keyspace parity-sidechain-node0 deploy-network-subgraphs ens-sync-script
       run-brokers-and-trackers: true
       command: npm run test-end-to-end
   broker:
@@ -86,14 +86,14 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: broker
-      docker-services: cassandra init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph
+      docker-services: cassandra init-keyspace parity-sidechain-node0 deploy-network-subgraphs
       command: npm run test-integration
   client-browser:
     needs: build
     uses: ./.github/workflows/test-setup.yml
     with:
       package: client
-      docker-services: init-keyspace parity-sidechain-node0 graph-deploy-streamregistry-subgraph
+      docker-services: init-keyspace parity-sidechain-node0 deploy-network-subgraphs
       run-brokers-and-trackers: true
       command: npm run test-browser
   cli-tools:
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: cli-tools
-      docker-services: parity-node0 graph-deploy-streamregistry-subgraph broker-node-storage-1
+      docker-services: parity-node0 deploy-network-subgraphs broker-node-storage-1
       command: npm run test
   tracker-docker-image:
     uses: ./.github/workflows/docker-build.yml

--- a/packages/broker/configs/development-1.env.json
+++ b/packages/broker/configs/development-1.env.json
@@ -51,7 +51,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/broker/configs/development-2.env.json
+++ b/packages/broker/configs/development-2.env.json
@@ -51,7 +51,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/broker/configs/development-3.env.json
+++ b/packages/broker/configs/development-3.env.json
@@ -51,7 +51,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/broker/configs/docker-1.env.json
+++ b/packages/broker/configs/docker-1.env.json
@@ -37,7 +37,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/broker/configs/docker-2.env.json
+++ b/packages/broker/configs/docker-2.env.json
@@ -37,7 +37,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/broker/configs/docker-3.env.json
+++ b/packages/broker/configs/docker-3.env.json
@@ -37,7 +37,7 @@
                     }
                 ]
             },
-            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-contracts"
+            "theGraphUrl": "http://10.200.10.1:8000/subgraphs/name/streamr-dev/network-subgraphs"
         },
         "metrics": false
     },

--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -51,7 +51,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
             }]
         },
         streamRegistryChainRPCs: sideChainConfig,
-        theGraphUrl: `http://${process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'}:8000/subgraphs/name/streamr-dev/network-contracts`,
+        theGraphUrl: `http://${process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'}:8000/subgraphs/name/streamr-dev/network-subgraphs`,
     },
     encryption: {
         rsaKeyLength: MIN_KEY_LENGTH

--- a/packages/client/src/registry/StreamRegistry.ts
+++ b/packages/client/src/registry/StreamRegistry.ts
@@ -316,7 +316,7 @@ export class StreamRegistry {
     ): GraphQLQuery {
         const query = `
         {
-            permissions (
+            streamPermissions (
                 first: ${pageSize}
                 orderBy: "id"
                 where: {

--- a/packages/client/src/registry/searchStreams.ts
+++ b/packages/client/src/registry/searchStreams.ts
@@ -138,7 +138,7 @@ const buildQuery = (
             $canGrant: Boolean
             $id_gt: String
         ) {
-            permissions (
+            streamPermissions (
                 first: ${pageSize},
                 orderBy: "stream__${orderBy.field}",
                 orderDirection: "${orderBy.direction}", 


### PR DESCRIPTION
Use the new `network-subgraphs` instead of `network-contracts`. 

The structure of the subgraphs mostly equal for all queries that client uses. Changes relevant to client:
- `permissions` root level query renamed to `streamPermissions`

**TODO update also production value (`config.schema.json`) when the mono graph is in production. Do not merge this to main before that as we can't make client releases from main until the mono graph has been deployed to production...**