### PR TITLE
feat(dht): Use `storeNumberOfCopies` config option

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -281,9 +281,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             recursiveFinder: this.recursiveFinder,
             ownPeerDescriptor: this.ownPeerDescriptor!,
             serviceId: this.config.serviceId,
-            storeHighestTtl: this.config.storeHighestTtl,
-            storeMaxTtl: this.config.storeMaxTtl,
-            storeNumberOfCopies: this.config.storeNumberOfCopies,
+            highestTtl: this.config.storeHighestTtl,
+            maxTtl: this.config.storeMaxTtl,
+            numberOfCopies: this.config.storeNumberOfCopies,
             localDataStore: this.localDataStore,
             dhtNodeEmitter: this,
             getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => {


### PR DESCRIPTION
The default value of 5 copies was hardcoded to `DataStore`. Now it uses the existing config option instead.

Also shortened some fields of `DataStore`.