### PR TITLE
refactor(trackerless-network): Simplify `NetworkStack` state

### DIFF
--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -84,11 +84,6 @@ export class FakeNetworkNode implements NetworkNodeStub {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getRtt(_nodeId: string): number | undefined {
-        throw new Error('not implemented')
-    }
-
-    // eslint-disable-next-line class-methods-use-this
     setExtraMetadata(_metadata: Record<string, unknown>): void {
         throw new Error('not implemented')
     }

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -134,11 +134,6 @@ export class NetworkNode {
         return this.stack.getStreamrNode()!.hasProxyConnection(streamPartId, contactNodeId, direction)
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    getRtt(_nodeId: NodeID): number | undefined {
-        throw new Error('Not implemented')
-    }
-
     async stop(): Promise<void> {
         this.stopped = true
         await this.stack.stop()

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -85,9 +85,6 @@ export class NetworkNode {
     }
 
     removeMessageListener<T>(cb: (msg: StreamMessage<T>) => void): void {
-        if (this.stopped) {
-            return
-        }
         pull(this.messageListeners, cb)
     }
 

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -4,13 +4,13 @@ import { MetricsContext, waitForEvent3 } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
 import { StreamPartID } from '@streamr/protocol'
 
-interface ReadynessEvents {
+interface ReadinessEvents {
     done: () => void
 }
 
-class ReadynessListener {
+class ReadinessListener {
 
-    private readonly emitter = new EventEmitter<ReadynessEvents>()
+    private readonly emitter = new EventEmitter<ReadinessEvents>()
     private readonly networkStack: NetworkStack
     private readonly dhtNode: DhtNode
 
@@ -29,7 +29,7 @@ class ReadynessListener {
 
     public async waitUntilReady(timeout: number): Promise<void> {
         if (this.dhtNode.getNumberOfConnections() === 0) {
-            await waitForEvent3<ReadynessEvents>(this.emitter, 'done', timeout)
+            await waitForEvent3<ReadinessEvents>(this.emitter, 'done', timeout)
         }
     }
 }
@@ -97,9 +97,9 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     }
 
     private async waitForFirstConnection(): Promise<void> {
-        const readynessListener = new ReadynessListener(this, this.layer0DhtNode!)
+        const readinessListener = new ReadinessListener(this, this.layer0DhtNode!)
         const timeout = this.options.networkNode?.firstConnectionTimeout ?? DEFAULT_FIRST_CONNECTION_TIMEOUT
-        await readynessListener.waitUntilReady(timeout)
+        await readinessListener.waitUntilReady(timeout)
     }
 
     async joinLayer0IfRequired(streamPartId: StreamPartID): Promise<void> {

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -88,9 +88,10 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     }
 
     private async joinDht(): Promise<void> {
-        setImmediate(() => {
+        setImmediate(async () => {
             if (this.options.layer0?.entryPoints !== undefined) {
-                this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints)
+                // TODO should catch possible rejection?
+                await this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints)
             }
         })
         await this.waitForFirstConnection()

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -28,9 +28,7 @@ class ReadynessListener {
     }
 
     public async waitUntilReady(timeout: number): Promise<void> {
-        if (this.dhtNode.getNumberOfConnections() > 0) {
-            return
-        } else {
+        if (this.dhtNode.getNumberOfConnections() === 0) {
             await waitForEvent3<ReadynessEvents>(this.emitter, 'done', timeout)
         }
     }

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -54,7 +54,6 @@ export interface NetworkStackEvents {
 
 export class NetworkStack extends EventEmitter<NetworkStackEvents> {
 
-    private connectionManager?: ConnectionManager
     private layer0DhtNode?: DhtNode
     private streamrNode?: StreamrNode
     private readonly metricsContext: MetricsContext
@@ -80,19 +79,19 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
 
     async start(doJoin = true): Promise<void> {
         await this.layer0DhtNode!.start()
-        this.connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
+        const connectionManager = this.layer0DhtNode!.getTransport() as ConnectionManager
         if ((this.options.layer0?.entryPoints !== undefined) && (this.options.layer0.entryPoints.some((entryPoint) => 
             isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())
         ))) {
             this.dhtJoinRequired = false
             await this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints)
-            await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager, this.connectionManager)
+            await this.streamrNode?.start(this.layer0DhtNode!, connectionManager, connectionManager)
         } else {
             if (doJoin) {
                 this.dhtJoinRequired = false
                 await this.joinDht()
             }
-            await this.streamrNode?.start(this.layer0DhtNode!, this.connectionManager, this.connectionManager)
+            await this.streamrNode?.start(this.layer0DhtNode!, connectionManager, connectionManager)
         }
     }
 
@@ -139,7 +138,6 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
         await this.streamrNode!.destroy()
         this.streamrNode = undefined
         this.layer0DhtNode = undefined
-        this.connectionManager = undefined
         this.emit('stopped')
     }
 

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -17,19 +17,13 @@ class ReadynessListener {
     constructor(networkStack: NetworkStack, dhtNode: DhtNode) {
         this.networkStack = networkStack
         this.dhtNode = dhtNode
-        this.networkStack.on('stopped', this.onStopped)
-        this.dhtNode.on('connected', this.onConnected)
+        this.networkStack.on('stopped', this.onDone)
+        this.dhtNode.on('connected', this.onDone)
     }
 
-    private onConnected = () => {
-        this.networkStack.off('stopped', this.onStopped)
-        this.dhtNode.off('connected', this.onConnected)
-        this.emitter.emit('done')
-    }
-
-    private onStopped = () => {
-        this.networkStack.off('stopped', this.onStopped)
-        this.dhtNode.off('connected', this.onConnected)
+    private onDone = () => {
+        this.networkStack.off('stopped', this.onDone)
+        this.dhtNode.off('connected', this.onDone)
         this.emitter.emit('done')
     }
 

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -84,6 +84,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
             isSamePeerDescriptor(entryPoint, this.layer0DhtNode!.getPeerDescriptor())
         ))) {
             this.dhtJoinRequired = false
+            // TODO should this go via this.join?
             await this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints)
         } else {
             if (doJoin) {

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -100,15 +100,15 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     }
 
     async joinLayer0IfRequired(streamPartId: StreamPartID): Promise<void> {
-        if (this.isJoinRequired(streamPartId)) {
+        if (this.streamrNode!.isProxiedStreamPart(streamPartId)) {
+            return
+        }
+        // TODO we could wrap joinDht with pOnce and call it here (no else-if needed in that case)
+        if (!this.layer0DhtNode!.hasJoined()) {
             await this.joinDht()
         } else if (this.layer0DhtNode!.getNumberOfConnections() < 1) {
             await this.waitForFirstConnection()
         }
-    }
-
-    private isJoinRequired(streamPartId: StreamPartID): boolean {
-        return !this.layer0DhtNode!.hasJoined() && this.streamrNode!.isJoinRequired(streamPartId)
     }
 
     getStreamrNode(): StreamrNode {

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -85,14 +85,13 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
         ))) {
             this.dhtJoinRequired = false
             await this.layer0DhtNode?.joinDht(this.options.layer0.entryPoints)
-            await this.streamrNode?.start(this.layer0DhtNode!, connectionManager, connectionManager)
         } else {
             if (doJoin) {
                 this.dhtJoinRequired = false
                 await this.joinDht()
             }
-            await this.streamrNode?.start(this.layer0DhtNode!, connectionManager, connectionManager)
         }
+        await this.streamrNode?.start(this.layer0DhtNode!, connectionManager, connectionManager)
     }
 
     private async joinDht(): Promise<void> {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -358,9 +358,9 @@ export class StreamrNode extends EventEmitter<Events> {
         this.knownStreamEntryPoints.set(streamPartId, entryPoints)
     }
 
-    isProxiedStreamPart(streamId: string, direction: ProxyDirection): boolean {
+    isProxiedStreamPart(streamId: string, direction?: ProxyDirection): boolean {
         return this.streams.get(streamId)?.type === StreamNodeType.PROXY 
-            && (this.streams.get(streamId)!.layer2 as ProxyStreamConnectionClient).getDirection() === direction
+            && ((direction === undefined) || (this.streams.get(streamId)!.layer2 as ProxyStreamConnectionClient).getDirection() === direction)
     }
 
     hasProxyConnection(streamId: string, nodeId: NodeID, direction: ProxyDirection): boolean {
@@ -398,11 +398,6 @@ export class StreamrNode extends EventEmitter<Events> {
     setExtraMetadata(metadata: Record<string, unknown>): void {
         this.extraMetadata = metadata
     }
-
-    isJoinRequired(streamPartId: StreamPartID): boolean {
-        return !this.streams.has(streamPartId) && Array.from(this.streams.values()).every((stream) => stream.type === StreamNodeType.PROXY)
-    }
-
 }
 
 [`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `unhandledRejection`, `SIGTERM`].forEach((term) => {


### PR DESCRIPTION
Simplify state handling of `NetworkState` by removing three fields. Also reduced code-duplication in `ReadynessListener` helper class.

Also small refactoring for `NetworkNode`:
- removed obsolete guard from `removeMessageListener()`
- removed legacy `getRtt()` method

## Future improvement

- use `pOnce` to manage concurrent calls to `joinDht` via `joinLayer0IfRequired`? Or should `joinDht` itself handle that concurrency?
