### PR TITLE
refactor: Use `NodeType` enum

### DIFF
--- a/packages/broker/test/unit/config.test.ts
+++ b/packages/broker/test/unit/config.test.ts
@@ -1,3 +1,4 @@
+import { NetworkNodeType } from 'streamr-client'
 import { overrideConfigToEnvVarsIfGiven } from '../../src/config/config'
 
 describe('overrideConfigToEnvVarsIfGiven', () => {
@@ -26,7 +27,7 @@ describe('overrideConfigToEnvVarsIfGiven', () => {
         process.env.STREAMR__BROKER__CLIENT__ORDER_MESSAGES = 'true'
         process.env.STREAMR__BROKER__CLIENT__GAP_FILL = 'false'
         process.env.STREAMR__BROKER__CLIENT__NETWORK__CONTROL_LAYER__PEER_DESCRIPTOR__ID = 'kademliaID'
-        process.env.STREAMR__BROKER__CLIENT__NETWORK__CONTROL_LAYER__PEER_DESCRIPTOR__TYPE = '0'
+        process.env.STREAMR__BROKER__CLIENT__NETWORK__CONTROL_LAYER__PEER_DESCRIPTOR__TYPE = NetworkNodeType.NODEJS
         process.env.STREAMR__BROKER__AUTHENTICATION__KEYS_1 = 'key-1'
         process.env.STREAMR__BROKER__AUTHENTICATION__KEYS_2 = 'key-2'
         overrideConfigToEnvVarsIfGiven(config)
@@ -41,7 +42,7 @@ describe('overrideConfigToEnvVarsIfGiven', () => {
                     controlLayer: {
                         peerDescriptor: {
                             id: 'kademliaID',
-                            type: 0
+                            type: NetworkNodeType.NODEJS
                         }
                     }
                 }

--- a/packages/dht/test/integration/DhtPeer.test.ts
+++ b/packages/dht/test/integration/DhtPeer.test.ts
@@ -4,6 +4,7 @@ import { getMockPeers, MockDhtRpc } from '../utils/utils'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
+    NodeType,
     PeerDescriptor,
     PingRequest,
     PingResponse
@@ -21,11 +22,11 @@ describe('DhtPeer', () => {
     const serviceId = 'test'
     const clientPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('dhtPeer'),
-        type: 0
+        type: NodeType.NODEJS
     }
     const serverPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('server'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     beforeEach(() => {

--- a/packages/dht/test/integration/DhtRpc.test.ts
+++ b/packages/dht/test/integration/DhtRpc.test.ts
@@ -2,7 +2,7 @@ import { getMockPeers, MockDhtRpc } from '../utils/utils'
 import { ProtoRpcClient, RpcCommunicator, RpcError, toProtoRpcClient } from '@streamr/proto-rpc'
 import { DhtRpcServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { generateId } from '../utils/utils'
-import { ClosestPeersRequest, ClosestPeersResponse, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { ClosestPeersRequest, ClosestPeersResponse, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { wait } from '@streamr/utils'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
@@ -16,12 +16,12 @@ describe('DhtRpc', () => {
 
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: generateId('peer1'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: generateId('peer2'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const outgoingListener2 = (message: RpcMessage, _requestId: string, _ucallContext?: DhtCallContext) => {

--- a/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode } from '../../src/dht/DhtNode'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { LatencyType, Simulator } from '../../src/connection/Simulator/Simulator'
 
@@ -16,7 +16,7 @@ describe('Mock connection Dht joining with latencies', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: 0,
+            type: NodeType.NODEJS,
             nodeName: '0'
         }
         for (let i = 1; i < 100; i++) {

--- a/packages/dht/test/integration/DhtWithMockConnections.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnections.test.ts
@@ -1,6 +1,6 @@
 import { Simulator } from '../../src/connection/Simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 
 describe('Mock IConnection DHT Joining', () => {
@@ -16,7 +16,7 @@ describe('Mock IConnection DHT Joining', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: 0,
+            type: NodeType.NODEJS,
             nodeName: '0'
         }
         for (let i = 1; i < 100; i++) {

--- a/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
@@ -1,7 +1,7 @@
 import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { LatencyType, Simulator } from '../../src/connection/Simulator/Simulator'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { getRandomRegion } from '../../src/connection/Simulator/pings'
 
 describe('Mock connection Dht joining with real latencies', () => {
@@ -17,7 +17,7 @@ describe('Mock connection Dht joining with real latencies', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: 0,
+            type: NodeType.NODEJS,
             region: getRandomRegion()
         }
         for (let i = 1; i < 100; i++) {

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -3,6 +3,7 @@ import { PeerID } from '../../src/helpers/PeerID'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node } from '../utils/utils'
 import { UUID } from '../../src/helpers/UUID'
+import { NodeType } from '../../src/exports'
 
 describe('Layer1', () => {
 
@@ -11,7 +12,7 @@ describe('Layer1', () => {
 
     const entryPoint0Descriptor = {
         kademliaId: PeerID.fromString(layer0EntryPointId).value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: layer0EntryPointId
     }
 

--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@streamr/utils'
 import { Simulator } from '../../src/connection/Simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node } from '../utils/utils'
 
 const logger = new Logger(module)
@@ -52,7 +52,7 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         entryPointDescriptor = {
             kademliaId: layer0EntryPoint.getNodeId().value,
-            type: 0,
+            type: NodeType.NODEJS,
             nodeName: layer0EntryPointId
         }
 

--- a/packages/dht/test/integration/RemoteRouter.test.ts
+++ b/packages/dht/test/integration/RemoteRouter.test.ts
@@ -1,6 +1,6 @@
 import { RpcCommunicator, toProtoRpcClient } from '@streamr/proto-rpc'
 import { RemoteRouter } from '../../src/dht/routing/RemoteRouter'
-import { Message, MessageType, PeerDescriptor, RouteMessageAck, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageAck, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RoutingServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
@@ -14,11 +14,11 @@ describe('RemoteRouter', () => {
     const serviceId = 'test'
     const clientPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('dhtPeer'),
-        type: 0
+        type: NodeType.NODEJS
     }
     const serverPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('server'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     beforeEach(() => {

--- a/packages/dht/test/integration/RemoteStore.test.ts
+++ b/packages/dht/test/integration/RemoteStore.test.ts
@@ -1,5 +1,6 @@
 import { RpcCommunicator, toProtoRpcClient } from '@streamr/proto-rpc'
 import {
+    NodeType,
     PeerDescriptor,
     StoreDataRequest,
     StoreDataResponse
@@ -19,11 +20,11 @@ describe('RemoteStore', () => {
     const serviceId = 'test'
     const clientPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('dhtPeer'),
-        type: 0
+        type: NodeType.NODEJS
     }
     const serverPeerDescriptor: PeerDescriptor = {
         kademliaId: generateId('server'),
-        type: 0
+        type: NodeType.NODEJS
     }
     const data = Any.pack(clientPeerDescriptor, PeerDescriptor)
     const request: StoreDataRequest = {

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode, Events as DhtNodeEvents } from '../../src/dht/DhtNode'
-import { Message, MessageType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { Logger, runAndWaitForEvents3, waitForCondition } from '@streamr/utils'
 import { createMockConnectionDhtNode, createWrappedClosestPeersRequest } from '../utils/utils'
@@ -35,7 +35,7 @@ describe('Route Message With Mock Connections', () => {
         entryPointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
             nodeName: 'entrypoint',
-            type: 0
+            type: NodeType.NODEJS
         }
 
         sourceNode = await createMockConnectionDhtNode(sourceId, simulator)

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -14,13 +14,13 @@ describe('SimultaneousConnections', () => {
 
     const peerDescriptor1 = {
         kademliaId: PeerID.fromString('mock1').value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'mock1'
     }
 
     const peerDescriptor2 = {
         kademliaId: PeerID.fromString('mock2').value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'mock2'
     }
 

--- a/packages/dht/test/integration/WebRtcConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectorRpc.test.ts
@@ -2,6 +2,7 @@ import { ProtoRpcClient, RpcCommunicator, toProtoRpcClient } from '@streamr/prot
 import { WebRtcConnectorServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import {
     IceCandidate,
+    NodeType,
     PeerDescriptor,
     RtcAnswer,
     RtcOffer,
@@ -27,12 +28,12 @@ describe('WebRTC rpc messages', () => {
 
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: generateId('peer1'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: generateId('peer2'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     beforeEach(() => {

--- a/packages/dht/test/integration/WebSocketConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebSocketConnectorRpc.test.ts
@@ -2,6 +2,7 @@ import { ProtoRpcClient, RpcCommunicator, toProtoRpcClient } from '@streamr/prot
 import { WebSocketConnectorServiceClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { generateId } from '../utils/utils'
 import {
+    NodeType,
     PeerDescriptor,
     WebSocketConnectionRequest,
     WebSocketConnectionResponse
@@ -18,12 +19,12 @@ describe('WebSocketConnectorRpc', () => {
 
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: generateId('peer1'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: generateId('peer2'),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     beforeEach(() => {

--- a/packages/dht/test/unit/RecursiveFinder.test.ts
+++ b/packages/dht/test/unit/RecursiveFinder.test.ts
@@ -2,6 +2,7 @@ import {
     FindMode,
     Message,
     MessageType,
+    NodeType,
     PeerDescriptor,
     RouteMessageWrapper
 } from '../../src/proto/packages/dht/protos/DhtRpc'
@@ -27,12 +28,12 @@ describe('RecursiveFinder', () => {
     const peerId1 = PeerID.fromString('peerid')
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: peerId1.value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'peerid'
     }
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('destination').value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'destination'
     }
     const recursiveFindRequest = createRecursiveFindRequest(FindMode.NODE)

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -1,5 +1,5 @@
 import { Router } from '../../src/dht/routing/Router'
-import { Message, MessageType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { PeerID, PeerIDKey } from '../../src/helpers/PeerID'
 import { DhtPeer } from '../../src/dht/DhtPeer'
 import { createWrappedClosestPeersRequest, createMockRoutingRpcCommunicator } from '../utils/utils'
@@ -12,12 +12,12 @@ describe('Router', () => {
     const peerId = PeerID.fromString('router')
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: peerId.value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'router'
     }
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('destination').value,
-        type: 0,
+        type: NodeType.NODEJS,
     }
     const rpcWrapper = createWrappedClosestPeersRequest(peerDescriptor1, peerDescriptor2)
     const message: Message = {

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -257,8 +257,8 @@ export const getMockPeers = (): PeerDescriptor[] => {
         type: NodeType.NODEJS,
     }
     const n4: PeerDescriptor = {
-        kademliaId: generateId('Neighbor1'),
-        type: NodeType.BROWSER,
+        kademliaId: generateId('Neighbor4'),
+        type: NodeType.NODEJS,
     }
     return [
         n1, n2, n3, n4

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -87,7 +87,7 @@ export const createMockConnectionLayer1Node = async (stringId: string, layer0Nod
     const id = PeerID.fromString(stringId)
     const descriptor: PeerDescriptor = {
         kademliaId: id.value,
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: stringId
     }
 

--- a/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
+++ b/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
@@ -1,4 +1,4 @@
-import { ClosestPeersResponse, PeerDescriptor } from '../proto/TestProtos'
+import { ClosestPeersResponse, NodeType, PeerDescriptor } from '../proto/TestProtos'
 import { RpcMessage } from '../../src/proto/ProtoRpc'
 import { RpcCommunicator } from '../../src/RpcCommunicator'
 import { DhtRpcServiceClient } from '../proto/TestProtos.client'
@@ -32,7 +32,7 @@ describe('DhtClientRpcTransport', () => {
 
         const peerDescriptor: PeerDescriptor = {
             peerId: new Uint8Array([56, 59, 77]),
-            type: 0
+            type: NodeType.NODEJS
         }
         const res = await client.getClosestPeers({ peerDescriptor, requestId: '1' })
         expect(res.peers.length).toEqual(4)

--- a/packages/proto-rpc/test/utils.ts
+++ b/packages/proto-rpc/test/utils.ts
@@ -85,8 +85,8 @@ export const getMockPeers = (): PeerDescriptor[] => {
         type: NodeType.NODEJS,
     }
     const n4: PeerDescriptor = {
-        peerId: generateId('Neighbor1'),
-        type: NodeType.BROWSER,
+        peerId: generateId('Neighbor4'),
+        type: NodeType.NODEJS,
     }
     return [
         n1, n2, n3, n4

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { LatencyType, Simulator, getRandomRegion } from '@streamr/dht'
+import { LatencyType, NodeType, Simulator, getRandomRegion } from '@streamr/dht'
 import fs from 'fs'
 import { createNetworkNodeWithSimulator, createRandomNodeId } from '../utils/utils'
 import { NetworkNode } from '../../src/NetworkNode'
@@ -27,7 +27,7 @@ const prepareLayer0 = async () => {
     const peerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
         region: getRandomRegion(),
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'entrypoint'
     }
     layer0Ep = peerDescriptor
@@ -43,7 +43,7 @@ const prepareStream = async (streamId: string) => {
     const peerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
         region: getRandomRegion(),
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: streamId
     }
     const streamPartId = toStreamPartID(toStreamID(streamId), 0)
@@ -66,7 +66,7 @@ const measureJoiningTime = async (count: number) => {
     const nodeId = createRandomNodeId()
     const peerDescriptor = {
         kademliaId: hexToBinary(nodeId),
-        type: 0,
+        type: NodeType.NODEJS,
         region: getRandomRegion(),
         nodeName: `${count}`
     }

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -1,4 +1,4 @@
-import { DhtNode, PeerDescriptor, Simulator } from '@streamr/dht'
+import { DhtNode, NodeType, PeerDescriptor, Simulator } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { createMockRandomGraphNodeAndDhtNode, createRandomNodeId, createStreamMessage } from '../utils/utils'
 import { range } from 'lodash'
@@ -9,7 +9,7 @@ import { randomEthereumAddress } from '@streamr/test-utils'
 describe('Propagation', () => {
     const entryPointDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 1
+        type: NodeType.NODEJS
     }
     let dhtNodes: DhtNode[]
     let randomGraphNodes: RandomGraphNode[]
@@ -33,7 +33,7 @@ describe('Propagation', () => {
         await Promise.all(range(NUM_OF_NODES).map(async (_i) => {
             const descriptor: PeerDescriptor = {
                 kademliaId: hexToBinary(createRandomNodeId()),
-                type: 1
+                type: NodeType.NODEJS
             }
             const [dht, graph] = createMockRandomGraphNodeAndDhtNode(
                 descriptor,

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -1,4 +1,4 @@
-import { DhtNode, Simulator, SimulatorTransport, PeerDescriptor, LatencyType } from '@streamr/dht'
+import { DhtNode, Simulator, SimulatorTransport, PeerDescriptor, LatencyType, NodeType } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'
 import { hexToBinary, wait, waitForCondition } from '@streamr/utils'
@@ -15,13 +15,13 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
     const streamId = 'Stream1'
     const entrypointDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const peerDescriptors: PeerDescriptor[] = range(numOfNodes).map(() => {
         return {
             kademliaId: hexToBinary(createRandomNodeId()),
-            type: 0
+            type: NodeType.NODEJS
         }
     })
     beforeEach(async () => {

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -1,4 +1,4 @@
-import { DhtNode, Simulator, PeerDescriptor, ConnectionManager, getRandomRegion } from '@streamr/dht'
+import { DhtNode, Simulator, PeerDescriptor, ConnectionManager, getRandomRegion, NodeType } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'
 import { wait, waitForCondition, hexToBinary } from '@streamr/utils'
@@ -19,7 +19,7 @@ describe('RandomGraphNode-DhtNode', () => {
     const entrypointDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
         nodeName: 'entrypoint',
-        type: 0,
+        type: NodeType.NODEJS,
         region: getRandomRegion()
     }
 
@@ -27,7 +27,7 @@ describe('RandomGraphNode-DhtNode', () => {
         return {
             kademliaId: hexToBinary(createRandomNodeId()),
             nodeName: `node${i}`,
-            type: 0,
+            type: NodeType.NODEJS,
             region: getRandomRegion()
         }
     })

--- a/packages/trackerless-network/test/integration/RemoteHandshaker.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteHandshaker.test.ts
@@ -5,6 +5,7 @@ import {
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import {
     ListeningRpcCommunicator,
+    NodeType,
     PeerDescriptor,
     Simulator,
     SimulatorTransport
@@ -22,11 +23,11 @@ describe('RemoteHandshaker', () => {
 
     const clientNode: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 1, 1]),
-        type: 1
+        type: NodeType.NODEJS
     }
     const serverNode: PeerDescriptor = {
         kademliaId: new Uint8Array([2, 2, 2]),
-        type: 1
+        type: NodeType.NODEJS
     }
 
     let simulator: Simulator

--- a/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
@@ -2,6 +2,7 @@ import { NeighborUpdate } from '../../src/proto/packages/trackerless-network/pro
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import {
     ListeningRpcCommunicator,
+    NodeType,
     PeerDescriptor,
     Simulator,
     SimulatorTransport
@@ -47,7 +48,7 @@ describe('RemoteNeighborUpdateManager', () => {
             async (_msg: NeighborUpdate, _context: ServerCallContext): Promise<NeighborUpdate> => {
                 const node: PeerDescriptor = {
                     kademliaId: new Uint8Array([4, 2, 4]),
-                    type: 0
+                    type: NodeType.NODEJS
                 }
 
                 const update: NeighborUpdate = {

--- a/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
@@ -22,11 +22,11 @@ describe('RemoteNeighborUpdateManager', () => {
 
     const clientNode: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 1, 1]),
-        type: 1
+        type: NodeType.NODEJS
     }
     const serverNode: PeerDescriptor = {
         kademliaId: new Uint8Array([2, 2, 2]),
-        type: 1
+        type: NodeType.NODEJS
     }
 
     let simulator: Simulator

--- a/packages/trackerless-network/test/integration/RemoteRandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteRandomGraphNode.test.ts
@@ -2,7 +2,8 @@ import {
     ListeningRpcCommunicator,
     Simulator,
     PeerDescriptor,
-    SimulatorTransport
+    SimulatorTransport,
+    NodeType
 } from '@streamr/dht'
 import { RemoteRandomGraphNode } from '../../src/logic/RemoteRandomGraphNode'
 import { NetworkRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
@@ -25,11 +26,11 @@ describe('RemoteRandomGraphNode', () => {
 
     const clientNode: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 1, 1]),
-        type: 1
+        type: NodeType.NODEJS
     }
     const serverNode: PeerDescriptor = {
         kademliaId: new Uint8Array([2, 2, 2]),
-        type: 1
+        type: NodeType.NODEJS
     }
 
     let recvCounter: number

--- a/packages/trackerless-network/test/unit/Handshaker.test.ts
+++ b/packages/trackerless-network/test/unit/Handshaker.test.ts
@@ -1,5 +1,5 @@
 import { Handshaker } from '../../src/logic/neighbor-discovery/Handshaker'
-import { ListeningRpcCommunicator, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
+import { ListeningRpcCommunicator, NodeType, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import { mockConnectionLocker, createMockRemoteNode, createRandomNodeId } from '../utils/utils'
 import { NodeList } from '../../src/logic/NodeList'
 import { range } from 'lodash'
@@ -11,7 +11,7 @@ describe('Handshaker', () => {
     const nodeId = createRandomNodeId()
     const peerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(nodeId),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const N = 4

--- a/packages/trackerless-network/test/unit/HandshakerServer.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakerServer.test.ts
@@ -4,6 +4,7 @@ import { InterleaveNotice, StreamHandshakeRequest } from '../../src/proto/packag
 import { createMockRemoteHandshaker, createMockRemoteNode, createRandomNodeId, mockConnectionLocker } from '../utils/utils'
 import { NodeID } from '../../src/identifiers'
 import { hexToBinary } from '@streamr/utils'
+import { NodeType } from '@streamr/dht'
 
 describe('HandshakerServer', () => {
 
@@ -12,7 +13,7 @@ describe('HandshakerServer', () => {
     const nodeId = createRandomNodeId()
     const ownPeerDescriptor = {
         kademliaId: hexToBinary(nodeId),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     let targetNeighbors: NodeList
@@ -49,7 +50,7 @@ describe('HandshakerServer', () => {
             requestId: 'requestId',
             senderDescriptor: {
                 kademliaId: senderId,
-                type: 0
+                type: NodeType.NODEJS
             }
         })
         const res = await handshakerServer.handshake(req, {} as any)
@@ -70,7 +71,7 @@ describe('HandshakerServer', () => {
             requestId: 'requestId',
             senderDescriptor: {
                 kademliaId: senderId,
-                type: 0
+                type: NodeType.NODEJS
             }
         })
         const res = await handshakerServer.handshake(req, {} as any)
@@ -90,7 +91,7 @@ describe('HandshakerServer', () => {
             requestId: 'requestId',
             senderDescriptor: {
                 kademliaId: senderId,
-                type: 0
+                type: NodeType.NODEJS
             }
         })
         const res = await handshakerServer.handshake(req, {} as any)
@@ -103,7 +104,7 @@ describe('HandshakerServer', () => {
             senderId: hexToBinary('0x1111'),
             interleaveTargetDescriptor: {
                 kademliaId: hexToBinary('0x2222'),
-                type: 0
+                type: NodeType.NODEJS
             }
 
         }
@@ -117,7 +118,7 @@ describe('HandshakerServer', () => {
             senderId: hexToBinary('0x1111'),
             interleaveTargetDescriptor: {
                 kademliaId: hexToBinary('0x2222'),
-                type: 0
+                type: NodeType.NODEJS
             }
         }
         await handshakerServer.interleaveNotice(req, {} as any)

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -5,6 +5,7 @@ import {
     ListeningRpcCommunicator,
     Simulator,
     SimulatorTransport,
+    NodeType,
 } from '@streamr/dht'
 import { NetworkRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
@@ -44,7 +45,7 @@ describe('NodeList', () => {
         ids.forEach((id) => {
             const peerDescriptor: PeerDescriptor = {
                 kademliaId: id,
-                type: 0
+                type: NodeType.NODEJS
             }
             nodeList.add(createRemoteGraphNode(peerDescriptor))
         })
@@ -61,7 +62,7 @@ describe('NodeList', () => {
     it('add', () => {
         const newDescriptor = {
             kademliaId: new Uint8Array([1, 2, 3]),
-            type: 0
+            type: NodeType.NODEJS
         }
         const newNode = createRemoteGraphNode(newDescriptor)
         nodeList.add(newNode)
@@ -69,7 +70,7 @@ describe('NodeList', () => {
 
         const newDescriptor2 = {
             kademliaId: new Uint8Array([1, 2, 4]),
-            type: 0
+            type: NodeType.NODEJS
         }
         const newNode2 = createRemoteGraphNode(newDescriptor2)
         nodeList.add(newNode2)

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -1,5 +1,5 @@
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
-import { PeerDescriptor } from '@streamr/dht'
+import { NodeType, PeerDescriptor } from '@streamr/dht'
 import { MockTransport } from '../utils/mock/Transport'
 import { createMockRemoteNode, createRandomNodeId, mockConnectionLocker } from '../utils/utils'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
@@ -16,7 +16,7 @@ describe('RandomGraphNode', () => {
     let randomGraphNode: RandomGraphNode
     const peerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     let targetNeighbors: NodeList

--- a/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
+++ b/packages/trackerless-network/test/unit/StreamEntrypointDiscovery.test.ts
@@ -1,5 +1,5 @@
 import { StreamEntryPointDiscovery } from '../../src/logic/StreamEntryPointDiscovery'
-import { PeerDescriptor, isSamePeerDescriptor, RecursiveFindResult } from '@streamr/dht'
+import { PeerDescriptor, isSamePeerDescriptor, RecursiveFindResult, NodeType } from '@streamr/dht'
 import { StreamObject } from '../../src/logic/StreamrNode'
 import { DataEntry } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { Any } from '../../src/proto/google/protobuf/any'
@@ -16,13 +16,13 @@ describe('StreamEntryPointDiscovery', () => {
 
     const peerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'fake'
     }
 
     const deletedPeerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0,
+        type: NodeType.NODEJS,
         nodeName: 'deleted'
     }
 

--- a/packages/trackerless-network/test/unit/StreamNodeServer.test.ts
+++ b/packages/trackerless-network/test/unit/StreamNodeServer.test.ts
@@ -1,4 +1,4 @@
-import { ListeningRpcCommunicator, PeerDescriptor } from '@streamr/dht'
+import { ListeningRpcCommunicator, NodeType, PeerDescriptor } from '@streamr/dht'
 import { StreamNodeServer } from '../../src/logic/StreamNodeServer'
 import { LeaveStreamNotice } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { MockTransport } from '../utils/mock/Transport'
@@ -12,12 +12,12 @@ describe('StreamNodeServer', () => {
     let streamNodeServer: StreamNodeServer
     const peerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const mockSender: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
 
     const message = createStreamMessage(

--- a/packages/trackerless-network/test/unit/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/unit/StreamrNode.test.ts
@@ -1,6 +1,6 @@
 import { StreamrNode } from '../../src/logic/StreamrNode'
 import { MockLayer0 } from '../utils/mock/MockLayer0'
-import { isSamePeerDescriptor, PeerDescriptor } from '@streamr/dht'
+import { isSamePeerDescriptor, NodeType, PeerDescriptor } from '@streamr/dht'
 import { createRandomNodeId, createStreamMessage, mockConnectionLocker } from '../utils/utils'
 import { MockTransport } from '../utils/mock/Transport'
 import { hexToBinary, waitForCondition } from '@streamr/utils'
@@ -12,7 +12,7 @@ describe('StreamrNode', () => {
     let node: StreamrNode
     const peerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
     const streamPartId = StreamPartIDUtils.parse('stream#0')
     const message = createStreamMessage(

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto'
-import { ConnectionLocker, DhtNode, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
+import { ConnectionLocker, DhtNode, NodeType, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import {
     ContentType,
@@ -79,7 +79,7 @@ export const createRandomNodeId = (): NodeID => {
 export const createMockRemoteNode = (peerDescriptor?: PeerDescriptor): RemoteRandomGraphNode => {
     const mockPeerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
     return new RemoteRandomGraphNode(peerDescriptor || mockPeerDescriptor, 'mock', {} as any)
 }
@@ -87,7 +87,7 @@ export const createMockRemoteNode = (peerDescriptor?: PeerDescriptor): RemoteRan
 export const createMockRemoteHandshaker = (): RemoteHandshaker => {
     const mockPeerDescriptor: PeerDescriptor = {
         kademliaId: hexToBinary(createRandomNodeId()),
-        type: 0
+        type: NodeType.NODEJS
     }
     return new RemoteHandshaker(mockPeerDescriptor, 'mock', {
         handshake: async () => {},


### PR DESCRIPTION
Use values of `NodeType` enum instead literals `0` and `1`.

All tests now use `NODEJS` as the node type is not relevant in any test (these tests used `BROWSER` before this PR https://github.com/streamr-dev/network/pull/1868/commits/6848b81575ad67b4d643f7e66ee0471e59859c44)