### PR TITLE
refactor: fix `@typescript-eslint/await-thenable` warnings

### DIFF
--- a/packages/broker/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/broker/src/plugins/operator/OperatorPlugin.ts
@@ -71,7 +71,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
         await this.maintainTopologyService.start()
 
         const maintainOperatorPoolValueHelper = new MaintainOperatorPoolValueHelper(this.serviceConfig)
-        const announceNodeToContractHelper = new AnnounceNodeToContractHelper(this.serviceConfig!)
+        const announceNodeToContractHelper = new AnnounceNodeToContractHelper(this.serviceConfig)
         await this.fleetState.start()
         // start tasks in background so that operations which take significant amount of time (e.g. fleetState.waitUntilReady())
         // don't block the startup of Broker

--- a/packages/broker/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/broker/test/integration/multiple-publisher-plugins.test.ts
@@ -163,7 +163,7 @@ describe('multiple publisher plugins', () => {
 
         await waitForCondition(() => receivedMessages.size() >= messages.length)
         expect(receivedMessages.values()).toIncludeSameMembers(messages)
-        await subscriber.close()
+        subscriber.close()
 
     })
 

--- a/packages/broker/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -59,7 +59,7 @@ describe('OperatorPlugin', () => {
         const receivedMessages = await collect(subscription, 1)
         clearInterval(publishTimer)
 
-        expect(receivedMessages![0].content).toEqual({ foo: 'bar' })
+        expect(receivedMessages[0].content).toEqual({ foo: 'bar' })
         await subscriber.destroy()
         await publisher.destroy()
     }, 30 * 1000)

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -95,7 +95,7 @@ describe('ConfigWizard', () => {
         it('happy path; create directories if needed', async () => {
             const dirPath = tmpDataDir + '/newdir1/newdir2/'
             const configPath = dirPath + 'test-config.json'
-            const configFileLocation: string = await createStorageFile(CONFIG, {
+            const configFileLocation: string = createStorageFile(CONFIG, {
                 storagePath: configPath
             })
             expect(configFileLocation).toBe(configPath)

--- a/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
+++ b/packages/broker/test/unit/plugins/storage/StorageEventListener.test.ts
@@ -38,13 +38,13 @@ describe(StorageEventListener, () => {
 
     it('start() registers storage event listener on client', async () => {
         expect(storageEventListeners.size).toBe(0)
-        await listener.start()
+        listener.start()
         expect(storageEventListeners.size).toBe(2)
     })
 
     it('destroy() unregisters storage event listener on client', async () => {
         expect(stubClient.off).toHaveBeenCalledTimes(0)
-        await listener.destroy()
+        listener.destroy()
         expect(stubClient.off).toHaveBeenCalledTimes(2)
     })
 
@@ -57,7 +57,7 @@ describe(StorageEventListener, () => {
     }
 
     it('storage node assignment event gets passed to onEvent', async () => {
-        await listener.start()
+        listener.start()
         addToStorageNode(clusterId)
         await wait(0)
         expect(onEvent).toHaveBeenCalledTimes(1)
@@ -69,7 +69,7 @@ describe(StorageEventListener, () => {
     })
 
     it('storage node assignment events meant for another recipient are ignored', async () => {
-        await listener.start()
+        listener.start()
         addToStorageNode(otherClusterId)
         await wait(0)
         expect(onEvent).toHaveBeenCalledTimes(0)

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -226,7 +226,7 @@ describe('Stream permissions', () => {
             user: otherUser.address,
             permissions: [StreamPermission.PUBLISH]
         })
-        await expect(otherUserClient.publish(stream.id, message)).resolves.toBeDefined()
+        await expect(() => otherUserClient.publish(stream.id, message)).resolves
         await otherUserClient.destroy()
     })
 })

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -226,7 +226,7 @@ describe('Stream permissions', () => {
             user: otherUser.address,
             permissions: [StreamPermission.PUBLISH]
         })
-        await expect(() => otherUserClient.publish(stream.id, message)).resolves
+        await expect(otherUserClient.publish(stream.id, message)).resolves.toBeDefined()
         await otherUserClient.destroy()
     })
 })

--- a/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
+++ b/packages/client/test/end-to-end/ProxyPublishSubscribe.test.ts
@@ -36,8 +36,8 @@ describe('PubSub with proxy connections', () => {
 
         onewayClient = createTestClient(pubPrivateKey)
 
-        proxyClient1 = await createTestClient(proxyPrivateKey1, proxyNodePort1, true)
-        proxyClient2 = await createTestClient(proxyPrivateKey2, proxyNodePort2, true)
+        proxyClient1 = createTestClient(proxyPrivateKey1, proxyNodePort1, true)
+        proxyClient2 = createTestClient(proxyPrivateKey2, proxyNodePort2, true)
         proxyNodeDescriptor1 = await proxyClient1.getPeerDescriptor()
         proxyNodeDescriptor2 = await proxyClient2.getPeerDescriptor()
 

--- a/packages/client/test/end-to-end/get-diagnostic-info.test.ts
+++ b/packages/client/test/end-to-end/get-diagnostic-info.test.ts
@@ -12,7 +12,7 @@ describe('getDiagnosticInfo', () => {
 
     beforeAll(async () => {
         const streamPath = `/get-diagnostic-info.test.ts/${Date.now()}`
-        client = await createTestClient(await fetchPrivateKeyWithGas())
+        client = createTestClient(await fetchPrivateKeyWithGas())
         stream = await client.createStream(streamPath)
         await stream.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })
         otherClient = await createClient()

--- a/packages/client/test/end-to-end/searchStreams.test.ts
+++ b/packages/client/test/end-to-end/searchStreams.test.ts
@@ -96,9 +96,9 @@ describe('searchStreams', () => {
     })
 
     it('no filters', async () => {
-        return expect(async () => {
-            await client.searchStreams(undefined, undefined)
-        }).rejects.toThrow('Requires a search term or a permission filter')
+        expect(() => {
+            client.searchStreams(undefined, undefined)
+        }).toThrow('Requires a search term or a permission filter')
     })
 
     describe('permission filter', () => {

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -19,7 +19,7 @@ export class FakeStorageNodeRegistry implements Methods<StorageNodeRegistry> {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    async getStorageNodeMetadata(nodeAddress: EthereumAddress): Promise<StorageNodeMetadata | never> {
+    async getStorageNodeMetadata(nodeAddress: EthereumAddress): Promise<StorageNodeMetadata> {
         const metadata = this.chain.storageNodeMetadatas.get(nodeAddress)
         if (metadata !== undefined) {
             return metadata

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -350,7 +350,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
 
     private isOwnWebSocketServer(peerDescriptor: PeerDescriptor): boolean {
         if ((peerDescriptor.websocket !== undefined) && (this.ownPeerDescriptor!.websocket !== undefined)) {
-            return ((peerDescriptor.websocket.port === this.ownPeerDescriptor!.websocket!.port) 
+            return ((peerDescriptor.websocket.port === this.ownPeerDescriptor!.websocket.port) 
                 && (peerDescriptor.websocket.host === this.ownPeerDescriptor!.websocket.host))
         } else {
             return false

--- a/packages/dht/test/integration/DhtRpc.test.ts
+++ b/packages/dht/test/integration/DhtRpc.test.ts
@@ -46,8 +46,8 @@ describe('DhtRpc', () => {
     })
 
     afterEach(async () => {
-        await rpcCommunicator1.stop()
-        await rpcCommunicator2.stop()
+        rpcCommunicator1.stop()
+        rpcCommunicator2.stop()
     })
 
     it('Happy path', async () => {

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -113,7 +113,7 @@ describe('Route Message With Mock Connections', () => {
                 sourceDescriptor: sourceNode.getPeerDescriptor(),
                 targetDescriptor: destinationNode.getPeerDescriptor()
             }
-            await sourceNode.router!.doRouteMessage({
+            sourceNode.router!.doRouteMessage({
                 message,
                 destinationPeer: destinationNode.getPeerDescriptor(),
                 requestId: v4(),
@@ -169,7 +169,7 @@ describe('Route Message With Mock Connections', () => {
                             sourceDescriptor: node.getPeerDescriptor(),
                             targetDescriptor: destinationNode.getPeerDescriptor()
                         }
-                        await node.router!.doRouteMessage({
+                        node.router!.doRouteMessage({
                             message,
                             destinationPeer: receiver.getPeerDescriptor(),
                             sourcePeer: node.getPeerDescriptor(),

--- a/packages/dht/test/integration/WebRtcConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectorRpc.test.ts
@@ -88,8 +88,8 @@ describe('WebRTC rpc messages', () => {
     })
 
     afterEach(async () => {
-        await rpcCommunicator1.stop()
-        await rpcCommunicator2.stop()
+        rpcCommunicator1.stop()
+        rpcCommunicator2.stop()
     })
 
     it('send connectionRequest', async () => {

--- a/packages/dht/test/integration/WebSocketConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebSocketConnectorRpc.test.ts
@@ -57,8 +57,8 @@ describe('WebSocketConnectorRpc', () => {
     })
 
     afterEach(async () => {
-        await rpcCommunicator1.stop()
-        await rpcCommunicator2.stop()
+        rpcCommunicator1.stop()
+        rpcCommunicator2.stop()
     })
 
     it('Happy path', async () => {
@@ -71,7 +71,7 @@ describe('WebSocketConnectorRpc', () => {
         { targetDescriptor: peerDescriptor2 },
         )
         const res1 = await response1
-        await (expect(res1.accepted)).toEqual(true)
+        expect(res1.accepted).toEqual(true)
 
         const response2 = client2.requestConnection({
             requester: peerDescriptor2,
@@ -82,6 +82,6 @@ describe('WebSocketConnectorRpc', () => {
         { targetDescriptor: peerDescriptor1 },
         )
         const res2 = await response2
-        await (expect(res2.accepted)).toEqual(true)
+        expect(res2.accepted).toEqual(true)
     })
 })

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -292,7 +292,7 @@ export async function fetchPrivateKeyWithGas(): Promise<string> {
     }
 
     if (!response.ok) {
-        throw new Error(`fetchPrivateKeyWithGas failed ${response.status} ${response.statusText}: ${response.text()}`)
+        throw new Error(`fetchPrivateKeyWithGas failed ${response.status} ${response.statusText}: ${await response.text()}`)
     }
 
     return response.text()

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -81,7 +81,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     async start(doJoin = true): Promise<void> {
         await this.layer0DhtNode!.start()
         this.connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
-        if ((this.options.layer0?.entryPoints !== undefined) && (this.options.layer0!.entryPoints!.some((entryPoint) => 
+        if ((this.options.layer0?.entryPoints !== undefined) && (this.options.layer0.entryPoints.some((entryPoint) => 
             isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())
         ))) {
             this.dhtJoinRequired = false

--- a/packages/trackerless-network/src/logic/protocol-integration/stream-message/StreamMessageTranslator.ts
+++ b/packages/trackerless-network/src/logic/protocol-integration/stream-message/StreamMessageTranslator.ts
@@ -135,8 +135,8 @@ export class StreamMessageTranslator {
         let newGroupKey: OldEncryptedGroupKey | undefined = undefined
         if (msg.newGroupKey) {
             newGroupKey = new OldEncryptedGroupKey(
-                msg.newGroupKey!.id,
-                msg.newGroupKey!.data,
+                msg.newGroupKey.id,
+                msg.newGroupKey.data,
             )
         }
         const translated = new OldStreamMessage<T>({

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -63,7 +63,7 @@ describe('Proxy connections', () => {
             }
         })
         await proxyNode1.start()
-        await proxyNode1.setStreamPartEntryPoints(streamPartId, [proxyNodeDescriptor1])
+        proxyNode1.setStreamPartEntryPoints(streamPartId, [proxyNodeDescriptor1])
         await proxyNode1.stack.getStreamrNode()!.joinStream(streamPartId)
        
         proxyNode2 = createNetworkNode({

--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -87,7 +87,7 @@ describe('inspect', () => {
                 123123,
                 sequenceNumber
             )
-            await publisherNode.getStreamrNode().publishToStream(streamPartId, msg)
+            publisherNode.getStreamrNode().publishToStream(streamPartId, msg)
             sequenceNumber += 1
         }, 200)
 

--- a/packages/trackerless-network/test/integration/RemoteRandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteRandomGraphNode.test.ts
@@ -93,7 +93,7 @@ describe('RemoteRandomGraphNode', () => {
     })
 
     it('leaveNotice', async () => {
-        await remoteRandomGraphNode.leaveStreamNotice(clientNode)
+        remoteRandomGraphNode.leaveStreamNotice(clientNode)
         await waitForCondition(() => recvCounter === 1)
     })
 

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -91,10 +91,10 @@ describe('Joining streams on offline nodes', () => {
         await entryPoint.getLayer0DhtNode().storeDataToDht(streamPartIdToDataKey(streamPartId), Any.pack(offlineDescriptor1, PeerDescriptor))
         await entryPoint.getLayer0DhtNode().storeDataToDht(streamPartIdToDataKey(streamPartId), Any.pack(offlineDescriptor2, PeerDescriptor))
         
-        await node1.getStreamrNode().subscribeToStream(streamPartId)
-        await node1.getStreamrNode().on('newMessage', () => { messageReceived = true })
+        node1.getStreamrNode().subscribeToStream(streamPartId)
+        node1.getStreamrNode().on('newMessage', () => { messageReceived = true })
         const msg = createStreamMessage(JSON.stringify({ hello: 'WORLD' }), streamPartId, randomEthereumAddress())
-        await node2.getStreamrNode().publishToStream(streamPartId, msg)
+        node2.getStreamrNode().publishToStream(streamPartId, msg)
         await waitForCondition(() => messageReceived, 25000)
     }, 30000)
 

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -48,8 +48,8 @@ describe('RandomGraphNode', () => {
         await randomGraphNode.start()
     })
 
-    afterEach(async () => {
-        await randomGraphNode.stop()
+    afterEach(() => {
+        randomGraphNode.stop()
     })
 
     it('getTargetNeighborIds', () => {

--- a/packages/trackerless-network/test/unit/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/unit/StreamrNode.test.ts
@@ -64,13 +64,13 @@ describe('StreamrNode', () => {
     })
 
     it('publish joins stream', async () => {
-        await node.publishToStream(streamPartId, message)
+        node.publishToStream(streamPartId, message)
         await waitForCondition(() => node.hasStream(streamPartId))
     })
 
     it('can unsubscribe', async () => {
         await node.joinStream(streamPartId)
-        await node.unsubscribeFromStream(streamPartId)
+        node.unsubscribeFromStream(streamPartId)
     })
 
 })


### PR DESCRIPTION
Fix code invocations where we use await a function/variable which is not a promise.

The `@typescript-eslint/await-thenable` eslint rule would warn about (it is currently not enabled, requires https://github.com/streamr-dev/network/pull/1171).

Also fixed some warnings for other rules:
- @typescript-eslint/no-unnecessary-type-assertion (commit 66bbe12)
- @typescript-eslint/no-redundant-type-constituents (commit df36afa)
- @typescript-eslint/no-base-to-string (commit 9a12235)