### PR TITLE
fix(network): Fix integration/RandomGraphNode-Layer1Node.test.ts issue with random IDs

### DIFF
--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -1,65 +1,14 @@
 /* eslint-disable @typescript-eslint/parameter-properties */
 
-import { DhtNode, Simulator, PeerDescriptor, PeerID, ConnectionManager, getRandomRegion } from '@streamr/dht'
+import { DhtNode, Simulator, PeerDescriptor, ConnectionManager, getRandomRegion } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'
-import { wait, waitForCondition, waitForEvent3 } from '@streamr/utils'
+import { wait, waitForCondition, hexToBinary } from '@streamr/utils'
 import { Logger } from '@streamr/utils'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
-import { EventEmitter } from 'eventemitter3'
-import { NodeID } from '../../src/identifiers'
+import { createRandomNodeId } from '../utils/utils'
 
 const logger = new Logger(module)
-
-interface SuccessEvents {
-    success: () => void
-}
-
-class SuccessListener extends EventEmitter<SuccessEvents> {
-
-    private numNeighbors = 0
-    private numNearby = 0
-
-    constructor(private node: RandomGraphNode,
-        private wantedNumNeighbors: number,
-        private wantedNumNearby: number) {
-
-        super()
-        node.on('targetNeighborConnected', this.onTargetNeighborConnected)
-        node.on('nearbyContactPoolIdAdded', this.onNearbyContactPoolIdAdded)
-    }
-
-    private onTargetNeighborConnected = (_nodeId: NodeID) => {
-        this.numNeighbors++
-
-        if (this.numNeighbors >= this.wantedNumNeighbors
-            && this.numNearby >= this.wantedNumNearby) {
-            this.node.off('targetNeighborConnected', this.onTargetNeighborConnected)
-            this.node.off('nearbyContactPoolIdAdded', this.onNearbyContactPoolIdAdded)
-            this.emit('success')
-        }
-    }
-
-    private onNearbyContactPoolIdAdded = () => {
-        this.numNearby++
-
-        if (this.numNeighbors >= this.wantedNumNeighbors
-            && this.numNearby >= this.wantedNumNearby) {
-            this.node.off('targetNeighborConnected', this.onTargetNeighborConnected)
-            this.node.off('nearbyContactPoolIdAdded', this.onNearbyContactPoolIdAdded)
-            this.emit('success')
-        }
-    }
-
-    public async waitForSuccess(timeout: number): Promise<void> {
-        if (this.numNeighbors >= this.wantedNumNeighbors
-            && this.numNearby >= this.wantedNumNearby) {
-            return
-        } else {
-            await waitForEvent3<SuccessEvents>(this, 'success', timeout)
-        }
-    }
-}
 
 describe('RandomGraphNode-DhtNode', () => {
     const numOfNodes = 64
@@ -70,7 +19,7 @@ describe('RandomGraphNode-DhtNode', () => {
 
     const streamId = 'Stream1'
     const entrypointDescriptor: PeerDescriptor = {
-        kademliaId: PeerID.fromString('entrypoint').value,
+        kademliaId: hexToBinary(createRandomNodeId()),
         nodeName: 'entrypoint',
         type: 0,
         region: getRandomRegion()
@@ -78,7 +27,7 @@ describe('RandomGraphNode-DhtNode', () => {
 
     const peerDescriptors: PeerDescriptor[] = range(numOfNodes).map((i) => {
         return {
-            kademliaId: PeerID.fromString(`${i}`).value,
+            kademliaId: hexToBinary(createRandomNodeId()),
             nodeName: `node${i}`,
             type: 0,
             region: getRandomRegion()
@@ -146,33 +95,24 @@ describe('RandomGraphNode-DhtNode', () => {
     })
 
     it('happy path single node ', async () => {
-
-        const successListener = new SuccessListener(graphNodes[0], 1, 1)
         await entryPointRandomGraphNode.start()
         await dhtNodes[0].joinDht([entrypointDescriptor])
 
         await graphNodes[0].start()
 
-        await successListener.waitForSuccess(15006)
+        await waitForCondition(() => graphNodes[0].getTargetNeighborIds().length === 1)
         expect(graphNodes[0].getNearbyContactPoolIds().length).toEqual(1)
         expect(graphNodes[0].getTargetNeighborIds().length).toEqual(1)
-
     })
 
     it('happy path 4 nodes', async () => {
-        const promise = Promise.all(range(4).map((i) => {
-            const successListener = new SuccessListener(graphNodes[i], 4, 4)
-            return waitForEvent3<SuccessEvents>(successListener, 'success', 15009)
-        }))
-
         entryPointRandomGraphNode.start()
         range(4).map((i) => graphNodes[i].start())
         await Promise.all(range(4).map(async (i) => {
             await dhtNodes[i].joinDht([entrypointDescriptor])
         }))
 
-        await promise
-
+        await waitForCondition(() => range(4).every((i) => graphNodes[i].getTargetNeighborIds().length === 4))
         range(4).map((i) => {
             expect(graphNodes[i].getNearbyContactPoolIds().length).toBeGreaterThanOrEqual(4)
             expect(graphNodes[i].getTargetNeighborIds().length).toBeGreaterThanOrEqual(4)

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/parameter-properties */
-
 import { DhtNode, Simulator, PeerDescriptor, ConnectionManager, getRandomRegion } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'


### PR DESCRIPTION
## Summary

Fixed issue with random IDs in `integration/RandomGraphNode-Layer1Node.test.ts`.
The test had an assumption that in a stream graph of 5 nodes 4 handshakes would always be required per node to construct a complete graph. This holds true with a certain sets of nodeIds. However, with randomized IDs some cases will require 5 handshakes to construct a complete graph.

The `SuccessListener`-logic was removed from the test and the affected test cases now use `waitForCondition` to wait for the graph to be complete.