### PR TITLE
test(utils) [NET-1016]: fix flaky withTimeout.test.ts

### DIFF
--- a/packages/utils/test/withTimeout.test.ts
+++ b/packages/utils/test/withTimeout.test.ts
@@ -3,24 +3,24 @@ import { AbortError } from '../src/asAbortable'
 
 describe('withTimeout', () => {
     it('resolves if given promise resolves before timeout', () => {
-        return expect(withTimeout(new Promise((resolve) => setTimeout(() => resolve(123), 10)), 20))
+        return expect(withTimeout(new Promise((resolve) => setTimeout(() => resolve(123), 10)), 50))
             .resolves.toEqual(123)
     })
 
     it('rejects if given promise resolves after timeout', () => {
-        return expect(withTimeout(new Promise((resolve) => setTimeout(() => resolve(123), 20)), 10))
+        return expect(withTimeout(new Promise((resolve) => setTimeout(() => resolve(123), 50)), 10))
             .rejects.toEqual(new TimeoutError(10))
     })
 
     it('rejects with given promise if given promise rejects before timeout', () => {
-        return expect(withTimeout(Promise.reject(new Error('foobar')), 20))
+        return expect(withTimeout(Promise.reject(new Error('foobar')), 50))
             .rejects.toEqual(new Error('foobar'))
     })
 
     it('rejection timeout can be given custom error context', () => {
         return expect(
             withTimeout(
-                new Promise((resolve) => setTimeout(() => resolve(123), 20)),
+                new Promise((resolve) => setTimeout(() => resolve(123), 50)),
                 10,
                 'no connection available'
             )
@@ -32,14 +32,14 @@ describe('withTimeout', () => {
         setTimeout(() => {
             abortController.abort()
         }, 10)
-        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController.signal))
+        return expect(withTimeout(new Promise<unknown>(() => {}), 50, 'context', abortController.signal))
             .rejects.toEqual(new AbortError('context'))
     })
 
     it('rejects if initially aborted', () => {
         const abortController = new AbortController()
         abortController.abort()
-        return expect(withTimeout(new Promise<unknown>(() => {}), 20, 'context', abortController.signal))
+        return expect(withTimeout(new Promise<unknown>(() => {}), 10, 'context', abortController.signal))
             .rejects.toEqual(new AbortError('context'))
     })
 


### PR DESCRIPTION
## Summary

Add more time between events to account for inaccurate JavaScript timers ("jitter").

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
