### PR TITLE
test(broker): add integration test for `AnnounceNodeToStreamService`

### DIFF
--- a/packages/broker/src/plugins/operator/AnnounceNodeToStreamService.ts
+++ b/packages/broker/src/plugins/operator/AnnounceNodeToStreamService.ts
@@ -31,6 +31,9 @@ export class AnnounceNodeToStreamService {
                         msgType: 'heartbeat',
                         peerDescriptor
                     })
+                    logger.debug('Published heartbeat to coordination stream', {
+                        streamId: this.coordinationStream
+                    })
                 } catch (err) {
                     logger.warn('Unable to publish to coordination stream', {
                         streamId: this.coordinationStream,
@@ -42,7 +45,6 @@ export class AnnounceNodeToStreamService {
     }
 
     async stop(): Promise<void> {
-        logger.info('Stop')
         this.abortController.abort()
     }
 }

--- a/packages/broker/test/integration/plugins/operator/AnnounceNodeToStreamService.test.ts
+++ b/packages/broker/test/integration/plugins/operator/AnnounceNodeToStreamService.test.ts
@@ -1,0 +1,43 @@
+import { setupOperatorContract } from './contractUtils'
+import { AnnounceNodeToStreamService } from '../../../../src/plugins/operator/AnnounceNodeToStreamService'
+import { createClient } from '../../../utils'
+import StreamrClient from 'streamr-client'
+import { fastPrivateKey } from '@streamr/test-utils'
+import { toStreamID } from '@streamr/protocol'
+import { collect, EthereumAddress } from '@streamr/utils'
+
+const TIMEOUT = 10 * 1000
+
+describe(AnnounceNodeToStreamService, () => {
+    let operatorContractAddress: EthereumAddress
+    let client: StreamrClient
+    let service: AnnounceNodeToStreamService
+
+    beforeEach(async () => {
+        const { operatorServiceConfig, nodeWallets } = await setupOperatorContract({
+            nodeCount: 1
+        })
+        operatorContractAddress = operatorServiceConfig.operatorContractAddress
+        const nodeWallet = nodeWallets[0]
+        client = createClient(nodeWallet.privateKey)
+        service = new AnnounceNodeToStreamService(client, operatorContractAddress, 250)
+        await service.start()
+    }, TIMEOUT)
+
+    afterEach(async () => {
+        await service?.stop()
+        await client?.destroy()
+    }, TIMEOUT)
+
+    it('publishes to stream', async () => {
+        const streamId = toStreamID('/operator/coordination', operatorContractAddress)
+        const anonymousClient = createClient(fastPrivateKey())
+        const subscription = await anonymousClient.subscribe(streamId)
+        const [{ content }] = await collect(subscription, 1)
+        expect(content).toEqual({
+            msgType: 'heartbeat',
+            peerDescriptor: await client.getPeerDescriptor()
+        })
+        await subscription.unsubscribe()
+    }, TIMEOUT)
+})

--- a/packages/broker/test/integration/plugins/operator/AnnounceNodeToStreamService.test.ts
+++ b/packages/broker/test/integration/plugins/operator/AnnounceNodeToStreamService.test.ts
@@ -38,6 +38,5 @@ describe(AnnounceNodeToStreamService, () => {
             msgType: 'heartbeat',
             peerDescriptor: await client.getPeerDescriptor()
         })
-        await subscription.unsubscribe()
     }, TIMEOUT)
 })


### PR DESCRIPTION
## Summary

Add integration test for  `AnnounceNodeToStreamService`.

I originally skipped writing the integration test for this service due to the "triviality" of the implementation (it does have unit test). However, I encountered it not working in practice so I felt an integration test is warranted after all.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
