### PR TITLE
test(client): [NET-1022]: Fix flaky `multiple-clients` test

### DIFF
--- a/packages/client/test/integration/multiple-clients.test.ts
+++ b/packages/client/test/integration/multiple-clients.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey } from '@streamr/test-utils'
 import { Message, MessageMetadata } from '../../src/Message'
 import { StreamPermission } from '../../src/permission'
 import { Stream } from '../../src/Stream'
@@ -35,18 +34,13 @@ describe('PubSub with multiple clients', () => {
     let stream: Stream
     let mainClient: StreamrClient
     let otherClient: StreamrClient
-    let privateKey: string
     let environment: FakeEnvironment
     const addAfter = addAfterFn()
 
     beforeEach(async () => {
         environment = new FakeEnvironment()
-        privateKey = fastPrivateKey()
         mainClient = environment.createClient({
-            id: 'subscriber-main',
-            auth: {
-                privateKey
-            }
+            id: 'subscriber-main'
         })
         stream = await createTestStream(mainClient, module)
         const storageNode = await environment.startStorageNode()
@@ -77,10 +71,7 @@ describe('PubSub with multiple clients', () => {
 
     async function createSubscriber() {
         const client = environment.createClient({
-            id: 'subscriber-other',
-            auth: {
-                privateKey
-            }
+            id: 'subscriber-other'
         })
         const user = await client.getAddress()
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], user })

--- a/packages/client/test/unit/ServerPersistence.test.ts
+++ b/packages/client/test/unit/ServerPersistence.test.ts
@@ -60,7 +60,7 @@ describe('ServerPersistence', () => {
             const instance = await ServerPersistence.createInstance({
                 loggerFactory: mockLoggerFactory(),
                 clientId,
-                namespaces: [NAMESPACE],
+                namespaces: ['EncryptionKeys'],
                 migrationsPath: join(__dirname, '../../src/encryption/migrations')
             })
             await instance.set('key', `value${i}`, 'EncryptionKeys')


### PR DESCRIPTION
The test was flaky, because we have concurrency bug (or missing feature) in encryption handling: if two clients open the local DB at the same time, it is possible that one of the client fails to open the DB as it has not "migrated" yet (i.e. the tables haven't been created). There is a separate ticket about this bug NET-1057, and in this PR we added a new test which focuses to this bug. The new test is not flaky as it always fails (and therefore it is currently skipped). 

The actual flaky test (`multiple-clients.test.ts`) has been resolved by using separate private keys for each subscriber. The feature under test here is more abstract, and the private keys of the subscribers are not relevant to this test. The main idea in the flaky test is to check whether there can be multiple publishers on a single stream. It could be implement with just with one subscriber, or like we do now, with two subscribers having separate private keys. 