### PR TITLE
refactor(client, broker, cli-tools): expose `getNodeId` 

### DIFF
--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -55,7 +55,7 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
             if (httpServerEndpoints.length > 0) {
                 httpServer = await startHttpServer(httpServerEndpoints, config.httpServer)
             }
-            const nodeId = (await streamrClient.getNode()).getNodeId()
+            const nodeId = await streamrClient.getNodeId()
             const brokerAddress = await streamrClient.getAddress()
             const mnemonic = generateMnemonicFromAddress(toEthereumAddress(brokerAddress))
 

--- a/packages/broker/src/plugins/operator/MaintainTopologyService.ts
+++ b/packages/broker/src/plugins/operator/MaintainTopologyService.ts
@@ -26,7 +26,7 @@ export async function setUpAndStartMaintainTopologyService({
 }): Promise<MaintainTopologyService> {
     // TODO: check that operatorFleetState is NOT started
     const maintainTopologyHelper = new MaintainTopologyHelper(serviceHelperConfig)
-    const nodeId = (await streamrClient.getNode()).getNodeId()
+    const nodeId = await streamrClient.getNodeId()
     const service = new MaintainTopologyService(
         streamrClient,
         new StreamAssignmentLoadBalancer(

--- a/packages/broker/src/plugins/operator/createIsLeaderFn.ts
+++ b/packages/broker/src/plugins/operator/createIsLeaderFn.ts
@@ -7,7 +7,7 @@ export async function createIsLeaderFn(
     operatorFleetState: OperatorFleetState,
     logger?: Logger
 ): Promise<() => boolean> {
-    const myNodeId = (await streamrClient.getNode()).getNodeId()
+    const myNodeId = await streamrClient.getNodeId()
     return () => {
         const leaderNodeId = operatorFleetState.getLeaderNodeId()
         const isLeader = myNodeId === leaderNodeId

--- a/packages/broker/test/unit/plugins/operator/AnnounceNodeToContractService.test.ts
+++ b/packages/broker/test/unit/plugins/operator/AnnounceNodeToContractService.test.ts
@@ -4,7 +4,6 @@ import { mock, MockProxy } from 'jest-mock-extended'
 import { AnnounceNodeToContractHelper } from '../../../../src/plugins/operator/AnnounceNodeToContractHelper'
 import { OperatorFleetState } from '../../../../src/plugins/operator/OperatorFleetState'
 import { wait, waitForCondition } from '@streamr/utils'
-import { NetworkNode } from '@streamr/trackerless-network'
 
 function setUp({
     nodeId,
@@ -20,13 +19,11 @@ function setUp({
     pollIntervalInMs: number
 }): { service: AnnounceNodeToContractService, helper: MockProxy<AnnounceNodeToContractHelper> } {
     let heartbeatTs: number | undefined = initialHeartbeatTs
-    const networkNode = mock<NetworkNode>()
     const streamrClient = mock<StreamrClient>()
     const helper = mock<AnnounceNodeToContractHelper>()
     const operatorFleetState = mock<OperatorFleetState>()
 
-    networkNode.getNodeId.mockReturnValue(nodeId)
-    streamrClient.getNode.mockResolvedValue(networkNode)
+    streamrClient.getNodeId.mockResolvedValue(nodeId)
     streamrClient.getPeerDescriptor.mockResolvedValue({ id: nodeId, type: NetworkNodeType.NODEJS })
     if (typeof leaderNodeId === 'string') {
         operatorFleetState.getLeaderNodeId.mockReturnValue(leaderNodeId)

--- a/packages/broker/test/unit/plugins/operator/createIsLeaderFn.test.ts
+++ b/packages/broker/test/unit/plugins/operator/createIsLeaderFn.test.ts
@@ -2,7 +2,6 @@ import { createIsLeaderFn } from '../../../../src/plugins/operator/createIsLeade
 import StreamrClient from 'streamr-client'
 import { mock, MockProxy } from 'jest-mock-extended'
 import { OperatorFleetState } from '../../../../src/plugins/operator/OperatorFleetState'
-import { NetworkNode } from '@streamr/trackerless-network'
 import { Logger } from '@streamr/utils'
 
 describe(createIsLeaderFn, () => {
@@ -10,12 +9,11 @@ describe(createIsLeaderFn, () => {
     let operatorFleetState: MockProxy<OperatorFleetState>
 
     beforeEach(() => {
-        const networkNode = mock<NetworkNode>()
         client = mock<StreamrClient>()
         operatorFleetState = mock<OperatorFleetState>()
-        networkNode.getNodeId.mockReturnValue('myNodeId')
-        client.getNode.mockResolvedValue(networkNode)
+        client.getNodeId.mockResolvedValue('myNodeId')
     })
+
     it('equality check works on newest info', async () => {
         const isLeader = await createIsLeaderFn(client, operatorFleetState)
 

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -636,6 +636,13 @@ export class StreamrClient {
     }
 
     /**
+     * Get the network-level node id of the client.
+     */
+    async getNodeId(): Promise<string> {
+        return this.node.getNodeId()
+    }
+
+    /**
      * Get diagnostic info about the underlying network. Useful for debugging issues.
      *
      * @remark returned object's structure can change without semver considerations

--- a/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
+++ b/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
@@ -61,8 +61,8 @@ describe('PubSub with proxy connections', () => {
         const proxyUser1 = await proxyClient1.getAddress()
         const proxyUser2 = await proxyClient2.getAddress()
 
-        proxyPeerKey1 = (await proxyClient1.getNode()).getNodeId()
-        proxyPeerKey2 = (await proxyClient2.getNode()).getNodeId()
+        proxyPeerKey1 = await proxyClient1.getNodeId()
+        proxyPeerKey2 = await proxyClient2.getNodeId()
 
         await onewayClient.setPermissions({
             streamId: stream.id,

--- a/packages/client/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/client/test/integration/NetworkNodeFacade.test.ts
@@ -24,10 +24,10 @@ describe('NetworkNodeFacade', () => {
                     privateKey: fastPrivateKey()
                 }
             })
-            const node = await client.getNode()
+            const nodeId = await client.getNodeId()
             const expectedPrefix = `${await client.getAddress()}#`
-            expect(node.getNodeId().startsWith(expectedPrefix)).toBe(true)
-            expect(node.getNodeId().length).toBeGreaterThan(expectedPrefix.length) // has more characters after #
+            expect(nodeId.startsWith(expectedPrefix)).toBe(true)
+            expect(nodeId.length).toBeGreaterThan(expectedPrefix.length) // has more characters after #
         })
 
         it('generates different ids for different clients with same private key', async () => {
@@ -45,13 +45,12 @@ describe('NetworkNodeFacade', () => {
             // same key, same address
             expect(await client1.getAddress()).toEqual(await client2.getAddress())
             const expectedPrefix = `${await client1.getAddress()}#`
-            const node1 = await client1.getNode()
-            const node2 = await client2.getNode()
-            expect(node1).not.toBe(node2)
+            const node1Id = await client1.getNodeId()
+            const node2Id = await client2.getNodeId()
             // both start with same prefix
-            expect(node1.getNodeId().startsWith(expectedPrefix)).toBe(true)
-            expect(node2.getNodeId().startsWith(expectedPrefix)).toBe(true)
-            expect(node1.getNodeId()).not.toEqual(node2.getNodeId())
+            expect(node1Id.startsWith(expectedPrefix)).toBe(true)
+            expect(node2Id.startsWith(expectedPrefix)).toBe(true)
+            expect(node1Id).not.toEqual(node2Id)
         })
 
         it('uses supplied network node id, if compatible', async () => {
@@ -68,8 +67,7 @@ describe('NetworkNodeFacade', () => {
                     }
                 }
             })
-            const node = await client.getNode()
-            expect(node.getNodeId()).toEqual(nodeId)
+            expect(await client.getNodeId()).toEqual(nodeId)
         })
 
         it('throws error if supplied network node id not compatible', async () => {

--- a/packages/client/test/integration/Subscriber2.test.ts
+++ b/packages/client/test/integration/Subscriber2.test.ts
@@ -332,7 +332,7 @@ describe('Subscriber', () => {
                 sub.on('error', onSubscriptionError)
 
                 const published = []
-                const nodeId = (await publisher.getNode()).getNodeId()
+                const nodeId = await publisher.getNodeId()
                 const node = environment.getNetwork().getNode(nodeId)!
                 for (let i = 0; i < NUM_MESSAGES; i++) {
                     const serializedContent = (i === MAX_ITEMS) ? 'invalid-json' : JSON.stringify({ foo: i })


### PR DESCRIPTION
## Summary

The whole having to get node first just to get node id is clumsy. Also `getNode()` is deprecated. Add a getNodeId() function to client API that delegates call.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
