### PR TITLE
refactor: cleanup of ts and jest configs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
             }
         ]
     },
-    setupFilesAfterEnv: ['jest-extended/all']
+    setupFilesAfterEnv: ['jest-extended/all'],
+    modulePathIgnorePatterns: ['dist']
 }

--- a/packages/trackerless-network/jest.config.js
+++ b/packages/trackerless-network/jest.config.js
@@ -1,40 +1,5 @@
-// For a detailed explanation regarding each configuration property, visit:
-// https://jestjs.io/docs/en/configuration.html
+const rootConfig = require('../../jest.config')
 module.exports = {
-
-    // Preset ts-jest
-    preset: 'ts-jest',
-
-    transform: {
-        '^.+\\.ts$': [
-            'ts-jest',
-            {
-                tsconfig: 'tsconfig.jest.json',
-                babelConfig: false
-            }
-        ]
-    },
-
-    // Automatically clear mock calls and instances between every test
-    clearMocks: true,
-
-    // An array of glob patterns indicating a set of files for which coverage information should be collected
-    collectCoverageFrom: ['src/**'],
-
-    // The directory where Jest should output its coverage files
-    coverageDirectory: 'coverage',
-
-    // The test environment that will be used for testing
-    testEnvironment: 'node',
-
-    // Default timeout of a test in milliseconds
-    testTimeout: 15000,
-    maxWorkers: 3,
-
-    // This option allows use of a custom test runner
-    testRunner: 'jest-circus/runner',
-
-    testPathIgnorePatterns: ['/node_modules/'],
-
-    setupFilesAfterEnv: ['jest-extended'],
+    ...rootConfig,
+    testTimeout: 15000
 }

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -8,9 +8,9 @@
         "src/**/*",
         "test/**/*"
     ],
-    "exclude": [
-    ],
     "references": [
-        { "path": "tsconfig.node.json" }
+        { "path": "../protocol/tsconfig.node.json" },
+        { "path": "../proto-rpc/tsconfig.node.json" },
+        { "path": "../dht/tsconfig.node.json" }
     ]
 }

--- a/packages/trackerless-network/tsconfig.node.json
+++ b/packages/trackerless-network/tsconfig.node.json
@@ -6,7 +6,6 @@
     },
     "include": [
         "src/**/*",
-        "package.json",
         "test/benchmark/first-message.ts",
         "test/utils/utils.ts"
     ],

--- a/packages/utils/tsconfig.jest.json
+++ b/packages/utils/tsconfig.jest.json
@@ -6,8 +6,5 @@
   "include": [
     "src/**/*",
     "test/**/*"
-  ],
-  "lib": [ 
-    "DOM"
   ]
 }

--- a/packages/utils/tsconfig.node.json
+++ b/packages/utils/tsconfig.node.json
@@ -5,9 +5,5 @@
   },
   "include": [
     "src/**/*"
-  ],
-  "lib": [ 
-    "DOM",
-    "ESNext"
   ]
 }


### PR DESCRIPTION
## Summary

Do some cleanup of tsconfig and jest files.

## Changes

- Exclude `dist` folders from jest to avoid `jest-haste-map: Haste module naming collision` warnings.
- In `trackerless-network` harmoninze jest.config to resemble other subpackages
- In `trackerless-network` harmonize tsconfigs to resemble other subpackages
- In `utils`  remove unnecessary lib definition

## Future improvements
- Consider whether `references` in tsconfig is a good thing or not.