### PR TITLE
docs: Fix `searchStreams` return type

### DIFF
--- a/docs/docs/usage/streamr-js-client/utility-functions.md
+++ b/docs/docs/usage/streamr-js-client/utility-functions.md
@@ -26,7 +26,7 @@ const streams = await streamr.searchStreams('foo');
 ```
 
 :::caution Important:
-Stream searches return an iterable AsyncGenerator object that you must iterate over. For example, 
+Stream searches return an iterable AsyncIterable object that you must iterate over. For example, 
 
 ```ts
 const streams = await searchStreams...


### PR DESCRIPTION
The return type of `searchStreams` is `AsyncIterable`:
https://github.com/streamr-dev/network/blob/696615fc7d6712eb312748bfdf5216237f079d97/packages/client/src/StreamrClient.ts#L389