### PR TITLE
feat(broker): Get `theGraphUrl` from client

### DIFF
--- a/packages/broker/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/broker/src/plugins/operator/OperatorPlugin.ts
@@ -2,7 +2,7 @@ import { toStreamID } from '@streamr/protocol'
 import { EthereumAddress, Logger, toEthereumAddress } from '@streamr/utils'
 import { Schema } from 'ajv'
 import { Signer } from 'ethers'
-import { CONFIG_TEST, StreamrClient } from 'streamr-client'
+import { StreamrClient } from 'streamr-client'
 import { Plugin } from '../../Plugin'
 import { AnnounceNodeToContractHelper } from './AnnounceNodeToContractHelper'
 import { AnnounceNodeToContractService } from './AnnounceNodeToContractService'
@@ -49,8 +49,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
         this.serviceConfig = {
             signer,
             operatorContractAddress: toEthereumAddress(this.pluginConfig.operatorContractAddress),
-            // TODO read from client, as we need to use production value in production environment (not ConfigTest)
-            theGraphUrl: CONFIG_TEST.contracts!.theGraphUrl!,
+            theGraphUrl: streamrClient.getConfig().contracts.theGraphUrl,
             maxSponsorshipsInWithdraw: DEFAULT_MAX_SPONSORSHIP_IN_WITHDRAW,
             minSponsorshipEarningsInWithdraw: DEFAULT_MIN_SPONSORSHIP_EARNINGS_IN_WITHDRAW
         }

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -659,6 +659,13 @@ export class StreamrClient {
         return (await this.node.getNode()).getDiagnosticInfo()
     }
 
+    /**
+     * @deprecated This in an internal method
+     */
+    getConfig(): StrictStreamrClientConfig {
+        return this.config
+    }
+
     // --------------------------------------------------------------------------------------------
     // Events
     // --------------------------------------------------------------------------------------------

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -35,7 +35,8 @@ export {
     NetworkNodeConfig,
     NetworkPeerDescriptor,
     ConnectivityMethod,
-    NetworkNodeType
+    NetworkNodeType,
+    StrictStreamrClientConfig
 } from './Config'
 export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'


### PR DESCRIPTION
Add new internal `getConfig()` to `StreamrClient`. Use that method in `OperatorPlugin` to get the url of The Graph. 

The config object always contains a value: if user has not specified any value (in `StreamrClient` construtor / in Broker's config file) the value is the production default value.

Note that the current production default (`https://api.thegraph.com/subgraphs/name/streamr-dev/streams` in `config.schema.json` at line 278) value doesn't work as that is not the mono subgraph URL. We have not yet deployed the mono subgraph to production, but when we do and update the correct value to `config.schema.json,` Broker starts to use it automatically.