### PR TITLE
refactor(trackerless-network): Remove `StreamrNodeConfig#id`

### DIFF
--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -87,7 +87,6 @@ interface Metrics extends MetricsDefinition {
 
 export interface StreamrNodeConfig {
     metricsContext?: MetricsContext
-    id?: NodeID
     streamPartitionNumOfNeighbors?: number
     streamPartitionMinPropagationTargets?: number
     nodeName?: string


### PR DESCRIPTION
Remove obsolete field. Node ids are automatically generated by `trackerless-network`.