### PR TITLE
NET-1038: support for `flagWithMetadata`

### DIFF
--- a/packages/broker/src/plugins/operator/InspectRandomNodeHelper.ts
+++ b/packages/broker/src/plugins/operator/InspectRandomNodeHelper.ts
@@ -88,8 +88,9 @@ export class InspectRandomNodeHelper {
         return Array.from(operatorIds)
     }
 
-    async flag(sponsorship: EthereumAddress, operator: EthereumAddress): Promise<void> {
-        await (await this.operatorContract.flag(sponsorship, operator)).wait()
+    async flagWithMetadata(sponsorship: EthereumAddress, operator: EthereumAddress, partition: number): Promise<void> {
+        const metadata = JSON.stringify({ partition })
+        await (await this.operatorContract.flagWithMetadata(sponsorship, operator, metadata)).wait()
     }
     
 }

--- a/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
+++ b/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
@@ -1,5 +1,4 @@
 import { Contract } from '@ethersproject/contracts'
-import { Wallet } from '@ethersproject/wallet'
 import type { Operator } from '@streamr/network-contracts'
 import { operatorABI } from '@streamr/network-contracts'
 import { Logger } from '@streamr/utils'

--- a/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
+++ b/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
@@ -46,16 +46,19 @@ export function parsePartitionFromMetadata(metadataAsString: string | undefined)
     return partition
 }
 
-export class VoteOnSuspectNodeHelper {
-    private readonly nodeWallet: Wallet
-    private readonly contract: Operator
-    private readonly callback: (sponsorship: string, operatorContractAddress: string, partition: number) => void
+export type ReviewRequestCallback = (sponsorship: string, operatorContractAddress: string, partition: number) => void
 
-    constructor(config: OperatorServiceConfig,
-        callback: (sponsorship: string, operatorContractAddress: string) => void) {
+export class VoteOnSuspectNodeHelper {
+    private readonly callback: ReviewRequestCallback
+    private readonly contract: Operator
+
+    constructor(
+        config: OperatorServiceConfig,
+        callback: ReviewRequestCallback,
+        contract = new Contract(config.operatorContractAddress, operatorABI, config.nodeWallet) as unknown as Operator
+    ) {
         this.callback = callback
-        this.nodeWallet = config.nodeWallet
-        this.contract = new Contract(config.operatorContractAddress, operatorABI, this.nodeWallet) as unknown as Operator
+        this.contract = contract
     }
 
     async start(): Promise<void> {
@@ -92,7 +95,6 @@ export class VoteOnSuspectNodeHelper {
     }
 
     stop(): void {
-        // TODO: remove only the listener added by this class
-        this.nodeWallet.provider.removeAllListeners()
+        this.contract.removeAllListeners()
     }
 }

--- a/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
+++ b/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
@@ -14,7 +14,7 @@ export class ParseError extends Error {
     public readonly reasonText: string
 
     constructor(reasonText: string) {
-        super(`failed to parse metadata: ${reasonText}`)
+        super(`Failed to parse metadata: ${reasonText}`)
         this.reasonText = reasonText
     }
 }

--- a/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
+++ b/packages/broker/src/plugins/operator/VoteOnSuspectNodeHelper.ts
@@ -4,16 +4,52 @@ import type { Operator } from '@streamr/network-contracts'
 import { operatorABI } from '@streamr/network-contracts'
 import { Logger } from '@streamr/utils'
 import { OperatorServiceConfig } from './OperatorPlugin'
+import { ensureValidStreamPartitionIndex } from '@streamr/protocol'
 
 export const VOTE_KICK = '0x0000000000000000000000000000000000000000000000000000000000000001'
 export const VOTE_NO_KICK = '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 const logger = new Logger(module)
 
+export class ParseError extends Error {
+    public readonly reasonText: string
+
+    constructor(reasonText: string) {
+        super(`failed to parse metadata: ${reasonText}`)
+        this.reasonText = reasonText
+    }
+}
+
+export function parsePartitionFromMetadata(metadataAsString: string | undefined): number | never {
+    if (metadataAsString === undefined) {
+        throw new ParseError('no metadata')
+    }
+
+    let metadata: Record<string, unknown>
+    try {
+        metadata = JSON.parse(metadataAsString)
+    } catch {
+        throw new ParseError('malformed metadata')
+    }
+
+    const partition = Number(metadata.partition)
+    if (isNaN(partition)) {
+        throw new ParseError('invalid or missing "partition" field')
+    }
+
+    try {
+        ensureValidStreamPartitionIndex(partition)
+    } catch {
+        throw new ParseError('invalid partition numbering')
+    }
+
+    return partition
+}
+
 export class VoteOnSuspectNodeHelper {
     private readonly nodeWallet: Wallet
     private readonly contract: Operator
-    private readonly callback: (sponsorship: string, operatorContractAddress: string) => void
+    private readonly callback: (sponsorship: string, operatorContractAddress: string, partition: number) => void
 
     constructor(config: OperatorServiceConfig,
         callback: (sponsorship: string, operatorContractAddress: string) => void) {
@@ -24,9 +60,29 @@ export class VoteOnSuspectNodeHelper {
 
     async start(): Promise<void> {
         logger.debug('Starting')
-        this.contract.on('ReviewRequest', async (sponsorship: string, targetOperator: string) => {
-            logger.debug('Receive review request', { address: this.contract.address, sponsorship, targetOperator })
-            this.callback(sponsorship, targetOperator)
+        this.contract.on('ReviewRequest', (sponsorship: string, targetOperator: string, metadataAsString?: string) => {
+            let partition: number
+            try {
+                partition = parsePartitionFromMetadata(metadataAsString)
+            } catch (err) {
+                if (err instanceof ParseError) {
+                    logger.warn(`Skip review request (${err.reasonText})`, {
+                        address: this.contract.address,
+                        sponsorship,
+                        targetOperator,
+                    })
+                } else {
+                    logger.warn('Encountered unexpected error', { err })
+                }
+                return
+            }
+            logger.debug('Receive review request', {
+                address: this.contract.address,
+                sponsorship,
+                targetOperator,
+                partition
+            })
+            this.callback(sponsorship, targetOperator, partition)
         })
     }
 

--- a/packages/broker/test/integration/plugins/operator/InspectRandomNodeHelper.test.ts
+++ b/packages/broker/test/integration/plugins/operator/InspectRandomNodeHelper.test.ts
@@ -76,7 +76,7 @@ describe('InspectRandomNodeHelper', () => {
             ...flagger.operatorServiceConfig,
             nodeWallet: flagger.nodeWallets[0]
         })
-        await inspectRandomNodeHelper.flag(toEthereumAddress(sponsorship.address), toEthereumAddress(target.operatorContract.address))
+        await inspectRandomNodeHelper.flagWithMetadata(toEthereumAddress(sponsorship.address), toEthereumAddress(target.operatorContract.address), 2)
 
         waitForCondition(async (): Promise<boolean> => {
             const result = await graphClient.queryEntity<{ operator: { flagsOpened: any[] } }>({ query: `

--- a/packages/broker/test/integration/plugins/operator/VoteOnSuspectNodeService.test.ts
+++ b/packages/broker/test/integration/plugins/operator/VoteOnSuspectNodeService.test.ts
@@ -75,7 +75,9 @@ describe('VoteOnSuspectNodeService', () => {
         mockVoteOnSuspectNodeHelper.voteOnFlag.mockResolvedValue(undefined)
         // @ts-expect-error mock
         voterVoteService.voteOnSuspectNodeHelper = mockVoteOnSuspectNodeHelper
-        await (await flagger.operatorContract.connect(flagger.nodeWallets[0]).flag(sponsorship.address, target.operatorContract.address)).wait()
+        await (await flagger.operatorContract.connect(flagger.nodeWallets[0])
+            .flagWithMetadata(sponsorship.address, target.operatorContract.address, JSON.stringify({ partition: 5 }))
+        ).wait()
         // check that voter votes
         await waitForCondition(() => mockVoteOnSuspectNodeHelper.voteOnFlag.mock.calls.length > 0, 10000)
         expect(mockVoteOnSuspectNodeHelper.voteOnFlag).toHaveBeenCalledTimes(1)

--- a/packages/broker/test/unit/plugins/operator/VoteOnSuspectNodeHelper.test.ts
+++ b/packages/broker/test/unit/plugins/operator/VoteOnSuspectNodeHelper.test.ts
@@ -1,0 +1,30 @@
+import {
+    ParseError,
+    parsePartitionFromMetadata,
+} from '../../../../src/plugins/operator/VoteOnSuspectNodeHelper'
+
+describe(parsePartitionFromMetadata, () => {
+    it('throws given undefined', () => {
+        expect(() => parsePartitionFromMetadata(undefined)).toThrowError(ParseError)
+    })
+
+    it('throws given invalid json', () => {
+        expect(() => parsePartitionFromMetadata('invalidjson')).toThrowError(ParseError)
+    })
+
+    it('throws given valid json without field "partition"', () => {
+        expect(() => parsePartitionFromMetadata('{}')).toThrowError(ParseError)
+    })
+
+    it('throws given valid json with field "partition" but not as a number', () => {
+        expect(() => parsePartitionFromMetadata('{ "partition": "foo" }')).toThrowError(ParseError)
+    })
+
+    it('throws given valid json with field "partition" but outside integer range', () => {
+        expect(() => parsePartitionFromMetadata('{ "partition": -50 }')).toThrowError(ParseError)
+    })
+
+    it('returns partition given valid json with field "partition" within integer range', () => {
+        expect(parsePartitionFromMetadata('{ "partition": 50 }')).toEqual(50)
+    })
+})

--- a/packages/protocol/src/utils/exports.ts
+++ b/packages/protocol/src/utils/exports.ts
@@ -1,5 +1,5 @@
 import { StreamID, toStreamID, StreamIDUtils } from './StreamID'
-import { MAX_PARTITION_COUNT, ensureValidStreamPartitionCount } from './partition'
+import { MAX_PARTITION_COUNT, ensureValidStreamPartitionCount, ensureValidStreamPartitionIndex } from './partition'
 import { StreamPartID, toStreamPartID, StreamPartIDUtils } from './StreamPartID'
 import { ProxyDirection } from './types'
 
@@ -11,6 +11,7 @@ export {
     StreamPartID,
     StreamPartIDUtils,
     ensureValidStreamPartitionCount,
+    ensureValidStreamPartitionIndex,
     MAX_PARTITION_COUNT,
     ProxyDirection
 }


### PR DESCRIPTION
## Summary

Add support for flagging _with metadata_ (i.e.`flagWithMetadata`).

## Changes

- Replace method `flag` with `flagWithMetadata` in InspectRandomNodeHelper
- Add support for metadata parsing on `ReviewRequest` events in VoteOnSuspectNodeHelper.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
