### PR TITLE
feat(broker): Expose `StreamrClient` instead of `NetworkNodeStub`

### DIFF
--- a/packages/broker/src/broker.ts
+++ b/packages/broker/src/broker.ts
@@ -1,20 +1,20 @@
 import { Logger, toEthereumAddress } from '@streamr/utils'
-import StreamrClient, { NetworkNodeStub } from 'streamr-client'
 import { Server as HttpServer } from 'http'
 import { Server as HttpsServer } from 'https'
-import { createPlugin } from './pluginRegistry'
-import { validateConfig } from './config/validateConfig'
+import StreamrClient from 'streamr-client'
 import { version as CURRENT_VERSION } from '../package.json'
-import { Config } from './config/config'
 import { HttpServerEndpoint, Plugin, PluginOptions } from './Plugin'
-import { startServer as startHttpServer, stopServer } from './httpServer'
+import { Config } from './config/config'
 import BROKER_CONFIG_SCHEMA from './config/config.schema.json'
+import { validateConfig } from './config/validateConfig'
 import { generateMnemonicFromAddress } from './helpers/generateMnemonicFromAddress'
+import { startServer as startHttpServer, stopServer } from './httpServer'
+import { createPlugin } from './pluginRegistry'
 
 const logger = new Logger(module)
 
 export interface Broker {
-    getNode: () => Promise<NetworkNodeStub>
+    getStreamrClient: () => StreamrClient
     start: () => Promise<unknown>
     stop: () => Promise<unknown>
 }
@@ -32,18 +32,12 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
         return createPlugin(name, pluginOptions)
     })
 
-    let started = false
     let httpServer: HttpServer | HttpsServer | undefined
 
-    const getNode = async (): Promise<NetworkNodeStub> => {
-        if (!started) {
-            throw new Error('cannot invoke on non-started broker')
-        }
-        return streamrClient.getNode()
-    }
-
     return {
-        getNode,
+        getStreamrClient: () => {
+            return streamrClient
+        },
         start: async () => {
             logger.info(`Start broker version ${CURRENT_VERSION}`)
             await Promise.all(plugins.map((plugin) => plugin.start()))
@@ -71,7 +65,6 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
                     'This makes it impossible to create network layer connections directly via local routers ' +
                     'More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')
             }
-            started = true
         },
         stop: async () => {
             if (httpServer !== undefined) {

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -28,7 +28,7 @@ const grantPermissions = async (streams: Stream[], brokerUsers: Wallet[]) => {
 
 export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
     const node = await (broker.getStreamrClient().getNode())
-    return Array.from(node.getStreamParts())
+    return node.getStreamParts()
 }
 
 describe('broker subscriptions', () => {

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -1,10 +1,10 @@
 import { Wallet } from '@ethersproject/wallet'
 import mqtt, { AsyncMqttClient } from 'async-mqtt'
-import StreamrClient, { Stream, StreamPermission } from 'streamr-client'
+import StreamrClient, { Stream, StreamPartID, StreamPermission } from 'streamr-client'
 import { fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { wait, waitForCondition } from '@streamr/utils'
 import { Broker } from '../../src/broker'
-import { startBroker, createClient, createTestStream, getStreamParts } from '../utils'
+import { startBroker, createClient, createTestStream } from '../utils'
 
 jest.setTimeout(50000)
 
@@ -24,6 +24,11 @@ const grantPermissions = async (streams: Stream[], brokerUsers: Wallet[]) => {
         })
         await s.grantPermissions(...assignments)
     }
+}
+
+export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
+    const node = await (broker.getStreamrClient().getNode())
+    return Array.from(node.getStreamParts())
 }
 
 describe('broker subscriptions', () => {

--- a/packages/broker/test/integration/broker-subscriptions.test.ts
+++ b/packages/broker/test/integration/broker-subscriptions.test.ts
@@ -27,8 +27,9 @@ const grantPermissions = async (streams: Stream[], brokerUsers: Wallet[]) => {
 }
 
 export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
-    const node = await (broker.getStreamrClient().getNode())
-    return node.getStreamParts()
+    const client = broker.getStreamrClient()
+    const subs = await client.getSubscriptions()
+    return subs.map((s) => s.streamPartId)
 }
 
 describe('broker subscriptions', () => {

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -153,7 +153,7 @@ export const createTestStream = async (
 }
 
 export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
-    const node = await broker.getNode()
+    const node = await (broker.getStreamrClient().getNode())
     return Array.from(node.getStreamParts())
 }
 

--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -1,18 +1,17 @@
+import { EthereumAddress, merge, toEthereumAddress } from '@streamr/utils'
+import { Wallet } from 'ethers'
+import padEnd from 'lodash/padEnd'
 import StreamrClient, {
     CONFIG_TEST,
+    NetworkPeerDescriptor,
     Stream,
-    StreamPermission,
     StreamMetadata,
-    StreamrClientConfig,
-    NetworkPeerDescriptor
+    StreamPermission,
+    StreamrClientConfig
 } from 'streamr-client'
-import padEnd from 'lodash/padEnd'
-import { Wallet } from 'ethers'
+import { v4 as uuid } from 'uuid'
 import { Broker, createBroker } from '../src/broker'
 import { Config } from '../src/config/config'
-import { StreamPartID } from '@streamr/protocol'
-import { EthereumAddress, toEthereumAddress, merge } from '@streamr/utils'
-import { v4 as uuid } from 'uuid'
 
 export const STREAMR_DOCKER_DEV_HOST = process.env.STREAMR_DOCKER_DEV_HOST || '127.0.0.1'
 
@@ -150,11 +149,6 @@ export const createTestStream = async (
         ...props
     })
     return stream
-}
-
-export const getStreamParts = async (broker: Broker): Promise<StreamPartID[]> => {
-    const node = await (broker.getStreamrClient().getNode())
-    return Array.from(node.getStreamParts())
 }
 
 export async function startStorageNode(


### PR DESCRIPTION
The `NetworkNodeStub` is an internal class. Therefore it is better to expose `StreamrClient` instead of that.

The client is currently used only in a test (`broker-subscriptions.test.ts`). Moved also a helper method from utils to the test and simplified it.