### PR TITLE
test(cli-tools) NET-1025: fix flaky cli tools tests

### DIFF
--- a/packages/cli-tools/test/stream-search.test.ts
+++ b/packages/cli-tools/test/stream-search.test.ts
@@ -1,6 +1,6 @@
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { randomString } from '@streamr/utils'
-import { createTestClient, runCommand } from './utils'
+import { createTestClient, runCommand, waitForTheGraphToHaveIndexed } from './utils'
 
 describe('search streams', () => {
 
@@ -9,6 +9,10 @@ describe('search streams', () => {
         const client = createTestClient(await fetchPrivateKeyWithGas())
         const stream1 = await client.createStream(`/${testId}-1`)
         const stream2 = await client.createStream(`/${testId}-2`)
+        await Promise.all([
+            waitForTheGraphToHaveIndexed(stream1, client),
+            waitForTheGraphToHaveIndexed(stream2, client)
+        ])
         await client.destroy()
         const outputLines = await runCommand(`stream search ${testId}`)
         expect(outputLines).toEqual([

--- a/packages/cli-tools/test/stream-show.test.ts
+++ b/packages/cli-tools/test/stream-show.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from '@ethersproject/wallet'
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { createTestClient, runCommand } from './utils'
+import { createTestClient, runCommand, waitForTheGraphToHaveIndexed } from './utils'
 
 describe('show stream', () => {
 
@@ -8,6 +8,7 @@ describe('show stream', () => {
         const creatorPrivateKey = await fetchPrivateKeyWithGas()
         const client = createTestClient(creatorPrivateKey)
         const stream = await client.createStream(`/${Date.now()}`)
+        await waitForTheGraphToHaveIndexed(stream, client)
         await client.destroy()
         const outputLines = await runCommand(`stream show ${stream.id} --include-permissions`)
         const outputJson = JSON.parse(outputLines.join(''))

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -76,11 +76,10 @@ export const createTestClient = (privateKey?: string): StreamrClient => {
 
 export const waitForTheGraphToHaveIndexed = async (stream: Stream, client: StreamrClient): Promise<void> => {
     await waitForCondition(async () => {
-        let count = 0
         // eslint-disable-next-line no-underscore-dangle
         for await (const _msg of client.searchStreams(stream.id, undefined)) {
-            count += 1
+            return true
         }
-        return count > 0
+        return false
     }, 15 * 1000, 600)
 }

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -1,7 +1,7 @@
-import { collect } from '@streamr/utils'
+import { collect, waitForCondition } from '@streamr/utils'
 import { spawn } from 'child_process'
 import merge2 from 'merge2'
-import { CONFIG_TEST, StreamrClient } from 'streamr-client'
+import { CONFIG_TEST, Stream, StreamrClient } from 'streamr-client'
 
 export const DOCKER_DEV_STORAGE_NODE = '0xde1112f631486CfC759A50196853011528bC5FA0'
 
@@ -72,4 +72,15 @@ export const createTestClient = (privateKey?: string): StreamrClient => {
         ...CONFIG_TEST,
         auth: (privateKey !== undefined) ? { privateKey } : undefined
     })
+}
+
+export const waitForTheGraphToHaveIndexed = async (stream: Stream, client: StreamrClient): Promise<void> => {
+    await waitForCondition(async () => {
+        let count = 0
+        // eslint-disable-next-line no-underscore-dangle
+        for await (const _msg of client.searchStreams(stream.id, undefined)) {
+            count += 1
+        }
+        return count > 0
+    }, 15 * 1000, 600)
 }


### PR DESCRIPTION
## Summary

Add waiting for the graph to have indexed streams in those tests that use cli-tools that depend on the graph results.
