### PR TITLE
refactor: extract `isLeader` helper function

### DIFF
--- a/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
@@ -32,7 +32,7 @@ export class AnnounceNodeToContractService {
         await this.operatorFleetState.waitUntilReady()
         const isLeader = await createIsLeaderFn(this.streamrClient, this.operatorFleetState)
         await scheduleAtInterval(async () => {
-            if (await this.isHeartbeatStale() && isLeader()) {
+            if (isLeader() && await this.isHeartbeatStale()) {
                 await this.writeHeartbeat()
             }
         }, this.pollIntervalInMs, true, this.abortController.signal)

--- a/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
@@ -30,7 +30,7 @@ export class AnnounceNodeToContractService {
 
     async start(): Promise<void> {
         await this.operatorFleetState.waitUntilReady()
-        const isLeader = await createIsLeaderFn(this.streamrClient, this.operatorFleetState)
+        const isLeader = await createIsLeaderFn(this.streamrClient, this.operatorFleetState, logger)
         await scheduleAtInterval(async () => {
             if (isLeader() && await this.isHeartbeatStale()) {
                 await this.writeHeartbeat()

--- a/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeToContractService.ts
@@ -2,6 +2,7 @@ import { Logger, scheduleAtInterval } from '@streamr/utils'
 import { OperatorFleetState } from './OperatorFleetState'
 import StreamrClient from 'streamr-client'
 import { AnnounceNodeToContractHelper } from './AnnounceNodeToContractHelper'
+import { createIsLeaderFn } from './createIsLeaderFn'
 
 const logger = new Logger(module)
 
@@ -29,8 +30,9 @@ export class AnnounceNodeToContractService {
 
     async start(): Promise<void> {
         await this.operatorFleetState.waitUntilReady()
+        const isLeader = await createIsLeaderFn(this.streamrClient, this.operatorFleetState)
         await scheduleAtInterval(async () => {
-            if (await this.isHeartbeatStale() && await this.isLeader()) {
+            if (await this.isHeartbeatStale() && isLeader()) {
                 await this.writeHeartbeat()
             }
         }, this.pollIntervalInMs, true, this.abortController.signal)
@@ -54,14 +56,6 @@ export class AnnounceNodeToContractService {
         const stale = lastHeartbeatTs !== undefined ? lastHeartbeatTs + this.writeIntervalInMs <= Date.now() : true
         logger.debug('Polled last heartbeat timestamp', { lastHeartbeatTs, stale })
         return stale
-    }
-
-    private async isLeader(): Promise<boolean> {
-        const myNodeId = (await this.streamrClient.getNode()).getNodeId()
-        const leaderNodeId = this.operatorFleetState.getLeaderNodeId()
-        const isLeader = myNodeId === leaderNodeId
-        logger.debug('Check if leader', { isLeader, leaderNodeId, myNodeId })
-        return isLeader
     }
 
     private async writeHeartbeat(): Promise<void> {

--- a/packages/broker/src/plugins/operator/createIsLeaderFn.ts
+++ b/packages/broker/src/plugins/operator/createIsLeaderFn.ts
@@ -1,0 +1,17 @@
+import StreamrClient from 'streamr-client'
+import { OperatorFleetState } from './OperatorFleetState'
+import { Logger } from '@streamr/utils'
+
+export async function createIsLeaderFn(
+    streamrClient: StreamrClient,
+    operatorFleetState: OperatorFleetState,
+    logger?: Logger
+): Promise<() => boolean> {
+    const myNodeId = (await streamrClient.getNode()).getNodeId()
+    return () => {
+        const leaderNodeId = operatorFleetState.getLeaderNodeId()
+        const isLeader = myNodeId === leaderNodeId
+        logger?.debug('Check whether leader', { isLeader, leaderNodeId, myNodeId })
+        return isLeader
+    }
+}

--- a/packages/broker/test/unit/plugins/operator/AnnounceNodeToContractService.test.ts
+++ b/packages/broker/test/unit/plugins/operator/AnnounceNodeToContractService.test.ts
@@ -115,6 +115,8 @@ describe(AnnounceNodeToContractService, () => {
             nodeId: 'myNodeId',
             leaderNodeId: [
                 'myNodeId',
+                'leaderNodeId',
+                'leaderNodeId',
                 'myNodeId',
                 'leaderNodeId',
                 'leaderNodeId',

--- a/packages/broker/test/unit/plugins/operator/createIsLeaderFn.test.ts
+++ b/packages/broker/test/unit/plugins/operator/createIsLeaderFn.test.ts
@@ -1,0 +1,40 @@
+import { createIsLeaderFn } from '../../../../src/plugins/operator/createIsLeaderFn'
+import StreamrClient from 'streamr-client'
+import { mock, MockProxy } from 'jest-mock-extended'
+import { OperatorFleetState } from '../../../../src/plugins/operator/OperatorFleetState'
+import { NetworkNode } from '@streamr/trackerless-network'
+import { Logger } from '@streamr/utils'
+
+describe(createIsLeaderFn, () => {
+    let client: MockProxy<StreamrClient>
+    let operatorFleetState: MockProxy<OperatorFleetState>
+
+    beforeEach(() => {
+        const networkNode = mock<NetworkNode>()
+        client = mock<StreamrClient>()
+        operatorFleetState = mock<OperatorFleetState>()
+        networkNode.getNodeId.mockReturnValue('myNodeId')
+        client.getNode.mockResolvedValue(networkNode)
+    })
+    it('equality check works on newest info', async () => {
+        const isLeader = await createIsLeaderFn(client, operatorFleetState)
+
+        operatorFleetState.getLeaderNodeId.mockReturnValueOnce('leaderNodeId')
+        expect(isLeader()).toBeFalse()
+
+        operatorFleetState.getLeaderNodeId.mockReturnValueOnce('myNodeId')
+        expect(isLeader()).toBeTrue()
+
+        operatorFleetState.getLeaderNodeId.mockReturnValueOnce(undefined)
+        expect(isLeader()).toBeFalse()
+    })
+
+    it('logs debug message if passed logger', async () => {
+        const logger = mock<Logger>()
+        const isLeader = await createIsLeaderFn(client, operatorFleetState, logger)
+
+        operatorFleetState.getLeaderNodeId.mockReturnValueOnce('leaderNodeId')
+        isLeader()
+        expect(logger.debug).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary

Extract `createIsLeaderFn` function for creating a function to check for leader. The same code can be used in all the places where we need to check for leader.

Also switch `isHeartbeatStale() && isLeader()` to `isLeader() && isHeartbeatStale()` for efficiency. Only the leader needs to actually go to the graph and query what the last heartbeat timestamp was.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
