### PR TITLE
test: Runs test with `--bail`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,7 +70,7 @@ jobs:
       command: |
         npm run test-unit
         npm run test-integration
-        npm run test-e2e
+        npm run test-end-to-end
   trackerless-network-browser:
     needs: build
     uses: ./.github/workflows/test-setup.yml

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -19,7 +19,7 @@
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "test": "jest test/unit test/integration && npm run test-sequential",
+    "test": "npm run test-unit && npm run test-integration && npm run test-sequential",
     "test-unit": "jest test/unit",
     "test-sequential": "jest --bail --forceExit --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
     "test-integration": "jest --bail --forceExit test/integration && npm run test-sequential"

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -21,8 +21,8 @@
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit test/integration && npm run test-sequential",
     "test-unit": "jest test/unit",
-    "test-sequential": "jest --forceExit --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --forceExit test/integration && npm run test-sequential"
+    "test-sequential": "jest --bail --forceExit --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
+    "test-integration": "jest --bail --forceExit test/integration && npm run test-sequential"
   },
   "author": "Streamr Network AG <contact@streamr.network>",
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -15,7 +15,7 @@
     "check": "tsc -p ./tsconfig.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "test": "npm run build && jest --forceExit"
+    "test": "npm run build && jest --bail --forceExit"
   },
   "keywords": [
     "streamr",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "clean": "jest --clearCache || true; rm -rf dist vendor *.tsbuildinfo node_modules/.cache || true",
     "docs": "typedoc --options typedoc.js",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "test": "jest --detectOpenHandles",
+    "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-unit": "jest --useStderr --forceExit test/unit",
     "test-integration": "jest --bail --useStderr --forceExit --testTimeout=40000 test/integration/*.test.*",
     "test-end-to-end": "jest --bail --useStderr --forceExit --testTimeout=40000 test/end-to-end/*.test.*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,8 +31,8 @@
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest --detectOpenHandles",
     "test-unit": "jest --useStderr --forceExit test/unit",
-    "test-integration": "jest --useStderr --forceExit --testTimeout=40000 test/integration/*.test.*",
-    "test-end-to-end": "jest --useStderr --forceExit --testTimeout=40000 test/end-to-end/*.test.*",
+    "test-integration": "jest --bail --useStderr --forceExit --testTimeout=40000 test/integration/*.test.*",
+    "test-end-to-end": "jest --bail --useStderr --forceExit --testTimeout=40000 test/end-to-end/*.test.*",
     "test-browser": "npm run build-browser-production && concurrently -k --success=first 'node ./test/browser/server.js' 'sleep 5 && nightwatch --headless --verbose --timeout=30000 --config=nightwatch.conf.js ./test/browser/browser.js'",
     "test-exports": "cd test/exports && npm run link && tsc --noEmit --project ./tsconfig.json && npm test"
   },

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -22,8 +22,8 @@
     "test": "jest test/unit test/integration test/end-to-end",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
-    "test-integration": "jest test/integration",
-    "test-end-to-end": "jest test/end-to-end",
+    "test-integration": "jest --bail test/integration",
+    "test-end-to-end": "jest --bail test/end-to-end",
     "benchmark": "jest test/benchmark",
     "prepare-kademlia-simulation": "cd test/data && node --max-old-space-size=8096 -- ../../../../node_modules/.bin/ts-node -P ../../tsconfig.node.json generateGroundTruthData.ts",
     "run-kademlia-simulation": "ts-node --project tsconfig.node.json $NODE_DEBUG_OPTION --files test/benchmark/kademlia-simulation/KademliaSimulation.ts"

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -19,7 +19,7 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
-    "test": "jest test/unit test/integration test/end-to-end",
+    "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
     "test-integration": "jest --bail test/integration",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
-    "test-integration": "jest test/integration"
+    "test-integration": "jest --bail test/integration"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.8.2",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -19,7 +19,7 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
-    "test": "jest",
+    "test": "npm run test-unit && npm run test-integration",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
     "test-integration": "jest --bail test/integration"

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -19,7 +19,7 @@
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "test": "jest",
+    "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
     "test-integration": "jest --bail test/integration",

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -23,7 +23,7 @@
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
     "test-integration": "jest --bail test/integration",
-    "test-e2e": "jest --bail test/end-to-end",
+    "test-end-to-end": "jest --bail test/end-to-end",
     "network": "ts-node bin/network",
     "run-joining-benchmark": "node --max-old-space-size=24288 dist/test/benchmark/first-message.js"
   },

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -22,8 +22,8 @@
     "test": "jest",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",
-    "test-integration": "jest test/integration",
-    "test-e2e": "jest test/end-to-end",
+    "test-integration": "jest --bail test/integration",
+    "test-e2e": "jest --bail test/end-to-end",
     "network": "ts-node bin/network",
     "run-joining-benchmark": "node --max-old-space-size=24288 dist/test/benchmark/first-message.js"
   },

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -55,10 +55,6 @@ describe('Propagation', () => {
         await Promise.all(dhtNodes.map((node) => node.stop()))
     })
 
-    it('this should fail', () => {
-        expect(1).toBeGreaterThan(2)
-    })
-
     it('All nodes receive messages', async () => {
         await waitForCondition(
             () => randomGraphNodes.every((node) => node.getTargetNeighborIds().length >= 3), 30000

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -55,6 +55,10 @@ describe('Propagation', () => {
         await Promise.all(dhtNodes.map((node) => node.stop()))
     })
 
+    it('this should fail', () => {
+        expect(1).toBeGreaterThan(2)
+    })
+
     it('All nodes receive messages', async () => {
         await waitForCondition(
             () => randomGraphNodes.every((node) => node.getTargetNeighborIds().length >= 3), 30000


### PR DESCRIPTION
Run integration and end-to-end tests with `--bail` flag so that we get feedback faster. Didn't update browser tests in this PR as it is not clear whether `karma`/`nightwatch` supports bailing.

Could also run unit tests with `--bail` for consistency, but there the feedback is already fast enough.

## Other chages

- Unified test script naming: `test-e2e` -> `test-end-to-end`
- Modified aggregation scripts, i.e. `npm run test` scripts which run e.g. both unit and integration tests: now we explicitly delegate to the other npm command instead of e.g. running jest with different arguments. This way it is clear which tests those scripts run (e.g. they don't usually run browser tests). And it is easy to keep test setup consistent as same command line arguments don't need to be updated to multiple scripts. In practice this also bails subsequent scripts as we use `&&` between the commands.