### PR TITLE
test(broker): Optimize integration tests

### DIFF
--- a/packages/broker/test/integration/plugins/operator/InspectRandomNodeHelper.test.ts
+++ b/packages/broker/test/integration/plugins/operator/InspectRandomNodeHelper.test.ts
@@ -1,5 +1,5 @@
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { Logger, TheGraphClient, toEthereumAddress, wait, waitForCondition } from '@streamr/utils'
+import { Logger, TheGraphClient, toEthereumAddress, waitForCondition } from '@streamr/utils'
 import fetch from 'node-fetch'
 import { InspectRandomNodeHelper } from '../../../../src/plugins/operator/InspectRandomNodeHelper'
 import { createClient, createTestStream } from '../../../utils'
@@ -69,11 +69,8 @@ describe('InspectRandomNodeHelper', () => {
 
         await delegate(flagger.operatorWallet, flagger.operatorContract.address, 200)
         await delegate(target.operatorWallet, target.operatorContract.address, 300)
-        await wait(3000) // sometimes these stake fail, possibly when they end up in the same block
         await stake(flagger.operatorContract, sponsorship.address, 150)
-        await wait(3000)
         await stake(target.operatorContract, sponsorship.address, 250)
-        await wait(3000)
 
         const inspectRandomNodeHelper = new InspectRandomNodeHelper({
             ...flagger.operatorServiceConfig,


### PR DESCRIPTION
Optimized some tests by removing waits:
- MQTT `Bridge`: 34s -> 11s
- `InspectRandomNodeHelper`: ~64s -> ~58s (maybe waits are not needed when fast-chain is used)