### PR TITLE
ci: ignore missing log file warning

### DIFF
--- a/.github/workflows/reusable/collect-and-upload-logs/action.yml
+++ b/.github/workflows/reusable/collect-and-upload-logs/action.yml
@@ -16,3 +16,4 @@ runs:
       with:
         name: logs-${{ inputs.artifact_prefix }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
         path: 'logs'
+        if-no-files-found: ignore


### PR DESCRIPTION
Currently we always upload CI log artifacts from GitHub actions (see commit https://github.com/streamr-dev/network/commit/e6349ec77eb9b0cfa2830e46445e93cfc383d954). Modified job definition so that it doesn't output a warning if there is no log file.