### PR TITLE
fix(dht): Websocket connected to self

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -341,13 +341,16 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         return connection!.send(binary, doNotConnect)
     }
 
-    private isConnectionToSelf(peerDescriptor: PeerDescriptor): boolean {
-        if (peerDescriptor.websocket && this.ownPeerDescriptor!.websocket) {
-            const isOwnWebSocketServer = (peerDescriptor.websocket.port === this.ownPeerDescriptor!.websocket!.port 
-                && peerDescriptor.websocket.ip === this.ownPeerDescriptor!.websocket.ip)
-            return isSamePeerDescriptor(peerDescriptor, this.ownPeerDescriptor!) || isOwnWebSocketServer
+    private isConnectionToSelf(peerDescriptor: PeerDescriptor): boolean { 
+        return isSamePeerDescriptor(peerDescriptor, this.ownPeerDescriptor!) || this.isOwnWebSocketServer(peerDescriptor)
+    }
+
+    private isOwnWebSocketServer(peerDescriptor: PeerDescriptor): boolean {
+        if ((peerDescriptor.websocket !== undefined) && (this.ownPeerDescriptor!.websocket !== undefined)) {
+            return ((peerDescriptor.websocket.port === this.ownPeerDescriptor!.websocket!.port) 
+                && (peerDescriptor.websocket.ip === this.ownPeerDescriptor!.websocket.ip))
         } else {
-            return isSamePeerDescriptor(peerDescriptor, this.ownPeerDescriptor!)
+            return false
         }
     }
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -308,4 +308,32 @@ describe('ConnectionManager', () => {
         await connectionManager4.stop()
     })
 
+    it('Cannot send to own WebSocketServer if kademliaIds do not match', async () => {
+        const connectionManager1 = new ConnectionManager({
+            transportLayer: mockTransport,
+            websocketHost: '127.0.0.1',
+            websocketPortRange: { min: 10001, max: 10001 }
+        })
+
+        await connectionManager1.start((report) => {
+            expect(report.ip).toEqual('127.0.0.1')
+            expect(report.openInternet).toEqual(true)
+            return createPeerDescriptor(report)
+        })
+        const peerDescriptor = connectionManager1.getPeerDescriptor()
+        peerDescriptor.kademliaId = new Uint8Array([12, 12, 12, 12])
+        const msg: Message = {
+            serviceId,
+            messageType: MessageType.RPC,
+            messageId: '1',
+            targetDescriptor: peerDescriptor,
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            } 
+        }
+        await expect(connectionManager1.send(msg))
+            .rejects
+            .toThrow('Cannot send to self')
+    })
 })

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -335,5 +335,7 @@ describe('ConnectionManager', () => {
         await expect(connectionManager1.send(msg))
             .rejects
             .toThrow('Cannot send to self')
+        
+        await connectionManager1.stop()
     })
 })


### PR DESCRIPTION
## Summary

Fixed a bug where nodes could connect to themselves if they are restarted with the same WS-server port and host but a differing PeerID