### PR TITLE
feat(network): NET-991 joining via multiple entry points

### DIFF
--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -15,7 +15,7 @@ const main = async () => {
         entryPoints: [peerDescriptor]
     })
     await dhtNode.start()
-    await dhtNode.joinDht(peerDescriptor)
+    await dhtNode.joinDht([peerDescriptor])
     console.info('Entry point started')
 }
 

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -111,6 +111,9 @@ export interface NetworkNodeConfig {
     /**
      * Whether to accept proxy connections. Enabling this option allows
      * this network node to act as proxy on behalf of other nodes / clients.
+     * When enabling this option, a WebSocket server should be configured for the client
+     * and the node needs to be in the open internet. The server can be started by setting
+     * the webSocketPort configuration to a free port in the network control layer configuration.
     */
     acceptProxyConnections?: boolean
 }

--- a/packages/dht/src/connection/ConnectivityChecker.ts
+++ b/packages/dht/src/connection/ConnectivityChecker.ts
@@ -78,7 +78,6 @@ export class ConnectivityChecker {
             return await retPromise
         } catch (e) {
             logger.error('error getting connectivityresponse')
-
             throw e
         }
     }
@@ -93,7 +92,7 @@ export class ConnectivityChecker {
                     logger.trace('handleIncomingConnectivityRequest ok')
                     return
                 }).catch((e) => {
-                    logger.error('handleIncomingConnectivityRequest poikkeus KIINNI' + e)
+                    logger.error('handleIncomingConnectivityRequest' + e)
                 })
             }
         })

--- a/packages/dht/src/connection/WebSocket/WebSocketConnector.ts
+++ b/packages/dht/src/connection/WebSocket/WebSocketConnector.ts
@@ -130,7 +130,7 @@ export class WebSocketConnector implements IWebSocketConnectorService {
                     return preconfiguredConnectivityResponse
                 } else {
                     // Do real connectivity checking
-
+                    
                     let response = noServerConnectivityResponse
 
                     response = await this.connectivityChecker.sendConnectivityRequest(this.entrypoints[0])

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -471,7 +471,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             && this.config.entryPoints.length > 0
         ) {
             setImmediate(async () => {
-                await this.peerDiscovery!.rejoinDht(this.config.entryPoints![0])
+                await Promise.all(this.config.entryPoints!.map((entryPoint) => 
+                    this.peerDiscovery!.rejoinDht(entryPoint)
+                )) 
             })
         }
     }
@@ -607,11 +609,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         await this.router!.send(msg, reachableThrough)
     }
 
-    public async joinDht(entryPointDescriptor: PeerDescriptor, doRandomJoin?: boolean): Promise<void> {
+    public async joinDht(entryPointDescriptors: PeerDescriptor[], doRandomJoin?: boolean): Promise<void> {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
-        await this.peerDiscovery!.joinDht(entryPointDescriptor, doRandomJoin)
+        await Promise.all(entryPointDescriptors.map((entryPoint) => 
+            this.peerDiscovery!.joinDht(entryPoint, doRandomJoin)
+        ))
     }
 
     public async startRecursiveFind(idToFind: Uint8Array, findMode?: FindMode, excludedPeer?: PeerDescriptor): Promise<RecursiveFindResult> {

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -53,10 +53,10 @@ describe('Kademlia correctness', () => {
     })
 
     it('Can find correct neighbors', async () => {
-        await entryPoint.joinDht(entrypointDescriptor)
+        await entryPoint.joinDht([entrypointDescriptor])
 
         await Promise.allSettled(
-            nodes.map((node) => node.joinDht(entrypointDescriptor))
+            nodes.map((node) => node.joinDht([entrypointDescriptor]))
         )
 
         let minimumCorrectNeighbors = Number.MAX_SAFE_INTEGER

--- a/packages/dht/test/benchmark/RecursiveFind.test.ts
+++ b/packages/dht/test/benchmark/RecursiveFind.test.ts
@@ -57,10 +57,10 @@ describe('Recursive find correctness', () => {
     })
 
     it('Entrypoint can find a node from the network (exact match)', async () => {
-        await entryPoint.joinDht(entrypointDescriptor)
+        await entryPoint.joinDht([entrypointDescriptor])
 
         await Promise.all(
-            nodes.map((node) => node.joinDht(entrypointDescriptor))
+            nodes.map((node) => node.joinDht([entrypointDescriptor]))
         )
 
         logger.info('waiting 120s')

--- a/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
@@ -25,7 +25,7 @@ describe('Layer0-Layer1', () => {
 
         epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor })
         await epDhtNode.start()
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
 
         node1 = new DhtNode({ peerIdString: '1', webSocketPort: 10017, entryPoints: [epPeerDescriptor] })
         node2 = new DhtNode({ peerIdString: '2', webSocketPort: 10018, entryPoints: [epPeerDescriptor] })
@@ -62,17 +62,17 @@ describe('Layer0-Layer1', () => {
 
     it('Happy path', async () => {
         await Promise.all([
-            node1.joinDht(epPeerDescriptor),
-            node2.joinDht(epPeerDescriptor)
+            node1.joinDht([epPeerDescriptor]),
+            node2.joinDht([epPeerDescriptor])
         ])
         await Promise.all([
-            stream1Node1.joinDht(epPeerDescriptor),
-            stream1Node2.joinDht(epPeerDescriptor)
+            stream1Node1.joinDht([epPeerDescriptor]),
+            stream1Node2.joinDht([epPeerDescriptor])
         ])
         
         await Promise.all([
-            stream2Node1.joinDht(epPeerDescriptor),
-            stream2Node2.joinDht(epPeerDescriptor)
+            stream2Node1.joinDht([epPeerDescriptor]),
+            stream2Node2.joinDht([epPeerDescriptor])
         ])
         expect(stream1Node1.getNeighborList().getSize()).toEqual(1)
         expect(stream1Node2.getNeighborList().getSize()).toEqual(1)

--- a/packages/dht/test/end-to-end/Layer0.test.ts
+++ b/packages/dht/test/end-to-end/Layer0.test.ts
@@ -20,7 +20,7 @@ describe('Layer0', () => {
         epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor })
         await epDhtNode.start()
         
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
 
         node1 = new DhtNode({ peerIdString: '1', webSocketPort: 10012, entryPoints: [epPeerDescriptor] })
         node2 = new DhtNode({ peerIdString: '2', webSocketPort: 10013, entryPoints: [epPeerDescriptor] })
@@ -46,10 +46,10 @@ describe('Layer0', () => {
 
     it('Happy path', async () => {
         await Promise.all([
-            node1.joinDht(epPeerDescriptor),
-            node2.joinDht(epPeerDescriptor),
-            node3.joinDht(epPeerDescriptor),
-            node4.joinDht(epPeerDescriptor)
+            node1.joinDht([epPeerDescriptor]),
+            node2.joinDht([epPeerDescriptor]),
+            node3.joinDht([epPeerDescriptor]),
+            node4.joinDht([epPeerDescriptor])
         ])
 
         expect(node1.getBucketSize()).toBeGreaterThanOrEqual(2)

--- a/packages/dht/test/end-to-end/Layer0MixedConnectionTypes.test.ts
+++ b/packages/dht/test/end-to-end/Layer0MixedConnectionTypes.test.ts
@@ -23,7 +23,7 @@ describe('Layer0MixedConnectionTypes', () => {
         epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 2 })
         await epDhtNode.start()
 
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
         node1 = new DhtNode({ peerIdString: 'Peer1', webSocketPort: 11222, entryPoints: [epPeerDescriptor] })
         node2 = new DhtNode({ peerIdString: 'Peer2', webSocketPort: 11228, entryPoints: [epPeerDescriptor] })
         node3 = new DhtNode({ peerIdString: 'Peer3', entryPoints: [epPeerDescriptor] })
@@ -38,7 +38,7 @@ describe('Layer0MixedConnectionTypes', () => {
             node5.start()
         ])
 
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
     })
 
     afterEach(async () => {
@@ -59,14 +59,14 @@ describe('Layer0MixedConnectionTypes', () => {
             waitForEvent3<ConnectionManagerEvents>((node4.getTransport() as ConnectionManager), 'newConnection'),
         ])
 
-        node3.joinDht(epPeerDescriptor)
-        node4.joinDht(epPeerDescriptor)
+        node3.joinDht([epPeerDescriptor])
+        node4.joinDht([epPeerDescriptor])
 
         await promise
         await Promise.all([
-            node1.joinDht(epPeerDescriptor),
-            node2.joinDht(epPeerDescriptor),
-            node5.joinDht(epPeerDescriptor)
+            node1.joinDht([epPeerDescriptor]),
+            node2.joinDht([epPeerDescriptor]),
+            node5.joinDht([epPeerDescriptor])
         ])
 
         expect(node1.getBucketSize()).toBeGreaterThanOrEqual(2)
@@ -79,11 +79,11 @@ describe('Layer0MixedConnectionTypes', () => {
 
     it('Simultaneous joins', async () => {
         await Promise.all([
-            node1.joinDht(epPeerDescriptor),
-            node2.joinDht(epPeerDescriptor),
-            node3.joinDht(epPeerDescriptor),
-            node4.joinDht(epPeerDescriptor),
-            node5.joinDht(epPeerDescriptor)
+            node1.joinDht([epPeerDescriptor]),
+            node2.joinDht([epPeerDescriptor]),
+            node3.joinDht([epPeerDescriptor]),
+            node4.joinDht([epPeerDescriptor]),
+            node5.joinDht([epPeerDescriptor])
         ])
         expect(node1.getBucketSize()).toBeGreaterThanOrEqual(2)
         expect(node2.getBucketSize()).toBeGreaterThanOrEqual(2)

--- a/packages/dht/test/end-to-end/Layer0WebRTC-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0WebRTC-Layer1.test.ts
@@ -94,8 +94,8 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
         await layer1Node3.start()
         await layer1Node4.start()
 
-        await layer0EntryPoint.joinDht(entrypointDescriptor)
-        await layer1EntryPoint.joinDht(entrypointDescriptor)
+        await layer0EntryPoint.joinDht([entrypointDescriptor])
+        await layer1EntryPoint.joinDht([entrypointDescriptor])
     })
 
     afterEach(async () => {
@@ -115,16 +115,16 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
     it('Happy Path', async () => {
         await Promise.all([
-            layer0Node1.joinDht(entrypointDescriptor),
-            layer0Node2.joinDht(entrypointDescriptor),
-            layer0Node3.joinDht(entrypointDescriptor),
-            layer0Node4.joinDht(entrypointDescriptor)
+            layer0Node1.joinDht([entrypointDescriptor]),
+            layer0Node2.joinDht([entrypointDescriptor]),
+            layer0Node3.joinDht([entrypointDescriptor]),
+            layer0Node4.joinDht([entrypointDescriptor])
         ])
 
-        await layer1Node1.joinDht(entrypointDescriptor)
-        await layer1Node2.joinDht(entrypointDescriptor)
-        await layer1Node3.joinDht(entrypointDescriptor)
-        await layer1Node4.joinDht(entrypointDescriptor)
+        await layer1Node1.joinDht([entrypointDescriptor])
+        await layer1Node2.joinDht([entrypointDescriptor])
+        await layer1Node3.joinDht([entrypointDescriptor])
+        await layer1Node4.joinDht([entrypointDescriptor])
 
         expect(layer1Node1.getBucketSize()).toBeGreaterThanOrEqual(2)
         expect(layer1Node2.getBucketSize()).toBeGreaterThanOrEqual(2)

--- a/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
@@ -24,7 +24,7 @@ describe('Layer0 with WebRTC connections', () => {
         epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor, nodeName: 'entrypoint', numberOfNodesPerKBucket: 8 })
         await epDhtNode.start()
 
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
 
         node1 = new DhtNode({ peerIdString: 'Peer0', nodeName: 'Peer0', entryPoints: [epPeerDescriptor] })
         node2 = new DhtNode({ peerIdString: 'Peer1', nodeName: 'Peer1', entryPoints: [epPeerDescriptor] })
@@ -38,7 +38,7 @@ describe('Layer0 with WebRTC connections', () => {
             node4.start()
         ])
 
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
     })
 
     afterEach(async () => {
@@ -67,8 +67,8 @@ describe('Layer0 with WebRTC connections', () => {
     it('Happy path two peers', async () => {
 
         await Promise.all([waitForEvent(new Peer0Listener(node2), 'peer0connected', 20000),
-            node2.joinDht(epPeerDescriptor),
-            node1.joinDht(epPeerDescriptor)
+            node2.joinDht([epPeerDescriptor]),
+            node1.joinDht([epPeerDescriptor])
         ])
 
         expect((node1.getTransport() as ConnectionManager).hasConnection(node2.getPeerDescriptor())).toEqual(true)
@@ -82,10 +82,10 @@ describe('Layer0 with WebRTC connections', () => {
 
     it('Happy path simultaneous joins', async () => {
         await Promise.all([
-            node1.joinDht(epPeerDescriptor),
-            node2.joinDht(epPeerDescriptor),
-            node3.joinDht(epPeerDescriptor),
-            node4.joinDht(epPeerDescriptor)
+            node1.joinDht([epPeerDescriptor]),
+            node2.joinDht([epPeerDescriptor]),
+            node3.joinDht([epPeerDescriptor]),
+            node4.joinDht([epPeerDescriptor])
         ])
 
         expect((node1.getTransport() as ConnectionManager).hasConnection(node2.getPeerDescriptor())).toEqual(true)

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
@@ -24,11 +24,11 @@ describe('Layer1 Scale', () => {
     beforeEach(async () => {
         epLayer0Node = new DhtNode({ peerDescriptor: epPeerDescriptor })
         await epLayer0Node.start()
-        await epLayer0Node.joinDht(epPeerDescriptor)
+        await epLayer0Node.joinDht([epPeerDescriptor])
 
         epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
         await epLayer1Node.start()
-        await epLayer1Node.joinDht(epPeerDescriptor)
+        await epLayer1Node.joinDht([epPeerDescriptor])
 
         layer0Nodes = []
         layer1Nodes = []
@@ -47,11 +47,8 @@ describe('Layer1 Scale', () => {
             await layer1.start()
             layer1Nodes.push(layer1)
         }
-
-        await Promise.all(layer0Nodes.map((node) => node.joinDht(epPeerDescriptor)))
-
-        await Promise.all(layer1Nodes.map((node) => node.joinDht(epPeerDescriptor)))
-
+        await Promise.all(layer0Nodes.map((node) => node.joinDht([epPeerDescriptor])))
+        await Promise.all(layer1Nodes.map((node) => node.joinDht([epPeerDescriptor])))
     }, 120000)
 
     afterEach(async () => {

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -24,11 +24,11 @@ describe('Layer1 Scale', () => {
     beforeEach(async () => {
         epLayer0Node = new DhtNode({ peerDescriptor: epPeerDescriptor, nodeName: 'entrypoint' })
         await epLayer0Node.start()
-        await epLayer0Node.joinDht(epPeerDescriptor)
+        await epLayer0Node.joinDht([epPeerDescriptor])
 
         epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID, nodeName: 'entrypoint' })
         await epLayer1Node.start()
-        await epLayer1Node.joinDht(epPeerDescriptor)
+        await epLayer1Node.joinDht([epPeerDescriptor])
 
         layer0Nodes = []
         layer1Nodes = []
@@ -48,9 +48,9 @@ describe('Layer1 Scale', () => {
             layer1Nodes.push(layer1)
         }
 
-        await Promise.all(layer0Nodes.map((node) => node.joinDht(epPeerDescriptor)))
+        await Promise.all(layer0Nodes.map((node) => node.joinDht([epPeerDescriptor])))
 
-        await Promise.all(layer1Nodes.map((node) => node.joinDht(epPeerDescriptor)))
+        await Promise.all(layer1Nodes.map((node) => node.joinDht([epPeerDescriptor])))
 
     }, 60000)
 

--- a/packages/dht/test/end-to-end/WebSocketConnectionRequest.test.ts
+++ b/packages/dht/test/end-to-end/WebSocketConnectionRequest.test.ts
@@ -20,7 +20,7 @@ describe('WebSocket IConnection Requests', () => {
         epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor })
         await epDhtNode.start()
 
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
 
         node1 = new DhtNode({ peerIdString: '2', nodeName: 'node1', webSocketPort: 10022, entryPoints: [epPeerDescriptor] })
         node2 = new DhtNode({ peerIdString: '1', nodeName: 'node2', entryPoints: [epPeerDescriptor] })
@@ -50,8 +50,8 @@ describe('WebSocket IConnection Requests', () => {
             }
         })
 
-        await node2.joinDht(epPeerDescriptor)
-        await node1.joinDht(epPeerDescriptor)
+        await node2.joinDht([epPeerDescriptor])
+        await node1.joinDht([epPeerDescriptor])
 
         await waitForCondition(() => { return (connected1 && connected2) })
 

--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -15,7 +15,7 @@ describe('DhtNodeExternalApi', () => {
         simulator = new Simulator(LatencyType.NONE)
         dhtNode1 = await createMockConnectionDhtNode('node1', simulator)
         remote = await createMockConnectionDhtNode('remote', simulator)
-        await dhtNode1.joinDht(dhtNode1.getPeerDescriptor())
+        await dhtNode1.joinDht([dhtNode1.getPeerDescriptor()])
     })
 
     afterEach(async () => {

--- a/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
@@ -35,8 +35,8 @@ describe('Mock connection Dht joining with latencies', () => {
     })
 
     it('Happy path', async () => {
-        await entryPoint.joinDht(entrypointDescriptor)
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await entryPoint.joinDht([entrypointDescriptor])
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 2)
             expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 2)

--- a/packages/dht/test/integration/DhtWithMockConnections.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnections.test.ts
@@ -35,8 +35,8 @@ describe('Mock IConnection DHT Joining', () => {
     })
 
     it('Happy path', async () => {
-        await entryPoint.joinDht(entrypointDescriptor)
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await entryPoint.joinDht([entrypointDescriptor])
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 2)
             expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 2)

--- a/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
@@ -36,8 +36,8 @@ describe('Mock connection Dht joining with real latencies', () => {
     })
 
     it('Happy path', async () => {
-        await entryPoint.joinDht(entrypointDescriptor)
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await entryPoint.joinDht([entrypointDescriptor])
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 3)
             expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 3)

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -25,7 +25,7 @@ describe('Layer1', () => {
     beforeEach(async () => {
         simulator = new Simulator()
         layer0EntryPoint = await createMockConnectionDhtNode(layer0EntryPointId, simulator)
-        await layer0EntryPoint.joinDht(entryPoint0Descriptor)
+        await layer0EntryPoint.joinDht([entryPoint0Descriptor])
 
         nodes = []
         layer1CleanUp = []
@@ -43,7 +43,7 @@ describe('Layer1', () => {
             nodes.push(node)
         }
 
-        await Promise.all(nodes.map((node) => node.joinDht(entryPoint0Descriptor)))
+        await Promise.all(nodes.map((node) => node.joinDht([entryPoint0Descriptor])))
 
     }, 30000)
 
@@ -56,7 +56,7 @@ describe('Layer1', () => {
 
     it('single layer1 dht', async () => {
         const layer1EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint.getNodeId().toString(), layer0EntryPoint)
-        await layer1EntryPoint.joinDht(entryPoint0Descriptor)
+        await layer1EntryPoint.joinDht([entryPoint0Descriptor])
         layer1CleanUp.push(layer1EntryPoint)
 
         const layer1Nodes: DhtNode[] = []
@@ -67,7 +67,7 @@ describe('Layer1', () => {
             layer1CleanUp.push(layer1)
         }
 
-        await Promise.all(layer1Nodes.map((node) => node.joinDht(entryPoint0Descriptor)))
+        await Promise.all(layer1Nodes.map((node) => node.joinDht([entryPoint0Descriptor])))
 
         for (let i = 0; i < NODE_COUNT; i++) {
             const layer0Node = nodes[i]
@@ -81,16 +81,16 @@ describe('Layer1', () => {
 
     it('multiple layer1 dht', async () => {
         const stream1EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint.getNodeId().toString(), layer0EntryPoint, 'one')
-        await stream1EntryPoint.joinDht(entryPoint0Descriptor)
+        await stream1EntryPoint.joinDht([entryPoint0Descriptor])
 
         const stream2EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint.getNodeId().toString(), layer0EntryPoint, 'two')
-        await stream2EntryPoint.joinDht(entryPoint0Descriptor)
+        await stream2EntryPoint.joinDht([entryPoint0Descriptor])
 
         const stream3EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint.getNodeId().toString(), layer0EntryPoint, 'three')
-        await stream3EntryPoint.joinDht(entryPoint0Descriptor)
+        await stream3EntryPoint.joinDht([entryPoint0Descriptor])
 
         const stream4EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint.getNodeId().toString(), layer0EntryPoint, 'four')
-        await stream4EntryPoint.joinDht(entryPoint0Descriptor)
+        await stream4EntryPoint.joinDht([entryPoint0Descriptor])
 
         layer1CleanUp.push(stream1EntryPoint)
         layer1CleanUp.push(stream2EntryPoint)
@@ -120,7 +120,7 @@ describe('Layer1', () => {
             layer1CleanUp.push(four)
         }
 
-        await Promise.all(layer1CleanUp.map((node) => node.joinDht(entryPoint0Descriptor)))
+        await Promise.all(layer1CleanUp.map((node) => node.joinDht([entryPoint0Descriptor])))
 
         for (let i = 0; i < NODE_COUNT; i++) {
             const layer0Node = nodes[i]

--- a/packages/dht/test/integration/MigrateData.test.ts
+++ b/packages/dht/test/integration/MigrateData.test.ts
@@ -96,7 +96,7 @@ describe('Migrating data from node to node in DHT', () => {
 
         logger.info('node 0 joining to the DHT')
 
-        await nodes[0].joinDht(entrypointDescriptor)
+        await nodes[0].joinDht([entrypointDescriptor])
 
         logger.info('storing data to node 0')
         const successfulStorers = await nodes[0].storeDataToDht(dataKey.value, data)
@@ -121,7 +121,7 @@ describe('Migrating data from node to node in DHT', () => {
         await Promise.all(
             nodes.map((node) => {
                 if (node.getNodeName() != '0') {
-                    node.joinDht(entrypointDescriptor)
+                    node.joinDht([entrypointDescriptor])
                 }
             })
         )
@@ -158,7 +158,7 @@ describe('Migrating data from node to node in DHT', () => {
         logger.info(NUM_NODES + ' nodes joining layer0 DHT')
         await Promise.all(
             nodes.map((node) => {
-                node.joinDht(entrypointDescriptor)
+                node.joinDht([entrypointDescriptor])
             })
         )
 

--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -56,8 +56,8 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
             nodeName: layer0EntryPointId
         }
 
-        await layer0EntryPoint.joinDht(entryPointDescriptor)
-        await layer1EntryPoint.joinDht(entryPointDescriptor)
+        await layer0EntryPoint.joinDht([entryPointDescriptor])
+        await layer1EntryPoint.joinDht([entryPointDescriptor])
     })
 
     afterEach(async () => {
@@ -76,15 +76,15 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
     })
 
     it('Happy Path', async () => {
-        await layer0Node1.joinDht(entryPointDescriptor)
-        await layer0Node2.joinDht(entryPointDescriptor)
-        await layer0Node3.joinDht(entryPointDescriptor)
-        await layer0Node4.joinDht(entryPointDescriptor)
+        await layer0Node1.joinDht([entryPointDescriptor])
+        await layer0Node2.joinDht([entryPointDescriptor])
+        await layer0Node3.joinDht([entryPointDescriptor])
+        await layer0Node4.joinDht([entryPointDescriptor])
 
-        await layer1Node1.joinDht(entryPointDescriptor)
-        await layer1Node2.joinDht(entryPointDescriptor)
-        await layer1Node3.joinDht(entryPointDescriptor)
-        await layer1Node4.joinDht(entryPointDescriptor)
+        await layer1Node1.joinDht([entryPointDescriptor])
+        await layer1Node2.joinDht([entryPointDescriptor])
+        await layer1Node3.joinDht([entryPointDescriptor])
+        await layer1Node4.joinDht([entryPointDescriptor])
 
         logger.info('layer1EntryPoint.getBucketSize() ' + layer1EntryPoint.getBucketSize())
         logger.info('layer1Node1.getBucketSize()' + layer1Node1.getBucketSize())

--- a/packages/dht/test/integration/MultipleEntryPointJoining.test.ts
+++ b/packages/dht/test/integration/MultipleEntryPointJoining.test.ts
@@ -1,0 +1,105 @@
+import { LatencyType, Simulator } from "../../src/connection/Simulator/Simulator"
+import { DhtNode } from "../../src/dht/DhtNode"
+import { PeerDescriptor } from "../../src/proto/packages/dht/protos/DhtRpc"
+import { createMockConnectionDhtNode } from "../utils/utils"
+
+describe('multiple entry point joining', () => {
+
+    describe('all nodes are entry points', () => {
+
+        let simulator: Simulator
+        let node1: DhtNode
+        let node2: DhtNode
+        let node3: DhtNode
+        let entryPoints: PeerDescriptor[]
+        
+        beforeEach(async () => {
+            simulator = new Simulator(LatencyType.RANDOM)
+
+            node1 = await createMockConnectionDhtNode('node1', simulator)
+            node2 = await createMockConnectionDhtNode('node2', simulator)
+            node3 = await createMockConnectionDhtNode('node3', simulator)
+
+            entryPoints = [
+                node1.getPeerDescriptor(),
+                node2.getPeerDescriptor(),
+                node3.getPeerDescriptor()
+            ]
+        })
+
+        afterEach(() => {
+            Promise.all([
+                node1.stop(),
+                node2.stop(),
+                node3.stop()
+            ])
+            simulator.stop()
+        })
+
+        it('can join simultaneously', async () => {
+            await Promise.all([
+                node1.joinDht(entryPoints),
+                node2.joinDht(entryPoints),
+                node3.joinDht(entryPoints)
+            ])
+            expect(node1.getBucketSize()).toEqual(2)
+            expect(node2.getBucketSize()).toEqual(2)
+            expect(node3.getBucketSize()).toEqual(2)
+        })
+
+        it('can join even if a node is offline', async () => {
+            await node3.stop()
+            await Promise.all([
+                node1.joinDht(entryPoints),
+                node2.joinDht(entryPoints)
+            ])
+            expect(node1.getBucketSize()).toEqual(1)
+            expect(node2.getBucketSize()).toEqual(1)
+        }, 10000)
+    })
+
+    describe('non entry point nodes can join via multiple entry points', () => {
+        let simulator: Simulator
+        let entryPoint1: DhtNode
+        let entryPoint2: DhtNode
+        let node1: DhtNode
+        let node2: DhtNode
+        let entryPoints: PeerDescriptor[]
+        
+        beforeEach(async () => {
+            simulator = new Simulator(LatencyType.RANDOM)
+            
+            entryPoint1 = await createMockConnectionDhtNode('entryPoint1', simulator)
+            entryPoint2 = await createMockConnectionDhtNode('entryPoint2', simulator)
+            
+            node1 = await createMockConnectionDhtNode('node1', simulator)
+            node2 = await createMockConnectionDhtNode('node2', simulator)
+
+            entryPoints = [
+                entryPoint1.getPeerDescriptor(),
+                entryPoint2.getPeerDescriptor(),
+            ]
+
+            await entryPoint1.joinDht(entryPoints)
+            await entryPoint2.joinDht(entryPoints)
+        })
+
+        afterEach(async () => {
+            await Promise.all([
+                entryPoint1.stop(),
+                entryPoint2.stop(),
+                node1.stop(),
+                node2.stop()
+            ])
+            simulator.stop()
+        })
+
+        it('non-entry point nodes can join', async () => {
+            await node1.joinDht(entryPoints)
+            expect(node1.getBucketSize()).toEqual(2)
+            await node2.joinDht(entryPoints)
+            expect(node2.getBucketSize()).toEqual(3)
+        })
+
+    })
+})

--- a/packages/dht/test/integration/MultipleEntryPointJoining.test.ts
+++ b/packages/dht/test/integration/MultipleEntryPointJoining.test.ts
@@ -27,8 +27,8 @@ describe('multiple entry point joining', () => {
             ]
         })
 
-        afterEach(() => {
-            Promise.all([
+        afterEach(async () => {
+            await Promise.all([
                 node1.stop(),
                 node2.stop(),
                 node3.stop()

--- a/packages/dht/test/integration/RecursiveFind.test.ts
+++ b/packages/dht/test/integration/RecursiveFind.test.ts
@@ -28,8 +28,8 @@ describe('Recursive find correctness', () => {
             const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, nodeId, 20, 60000)
             nodes.push(node)
         }
-        await entryPoint.joinDht(entrypointDescriptor)
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await entryPoint.joinDht([entrypointDescriptor])
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         await waitConnectionManagersReadyForTesting(nodes.map((node) => node.connectionManager!), 20)
     }, 90000)
 

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -47,10 +47,10 @@ describe('Route Message With Mock Connections', () => {
             routerNodes.push(node)
         }
 
-        await destinationNode.joinDht(entryPointDescriptor)
-        await sourceNode.joinDht(entryPointDescriptor)
-        await Promise.all(routerNodes.map((node) => node.joinDht(entryPointDescriptor)))
-        await entryPoint.joinDht(entryPointDescriptor)
+        await destinationNode.joinDht([entryPointDescriptor])
+        await sourceNode.joinDht([entryPointDescriptor])
+        await Promise.all(routerNodes.map((node) => node.joinDht([entryPointDescriptor])))
+        await entryPoint.joinDht([entryPointDescriptor])
     }, 15000)
 
     afterEach(async () => {

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -34,7 +34,7 @@ describe('Scaling down a Dht network', () => {
             const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, nodeId, MAX_CONNECTIONS)
             nodes.push(node)
         }
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
     }, 60000)
 
     afterEach(async () => {

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -39,7 +39,7 @@ describe('Storing data in DHT', () => {
             nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         await waitConnectionManagersReadyForTesting(nodes.map((node) => node.connectionManager!), MAX_CONNECTIONS)
     }, 90000)
 

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -39,7 +39,7 @@ describe('Storing data in DHT', () => {
             nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }
-        await Promise.all(nodes.map((node) => node.joinDht(entrypointDescriptor)))
+        await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         await waitConnectionManagersReadyForTesting(nodes.map((node) => node.connectionManager!), MAX_CONNECTIONS)
     }, 90000)
 

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -30,8 +30,8 @@ describe('Storing data in DHT with two peers', () => {
         await entryPoint.start()
         await otherNode.start()
 
-        await entryPoint.joinDht(entryPoint.getPeerDescriptor())
-        await otherNode.joinDht(entryPoint.getPeerDescriptor())
+        await entryPoint.joinDht([entryPoint.getPeerDescriptor()])
+        await otherNode.joinDht([entryPoint.getPeerDescriptor()])
     })
 
     afterEach(async () => {

--- a/packages/trackerless-network/bin/bootstrap-node.ts
+++ b/packages/trackerless-network/bin/bootstrap-node.ts
@@ -31,14 +31,14 @@ async function run(): Promise<void> {
 
     const layer0 = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 8 })
     await layer0.start()
-    await layer0.joinDht(epPeerDescriptor)
+    await layer0.joinDht([epPeerDescriptor])
 
     const connectionManager = layer0.getTransport() as ConnectionManager
     const streamrNode = new StreamrNode({})
     await streamrNode.start(layer0, connectionManager, connectionManager)
 
-    await streamrNode.joinStream(streamPartId, epPeerDescriptor)
-    streamrNode.subscribeToStream(streamPartId, epPeerDescriptor)
+    await streamrNode.joinStream(streamPartId)
+    streamrNode.subscribeToStream(streamPartId)
 
     streamrNode.on(StreamrNodeEvent.NEW_MESSAGE, (msg: StreamMessage) => {
         // eslint-disable-next-line no-console

--- a/packages/trackerless-network/bin/full-node-webrtc.ts
+++ b/packages/trackerless-network/bin/full-node-webrtc.ts
@@ -41,13 +41,13 @@ async function run(): Promise<void> {
     })
     await layer0.start()
 
-    await layer0.joinDht(epPeerDescriptor)
+    await layer0.joinDht([epPeerDescriptor])
 
     const connectionManager = layer0.getTransport() as ConnectionManager
     const streamrNode = new StreamrNode({})
     await streamrNode.start(layer0, connectionManager, connectionManager)
 
-    streamrNode.subscribeToStream(streamPartId, epPeerDescriptor)
+    streamrNode.subscribeToStream(streamPartId)
 
     streamrNode.on(StreamrNodeEvent.NEW_MESSAGE, (msg: StreamMessage) => {
         // eslint-disable-next-line no-console

--- a/packages/trackerless-network/bin/full-node-websocket.ts
+++ b/packages/trackerless-network/bin/full-node-websocket.ts
@@ -41,13 +41,13 @@ async function run(): Promise<void> {
 
     await layer0.start()
 
-    await layer0.joinDht(epPeerDescriptor)
+    await layer0.joinDht([epPeerDescriptor])
 
     const connectionManager = layer0.getTransport() as ConnectionManager
     const streamrNode = new StreamrNode({})
     await streamrNode.start(layer0, connectionManager, connectionManager)
 
-    streamrNode.subscribeToStream(streamPartId, epPeerDescriptor)
+    streamrNode.subscribeToStream(streamPartId)
 
     streamrNode.on(StreamrNodeEvent.NEW_MESSAGE, (msg: StreamMessage) => {
         // eslint-disable-next-line no-console

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -81,10 +81,11 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     async start(doJoin = true): Promise<void> {
         await this.layer0DhtNode!.start()
         this.connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
-        const entryPoint = this.options.layer0.entryPoints![0]
-        if (isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())) {
+        if (this.options.layer0.entryPoints!.some((entryPoint) => 
+            isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())
+        )) {
             this.dhtJoinRequired = false
-            await this.layer0DhtNode?.joinDht(entryPoint)
+            await this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints!)
             await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager!, this.connectionManager!)
         } else {
             if (doJoin) {
@@ -97,7 +98,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
 
     private async joinDht(): Promise<void> {
         setImmediate(() => {
-            this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints![0])
+            this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints!)
         })
         await this.waitForFirstConnection()
     }

--- a/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
@@ -2,9 +2,6 @@ import { createHash } from 'crypto'
 import {
     isSamePeerDescriptor,
     PeerDescriptor,
-    PeerID,
-    Contact,
-    SortedContactList,
     RecursiveFindResult,
     DataEntry
 } from '@streamr/dht'

--- a/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
@@ -198,13 +198,7 @@ export class StreamEntryPointDiscovery {
             if (this.config.streams.has(streamPartID)) {
                 const stream = this.config.streams.get(streamPartID)
                 const rediscoveredEntrypoints = await this.discoverEntryPoints(streamPartID)
-                const sortedEntrypoints = new SortedContactList(PeerID.fromString(streamPartID), 4)
-                sortedEntrypoints.addContacts(
-                    rediscoveredEntrypoints
-                        .filter((entryPoint) => !isSamePeerDescriptor(entryPoint, this.config.ownPeerDescriptor))
-                        .map((entryPoint) => new Contact(entryPoint)))
-                await Promise.allSettled(sortedEntrypoints.getAllContacts()
-                    .map((entryPoint) => stream!.layer1!.joinDht(entryPoint.getPeerDescriptor(), false)))
+                await stream!.layer1!.joinDht(rediscoveredEntrypoints, false)
                 if (stream!.layer1!.getBucketSize() < 4) {
                     throw new Error(`Network split is still possible`)
                 }

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -217,7 +217,7 @@ export class StreamrNode extends EventEmitter<Events> {
             forwardingPeer
         )
         entryPoints = knownEntryPoints.concat(discoveryResult.discoveredEntryPoints)
-        await Promise.all(sampleSize(entryPoints, 4).map((entryPoint) => layer1.joinDht(entryPoint)))
+        await layer1.joinDht(sampleSize(entryPoints, 4))
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
             streamPartId,
             discoveryResult.joiningEmptyStream,

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -74,12 +74,12 @@ describe('random graph with real connections', () => {
             connectionLocker: dhtNode4.getTransport() as ConnectionManager,
             ownPeerDescriptor: dhtNode4.getPeerDescriptor()
         })
-        await epDhtNode.joinDht(epPeerDescriptor)
+        await epDhtNode.joinDht([epPeerDescriptor])
         await Promise.all([
-            dhtNode1.joinDht(epPeerDescriptor),
-            dhtNode2.joinDht(epPeerDescriptor),
-            dhtNode3.joinDht(epPeerDescriptor),
-            dhtNode4.joinDht(epPeerDescriptor)
+            dhtNode1.joinDht([epPeerDescriptor]),
+            dhtNode2.joinDht([epPeerDescriptor]),
+            dhtNode3.joinDht([epPeerDescriptor]),
+            dhtNode4.joinDht([epPeerDescriptor])
         ])
         await Promise.all([
             randomGraphNode1.start(),

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -23,7 +23,7 @@ describe('Propagation', () => {
         randomGraphNodes = []
         const [entryPoint, node1] = createMockRandomGraphNodeAndDhtNode(entryPointDescriptor, entryPointDescriptor, STREAM_ID, simulator)
         await entryPoint.start()
-        await entryPoint.joinDht(entryPointDescriptor)
+        await entryPoint.joinDht([entryPointDescriptor])
         await node1.start()
         node1.on('message', () => {totalReceived += 1})
         dhtNodes.push(entryPoint)
@@ -42,7 +42,7 @@ describe('Propagation', () => {
             )
             await dht.start()
             await graph.start()
-            await dht.joinDht(entryPointDescriptor).then(() => {
+            await dht.joinDht([entryPointDescriptor]).then(() => {
                 graph.on('message', () => { totalReceived += 1 })
                 dhtNodes.push(dht)
                 randomGraphNodes.push(graph)

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -57,7 +57,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         })
 
         await dhtEntryPoint.start()
-        await dhtEntryPoint.joinDht(entrypointDescriptor)
+        await dhtEntryPoint.joinDht([entrypointDescriptor])
         await Promise.all(dhtNodes.map((node) => node.start()))
     })
 
@@ -70,7 +70,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
     })
 
     it('happy path single peer', async () => {
-        await dhtNodes[0].joinDht(entrypointDescriptor)
+        await dhtNodes[0].joinDht([entrypointDescriptor])
         entryPointRandomGraphNode.start()
         await graphNodes[0].start()
         await Promise.all([
@@ -85,7 +85,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         entryPointRandomGraphNode.start()
         range(4).map((i) => graphNodes[i].start())
         await Promise.all(range(4).map(async (i) => {
-            await dhtNodes[i].joinDht(entrypointDescriptor)
+            await dhtNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(range(4).map((i) => {
             return waitForCondition(() => {
@@ -113,7 +113,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
     it('happy path 64 peers', async () => {
         await Promise.all(range(numOfNodes).map((i) => graphNodes[i].start()))
         await Promise.all(range(numOfNodes).map((i) => {
-            dhtNodes[i].joinDht(entrypointDescriptor)
+            dhtNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(graphNodes.map((node) =>
             waitForCondition(() => node.getTargetNeighborStringIds().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -131,7 +131,7 @@ describe('RandomGraphNode-DhtNode', () => {
         })
 
         await dhtEntryPoint.start()
-        await dhtEntryPoint.joinDht(entrypointDescriptor)
+        await dhtEntryPoint.joinDht([entrypointDescriptor])
         await Promise.all(dhtNodes.map((node) => node.start()))
     })
 
@@ -147,7 +147,7 @@ describe('RandomGraphNode-DhtNode', () => {
 
         const successListener = new SuccessListener(graphNodes[0], 1, 1)
         await entryPointRandomGraphNode.start()
-        await dhtNodes[0].joinDht(entrypointDescriptor)
+        await dhtNodes[0].joinDht([entrypointDescriptor])
 
         await graphNodes[0].start()
 
@@ -166,7 +166,7 @@ describe('RandomGraphNode-DhtNode', () => {
         entryPointRandomGraphNode.start()
         range(4).map((i) => graphNodes[i].start())
         await Promise.all(range(4).map(async (i) => {
-            await dhtNodes[i].joinDht(entrypointDescriptor)
+            await dhtNodes[i].joinDht([entrypointDescriptor])
         }))
 
         await promise
@@ -192,7 +192,7 @@ describe('RandomGraphNode-DhtNode', () => {
     it('happy path 64 peers', async () => {
         await Promise.all(range(numOfNodes).map((i) => graphNodes[i].start()))
         await Promise.all(range(numOfNodes).map((i) => {
-            dhtNodes[i].joinDht(entrypointDescriptor)
+            dhtNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(graphNodes.map((node) =>
             waitForCondition(() => node.getTargetNeighborStringIds().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -65,8 +65,8 @@ describe('StreamrNode', () => {
             layer02.start()
         ])
         await Promise.all([
-            layer01.joinDht(peer1),
-            layer02.joinDht(peer1)
+            layer01.joinDht([peer1]),
+            layer02.joinDht([peer1])
         ])
 
         node1 = new StreamrNode({})


### PR DESCRIPTION
## Summary

The layer0 and layer1 DHTs can now be joined using a list of `PeerDescriptors`.

This makes it possible for peers to join the DHTs using a multiple configured entry points increasing the reliability of the joining procedure.

Entry point nodes can now be restarted and they will join the existing network without a risk of splitting the network.

## Limitations and future improvements

It could be useful to add a configurable limit to the number of entry points that are used by random or by id proximity to load balance the joining process.

