### PR TITLE
refactor(trackerless-network): Remove redundant fields from `RemoteProxyServer` RPCs

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -131,10 +131,6 @@ message ProxyConnectionRequest {
 }
 
 message ProxyConnectionResponse {
-  bytes senderId = 1; // TODO: remove redundant info NET-1028
-  string streamId = 2;
-  uint32 streamPartition = 3;
-  ProxyDirection direction = 4;  
   bool accepted = 5;
 }
 

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -126,8 +126,6 @@ message NeighborUpdate {
 }
 
 message ProxyConnectionRequest {
-  string streamId = 2;
-  uint32 streamPartition = 3; 
   ProxyDirection direction = 4;
   bytes userId = 5;
 }

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -126,13 +126,10 @@ message NeighborUpdate {
 }
 
 message ProxyConnectionRequest {
-  bytes senderId = 1; // TODO: remove redundant info NET-1028
   string streamId = 2;
   uint32 streamPartition = 3; 
   ProxyDirection direction = 4;
   bytes userId = 5;
-  // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-  dht.PeerDescriptor senderDescriptor = 6;
 }
 
 message ProxyConnectionResponse {

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -78,7 +78,8 @@ export class ProxyStreamConnectionServer extends EventEmitter<Events> implements
     // IProxyConnectionRpc server method
     async requestConnection(request: ProxyConnectionRequest, context: ServerCallContext): Promise<ProxyConnectionResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).sourceDescriptor!
-        this.connections.set(getNodeIdFromPeerDescriptor(senderPeerDescriptor), {
+        const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        this.connections.set(senderId, {
             direction: request.direction,
             userId: toEthereumAddress(binaryToHex(request.userId, true)),
             remote: new RemoteRandomGraphNode(
@@ -90,8 +91,8 @@ export class ProxyStreamConnectionServer extends EventEmitter<Events> implements
         const response: ProxyConnectionResponse = {
             accepted: true
         }
-        logger.trace(`Accepted connection request from ${request.senderId} to ${request.streamId}/${request.streamPartition}`)
-        this.emit('newConnection', binaryToHex(request.senderId) as NodeID)
+        logger.trace(`Accepted connection request from ${senderId} to ${this.config.streamPartId}`)
+        this.emit('newConnection', senderId)
         return response
     }
 }

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -77,7 +77,7 @@ export class ProxyStreamConnectionServer extends EventEmitter<Events> implements
 
     // IProxyConnectionRpc server method
     async requestConnection(request: ProxyConnectionRequest, context: ServerCallContext): Promise<ProxyConnectionResponse> {
-        const senderPeerDescriptor = (context as DhtCallContext).sourceDescriptor!
+        const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
         this.connections.set(senderId, {
             direction: request.direction,

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -88,11 +88,7 @@ export class ProxyStreamConnectionServer extends EventEmitter<Events> implements
             )
         })
         const response: ProxyConnectionResponse = {
-            accepted: true,
-            streamId: request.streamId,
-            streamPartition: request.streamPartition,
-            direction: request.direction,
-            senderId: request.senderId
+            accepted: true
         }
         logger.trace(`Accepted connection request from ${request.senderId} to ${request.streamId}/${request.streamPartition}`)
         this.emit('newConnection', binaryToHex(request.senderId) as NodeID)

--- a/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
@@ -1,11 +1,9 @@
 import { DhtRpcOptions } from '@streamr/dht'
+import { EthereumAddress, Logger, hexToBinary } from '@streamr/utils'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
+import { ProxyConnectionRequest, ProxyDirection } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { IProxyConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Remote } from '../Remote'
-import { StreamPartIDUtils, toStreamID } from '@streamr/protocol'
-import { ProxyDirection, ProxyConnectionRequest } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { EthereumAddress, Logger, hexToBinary } from '@streamr/utils'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
 
 const logger = new Logger(module)
 

--- a/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
@@ -12,15 +12,12 @@ const logger = new Logger(module)
 export class RemoteProxyServer extends Remote<IProxyConnectionRpcClient> {
 
     async requestConnection(ownPeerDescriptor: PeerDescriptor, direction: ProxyDirection, userId: EthereumAddress): Promise<boolean> {
-        const streamPartId = StreamPartIDUtils.parse(this.graphId)
         const options: DhtRpcOptions = {
             sourceDescriptor: ownPeerDescriptor,
             targetDescriptor: this.remotePeerDescriptor,
             timeout: 5000
         }
         const request: ProxyConnectionRequest = {
-            streamId: toStreamID(streamPartId),
-            streamPartition: StreamPartIDUtils.getStreamPartition(streamPartId),
             direction,
             userId: hexToBinary(userId)
         }

--- a/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
@@ -19,8 +19,6 @@ export class RemoteProxyServer extends Remote<IProxyConnectionRpcClient> {
             timeout: 5000
         }
         const request: ProxyConnectionRequest = {
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor)),
-            senderDescriptor: ownPeerDescriptor,
             streamId: toStreamID(streamPartId),
             streamPartition: StreamPartIDUtils.getStreamPartition(streamPartId),
             direction,

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -321,6 +321,10 @@ export interface ConnectivityRequest {
      * @generated from protobuf field: bool tls = 2;
      */
     tls: boolean;
+    /**
+     * @generated from protobuf field: optional string host = 3;
+     */
+    host?: string;
 }
 /**
  * @generated from protobuf message dht.ConnectivityResponse
@@ -1029,7 +1033,8 @@ class ConnectivityRequest$Type extends MessageType$<ConnectivityRequest> {
     constructor() {
         super("dht.ConnectivityRequest", [
             { no: 1, name: "port", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 2, name: "tls", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 2, name: "tls", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "host", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -72,6 +72,8 @@ export interface StreamMessage {
      */
     signature: Uint8Array;
     /**
+     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
+     *
      * @generated from protobuf field: MessageID messageId = 6;
      */
     messageId?: MessageID;
@@ -164,6 +166,8 @@ export interface StreamHandshakeRequest {
      */
     neighborIds: Uint8Array[];
     /**
+     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
+     *
      * @generated from protobuf field: dht.PeerDescriptor senderDescriptor = 6;
      */
     senderDescriptor?: PeerDescriptor;
@@ -202,6 +206,8 @@ export interface InterleaveNotice {
      */
     randomGraphId: string;
     /**
+     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
+     *
      * @generated from protobuf field: dht.PeerDescriptor interleaveTargetDescriptor = 3;
      */
     interleaveTargetDescriptor?: PeerDescriptor;
@@ -245,10 +251,6 @@ export interface NeighborUpdate {
  */
 export interface ProxyConnectionRequest {
     /**
-     * @generated from protobuf field: bytes senderId = 1;
-     */
-    senderId: Uint8Array; // TODO: remove redundant info NET-1028
-    /**
      * @generated from protobuf field: string streamId = 2;
      */
     streamId: string;
@@ -264,10 +266,6 @@ export interface ProxyConnectionRequest {
      * @generated from protobuf field: bytes userId = 5;
      */
     userId: Uint8Array;
-    /**
-     * @generated from protobuf field: dht.PeerDescriptor senderDescriptor = 6;
-     */
-    senderDescriptor?: PeerDescriptor;
 }
 /**
  * @generated from protobuf message ProxyConnectionResponse
@@ -538,12 +536,10 @@ export const NeighborUpdate = new NeighborUpdate$Type();
 class ProxyConnectionRequest$Type extends MessageType<ProxyConnectionRequest> {
     constructor() {
         super("ProxyConnectionRequest", [
-            { no: 1, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "streamId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "streamPartition", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 4, name: "direction", kind: "enum", T: () => ["ProxyDirection", ProxyDirection] },
-            { no: 5, name: "userId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 6, name: "senderDescriptor", kind: "message", T: () => PeerDescriptor }
+            { no: 5, name: "userId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -264,22 +264,6 @@ export interface ProxyConnectionRequest {
  */
 export interface ProxyConnectionResponse {
     /**
-     * @generated from protobuf field: bytes senderId = 1;
-     */
-    senderId: Uint8Array; // TODO: remove redundant info NET-1028
-    /**
-     * @generated from protobuf field: string streamId = 2;
-     */
-    streamId: string;
-    /**
-     * @generated from protobuf field: uint32 streamPartition = 3;
-     */
-    streamPartition: number;
-    /**
-     * @generated from protobuf field: ProxyDirection direction = 4;
-     */
-    direction: ProxyDirection;
-    /**
      * @generated from protobuf field: bool accepted = 5;
      */
     accepted: boolean;
@@ -541,10 +525,6 @@ export const ProxyConnectionRequest = new ProxyConnectionRequest$Type();
 class ProxyConnectionResponse$Type extends MessageType<ProxyConnectionResponse> {
     constructor() {
         super("ProxyConnectionResponse", [
-            { no: 1, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "streamId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "streamPartition", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 4, name: "direction", kind: "enum", T: () => ["ProxyDirection", ProxyDirection] },
             { no: 5, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -251,14 +251,6 @@ export interface NeighborUpdate {
  */
 export interface ProxyConnectionRequest {
     /**
-     * @generated from protobuf field: string streamId = 2;
-     */
-    streamId: string;
-    /**
-     * @generated from protobuf field: uint32 streamPartition = 3;
-     */
-    streamPartition: number;
-    /**
      * @generated from protobuf field: ProxyDirection direction = 4;
      */
     direction: ProxyDirection;
@@ -536,8 +528,6 @@ export const NeighborUpdate = new NeighborUpdate$Type();
 class ProxyConnectionRequest$Type extends MessageType<ProxyConnectionRequest> {
     constructor() {
         super("ProxyConnectionRequest", [
-            { no: 2, name: "streamId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "streamPartition", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
             { no: 4, name: "direction", kind: "enum", T: () => ["ProxyDirection", ProxyDirection] },
             { no: 5, name: "userId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);

--- a/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
+++ b/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
@@ -4,7 +4,6 @@ import { hexToBinary } from '@streamr/utils'
 import { RemoteProxyServer } from '../../src/logic/proxy/RemoteProxyServer'
 import { ProxyDirection } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 
 describe('RemoteProxyServer', () => {
 

--- a/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
+++ b/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
@@ -15,17 +15,13 @@ describe('RemoteProxyServer', () => {
         const serverPeerDescriptor = createMockPeerDescriptor()
         const server = new RemoteProxyServer(
             serverPeerDescriptor,
-            StreamPartIDUtils.parse('stream-id#5'), 
+            StreamPartIDUtils.parse('stream#0'),
             client
         )
         const clientPeerDescriptor = createMockPeerDescriptor()
         const userId = randomEthereumAddress()
         server.requestConnection(clientPeerDescriptor, ProxyDirection.PUBLISH, userId)
         expect(client.requestConnection).toBeCalledWith({
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(clientPeerDescriptor)),
-            senderDescriptor: clientPeerDescriptor,
-            streamId: 'stream-id',
-            streamPartition: 5,
             direction: ProxyDirection.PUBLISH,
             userId: hexToBinary(userId)
         }, {

--- a/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
+++ b/packages/trackerless-network/test/unit/RemoteProxyServer.test.ts
@@ -1,0 +1,37 @@
+import { StreamPartIDUtils } from '@streamr/protocol'
+import { randomEthereumAddress } from '@streamr/test-utils'
+import { hexToBinary } from '@streamr/utils'
+import { RemoteProxyServer } from '../../src/logic/proxy/RemoteProxyServer'
+import { ProxyDirection } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
+import { createMockPeerDescriptor } from '../utils/utils'
+import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+
+describe('RemoteProxyServer', () => {
+
+    it('happy path', () => {
+        const client = {
+            requestConnection: jest.fn()
+        }
+        const serverPeerDescriptor = createMockPeerDescriptor()
+        const server = new RemoteProxyServer(
+            serverPeerDescriptor,
+            StreamPartIDUtils.parse('stream-id#5'), 
+            client
+        )
+        const clientPeerDescriptor = createMockPeerDescriptor()
+        const userId = randomEthereumAddress()
+        server.requestConnection(clientPeerDescriptor, ProxyDirection.PUBLISH, userId)
+        expect(client.requestConnection).toBeCalledWith({
+            senderId: hexToBinary(getNodeIdFromPeerDescriptor(clientPeerDescriptor)),
+            senderDescriptor: clientPeerDescriptor,
+            streamId: 'stream-id',
+            streamPartition: 5,
+            direction: ProxyDirection.PUBLISH,
+            userId: hexToBinary(userId)
+        }, {
+            sourceDescriptor: clientPeerDescriptor,
+            targetDescriptor: serverPeerDescriptor,
+            timeout: 5000
+        })
+    })
+})

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -76,20 +76,20 @@ export const createRandomNodeId = (): NodeID => {
     return randomBytes(10).toString('hex') as NodeID
 }
 
-export const createMockRemoteNode = (peerDescriptor?: PeerDescriptor): RemoteRandomGraphNode => {
-    const mockPeerDescriptor: PeerDescriptor = {
+// TODO use this in tests
+export const createMockPeerDescriptor = (): PeerDescriptor => {
+    return {
         kademliaId: hexToBinary(createRandomNodeId()),
         type: NodeType.NODEJS
     }
-    return new RemoteRandomGraphNode(peerDescriptor || mockPeerDescriptor, 'mock', {} as any)
+}
+
+export const createMockRemoteNode = (peerDescriptor?: PeerDescriptor): RemoteRandomGraphNode => {
+    return new RemoteRandomGraphNode(peerDescriptor || createMockPeerDescriptor(), 'mock', {} as any)
 }
 
 export const createMockRemoteHandshaker = (): RemoteHandshaker => {
-    const mockPeerDescriptor: PeerDescriptor = {
-        kademliaId: hexToBinary(createRandomNodeId()),
-        type: NodeType.NODEJS
-    }
-    return new RemoteHandshaker(mockPeerDescriptor, 'mock', {
+    return new RemoteHandshaker(createMockPeerDescriptor(), 'mock', {
         handshake: async () => {},
         interleaveNotice: async () => {}
     } as any)


### PR DESCRIPTION
- `streamId` ja `streamPartition` are redundant fields, as the receiving `ProxyStreamConnectionServer` already knows which `streamPartId` it operates on (as there is a separate server for each stream part)
- `senderId` and `senderDescriptor` are redundant, because the info can be read from the call context

Also added unit test.
