### PR TITLE
test(broker): add missing test for `ConsistentHashRing`

### DIFF
--- a/packages/broker/test/unit/plugins/operator/ConsistentHashRing.test.ts
+++ b/packages/broker/test/unit/plugins/operator/ConsistentHashRing.test.ts
@@ -138,4 +138,13 @@ describe(ConsistentHashRing, () => {
         const assignments4 = h2.get(toStreamPartID(toStreamID('barbar'), 0))
         expect(assignments4).toIncludeSameMembers(['node-3', 'node-4', 'node-5']) // expectation based on arbitrary hashing
     })
+
+    it('handles properly situation where redundancy factor > number of nodes', () => {
+        const h = new ConsistentHashRing(10)
+        h.add('node-1')
+        h.add('node-2')
+
+        const result = h.get(toStreamPartID(toStreamID('streamId'), 0))
+        expect(result).toEqual(['node-1', 'node-2'])
+    })
 })


### PR DESCRIPTION
## Summary

Add missing test to `ConsistentHashRing` that it handles properly situation where redundancy factor > number of nodes. 
