### PR TITLE
Update projects contracts link in project-contracts.md 

### DIFF
--- a/docs/docs/help/project-contracts.md
+++ b/docs/docs/help/project-contracts.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 ---
 
 # Project contracts
-- The main configuration file used throughout the project: [https://github.com/streamr-dev/network-contracts/blob/master/packages/config/src/networks.json](https://github.com/streamr-dev/network-contracts/blob/master/packages/config/src/networks.json)
+- The main configuration file used throughout the project: [https://github.com/streamr-dev/network-contracts/blob/master/packages/config/src/index.ts](https://github.com/streamr-dev/network-contracts/blob/master/packages/config/src/index.ts)
 - On-chain stream registry [smart contracts](https://github.com/streamr-dev/network-contracts/tree/master/packages/network-contracts/contracts/StreamRegistry)
 <!-- TODO can we view a linked JSON? -->
 


### PR DESCRIPTION
## Summary

The link to the project contracts was outdated and returned a 404 error. Now updated to current URL.
