### PR TITLE
NET-1013: re-enable skipped 'subscriber is able to receive messages' test case 

### DIFF
--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -10,7 +10,7 @@ import { createTestStream, createTestClient } from '../test-utils/utils'
 import { waitForCondition } from '@streamr/utils'
 import { createNetworkNode } from '@streamr/trackerless-network'
 
-const TIMEOUT = 10 * 1000
+const TIMEOUT = 15 * 1000
 
 const PAYLOAD = { hello: 'world' }
 
@@ -88,7 +88,7 @@ describe('publish-subscribe', () => {
                 permissions: [StreamPermission.SUBSCRIBE],
                 user: subscriberWallet.address
             })
-        }, TIMEOUT * 3)
+        }, TIMEOUT * 2)
 
         it('messages are published encrypted', async () => {
             await publisherClient.publish(stream.id, PAYLOAD)

--- a/packages/client/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/publish-subscribe.test.ts
@@ -10,7 +10,7 @@ import { createTestStream, createTestClient } from '../test-utils/utils'
 import { waitForCondition } from '@streamr/utils'
 import { createNetworkNode } from '@streamr/trackerless-network'
 
-const TIMEOUT = 30 * 1000
+const TIMEOUT = 10 * 1000
 
 const PAYLOAD = { hello: 'world' }
 
@@ -31,7 +31,7 @@ async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID)
         networkNode.addMessageListener((msg) => {
             messages.push(msg.getContent())
         })
-        await waitForCondition(() => messages.length > 0, TIMEOUT - 100)
+        await waitForCondition(() => messages.length > 0, TIMEOUT)
         return messages
     } finally {
         await networkNode.stop()
@@ -88,7 +88,7 @@ describe('publish-subscribe', () => {
                 permissions: [StreamPermission.SUBSCRIBE],
                 user: subscriberWallet.address
             })
-        }, TIMEOUT)
+        }, TIMEOUT * 3)
 
         it('messages are published encrypted', async () => {
             await publisherClient.publish(stream.id, PAYLOAD)
@@ -103,7 +103,7 @@ describe('publish-subscribe', () => {
             await subscriberClient.subscribe(stream.id, (msg: any) => {
                 messages.push(msg)
             })
-            await waitForCondition(() => messages.length > 0)
+            await waitForCondition(() => messages.length > 0, TIMEOUT)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)
     })
@@ -124,14 +124,13 @@ describe('publish-subscribe', () => {
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)
 
-        // TODO: flaky test fix in NET-1013
-        it.skip('subscriber is able to receive messages', async () => {
+        it('subscriber is able to receive messages', async () => {
             const messages: unknown[] = []
             await subscriberClient.subscribe(stream.id, (msg: any) => {
                 messages.push(msg)
             })
             await publisherClient.publish(stream.id, PAYLOAD)
-            await waitForCondition(() => messages.length > 0, TIMEOUT - 1000)
+            await waitForCondition(() => messages.length > 0, TIMEOUT)
             expect(messages).toEqual([PAYLOAD])
         }, TIMEOUT)
     })


### PR DESCRIPTION
## Summary

Re-enabled `subscriber is able to receive messages` from `test/end-to-end/publish-subsribe.test.ts` as flakyness was fixed after #1840 and #1860 

Passed 100 runs locally.
