### PR TITLE
refactor(DHT): node name default is kademliaId as hex, log cleanup

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -44,7 +44,6 @@ export class ConnectionManagerConfig {
     websocketHost?: string
     websocketPortRange?: PortRange
     entryPoints?: PeerDescriptor[]
-    nodeName?: string
     maxConnections: number = 80
     iceServers?: IceServer[]
     metricsContext?: MetricsContext
@@ -211,7 +210,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         const disconnectionCandidates = new SortedContactList(peerIdFromPeerDescriptor(this.ownPeerDescriptor!), 100000)
         this.connections.forEach((connection) => {
             if (!this.locks.isLocked(connection.peerIdKey) && Date.now() - connection.getLastUsed() > lastUsedLimit) {
-                logger.trace('disconnecting in timeout interval: ' + this.config.nodeName + ', '
+                logger.trace('disconnecting in timeout interval: ' + this.ownPeerDescriptor?.nodeName + ', '
                     + connection.getPeerDescriptor()?.nodeName + ' ')
                 disconnectionCandidates.addContact(new Contact(connection.getPeerDescriptor()!))
             }
@@ -219,7 +218,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         const sortedCandidates = disconnectionCandidates.getAllContacts()
         const targetNum = this.connections.size - maxConnections
         for (let i = 0; i < sortedCandidates.length && i < targetNum; i++) {
-            logger.trace(this.config.nodeName + ' garbageCollecting '
+            logger.trace(this.ownPeerDescriptor?.nodeName + ' garbageCollecting '
                 + sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor().nodeName)
             this.gracefullyDisconnectAsync(sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor(),
                 DisconnectMode.NORMAL).catch((_e) => { })
@@ -404,7 +403,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
             return
         }
         if (this.messageDuplicateDetector.isMostLikelyDuplicate(message.messageId)) {
-            logger.trace('handleMessage filtered duplicate ' + this.config.nodeName + ', '
+            logger.trace('handleMessage filtered duplicate ' + this.ownPeerDescriptor?.nodeName + ', '
                 + message.sourceDescriptor?.nodeName + ' ' + message.serviceId + ' ' + message.messageId)
             return
         }
@@ -412,7 +411,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         if (message.serviceId === this.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else {
-            logger.trace('emit "message" ' + this.config.nodeName + ', ' + message.sourceDescriptor?.nodeName
+            logger.trace('emit "message" ' + this.ownPeerDescriptor?.nodeName + ', ' + message.sourceDescriptor?.nodeName
                 + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)
         }
@@ -427,7 +426,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         let message: Message | undefined
         try {
             message = Message.fromBinary(data)
-            logger.trace(`${this.config.nodeName} received protojson: ${protoToString(message, Message)}`)
+            logger.trace(`${this.ownPeerDescriptor?.nodeName} received protojson: ${protoToString(message, Message)}`)
         } catch (e) {
             logger.debug(`Parsing incoming data into Message failed: ${e}`)
             return
@@ -448,7 +447,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
     }
 
     private onDisconnected = (connection: ManagedConnection, disconnectionType: DisconnectionType) => {
-        logger.trace(' ' + this.config.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
+        logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
             ' onDisconnected() ' + disconnectionType)
 
         const hexKey = keyFromPeerDescriptor(connection.getPeerDescriptor()!)
@@ -456,15 +455,15 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         if (storedConnection && storedConnection.connectionId.equals(connection.connectionId)) {
             this.locks.clearAllLocks(hexKey)
             this.connections.delete(hexKey)
-            logger.trace(' ' + this.config.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
+            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
                 ' deleted connection in onDisconnected() ' + disconnectionType)
             this.emit('disconnected', connection.getPeerDescriptor()!, disconnectionType)
             this.onConnectionCountChange()
         } else {
-            logger.trace(' ' + this.config.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
+            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
                 ' onDisconnected() did nothing, no such connection in connectionManager')
             if (storedConnection) {
-                logger.trace(this.config.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
+                logger.trace(this.ownPeerDescriptor?.nodeName + ', ' + connection.getPeerDescriptor()?.nodeName +
                     ' connectionIds do not match ' + storedConnection.connectionId + ' ' + connection.connectionId)
             }
         }
@@ -496,16 +495,16 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
     }
 
     private acceptIncomingConnection(newConnection: ManagedConnection): boolean {
-        logger.trace(' ' + this.config.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName + ' acceptIncomingConnection()')
+        logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName + ' acceptIncomingConnection()')
         const newPeerID = peerIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
         const hexKey = keyFromPeerDescriptor(newConnection.getPeerDescriptor()!)
         if (this.connections.has(hexKey)) {
             if (newPeerID.hasSmallerHashThan(peerIdFromPeerDescriptor(this.ownPeerDescriptor!))) {
-                logger.trace(' ' + this.config.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName +
+                logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName +
                     ' acceptIncomingConnection() replace current connection')
                 // replace the current connection
                 const oldConnection = this.connections.get(newPeerID.toKey())!
-                logger.trace('replaced: ' + this.config.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName + ' ')
+                logger.trace('replaced: ' + this.ownPeerDescriptor?.nodeName + ', ' + newConnection.getPeerDescriptor()?.nodeName + ' ')
                 const buffer = oldConnection.stealOutputBuffer()
                 
                 for (const data of buffer) {
@@ -528,20 +527,12 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
     }
 
     private async closeConnection(peerDescriptor: PeerDescriptor, disconnectionType: DisconnectionType, reason?: string): Promise<void> {
-        logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' + 'closeConnection()')
+        logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' + 'closeConnection() ' + reason)
         const id = keyFromPeerDescriptor(peerDescriptor)
         this.locks.clearAllLocks(id)
         if (this.connections.has(id)) {
-            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' +
-                'closeConnection() this.connections had the id')
-            logger.trace(`Closeconnection called to Peer ${id}${reason ? `: ${reason}` : ''}`)
             const connectionToClose = this.connections.get(id)!
-            logger.trace('disconnecting: ' + this.config.nodeName + ', ' + connectionToClose.getPeerDescriptor()?.nodeName)
-            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' +
-                'closeConnection() calling connection.close()')
             await connectionToClose.close(disconnectionType)
-            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' +
-                'closeConnection() connection.close() called')
 
         } else {
             logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + peerDescriptor.nodeName + ' ' +
@@ -646,7 +637,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         try {
             await remoteConnectionLocker.gracefulDisconnect(disconnectMode)
         } catch (ex) {
-            logger.debug(' ' + this.ownPeerDescriptor?.nodeName + ', ' + targetDescriptor.nodeName +
+            logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + targetDescriptor.nodeName +
                 ' remoteConnectionLocker.gracefulDisconnect() failed' + ex)
         }
     }
@@ -682,7 +673,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
 
     // IConnectionLocker server implementation
     private async gracefulDisconnect(disconnectNotice: DisconnectNotice, _context: ServerCallContext): Promise<Empty> {
-        logger.trace(' ' + this.config.nodeName + ', ' + disconnectNotice.peerDescriptor?.nodeName
+        logger.trace(' ' + this.ownPeerDescriptor?.nodeName + ', ' + disconnectNotice.peerDescriptor?.nodeName
             + ' received gracefulDisconnect notice')
 
         if (disconnectNotice.disconnecMode === DisconnectMode.LEAVING) {

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -81,10 +81,7 @@ export class ManagedConnection extends EventEmitter<Events> {
             this.handshaker = new Handshaker(this.ownPeerDescriptor, this.protocolVersion, outgoingConnection)
 
             this.handshaker.once('handshakeFailed', (errorMessage) => {
-                logger.trace('IL handshake failed for outgoing connection ' + errorMessage + ' ' +
-                    this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName + ' objectid: ' + this.objectId
-                    + ' outputBuffer.length: ' + this.outputBuffer.length)
-                logger.trace(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName + ' emitting handshakeFailed')
+                logger.trace(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName + ' handshakeFailed: ' + errorMessage)
                 this.emit('handshakeFailed')
             })
 
@@ -272,9 +269,8 @@ export class ManagedConnection extends EventEmitter<Events> {
                         result2 = await raceEvents3<Events>(this,
                             ['bufferSentByOtherConnection', 'closing', 'disconnected'], 15000)
                     } catch (ex) {
-                        logger.debug(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName +
+                        logger.trace(' ' + this.ownPeerDescriptor.nodeName + ', ' + this.peerDescriptor?.nodeName +
                             ' Exception from raceEvents3 while waiting bufferSentByOtherConnection or closing ' + ex)
-                        logger.trace(this.connectionId + ' Exception from raceEvents3 while waiting bufferSentByOtherConnection')
                         throw ex
                     }
                     if (result2.winnerName === 'bufferSentByOtherConnection') {

--- a/packages/dht/src/connection/Simulator/SimulatorTransport.ts
+++ b/packages/dht/src/connection/Simulator/SimulatorTransport.ts
@@ -4,6 +4,6 @@ import { Simulator } from './Simulator'
 
 export class SimulatorTransport extends ConnectionManager {
     constructor(ownPeerDescriptor: PeerDescriptor, simulator: Simulator) {
-        super({ ownPeerDescriptor: ownPeerDescriptor, simulator, serviceIdPrefix: 'simulator/', nodeName: ownPeerDescriptor.nodeName })
+        super({ ownPeerDescriptor: ownPeerDescriptor, simulator, serviceIdPrefix: 'simulator/' })
     }
 }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -25,7 +25,8 @@ import { DhtRpcServiceClient, ExternalApiServiceClient } from '../proto/packages
 import {
     Logger,
     MetricsContext,
-    hexToBinary
+    hexToBinary,
+    binaryToHex
 } from '@streamr/utils'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
 import { RandomContactList } from './contact/RandomContactList'
@@ -141,7 +142,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     } else {
         kademliaId = hexToBinary(peerId!)
     }
-    const ret: PeerDescriptor = { kademliaId, nodeName: nodeName, type: NodeType.NODEJS }
+    const ret: PeerDescriptor = { kademliaId, nodeName: nodeName ? nodeName : binaryToHex(kademliaId), type: NodeType.NODEJS }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
         ret.openInternet = true
@@ -212,7 +213,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 webrtcDatachannelBufferThresholdHigh: this.config.webrtcDatachannelBufferThresholdHigh,
                 webrtcNewConnectionTimeout: this.config.webrtcNewConnectionTimeout,
                 webrtcPortRange: this.config.webrtcPortRange,
-                nodeName: this.getNodeName(),
                 maxConnections: this.config.maxConnections,
                 tlsCertificate: this.config.tlsCertificate,
                 externalIp: this.config.externalIp
@@ -705,14 +705,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     public getNumberOfWeakLockedConnections(): number {
         return this.connectionManager!.getNumberOfWeakLockedConnections()
-    }
-
-    public getNodeName(): string {
-        if (this.config.nodeName) {
-            return this.config.nodeName
-        } else {
-            return 'unnamed node'
-        }
     }
 
     public isJoinOngoing(): boolean {

--- a/packages/dht/src/dht/DhtPeer.ts
+++ b/packages/dht/src/dht/DhtPeer.ts
@@ -69,7 +69,7 @@ export class DhtPeer extends Remote<IDhtRpcServiceClient> implements KBucketCont
                 return true
             }
         } catch (err) {
-            logger.debug(`ping failed on ${this.serviceId} to ${this.peerId.toKey()}: ${err}`)
+            logger.trace(`ping failed on ${this.serviceId} to ${this.peerId.toKey()}: ${err}`)
         }
         return false
     }

--- a/packages/dht/src/dht/routing/RemoteRouter.ts
+++ b/packages/dht/src/dht/routing/RemoteRouter.ts
@@ -30,9 +30,7 @@ export class RemoteRouter extends Remote<IRoutingServiceClient> {
             timeout: 10000
         }
         try {
-            logger.trace('calling dhtClient.routeMessage')
             const ack = await this.client.routeMessage(message, options)
-            logger.trace('dhtClient.routeMessage returned')
             // Success signal if sent to destination and error includes duplicate
             if (
                 isSamePeerDescriptor(params.destinationPeer!, this.peerDescriptor)
@@ -45,7 +43,7 @@ export class RemoteRouter extends Remote<IRoutingServiceClient> {
         } catch (err) {
             const fromNode = params.previousPeer ?
                 peerIdFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
-            logger.debug(`Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`)
+            logger.trace(`Failed to send routeMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`)
             return false
         }
         return true
@@ -75,7 +73,7 @@ export class RemoteRouter extends Remote<IRoutingServiceClient> {
             const fromNode = params.previousPeer ?
                 keyFromPeerDescriptor(params.previousPeer) : keyFromPeerDescriptor(params.sourcePeer!)
 
-            logger.debug(
+            logger.trace(
                 `Failed to send forwardMessage from ${fromNode} to ${this.peerId.toKey()} with: ${err}`
             )
             return false

--- a/packages/dht/src/dht/store/DataStore.ts
+++ b/packages/dht/src/dht/store/DataStore.ts
@@ -136,10 +136,10 @@ export class DataStore implements IStoreService {
         try {
             const response = await remoteStore.migrateData({ dataEntry }, doNotConnect)
             if (response.error) {
-                logger.debug('RemoteStore::migrateData() returned error: ' + response.error)
+                logger.trace('RemoteStore::migrateData() returned error: ' + response.error)
             }
         } catch (e) {
-            logger.debug('RemoteStore::migrateData() threw an exception ' + e)
+            logger.trace('RemoteStore::migrateData() threw an exception ' + e)
         }
     }
 
@@ -177,10 +177,10 @@ export class DataStore implements IStoreService {
                     successfulNodes.push(closestNodes[i])
                     logger.trace('remoteStore.storeData() returned success')
                 } else {
-                    logger.debug('remoteStore.storeData() returned error: ' + response.error)
+                    logger.trace('remoteStore.storeData() returned error: ' + response.error)
                 }
             } catch (e) {
-                logger.debug('remoteStore.storeData() threw an exception ' + e)
+                logger.trace('remoteStore.storeData() threw an exception ' + e)
             }
         }
         return successfulNodes
@@ -217,11 +217,11 @@ export class DataStore implements IStoreService {
                 if (response.deleted) {
                     logger.trace('remoteStore.deleteData() returned success')
                 } else {
-                    logger.debug('could not delete data from ' + PeerID.fromValue(closestNodes[i].kademliaId))
+                    logger.trace('could not delete data from ' + PeerID.fromValue(closestNodes[i].kademliaId))
                 }
                 successfulNodes.push(closestNodes[i])
             } catch (e) {
-                logger.debug('remoteStore.deleteData() threw an exception ' + e)
+                logger.trace('remoteStore.deleteData() threw an exception ' + e)
             }
         }
     }

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -86,7 +86,7 @@ describe('Kademlia correctness', () => {
                     correctNeighbors++
                 }
             } catch (e) {
-                console.error('Node ' + nodes[i].getNodeName() + ' had only ' + kademliaNeighbors.length + ' kademlia neighbors')
+                console.error('Node ' + nodes[i].getPeerDescriptor().nodeName + ' had only ' + kademliaNeighbors.length + ' kademlia neighbors')
             }
             if (correctNeighbors === 0) {
                 console.log('No correct neighbors found for node ' + i)

--- a/packages/dht/test/benchmark/RecursiveFind.test.ts
+++ b/packages/dht/test/benchmark/RecursiveFind.test.ts
@@ -70,7 +70,7 @@ describe('Recursive find correctness', () => {
         debugVars['waiting'] = false
         logger.info('waiting over')
 
-        nodes.forEach((node) => logger.info(node.getNodeName() + ': connections:' +
+        nodes.forEach((node) => logger.info(node.getPeerDescriptor().nodeName + ': connections:' +
             node.getNumberOfConnections() + ', kbucket: ' + node.getBucketSize()
             + ', localLocked: ' + node.getNumberOfLocalLockedConnections()
             + ', remoteLocked: ' + node.getNumberOfRemoteLockedConnections()

--- a/packages/dht/test/integration/MigrateData.test.ts
+++ b/packages/dht/test/integration/MigrateData.test.ts
@@ -114,13 +114,13 @@ describe('Migrating data from node to node in DHT', () => {
                 hasDataMarker = '<-'
             }
 
-            logger.info(contact.getPeerDescriptor().nodeName + ' ' + node.getNodeName() + hasDataMarker)
+            logger.info(contact.getPeerDescriptor().nodeName + ' ' + node.getPeerDescriptor().nodeName + hasDataMarker)
         })
 
         logger.info(NUM_NODES + ' nodes joining layer0 DHT')
         await Promise.all(
             nodes.map((node) => {
-                if (node.getNodeName() != '0') {
+                if (node.getPeerDescriptor().nodeName != '0') {
                     node.joinDht([entrypointDescriptor])
                 }
             })
@@ -142,7 +142,7 @@ describe('Migrating data from node to node in DHT', () => {
                 hasDataMarker = '<-'
             }
 
-            logger.info('' + node.getNodeName() + hasDataMarker)
+            logger.info('' + node.getPeerDescriptor().nodeName + hasDataMarker)
         })
 
         const closestNode = nodesById.get(PeerID.fromValue(closest[0].getPeerDescriptor().kademliaId).toKey())!

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -55,7 +55,7 @@ describe('Scaling down a Dht network', () => {
             const nodeIsCleaned = nodes.every((node) =>
                 node.getAllConnectionPeerDescriptors().every((peer) => {
                     if (isSamePeerDescriptor(peer, stoppingPeerDescriptor)) {
-                        logger.error(' ' + node.getNodeName() + ', ' + stoppingPeerDescriptor.nodeName + ' cleaning up failed')
+                        logger.error(' ' + node.getPeerDescriptor().nodeName + ', ' + stoppingPeerDescriptor.nodeName + ' cleaning up failed')
                     }
                     return !isSamePeerDescriptor(peer, stoppingPeerDescriptor)
                 })

--- a/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
@@ -35,10 +35,10 @@ describe('WebRTC Connection Management', () => {
         simulator = new Simulator(LatencyType.FIXED, 500)
 
         connectorTransport1 = new SimulatorTransport(peerDescriptor1, simulator)
-        manager1 = new ConnectionManager({ transportLayer: connectorTransport1, nodeName: peerDescriptor1.nodeName })
+        manager1 = new ConnectionManager({ transportLayer: connectorTransport1 })
 
         connectorTransport2 = new SimulatorTransport(peerDescriptor2, simulator)
-        manager2 = new ConnectionManager({ transportLayer: connectorTransport2, nodeName: peerDescriptor2.nodeName })
+        manager2 = new ConnectionManager({ transportLayer: connectorTransport2 })
 
         await manager1.start((_msg) => peerDescriptor1)
         await manager2.start((_msg) => peerDescriptor2)

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -66,8 +66,7 @@ export const createMockConnectionDhtNode = async (stringId: string,
 
     const mockConnectionManager = new ConnectionManager({
         ownPeerDescriptor: peerDescriptor,
-        simulator: simulator,
-        nodeName: nodeName ? nodeName : stringId
+        simulator: simulator
     })
 
     const node = new DhtNode({

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -37,14 +37,12 @@ describe('RandomGraphNode-DhtNode', () => {
         const simulator = new Simulator()
         const entrypointCm = new ConnectionManager({
             ownPeerDescriptor: entrypointDescriptor,
-            nodeName: entrypointDescriptor.nodeName,
             simulator
         })
 
         const cms: ConnectionManager[] = range(numOfNodes).map((i) =>
             new ConnectionManager({
                 ownPeerDescriptor: peerDescriptors[i],
-                nodeName: peerDescriptors[i].nodeName,
                 simulator
             })
         )


### PR DESCRIPTION
## Summary

The node name in peerDescriptor is now kademliaId as hex by default.
reduced log levels for failing rpc requests, removed trace unnecessary log lines
