### PR TITLE
fix(client): Invalidate permission cache after publish failure

### DIFF
--- a/packages/client/src/publish/MessageFactory.ts
+++ b/packages/client/src/publish/MessageFactory.ts
@@ -23,7 +23,7 @@ import { StreamrClientError } from '../StreamrClientError'
 export interface MessageFactoryOptions {
     streamId: StreamID
     authentication: Authentication
-    streamRegistry: Pick<StreamRegistry, 'getStream' | 'hasPublicSubscribePermission' | 'isStreamPublisher'>
+    streamRegistry: Pick<StreamRegistry, 'getStream' | 'hasPublicSubscribePermission' | 'isStreamPublisher' | 'clearStreamCache'>
     groupKeyQueue: GroupKeyQueue
 }
 
@@ -51,7 +51,7 @@ export class MessageFactory {
     private defaultPartition: number | undefined
     private readonly defaultMessageChainIds: Mapping<[partition: number], string>
     private readonly prevMsgRefs: Map<string, MessageRef> = new Map()
-    private readonly streamRegistry: Pick<StreamRegistry, 'getStream' | 'hasPublicSubscribePermission' | 'isStreamPublisher'>
+    private readonly streamRegistry: Pick<StreamRegistry, 'getStream' | 'hasPublicSubscribePermission' | 'isStreamPublisher' | 'clearStreamCache'>
     private readonly groupKeyQueue: GroupKeyQueue
 
     constructor(opts: MessageFactoryOptions) {
@@ -73,6 +73,7 @@ export class MessageFactory {
         const publisherId = await this.authentication.getAddress()
         const isPublisher = await this.streamRegistry.isStreamPublisher(this.streamId, publisherId)
         if (!isPublisher) {
+            this.streamRegistry.clearStreamCache(this.streamId)
             throw new StreamrClientError(`You don't have permission to publish to this stream. Using address: ${publisherId}`, 'MISSING_PERMISSION')
         }
 

--- a/packages/client/test/end-to-end/Permissions.test.ts
+++ b/packages/client/test/end-to-end/Permissions.test.ts
@@ -226,7 +226,7 @@ describe('Stream permissions', () => {
             user: otherUser.address,
             permissions: [StreamPermission.PUBLISH]
         })
-        await expect(() => otherUserClient.publish(stream.id, message)).resolves
+        await expect(otherUserClient.publish(stream.id, message)).resolves.toBeDefined()
         await otherUserClient.destroy()
     })
 })

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -181,6 +181,7 @@ export const createStreamRegistry = (opts?: {
         isStreamSubscriber: async () => {
             return opts?.isStreamSubscriber ?? true
         },
+        clearStreamCache: () => {}
     } as any
 }
 

--- a/packages/client/test/unit/Publisher.test.ts
+++ b/packages/client/test/unit/Publisher.test.ts
@@ -9,7 +9,8 @@ describe('Publisher', () => {
         const authentication = createRandomAuthentication()
         const streamIdBuilder = new StreamIDBuilder(authentication)
         const streamRegistry = {
-            isStreamPublisher: async () => false
+            isStreamPublisher: async () => false,
+            clearStreamCache: () => {}
         }
         const publisher = new Publisher(
             undefined as any,


### PR DESCRIPTION
## Background

When a user tries to publish message, we always check whether the user has a publish permission for the stream. The result of that check is cached so that subsequent checks are super-fast. 

We should also invalidate the cache if the publishing fails, so that if someone grants the permission we don't cache the invalid `false` value (and therefore throw the error when there is actually a permission granted).

## Change

Now we invalidate cache in `MessageFactory.ts`. 

Fixed also a test case, which covered this use case, but it had incorrect await logic and therefore it didn't catch the bug. 
