### PR TITLE
fix(network): Fix flaky browser test RandomGraphNode-Layer1Node

### DIFF
--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -137,6 +137,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
                     }
                 })
             })
+            // NET-1074 Investigate why sometimes unidirectional connections remain.
             return mismatchCounter <= 2
         }, 20000, 1000)
     }, 90000)

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -124,19 +124,20 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
             waitForCondition(() => node.getNumberOfOutgoingHandshakes() === 0)
         ))
 
-        await wait(20000)
-        let mismatchCounter = 0
-        graphNodes.forEach((node) => {
-            const nodeId = node.getOwnNodeId()
-            node.getTargetNeighborIds().forEach((neighborId) => {
-                if (neighborId !== entryPointRandomGraphNode.getOwnNodeId()) {
-                    const neighbor = graphNodes.find((n) => n.getOwnNodeId() === neighborId)
-                    if (!neighbor!.getTargetNeighborIds().includes(nodeId)) {
-                        mismatchCounter += 1
+        await waitForCondition(() => {
+            let mismatchCounter = 0
+            graphNodes.forEach((node) => {
+                const nodeId = node.getOwnNodeId()
+                node.getTargetNeighborIds().forEach((neighborId) => {
+                    if (neighborId !== entryPointRandomGraphNode.getOwnNodeId()) {
+                        const neighbor = graphNodes.find((n) => n.getOwnNodeId() === neighborId)
+                        if (!neighbor!.getTargetNeighborIds().includes(nodeId)) {
+                            mismatchCounter += 1
+                        }
                     }
-                }
+                })
             })
-        })
-        expect(mismatchCounter).toBeLessThanOrEqual(2)
+            return mismatchCounter === 0
+        }, 20000, 1000)
     }, 90000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -137,7 +137,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
                     }
                 })
             })
-            return mismatchCounter === 0
+            return mismatchCounter > 2
         }, 20000, 1000)
     }, 90000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -1,7 +1,7 @@
 import { DhtNode, Simulator, SimulatorTransport, PeerDescriptor, LatencyType, NodeType } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'
-import { hexToBinary, wait, waitForCondition } from '@streamr/utils'
+import { hexToBinary, waitForCondition } from '@streamr/utils'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
 import { createRandomNodeId } from '../utils/utils'
 

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -137,7 +137,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
                     }
                 })
             })
-            return mismatchCounter > 2
+            return mismatchCounter <= 2
         }, 20000, 1000)
     }, 90000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -159,7 +159,7 @@ describe('RandomGraphNode-DhtNode', () => {
                     }
                 })
             })
-            return mismatchCounter > 2
+            return mismatchCounter <= 2
         }, 20000, 1000)
     }, 95000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -159,6 +159,7 @@ describe('RandomGraphNode-DhtNode', () => {
                     }
                 })
             })
+            // NET-1074 Investigate why sometimes unidirectional connections remain.
             return mismatchCounter <= 2
         }, 20000, 1000)
     }, 95000)

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -146,21 +146,20 @@ describe('RandomGraphNode-DhtNode', () => {
         await Promise.all(graphNodes.map((node) =>
             waitForCondition(() => node.getNumberOfOutgoingHandshakes() === 0)
         ))
-        await wait(10000)
-        let mismatchCounter = 0
-        graphNodes.forEach((node) => {
-            const nodeId = node.getOwnNodeId()
-            node.getTargetNeighborIds().forEach((neighborId) => {
-                if (neighborId !== entryPointRandomGraphNode.getOwnNodeId()) {
-                    const neighbor = graphNodes.find((n) => n.getOwnNodeId() === neighborId)
-                    if (!neighbor!.getTargetNeighborIds().includes(nodeId)) {
-                        logger.info('mismatching ids length: ' + nodeId + ' ' + neighbor!.getTargetNeighborIds().length)
-                        mismatchCounter += 1
+        await waitForCondition(() => {
+            let mismatchCounter = 0
+            graphNodes.forEach((node) => {
+                const nodeId = node.getOwnNodeId()
+                node.getTargetNeighborIds().forEach((neighborId) => {
+                    if (neighborId !== entryPointRandomGraphNode.getOwnNodeId()) {
+                        const neighbor = graphNodes.find((n) => n.getOwnNodeId() === neighborId)
+                        if (!neighbor!.getTargetNeighborIds().includes(nodeId)) {
+                            mismatchCounter += 1
+                        }
                     }
-                }
-        
+                })
             })
-        })
-        expect(mismatchCounter).toBeLessThanOrEqual(2)
+            return mismatchCounter === 0
+        }, 20000, 1000)
     }, 95000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -159,7 +159,7 @@ describe('RandomGraphNode-DhtNode', () => {
                     }
                 })
             })
-            return mismatchCounter === 0
+            return mismatchCounter > 2
         }, 20000, 1000)
     }, 95000)
 })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -1,7 +1,7 @@
 import { DhtNode, Simulator, PeerDescriptor, ConnectionManager, getRandomRegion, NodeType } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { range } from 'lodash'
-import { wait, waitForCondition, hexToBinary } from '@streamr/utils'
+import { waitForCondition, hexToBinary } from '@streamr/utils'
 import { Logger } from '@streamr/utils'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
 import { createRandomNodeId } from '../utils/utils'


### PR DESCRIPTION
## Summary

64 node runs `RandomGraphNode-Layer1Node` tests now use `waitForCondition` for all connections to be bidirectional.
