### PR TITLE
fix(DHT): DHT default uuid KademliaID fix

### DIFF
--- a/packages/client/test/end-to-end/StreamrClient.test.ts
+++ b/packages/client/test/end-to-end/StreamrClient.test.ts
@@ -1,8 +1,6 @@
 import { fastPrivateKey } from '@streamr/test-utils'
 import { CONFIG_TEST, StreamrClient } from '../../src'
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-
 describe('StreamrClient', () => {
     let client: StreamrClient
 
@@ -23,7 +21,7 @@ describe('StreamrClient', () => {
         await client.subscribe('foobar')
         const descriptor = await client.getPeerDescriptor()
         expect(descriptor).toMatchObject({
-            id: expect.stringMatching(UUID_REGEX),
+            id: expect.stringMatching(/^[0-9A-Fa-f]+$/),
             type: 'nodejs',
         })
     }, 30 * 1000)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -96,7 +96,7 @@ export class DhtNodeConfig {
     storeMaxTtl = 60000
     storeNumberOfCopies = 5
     metricsContext = new MetricsContext()
-    peerIdString = new UUID().toString()
+    peerIdString = new UUID().toHex()
 
     transportLayer?: ITransport
     peerDescriptor?: PeerDescriptor

--- a/packages/dht/src/helpers/UUID.ts
+++ b/packages/dht/src/helpers/UUID.ts
@@ -1,4 +1,5 @@
 import { v4, parse, stringify } from 'uuid'
+import { binaryToHex } from '@streamr/utils'
 
 export class UUID {
     private buf: Uint8Array
@@ -18,6 +19,10 @@ export class UUID {
 
     toString(): string {
         return stringify(this.buf)
+    }
+
+    toHex(): string {
+        return binaryToHex(this.buf)
     }
 
     equals(other: UUID): boolean {

--- a/packages/dht/test/unit/UUID.test.ts
+++ b/packages/dht/test/unit/UUID.test.ts
@@ -25,6 +25,12 @@ describe('UUID', () => {
         expect(uuid.toString() === stringId).toEqual(true)
     })
 
+    it('toHex', () => {
+        const stringId = v4()
+        const uuid = new UUID(stringId)
+        expect(uuid.toHex() === stringId.replaceAll('-', '')).toEqual(true)
+    })
+
     it('Throws if incorrect string is given as uuid string parameter', () => {
         expect(()=> {new UUID('äå%')}).toThrow(TypeError)
     })


### PR DESCRIPTION
## Summary

By default a UUID v4 string contains `-` which cannot be properly translated with the `binaryToHex` and `hexToBinary` utils. This caused the default kademliaId of the DhtNodes to be invalid.