### PR TITLE
refactor: Simplify object literals

### DIFF
--- a/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/broker/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -65,7 +65,7 @@ describe('Storage: lots of data', () => {
         for (let i = 0; i < NUM_MESSAGES; i++) {
             randomFillSync(randomBuffer)
             const msg = buildMsg({
-                streamId: streamId,
+                streamId,
                 streamPartition: 0,
                 timestamp: 1000000 + (i + 1),
                 sequenceNumber: 0,

--- a/packages/dht/src/connection/RemoteConnectionLocker.ts
+++ b/packages/dht/src/connection/RemoteConnectionLocker.ts
@@ -74,7 +74,7 @@ export class RemoteConnectionLocker {
         const request: DisconnectNotice = {
             peerDescriptor: this.ownPeerDescriptor,
             protocolVersion: this.protocolVersion,
-            disconnecMode: disconnecMode
+            disconnecMode
         }
         const options = {
             sourceDescriptor: this.ownPeerDescriptor,

--- a/packages/dht/src/connection/WebSocket/WebSocketServer.ts
+++ b/packages/dht/src/connection/WebSocket/WebSocketServer.ts
@@ -84,12 +84,12 @@ export class WebSocketServer extends EventEmitter<ConnectionSourceEvents> {
 
         if (typeof NodeJsWsServer !== 'undefined') {
             return new NodeJsWsServer({
-                httpServer: httpServer,
+                httpServer,
                 autoAcceptConnections: false
             })
         } else {
             return this.wsServer = new WsServer({
-                httpServer: httpServer,
+                httpServer,
                 autoAcceptConnections: false
             })
         }

--- a/packages/dht/src/dht/DhtPeer.ts
+++ b/packages/dht/src/dht/DhtPeer.ts
@@ -37,7 +37,7 @@ export class DhtPeer extends Remote<IDhtRpcServiceClient> implements KBucketCont
     async getClosestPeers(kademliaId: Uint8Array): Promise<PeerDescriptor[]> {
         logger.trace(`Requesting getClosestPeers on ${this.serviceId} from ${this.peerId.toKey()}`)
         const request: ClosestPeersRequest = {
-            kademliaId: kademliaId,
+            kademliaId,
             requestId: v4()
         }
         const options: DhtRpcOptions = {

--- a/packages/dht/src/dht/store/DataStore.ts
+++ b/packages/dht/src/dht/store/DataStore.ts
@@ -232,7 +232,7 @@ export class DataStore implements IStoreService {
         const { incomingSourceDescriptor } = context as DhtCallContext
         const { kademliaId, data, storerTime } = request
         this.localDataStore.storeEntry({ 
-            kademliaId: kademliaId, 
+            kademliaId, 
             storer: incomingSourceDescriptor!, 
             ttl,
             storedAt: Timestamp.now(),

--- a/packages/dht/src/dht/store/RemoteStore.ts
+++ b/packages/dht/src/dht/store/RemoteStore.ts
@@ -49,7 +49,7 @@ export class RemoteStore extends Remote<IStoreServiceClient> {
             sourceDescriptor: this.ownPeerDescriptor,
             targetDescriptor: this.peerDescriptor,
             timeout: 10000,
-            doNotConnect: doNotConnect
+            doNotConnect
         }
 
         return this.client.migrateData(request, options)      

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -35,7 +35,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
                     rpcMessage: msg
                 },
                 messageType: MessageType.RPC, 
-                targetDescriptor: targetDescriptor
+                targetDescriptor
             }
 
             if (msg.header.response || callContext && callContext.doNotConnect && callContext.doNotMindStopped ) {

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -126,7 +126,7 @@ describe('ConnectionManager', () => {
         })
 
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: {
@@ -188,7 +188,7 @@ describe('ConnectionManager', () => {
         })
 
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: {
@@ -237,7 +237,7 @@ describe('ConnectionManager', () => {
         const connectionManager4 = new ConnectionManager({ ownPeerDescriptor: mockPeerDescriptor4, simulator: simulator2 })
 
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: {

--- a/packages/dht/test/integration/RemoteRouter.test.ts
+++ b/packages/dht/test/integration/RemoteRouter.test.ts
@@ -38,7 +38,7 @@ describe('RemoteRouter', () => {
     it('routeMessage happy path', async () => {
         const rpcWrapper = createWrappedClosestPeersRequest(clientPeerDescriptor, serverPeerDescriptor)
         const routed: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageId: 'routed',
             messageType: MessageType.RPC,
             body: {
@@ -61,7 +61,7 @@ describe('RemoteRouter', () => {
         serverRpcCommunicator.registerRpcMethod(RouteMessageWrapper, RouteMessageAck, 'routeMessage', MockRoutingService.throwRouteMessageError)
         const rpcWrapper = createWrappedClosestPeersRequest(clientPeerDescriptor, serverPeerDescriptor)
         const routed: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageId: 'routed',
             messageType: MessageType.RPC,
             body: {

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -82,7 +82,7 @@ describe('Route Message With Mock Connections', () => {
 
         await runAndWaitForEvents3<DhtNodeEvents>([() => {
             sourceNode.router!.doRouteMessage({
-                message: message,
+                message,
                 destinationPeer: destinationNode.getPeerDescriptor(),
                 requestId: v4(),
                 sourcePeer: sourceNode.getPeerDescriptor(),
@@ -114,7 +114,7 @@ describe('Route Message With Mock Connections', () => {
                 targetDescriptor: destinationNode.getPeerDescriptor()
             }
             await sourceNode.router!.doRouteMessage({
-                message: message,
+                message,
                 destinationPeer: destinationNode.getPeerDescriptor(),
                 requestId: v4(),
                 sourcePeer: sourceNode.getPeerDescriptor(),
@@ -170,7 +170,7 @@ describe('Route Message With Mock Connections', () => {
                             targetDescriptor: destinationNode.getPeerDescriptor()
                         }
                         await node.router!.doRouteMessage({
-                            message: message,
+                            message,
                             destinationPeer: receiver.getPeerDescriptor(),
                             sourcePeer: node.getPeerDescriptor(),
                             requestId: v4(),
@@ -229,7 +229,7 @@ describe('Route Message With Mock Connections', () => {
             messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
-                rpcMessage: rpcMessage
+                rpcMessage
             },
             sourceDescriptor: sourceNode.getPeerDescriptor()!,
             targetDescriptor: entryPoint.getPeerDescriptor()!

--- a/packages/dht/test/integration/RpcErrors.test.ts
+++ b/packages/dht/test/integration/RpcErrors.test.ts
@@ -127,7 +127,7 @@ describe('RPC errors', () => {
         }
 
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: RpcMessage.toBinary(rpcMessage)

--- a/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
@@ -84,7 +84,7 @@ describe('WebRTC Connection Management', () => {
 
     it('Peer2 can open WebRTC Datachannel', (done) => {
         const dummyMessage: Message = {
-            serviceId: serviceId,
+            serviceId,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
@@ -105,7 +105,7 @@ describe('WebRTC Connection Management', () => {
 
     it('Connecting to self throws', async () => {
         const dummyMessage: Message = {
-            serviceId: serviceId,
+            serviceId,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
@@ -121,7 +121,7 @@ describe('WebRTC Connection Management', () => {
 
     it('Connects and disconnects webrtc connections', async () => {
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: {
@@ -176,7 +176,7 @@ describe('WebRTC Connection Management', () => {
 
     it('Disconnects webrtcconnection while being connected', async () => {
         const msg: Message = {
-            serviceId: serviceId,
+            serviceId,
             messageType: MessageType.RPC,
             messageId: '1',
             body: {

--- a/packages/dht/test/integration/WebSocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebSocketConnectionManagement.test.ts
@@ -65,7 +65,7 @@ describe('WebSocket Connection Management', () => {
 
     it('Can open connections to serverless peer', (done) => {
         const dummyMessage: Message = {
-            serviceId: serviceId,
+            serviceId,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
@@ -87,7 +87,7 @@ describe('WebSocket Connection Management', () => {
 
     it('Can open connections to peer with server', async () => {
         const dummyMessage: Message = {
-            serviceId: serviceId,
+            serviceId,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
@@ -110,7 +110,7 @@ describe('WebSocket Connection Management', () => {
 
     it('Connecting to self throws', async () => {
         const dummyMessage: Message = {
-            serviceId: serviceId,
+            serviceId,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()

--- a/packages/proto-rpc/examples/wakeup/wakeup.ts
+++ b/packages/proto-rpc/examples/wakeup/wakeup.ts
@@ -42,7 +42,7 @@ class Node {
     public wakeUpOtherNode(targetNodeId: string, reason: string) {
         // pass targetNodeId in CallContext
         this.client.wakeUp({ reason: reason }, {
-            targetNodeId: targetNodeId,
+            targetNodeId,
             // By setting the notification flag the client will not wait for a response from the server
             // and the server will know not to send a response.
             notification: true

--- a/packages/proto-rpc/src/RpcCommunicator.ts
+++ b/packages/proto-rpc/src/RpcCommunicator.ts
@@ -357,7 +357,7 @@ export class RpcCommunicator extends EventEmitter<RpcCommunicatorEvents> {
             RpcResponseParams
     ): RpcMessage {
         return {
-            body: body,
+            body,
             header: {
                 response: 'response',
                 method: request.header.method

--- a/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
+++ b/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
@@ -48,7 +48,7 @@ describe('RpcCommunicator', () => {
         }
         /*
         response = {
-            appId: appId,
+            appId,
             messageId: 'aaaa',
             body: RpcMessage.toBinary(responseRpcMessage),
             messageType: MessageType.RPC

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -246,7 +246,7 @@ export class StreamrNode extends EventEmitter<Events> {
             transportLayer: this.layer0!,
             serviceId: 'layer1::' + streamPartID,
             peerDescriptor: this.layer0!.getPeerDescriptor(),
-            entryPoints: entryPoints,
+            entryPoints,
             numberOfNodesPerKBucket: 4,
             rpcRequestTimeout: 15000,
             dhtJoinTimeout: 60000,
@@ -258,7 +258,7 @@ export class StreamrNode extends EventEmitter<Events> {
         return createRandomGraphNode({
             randomGraphId: streamPartID,
             P2PTransport: this.P2PTransport!,
-            layer1: layer1,
+            layer1,
             connectionLocker: this.connectionLocker!,
             ownPeerDescriptor: this.layer0!.getPeerDescriptor(),
             minPropagationTargets: this.config.streamPartitionMinPropagationTargets,
@@ -338,10 +338,10 @@ export class StreamrNode extends EventEmitter<Events> {
         return new ProxyStreamConnectionClient({
             P2PTransport: this.P2PTransport!,
             ownPeerDescriptor: this.layer0!.getPeerDescriptor(),
-            streamPartId: streamPartId,
+            streamPartId,
             connectionLocker: this.connectionLocker!,
             nodeName: this.config.nodeName,
-            userId: userId
+            userId
         })
     }
 

--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -65,8 +65,8 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
         N: numOfTargetNeighbors
     })
     const neighborFinder = config.neighborFinder ?? new NeighborFinder({
-        targetNeighbors: targetNeighbors,
-        nearbyContactPool: nearbyContactPool,
+        targetNeighbors,
+        nearbyContactPool,
         doFindNeighbors: (excludedIds) => handshaker!.attemptHandshakesOnContacts(excludedIds),
         N: numOfTargetNeighbors
     })

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -85,10 +85,10 @@ describe('Handshakes', () => {
         targetNeighbors = new PeerList(handshakerPeerId, 4)
         handshaker = new Handshaker({
             ownPeerDescriptor: peerDescriptor2,
-            randomGraphId: randomGraphId,
+            randomGraphId,
             nearbyContactPool: contactPool,
             randomContactPool: contactPool,
-            targetNeighbors: targetNeighbors,
+            targetNeighbors,
             connectionLocker: mockConnectionLocker,
             rpcCommunicator: rpcCommunicator2,
             N: 4

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -89,14 +89,15 @@ describe('RandomGraphNode-DhtNode', () => {
         const simulator = new Simulator()
         const entrypointCm = new ConnectionManager({
             ownPeerDescriptor: entrypointDescriptor,
-            nodeName: entrypointDescriptor.nodeName, simulator: simulator
+            nodeName: entrypointDescriptor.nodeName,
+            simulator
         })
 
         const cms: ConnectionManager[] = range(numOfNodes).map((i) =>
             new ConnectionManager({
                 ownPeerDescriptor: peerDescriptors[i],
                 nodeName: peerDescriptors[i].nodeName,
-                simulator: simulator
+                simulator
             })
         )
 

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -65,7 +65,7 @@ describe('stream without default entrypoints', () => {
             const transport = new SimulatorTransport(peerDescriptor, simulator)
             const node = new NetworkNode({
                 layer0: {
-                    peerDescriptor: peerDescriptor,
+                    peerDescriptor,
                     transportLayer: transport,
                     entryPoints: [entryPointPeerDescriptor]
                 },


### PR DESCRIPTION
Omit key field from object literal when it equals to the value field:

e.g. from
```
{
    foo: foo,
    bar: 123
}
```

to

```
{
    foo,
    bar: 123
}
```
