### PR TITLE
test: Disable fake timers in browser tests

### DIFF
--- a/packages/dht/src/connection/Simulator/Simulator.ts
+++ b/packages/dht/src/connection/Simulator/Simulator.ts
@@ -12,6 +12,7 @@ import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import Heap from 'heap'
 import { debugVars } from '../../helpers/debugHelpers'
 import * as sinon from 'sinon'
+import { isRunningInElectron } from '@streamr/test-utils'
 
 const logger = new Logger(module)
 
@@ -116,14 +117,16 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
     private static clock: sinon.SinonFakeTimers | undefined
 
     static useFakeTimers(on = true): void {
-        if (on) {
-            if (!Simulator.clock) {
-                Simulator.clock = sinon.useFakeTimers()
-            }
-        } else {
-            if (Simulator.clock) {
-                Simulator.clock.restore()
-                Simulator.clock = undefined
+        if (!isRunningInElectron()) {  // never use fake timers in browser environment
+            if (on) {
+                if (!Simulator.clock) {
+                    Simulator.clock = sinon.useFakeTimers()
+                }
+            } else {
+                if (Simulator.clock) {
+                    Simulator.clock.restore()
+                    Simulator.clock = undefined
+                }
             }
         }
     }

--- a/packages/dht/src/connection/Simulator/Simulator.ts
+++ b/packages/dht/src/connection/Simulator/Simulator.ts
@@ -12,7 +12,15 @@ import { keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import Heap from 'heap'
 import { debugVars } from '../../helpers/debugHelpers'
 import * as sinon from 'sinon'
-import { isRunningInElectron } from '@streamr/test-utils'
+
+// TODO take this from @streamr/test-utils (we can't access devDependencies as Simulator
+// is currently in "src" directory instead of "test" directory)
+// eslint-disable-next-line no-underscore-dangle
+declare let _streamr_electron_test: any
+export function isRunningInElectron(): boolean {
+    // eslint-disable-next-line no-underscore-dangle
+    return typeof _streamr_electron_test !== 'undefined'
+}
 
 const logger = new Logger(module)
 


### PR DESCRIPTION
Do not use fake timers in browser tests so that we actually test the timer-related environment specific behavior (as NodeJS and browsers have a somewhat different implementations for `setTimeout` and other async tooling).

There is also some issue how `Simulator` handles `setImmediate` in browser environments (NET-1052). We can continue to use browsers tests by disabling the fake timers. We may want to re-enable the fake timers later, see NET-1053.