### PR TITLE
feat(dht): PeerID from key

### DIFF
--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -40,6 +40,10 @@ export class PeerID {
         return new PeerID({ value })
     }
 
+    static fromKey(value: PeerIDKey): PeerID {
+        return new PeerID({ value: Buffer.from(value, 'hex') })
+    }
+
     static fromString(stringValue: string): PeerID {
         return new PeerID({ stringValue })
     }

--- a/packages/dht/test/unit/PeerID.test.ts
+++ b/packages/dht/test/unit/PeerID.test.ts
@@ -11,4 +11,12 @@ describe('PeerID', () => {
         expect(id1.toString()).toEqual(id2.toString())
         expect(stringId).toEqual(id2.toString())
     })
+
+    it('peerKey', () => {
+        const peerIdFromString = PeerID.fromString('peerId')
+        const peerKey = peerIdFromString.toKey()
+        const peerIdFromKey = PeerID.fromKey(peerKey)
+        expect(peerIdFromString.equals(peerIdFromKey)).toEqual(true)        
+    })
+
 })


### PR DESCRIPTION
## Summary

a `PeerID`-object can now be created from a `PeerIDKey`