### PR TITLE
fix(DHT): Fix integration/store.test.ts flakyness

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -269,7 +269,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ownPeerId: this.ownPeerId!,
             addContact: this.addNewContact.bind(this),
             isPeerCloserToIdThanSelf: this.isPeerCloserToIdThanSelf.bind(this),
-            getClosestPeerDescriptors: this.getClosestPeerDescriptors.bind(this),
             localDataStore: this.localDataStore
         })
         this.dataStore = new DataStore({

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -55,7 +55,7 @@ describe('Storing data in DHT', () => {
         expect(successfulStorers.length).toBeGreaterThan(4)
     }, 90000)
 
-    it.only('Storing and getting data works', async () => {
+    it('Storing and getting data works', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
         const data = Any.pack(entrypointDescriptor, PeerDescriptor)

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -12,7 +12,7 @@ describe('Storing data in DHT', () => {
     const simulator = new Simulator(LatencyType.RANDOM)
     const NUM_NODES = 100
     const MAX_CONNECTIONS = 20
-    const K = 2
+    const K = 4
     const nodeIndicesById: Record<string, number> = {}
 
     const getRandomNode = () => {
@@ -55,7 +55,7 @@ describe('Storing data in DHT', () => {
         expect(successfulStorers.length).toBeGreaterThan(4)
     }, 90000)
 
-    it('Storing and getting data works', async () => {
+    it.only('Storing and getting data works', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
         const data = Any.pack(entrypointDescriptor, PeerDescriptor)

--- a/packages/dht/test/unit/RecursiveFinder.test.ts
+++ b/packages/dht/test/unit/RecursiveFinder.test.ts
@@ -67,7 +67,6 @@ describe('RecursiveFinder', () => {
             localDataStore: new LocalDataStore(),
             sessionTransport: new MockTransport(),
             addContact: (_contact, _setActive) => {},
-            getClosestPeerDescriptors: (_kademliaId, _limit) => [],
             isPeerCloserToIdThanSelf: (_peer1, _compareToId) => true,
             rpcCommunicator: createMockRoutingRpcCommunicator()
         })


### PR DESCRIPTION
## Summary

Fixed flakyness in `integration/store.test.ts` caused by two problems: 

The network could temporarily split or the routing connections could be cutoff in the middle of transport due to ConnectionManagers garbage collection.

Getting closest peers to ids on a routing peer during `RecursiveFind` could give incorrect results.

Test did not fail after 70 runs.

## Changes

- Avoid network splits in test case by increasing K
- Get closest peers to the searched id in RecursiveFind by using connections instead of k-bucket