### PR TITLE
Pr suggestion 1

### DIFF
--- a/packages/broker/test/integration/plugins/operator/MaintainOperatorValueHelper.test.ts
+++ b/packages/broker/test/integration/plugins/operator/MaintainOperatorValueHelper.test.ts
@@ -15,7 +15,7 @@ const theGraphUrl = `http://${STREAMR_DOCKER_DEV_HOST}:8800/subgraphs/name/strea
 
 const STREAM_CREATION_KEY = '0xb1abdb742d3924a45b0a54f780f0f21b9d9283b231a0a0b35ce5e455fa5375e7'
 
-describe('OperatorValueBreachWatcher', () => {
+describe('MaintainOperatorValueHelper', () => {
     let provider: Provider
     let deployConfig: SetupOperatorOpts
 

--- a/packages/broker/test/integration/plugins/operator/MaintainOperatorValueHelper.test.ts
+++ b/packages/broker/test/integration/plugins/operator/MaintainOperatorValueHelper.test.ts
@@ -1,0 +1,51 @@
+import { Wallet } from 'ethers'
+import { Contract } from '@ethersproject/contracts'
+import { Provider } from '@ethersproject/providers'
+
+import { operatorFactoryABI, OperatorFactory } from '@streamr/network-contracts'
+import { config } from '@streamr/config'
+
+import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
+import { setupOperatorContract, SetupOperatorOpts } from './setupOperatorContract'
+import { getProvider } from './smartContractUtils'
+import { MaintainOperatorValueHelper } from '../../../../src/plugins/operator/MaintainOperatorValueHelper'
+
+const chainConfig = config.dev2
+const theGraphUrl = `http://${STREAMR_DOCKER_DEV_HOST}:8800/subgraphs/name/streamr-dev/network-subgraphs`
+
+const STREAM_CREATION_KEY = '0xb1abdb742d3924a45b0a54f780f0f21b9d9283b231a0a0b35ce5e455fa5375e7'
+
+describe('OperatorValueBreachWatcher', () => {
+    let provider: Provider
+    let deployConfig: SetupOperatorOpts
+
+    beforeAll(async () => {
+        provider = getProvider()
+        deployConfig = {
+            provider,
+            chainConfig,
+            theGraphUrl,
+            operatorSettings: {
+                operatorSharePercent: 10
+            }
+        }
+    }, 60 * 1000)
+
+    it('can find a random operator with getRandomOperator(), excluding himself', async () => {
+        const { operatorContract, operatorConfig } = await setupOperatorContract(deployConfig)
+        // deploy another operator to make sure there are at least 2 operators
+        await setupOperatorContract(deployConfig)
+
+        const helper = new MaintainOperatorValueHelper(operatorConfig)
+        const randomOperatorAddress = await helper.getRandomOperator()
+        expect(randomOperatorAddress).toBeDefined()
+
+        // check it's a valid operator, deployed by the OperatorFactory
+        const adminWallet = new Wallet(STREAM_CREATION_KEY, provider)
+        const operatorFactory = new Contract(chainConfig.contracts.OperatorFactory, operatorFactoryABI, adminWallet) as unknown as OperatorFactory
+        const isDeployedByFactory = (await operatorFactory.deploymentTimestamp(randomOperatorAddress!)).gt(0)
+        expect(isDeployedByFactory).toBeTrue()
+        // check it's not my operator
+        expect(randomOperatorAddress).not.toEqual(operatorContract.address)
+    }, 30 * 1000)
+})

--- a/packages/broker/test/integration/plugins/operator/OperatorValueBreachWatcher.test.ts
+++ b/packages/broker/test/integration/plugins/operator/OperatorValueBreachWatcher.test.ts
@@ -1,9 +1,8 @@
-import { Wallet } from 'ethers'
 import { Contract } from '@ethersproject/contracts'
 import { Provider, JsonRpcProvider } from '@ethersproject/providers'
 import { parseEther } from '@ethersproject/units'
 
-import { tokenABI, TestToken, operatorFactoryABI, OperatorFactory } from '@streamr/network-contracts'
+import { tokenABI, TestToken } from '@streamr/network-contracts'
 import { Logger, toEthereumAddress, waitForCondition } from '@streamr/utils'
 import { config } from '@streamr/config'
 
@@ -46,25 +45,6 @@ describe('OperatorValueBreachWatcher', () => {
             }
         }
     }, 60 * 1000)
-
-    it('can find a random operator, excluding himself', async () => {
-        const { operatorContract, operatorConfig } = await setupOperatorContract(deployConfig)
-        // deploy another operator to make sure there are at least 2 operators
-        await setupOperatorContract(deployConfig)
-
-        const operatorValueBreachWatcher = new OperatorValueBreachWatcher(operatorConfig)
-        const randomOperatorAddress = await operatorValueBreachWatcher.helper.getRandomOperator()
-        if (randomOperatorAddress === undefined) {
-            throw new Error('No random operator found')
-        }
-        // check it's a valid operator, deployed by the OperatorFactory
-        const adminWallet = new Wallet(STREAM_CREATION_KEY, provider)
-        const operatorFactory = new Contract(chainConfig.contracts.OperatorFactory, operatorFactoryABI, adminWallet) as unknown as OperatorFactory
-        const isDeployedByFactory = (await operatorFactory.deploymentTimestamp(randomOperatorAddress)).gt(0)
-        expect(isDeployedByFactory).toBeTrue()
-        // check it's not my operator
-        expect(randomOperatorAddress).not.toEqual(operatorContract.address)
-    }, 30 * 1000)
 
     it('withdraws the other Operators earnings when they are above the penalty limit', async () => {
         const { operatorConfig: watcherConfig } = await setupOperatorContract(deployConfig)

--- a/packages/broker/test/integration/plugins/operator/setupOperatorContract.ts
+++ b/packages/broker/test/integration/plugins/operator/setupOperatorContract.ts
@@ -11,7 +11,20 @@ export interface SetupOperatorOpts {
     nodeAddresses?: EthereumAddress[]
     provider: Provider
     // eslint-disable-next-line max-len
-    chainConfig: { contracts: { DATA: string, OperatorFactory: string, OperatorDefaultDelegationPolicy: string, OperatorDefaultPoolYieldPolicy: string, OperatorDefaultUndelegationPolicy: string } }
+    chainConfig: {
+        contracts: {
+            DATA: string
+            OperatorFactory: string
+            OperatorDefaultDelegationPolicy: string
+            OperatorDefaultPoolYieldPolicy: string
+            OperatorDefaultUndelegationPolicy: string
+        }
+    }
+    operatorSettings?: {
+        minOperatorStakePercent?: number
+        operatorSharePercent?: number
+        operatorMetadata?: string
+    }
     theGraphUrl: string
     adminKey?: string
 }
@@ -21,7 +34,7 @@ export async function setupOperatorContract(
 ): Promise<{ operatorWallet: Wallet, operatorContract: Operator, operatorConfig: OperatorServiceConfig }> {
     const operatorWallet = await generateWalletWithGasAndTokens(opts.provider, opts.chainConfig, opts.adminKey)
 
-    const operatorContract = await deployOperatorContract(opts.chainConfig, operatorWallet)
+    const operatorContract = await deployOperatorContract(opts.chainConfig, operatorWallet, opts.operatorSettings)
     const operatorConfig = {
         operatorContractAddress: toEthereumAddress(operatorContract.address),
         signer: operatorWallet,


### PR DESCRIPTION
## Summary

Two suggestions to PR https://github.com/streamr-dev/network/pull/1629

1) Use `setupOperatorContract` in introduced integration tests to avoid repetition.

2) Move `can find a random operator, excluding himself` under file MaintainOperatorValueHelper.test.ts since it is really testing its behavior.