### PR TITLE
NET-1006: Default webSocketPort

### DIFF
--- a/packages/client/src/ConfigTest.ts
+++ b/packages/client/src/ConfigTest.ts
@@ -23,6 +23,7 @@ export const CONFIG_TEST: StreamrClientConfig = {
                     port: 40401
                 }
             }],
+            webSocketPort: undefined,
             iceServers: [],
             webrtcAllowPrivateAddresses: true
         }

--- a/packages/client/src/config.schema.json
+++ b/packages/client/src/config.schema.json
@@ -90,7 +90,8 @@
                             }]
                         },
                         "webSocketPort": {
-                            "type": "number"
+                            "type": "number",
+                            "default": 32200
                         },
                         "peerDescriptor": {
                             "$ref": "#/definitions/peerDescriptor"

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -115,6 +115,8 @@ module.exports = (env, argv) => {
                 '@streamr/dht': path.resolve('../dht/src/exports.ts'),
                 [path.resolve(__dirname, '../dht/src/connection/WebRTC/NodeWebRtcConnection.ts')]:
                     path.resolve(__dirname, '../dht/src/connection/WebRTC/BrowserWebRtcConnection.ts'),
+                [path.resolve(__dirname, '../dht/src/helpers/browser/isNodeJS.ts')]:
+                    path.resolve(__dirname, '../dht/src/helpers/browser/isBrowser.ts'),
                 // swap out ServerPersistence for BrowserPersistence
                 [path.resolve('./src/utils/persistence/ServerPersistence.ts')]: (
                     path.resolve('./src/utils/persistence/BrowserPersistence.ts')

--- a/packages/dht/src/helpers/browser/isBrowser.ts
+++ b/packages/dht/src/helpers/browser/isBrowser.ts
@@ -1,0 +1,1 @@
+export const isNodeJS = (): boolean => false

--- a/packages/dht/src/helpers/browser/isNodeJS.ts
+++ b/packages/dht/src/helpers/browser/isNodeJS.ts
@@ -1,0 +1,1 @@
+export const isNodeJS = (): boolean => true


### PR DESCRIPTION
## Summary

Default `webSocketPort` value 32200.
Add check for browser run times in DHT to avoid starting WebSocket servers

## Changes

Provide a bullet list of individual changes. Leave this section out if change
set is small and obvious from summary.

## Limitations and future improvements

Provide a bullet list or description of known omissions or limitations of the
solution and/or any ideas for future improvement. Leave section ouf if
not applicable.

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
