### PR TITLE
clean: remove extraneous package.json in dist folders

### DIFF
--- a/packages/broker/tsconfig.node.json
+++ b/packages/broker/tsconfig.node.json
@@ -6,8 +6,7 @@
     "include": [
         "src/**/*",
         "src/**/*.json",
-        "bin/*.ts",
-        "package.json"
+        "bin/*.ts"
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },

--- a/packages/cli-tools/tsconfig.json
+++ b/packages/cli-tools/tsconfig.json
@@ -5,7 +5,6 @@
         "outDir": "dist"
     },
     "include": [
-        "package.json",
         "src/**/*",
         "bin/**/*"
     ],

--- a/packages/network-tracker/tsconfig.node.json
+++ b/packages/network-tracker/tsconfig.node.json
@@ -5,8 +5,7 @@
     },
     "include": [
         "src/**/*",
-        "bin/*.ts",
-        "package.json"
+        "bin/*.ts"
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },


### PR DESCRIPTION
## Summary

Remove extraneous package.json files in dist folders. The only package that requires the package.json to be in the dist folder is the client package. Also gets rid of jest warning:

```
jest-haste-map: Haste module naming collision: streamr-broker
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/package.json
    * <rootDir>/dist/package.json
```