### PR TITLE
refactor(trackerless-network): [NET-1027] Remove redundant `senderId` from protobuf messages

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -134,7 +134,6 @@ message ProxyConnectionResponse {
 }
 
 message TemporaryConnectionRequest {
-  bytes senderId = 1; // TODO is it possible to remove this field? (NET-1028)
 }
 
 message TemporaryConnectionResponse {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -104,10 +104,9 @@ message StreamHandshakeResponse {
 }
 
 message InterleaveNotice {
-  bytes senderId = 1; // TODO is it possible to remove this field? (NET-1028)
-  string randomGraphId = 2;
+  string randomGraphId = 1;
   // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-  dht.PeerDescriptor interleaveTargetDescriptor = 3;
+  dht.PeerDescriptor interleaveTargetDescriptor = 2;
 }
 
 message LeaveStreamNotice {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -91,7 +91,7 @@ message GroupKey {
 
 message StreamHandshakeRequest {
   string randomGraphId = 1;
-  bytes senderId = 2;
+  bytes senderId = 2; // TODO is it possible to remove this field? (NET-1028)
   string requestId = 3;
   optional bytes concurrentHandshakeTargetId = 4;
   repeated bytes neighborIds = 5;
@@ -107,7 +107,7 @@ message StreamHandshakeResponse {
 }
 
 message InterleaveNotice {
-  bytes senderId = 1;
+  bytes senderId = 1; // TODO is it possible to remove this field? (NET-1028)
   string randomGraphId = 2;
   // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
   dht.PeerDescriptor interleaveTargetDescriptor = 3;
@@ -115,7 +115,7 @@ message InterleaveNotice {
 
 message LeaveStreamNotice {
   string randomGraphId = 1;
-  bytes senderId = 2;
+  bytes senderId = 2; // TODO is it possible to remove this field? (NET-1028)
 }
 
 message NeighborUpdate {
@@ -135,7 +135,7 @@ message ProxyConnectionResponse {
 }
 
 message TemporaryConnectionRequest {
-  bytes senderId = 1;
+  bytes senderId = 1; // TODO is it possible to remove this field? (NET-1028)
 }
 
 message TemporaryConnectionResponse {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -91,13 +91,10 @@ message GroupKey {
 
 message StreamHandshakeRequest {
   string randomGraphId = 1;
-  bytes senderId = 2; // TODO is it possible to remove this field? (NET-1028)
-  string requestId = 3;
-  optional bytes concurrentHandshakeTargetId = 4;
-  repeated bytes neighborIds = 5;
-  // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-  dht.PeerDescriptor senderDescriptor = 6;
-  optional bytes interleaveSourceId = 7;
+  string requestId = 2;
+  optional bytes concurrentHandshakeTargetId = 3;
+  repeated bytes neighborIds = 4;
+  optional bytes interleaveSourceId = 5;
 }
 
 message StreamHandshakeResponse {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -111,7 +111,6 @@ message InterleaveNotice {
 
 message LeaveStreamNotice {
   string randomGraphId = 1;
-  bytes senderId = 2; // TODO is it possible to remove this field? (NET-1028)
 }
 
 message NeighborUpdate {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -126,12 +126,12 @@ message NeighborUpdate {
 }
 
 message ProxyConnectionRequest {
-  ProxyDirection direction = 4;
-  bytes userId = 5;
+  ProxyDirection direction = 1;
+  bytes userId = 2;
 }
 
 message ProxyConnectionResponse {
-  bool accepted = 5;
+  bool accepted = 1;
 }
 
 message TemporaryConnectionRequest {

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -119,10 +119,9 @@ message LeaveStreamNotice {
 }
 
 message NeighborUpdate {
-  bytes senderId = 1; // TODO: remove redundant info NET-1028
-  string randomGraphId = 2;
-  bool removeMe = 3;
-  repeated dht.PeerDescriptor neighborDescriptors = 4;
+  string randomGraphId = 1;
+  bool removeMe = 2;
+  repeated dht.PeerDescriptor neighborDescriptors = 3;
 }
 
 message ProxyConnectionRequest {

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -87,8 +87,7 @@ export class RandomGraphNode extends EventEmitter<Events> implements IStreamNode
             rpcCommunicator: this.config.rpcCommunicator,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: NodeID) => this.broadcast(message, previousNode),
-            onLeaveNotice: (notice: LeaveStreamNotice) => {
-                const senderId = binaryToHex(notice.senderId) as NodeID
+            onLeaveNotice: (senderId: NodeID) => {
                 const contact = this.config.nearbyNodeView.getNeighborById(senderId)
                 || this.config.randomNodeView.getNeighborById(senderId)
                 || this.config.targetNeighbors.getNeighborById(senderId)

--- a/packages/trackerless-network/src/logic/RemoteRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RemoteRandomGraphNode.ts
@@ -1,12 +1,11 @@
-import { INetworkRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
-import { PeerDescriptor, DhtRpcOptions } from '@streamr/dht'
+import { DhtRpcOptions, PeerDescriptor } from '@streamr/dht'
+import { Logger } from '@streamr/utils'
 import {
-    StreamMessage,
-    LeaveStreamNotice
+    LeaveStreamNotice,
+    StreamMessage
 } from '../proto/packages/trackerless-network/protos/NetworkRpc'
-import { Logger, hexToBinary } from '@streamr/utils'
+import { INetworkRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Remote } from './Remote'
-import { getNodeIdFromPeerDescriptor } from '../identifiers'
 
 const logger = new Logger(module)
 
@@ -30,7 +29,6 @@ export class RemoteRandomGraphNode extends Remote<INetworkRpcClient> {
             notification: true
         }
         const notification: LeaveStreamNotice = {
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor)),
             randomGraphId: this.graphId
         }
         this.client.leaveStreamNotice(notification, options).catch(() => {

--- a/packages/trackerless-network/src/logic/StreamNodeServer.ts
+++ b/packages/trackerless-network/src/logic/StreamNodeServer.ts
@@ -15,7 +15,7 @@ export interface StreamNodeServerConfig {
     randomGraphId: string
     markAndCheckDuplicate: (messageId: MessageID, previousMessageRef?: MessageRef) => boolean
     broadcast: (message: StreamMessage, previousNode?: NodeID) => void
-    onLeaveNotice(notice: LeaveStreamNotice): void
+    onLeaveNotice(senderId: NodeID): void
     markForInspection(senderId: NodeID, messageId: MessageID): void
     rpcCommunicator: ListeningRpcCommunicator
 }
@@ -37,9 +37,11 @@ export class StreamNodeServer implements INetworkRpc {
         return Empty
     }
 
-    async leaveStreamNotice(message: LeaveStreamNotice, _context: ServerCallContext): Promise<Empty> {
+    async leaveStreamNotice(message: LeaveStreamNotice, context: ServerCallContext): Promise<Empty> {
         if (message.randomGraphId === this.config.randomGraphId) {
-            this.config.onLeaveNotice(message)
+            const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
+            const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+            this.config.onLeaveNotice(senderId)
         }
         return Empty
     }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakerServer.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakerServer.ts
@@ -2,7 +2,7 @@ import { Empty } from '../../proto/google/protobuf/empty'
 import { InterleaveNotice, StreamHandshakeRequest, StreamHandshakeResponse } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { NodeList } from '../NodeList'
-import { ConnectionLocker, PeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, DhtCallContext, PeerDescriptor } from '@streamr/dht'
 import { IHandshakeRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { RemoteHandshaker } from './RemoteHandshaker'
 import { RemoteRandomGraphNode } from '../RemoteRandomGraphNode'
@@ -29,20 +29,21 @@ export class HandshakerServer implements IHandshakeRpc {
         this.config = config
     }
 
-    async handshake(request: StreamHandshakeRequest, _context: ServerCallContext): Promise<StreamHandshakeResponse> {
-        return this.handleRequest(request)
+    async handshake(request: StreamHandshakeRequest, context: ServerCallContext): Promise<StreamHandshakeResponse> {
+        return this.handleRequest(request, context)
     }
 
-    private handleRequest(request: StreamHandshakeRequest): StreamHandshakeResponse {
+    private handleRequest(request: StreamHandshakeRequest, context: ServerCallContext): StreamHandshakeResponse {
+        const senderDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const getInterleaveSourceIds = () => (request.interleaveSourceId !== undefined) ? [binaryToHex(request.interleaveSourceId) as NodeID] : []
-        if (this.config.targetNeighbors.hasNode(request.senderDescriptor!)
-            || this.config.ongoingHandshakes.has(getNodeIdFromPeerDescriptor(request.senderDescriptor!))
+        if (this.config.targetNeighbors.hasNode(senderDescriptor)
+            || this.config.ongoingHandshakes.has(getNodeIdFromPeerDescriptor(senderDescriptor))
         ) {
-            return this.acceptHandshake(request, request.senderDescriptor!)
+            return this.acceptHandshake(request, senderDescriptor)
         } else if (this.config.targetNeighbors.size() + this.config.ongoingHandshakes.size < this.config.N) {
-            return this.acceptHandshake(request, request.senderDescriptor!)
+            return this.acceptHandshake(request, senderDescriptor)
         } else if (this.config.targetNeighbors.size(getInterleaveSourceIds()) >= 2) {
-            return this.acceptHandshakeWithInterleaving(request, request.senderDescriptor!)
+            return this.acceptHandshakeWithInterleaving(request, senderDescriptor)
         } else {
             return this.rejectHandshake(request)
         }
@@ -54,7 +55,7 @@ export class HandshakerServer implements IHandshakeRpc {
             accepted: true
         }
         this.config.targetNeighbors.add(this.config.createRemoteNode(requester))
-        this.config.connectionLocker.lockConnection(request.senderDescriptor!, this.config.randomGraphId)
+        this.config.connectionLocker.lockConnection(requester, this.config.randomGraphId)
         return res
     }
 
@@ -69,7 +70,7 @@ export class HandshakerServer implements IHandshakeRpc {
 
     private acceptHandshakeWithInterleaving(request: StreamHandshakeRequest, requester: PeerDescriptor): StreamHandshakeResponse {
         const exclude = request.neighborIds.map((id: Uint8Array) => binaryToHex(id) as NodeID)
-        exclude.push(binaryToHex(request.senderId) as NodeID)
+        exclude.push(getNodeIdFromPeerDescriptor(requester))
         if (request.interleaveSourceId !== undefined) {
             exclude.push(binaryToHex(request.interleaveSourceId) as NodeID)
         }
@@ -77,12 +78,12 @@ export class HandshakerServer implements IHandshakeRpc {
         const furthestPeerDescriptor = furthest ? furthest.getPeerDescriptor() : undefined
         if (furthest) {
             const remote = this.config.createRemoteHandshaker(furthest.getPeerDescriptor())
-            remote.interleaveNotice(this.config.ownPeerDescriptor, request.senderDescriptor!)
+            remote.interleaveNotice(this.config.ownPeerDescriptor, requester)
             this.config.targetNeighbors.remove(furthest.getPeerDescriptor())
             this.config.connectionLocker.unlockConnection(furthestPeerDescriptor!, this.config.randomGraphId)
         }
         this.config.targetNeighbors.add(this.config.createRemoteNode(requester))
-        this.config.connectionLocker.lockConnection(request.senderDescriptor!, this.config.randomGraphId)
+        this.config.connectionLocker.lockConnection(requester, this.config.randomGraphId)
         return {
             requestId: request.requestId,
             accepted: true,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
@@ -23,11 +23,9 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
         const request: StreamHandshakeRequest = {
             randomGraphId: this.graphId,
             requestId: new UUID().toString(),
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor)),
             neighborIds: neighborIds.map((id) => hexToBinary(id)),
             concurrentHandshakeTargetId: (concurrentHandshakeTargetId !== undefined) ? hexToBinary(concurrentHandshakeTargetId) : undefined,
-            interleaveSourceId: (interleaveSourceId !== undefined) ? hexToBinary(interleaveSourceId) : undefined,
-            senderDescriptor: ownPeerDescriptor
+            interleaveSourceId: (interleaveSourceId !== undefined) ? hexToBinary(interleaveSourceId) : undefined
         }
         const options: DhtRpcOptions = {
             sourceDescriptor: ownPeerDescriptor,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/RemoteHandshaker.ts
@@ -53,8 +53,7 @@ export class RemoteHandshaker extends Remote<IHandshakeRpcClient> {
         }
         const notification: InterleaveNotice = {
             randomGraphId: this.graphId,
-            interleaveTargetDescriptor: originatorDescriptor,
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor))
+            interleaveTargetDescriptor: originatorDescriptor
         }
         this.client.interleaveNotice(notification, options).catch(() => {
             logger.debug('Failed to send interleaveNotice')

--- a/packages/trackerless-network/src/logic/neighbor-discovery/RemoteNeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/RemoteNeighborUpdateManager.ts
@@ -1,9 +1,9 @@
 import { DhtRpcOptions, PeerDescriptor } from '@streamr/dht'
-import { Logger, hexToBinary } from '@streamr/utils'
-import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { Remote } from '../Remote'
-import { INeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { Logger } from '@streamr/utils'
 import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
+import { INeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { Remote } from '../Remote'
 
 const logger = new Logger(module)
 
@@ -20,7 +20,6 @@ export class RemoteNeighborUpdateManager extends Remote<INeighborUpdateRpcClient
             targetDescriptor: this.remotePeerDescriptor,
         }
         const request: NeighborUpdate = {
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor)),
             randomGraphId: this.graphId,
             neighborDescriptors: neighbors,
             removeMe: false

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -1,25 +1,25 @@
-import { 
+import {
     ITransport,
     ListeningRpcCommunicator,
     PeerDescriptor
 } from '@streamr/dht'
-import { LeaveStreamNotice, MessageID, MessageRef, ProxyDirection, StreamMessage } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { IStreamNode } from '../IStreamNode'
-import { EventEmitter } from 'eventemitter3'
 import { ConnectionLocker } from '@streamr/dht/src/exports'
-import { StreamNodeServer } from '../StreamNodeServer'
-import { Logger, wait, binaryToHex, EthereumAddress, addManagedEventListener } from '@streamr/utils'
-import { DuplicateMessageDetector } from '../DuplicateMessageDetector'
-import { NodeList } from '../NodeList'
-import { Propagation } from '../propagation/Propagation'
-import { sampleSize } from 'lodash'
-import { RemoteProxyServer } from './RemoteProxyServer'
-import { NetworkRpcClient, ProxyConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
-import { RemoteRandomGraphNode } from '../RemoteRandomGraphNode'
-import { markAndCheckDuplicate } from '../utils'
 import { StreamPartID } from '@streamr/protocol'
+import { EthereumAddress, Logger, addManagedEventListener, wait } from '@streamr/utils'
+import { EventEmitter } from 'eventemitter3'
+import { sampleSize } from 'lodash'
 import { NodeID, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { LeaveStreamNotice, MessageID, MessageRef, ProxyDirection, StreamMessage } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
+import { NetworkRpcClient, ProxyConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { DuplicateMessageDetector } from '../DuplicateMessageDetector'
+import { IStreamNode } from '../IStreamNode'
+import { NodeList } from '../NodeList'
+import { RemoteRandomGraphNode } from '../RemoteRandomGraphNode'
+import { StreamNodeServer } from '../StreamNodeServer'
+import { Propagation } from '../propagation/Propagation'
+import { markAndCheckDuplicate } from '../utils'
+import { RemoteProxyServer } from './RemoteProxyServer'
 
 export const retry = async <T>(task: () => Promise<T>, description: string, abortSignal: AbortSignal, delay = 10000): Promise<T> => {
     // eslint-disable-next-line no-constant-condition
@@ -76,8 +76,7 @@ export class ProxyStreamConnectionClient extends EventEmitter implements IStream
             randomGraphId: this.config.streamPartId,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: NodeID) => this.broadcast(message, previousNode),
-            onLeaveNotice: (notice: LeaveStreamNotice) => {
-                const senderId = binaryToHex(notice.senderId) as NodeID
+            onLeaveNotice: (senderId: NodeID) => {
                 const contact = this.targetNeighbors.getNeighborById(senderId)
                 if (contact) {
                     setImmediate(() => this.onNodeDisconnected(contact.getPeerDescriptor()))

--- a/packages/trackerless-network/src/logic/temporary-connection/RemoteTemporaryConnectionRpcServer.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/RemoteTemporaryConnectionRpcServer.ts
@@ -1,8 +1,7 @@
 import { DhtRpcOptions, PeerDescriptor } from '@streamr/dht'
 import { ITemporaryConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Remote } from '../Remote'
-import { TemporaryConnectionRequest } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { Logger, hexToBinary } from '@streamr/utils'
+import { Logger } from '@streamr/utils'
 import { getNodeIdFromPeerDescriptor } from '../../identifiers'
 
 const logger = new Logger(module)
@@ -14,11 +13,8 @@ export class RemoteTemporaryConnectionRpcServer extends Remote<ITemporaryConnect
             sourceDescriptor: ownPeerDescriptor,
             targetDescriptor: this.remotePeerDescriptor,
         }
-        const request: TemporaryConnectionRequest = {
-            senderId: hexToBinary(getNodeIdFromPeerDescriptor(ownPeerDescriptor))
-        }
         try {
-            const response = await this.client.openConnection(request, options)
+            const response = await this.client.openConnection({}, options)
             return response.accepted
         } catch (err: any) {
             logger.debug(`temporaryConnection to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed: ${err}`)

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -188,17 +188,13 @@ export interface StreamHandshakeResponse {
  */
 export interface InterleaveNotice {
     /**
-     * @generated from protobuf field: bytes senderId = 1;
-     */
-    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
-    /**
-     * @generated from protobuf field: string randomGraphId = 2;
+     * @generated from protobuf field: string randomGraphId = 1;
      */
     randomGraphId: string;
     /**
      * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
      *
-     * @generated from protobuf field: dht.PeerDescriptor interleaveTargetDescriptor = 3;
+     * @generated from protobuf field: dht.PeerDescriptor interleaveTargetDescriptor = 2;
      */
     interleaveTargetDescriptor?: PeerDescriptor;
 }
@@ -450,9 +446,8 @@ export const StreamHandshakeResponse = new StreamHandshakeResponse$Type();
 class InterleaveNotice$Type extends MessageType<InterleaveNotice> {
     constructor() {
         super("InterleaveNotice", [
-            { no: 1, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "interleaveTargetDescriptor", kind: "message", T: () => PeerDescriptor }
+            { no: 1, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "interleaveTargetDescriptor", kind: "message", T: () => PeerDescriptor }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -268,10 +268,6 @@ export interface ProxyConnectionResponse {
  * @generated from protobuf message TemporaryConnectionRequest
  */
 export interface TemporaryConnectionRequest {
-    /**
-     * @generated from protobuf field: bytes senderId = 1;
-     */
-    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
 }
 /**
  * @generated from protobuf message TemporaryConnectionResponse
@@ -531,9 +527,7 @@ export const ProxyConnectionResponse = new ProxyConnectionResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class TemporaryConnectionRequest$Type extends MessageType<TemporaryConnectionRequest> {
     constructor() {
-        super("TemporaryConnectionRequest", [
-            { no: 1, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
-        ]);
+        super("TemporaryConnectionRequest", []);
     }
 }
 /**

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -150,29 +150,19 @@ export interface StreamHandshakeRequest {
      */
     randomGraphId: string;
     /**
-     * @generated from protobuf field: bytes senderId = 2;
-     */
-    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
-    /**
-     * @generated from protobuf field: string requestId = 3;
+     * @generated from protobuf field: string requestId = 2;
      */
     requestId: string;
     /**
-     * @generated from protobuf field: optional bytes concurrentHandshakeTargetId = 4;
+     * @generated from protobuf field: optional bytes concurrentHandshakeTargetId = 3;
      */
     concurrentHandshakeTargetId?: Uint8Array;
     /**
-     * @generated from protobuf field: repeated bytes neighborIds = 5;
+     * @generated from protobuf field: repeated bytes neighborIds = 4;
      */
     neighborIds: Uint8Array[];
     /**
-     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-     *
-     * @generated from protobuf field: dht.PeerDescriptor senderDescriptor = 6;
-     */
-    senderDescriptor?: PeerDescriptor;
-    /**
-     * @generated from protobuf field: optional bytes interleaveSourceId = 7;
+     * @generated from protobuf field: optional bytes interleaveSourceId = 5;
      */
     interleaveSourceId?: Uint8Array;
 }
@@ -431,12 +421,10 @@ class StreamHandshakeRequest$Type extends MessageType<StreamHandshakeRequest> {
     constructor() {
         super("StreamHandshakeRequest", [
             { no: 1, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 3, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "concurrentHandshakeTargetId", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
-            { no: 5, name: "neighborIds", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
-            { no: 6, name: "senderDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 7, name: "interleaveSourceId", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ }
+            { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "concurrentHandshakeTargetId", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "neighborIds", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 5, name: "interleaveSourceId", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -206,10 +206,6 @@ export interface LeaveStreamNotice {
      * @generated from protobuf field: string randomGraphId = 1;
      */
     randomGraphId: string;
-    /**
-     * @generated from protobuf field: bytes senderId = 2;
-     */
-    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
 }
 /**
  * @generated from protobuf message NeighborUpdate
@@ -459,8 +455,7 @@ export const InterleaveNotice = new InterleaveNotice$Type();
 class LeaveStreamNotice$Type extends MessageType<LeaveStreamNotice> {
     constructor() {
         super("LeaveStreamNotice", [
-            { no: 1, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+            { no: 1, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -152,7 +152,7 @@ export interface StreamHandshakeRequest {
     /**
      * @generated from protobuf field: bytes senderId = 2;
      */
-    senderId: Uint8Array;
+    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
     /**
      * @generated from protobuf field: string requestId = 3;
      */
@@ -200,7 +200,7 @@ export interface InterleaveNotice {
     /**
      * @generated from protobuf field: bytes senderId = 1;
      */
-    senderId: Uint8Array;
+    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
     /**
      * @generated from protobuf field: string randomGraphId = 2;
      */
@@ -223,26 +223,22 @@ export interface LeaveStreamNotice {
     /**
      * @generated from protobuf field: bytes senderId = 2;
      */
-    senderId: Uint8Array;
+    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
 }
 /**
  * @generated from protobuf message NeighborUpdate
  */
 export interface NeighborUpdate {
     /**
-     * @generated from protobuf field: bytes senderId = 1;
-     */
-    senderId: Uint8Array; // TODO: remove redundant info NET-1028
-    /**
-     * @generated from protobuf field: string randomGraphId = 2;
+     * @generated from protobuf field: string randomGraphId = 1;
      */
     randomGraphId: string;
     /**
-     * @generated from protobuf field: bool removeMe = 3;
+     * @generated from protobuf field: bool removeMe = 2;
      */
     removeMe: boolean;
     /**
-     * @generated from protobuf field: repeated dht.PeerDescriptor neighborDescriptors = 4;
+     * @generated from protobuf field: repeated dht.PeerDescriptor neighborDescriptors = 3;
      */
     neighborDescriptors: PeerDescriptor[];
 }
@@ -251,11 +247,11 @@ export interface NeighborUpdate {
  */
 export interface ProxyConnectionRequest {
     /**
-     * @generated from protobuf field: ProxyDirection direction = 4;
+     * @generated from protobuf field: ProxyDirection direction = 1;
      */
     direction: ProxyDirection;
     /**
-     * @generated from protobuf field: bytes userId = 5;
+     * @generated from protobuf field: bytes userId = 2;
      */
     userId: Uint8Array;
 }
@@ -264,7 +260,7 @@ export interface ProxyConnectionRequest {
  */
 export interface ProxyConnectionResponse {
     /**
-     * @generated from protobuf field: bool accepted = 5;
+     * @generated from protobuf field: bool accepted = 1;
      */
     accepted: boolean;
 }
@@ -275,7 +271,7 @@ export interface TemporaryConnectionRequest {
     /**
      * @generated from protobuf field: bytes senderId = 1;
      */
-    senderId: Uint8Array;
+    senderId: Uint8Array; // TODO is it possible to remove this field? (NET-1028)
 }
 /**
  * @generated from protobuf message TemporaryConnectionResponse
@@ -497,10 +493,9 @@ export const LeaveStreamNotice = new LeaveStreamNotice$Type();
 class NeighborUpdate$Type extends MessageType<NeighborUpdate> {
     constructor() {
         super("NeighborUpdate", [
-            { no: 1, name: "senderId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "removeMe", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 4, name: "neighborDescriptors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
+            { no: 1, name: "randomGraphId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "removeMe", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "neighborDescriptors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
         ]);
     }
 }
@@ -512,8 +507,8 @@ export const NeighborUpdate = new NeighborUpdate$Type();
 class ProxyConnectionRequest$Type extends MessageType<ProxyConnectionRequest> {
     constructor() {
         super("ProxyConnectionRequest", [
-            { no: 4, name: "direction", kind: "enum", T: () => ["ProxyDirection", ProxyDirection] },
-            { no: 5, name: "userId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+            { no: 1, name: "direction", kind: "enum", T: () => ["ProxyDirection", ProxyDirection] },
+            { no: 2, name: "userId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
 }
@@ -525,7 +520,7 @@ export const ProxyConnectionRequest = new ProxyConnectionRequest$Type();
 class ProxyConnectionResponse$Type extends MessageType<ProxyConnectionResponse> {
     constructor() {
         super("ProxyConnectionResponse", [
-            { no: 5, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
@@ -48,7 +48,6 @@ describe('RemoteNeighborUpdateManager', () => {
                     kademliaId: new Uint8Array([4, 2, 4]),
                     type: NodeType.NODEJS
                 }
-
                 const update: NeighborUpdate = {
                     randomGraphId: 'testStream',
                     neighborDescriptors: [

--- a/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
+++ b/packages/trackerless-network/test/integration/RemoteNeighborUpdateManager.test.ts
@@ -1,4 +1,3 @@
-import { NeighborUpdate } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import {
     ListeningRpcCommunicator,
@@ -8,12 +7,11 @@ import {
     SimulatorTransport
 } from '@streamr/dht'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
+import { RemoteNeighborUpdateManager } from '../../src/logic/neighbor-discovery/RemoteNeighborUpdateManager'
+import { NeighborUpdate } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import {
     NeighborUpdateRpcClient,
 } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
-import { RemoteNeighborUpdateManager } from '../../src/logic/neighbor-discovery/RemoteNeighborUpdateManager'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
-import { hexToBinary } from '@streamr/utils'
 
 describe('RemoteNeighborUpdateManager', () => {
     let mockServerRpc: ListeningRpcCommunicator
@@ -52,7 +50,6 @@ describe('RemoteNeighborUpdateManager', () => {
                 }
 
                 const update: NeighborUpdate = {
-                    senderId: hexToBinary(getNodeIdFromPeerDescriptor(node)),
                     randomGraphId: 'testStream',
                     neighborDescriptors: [
                         node

--- a/packages/trackerless-network/test/unit/HandshakerServer.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakerServer.test.ts
@@ -39,58 +39,46 @@ describe('HandshakerServer', () => {
     })
 
     it('handshake', async () => {
-        const senderId = hexToBinary('0x1111')
         const req = StreamHandshakeRequest.create({
             randomGraphId: 'random-graph',
-            senderId,
-            requestId: 'requestId',
-            senderDescriptor: {
-                kademliaId: senderId,
-                type: NodeType.NODEJS
-            }
+            requestId: 'requestId'
         })
-        const res = await handshakerServer.handshake(req, {} as any)
+        const res = await handshakerServer.handshake(req, {
+            incomingSourceDescriptor: createMockPeerDescriptor()
+        } as any)
         expect(res.accepted).toEqual(true)
         expect(res.interleaveTargetDescriptor).toBeUndefined()
         expect(res.requestId).toEqual('requestId')
     })
 
     it('handshake interleave', async () => {
-        const senderId = hexToBinary('0x1111')
         targetNeighbors.add(createMockRemoteNode())
         targetNeighbors.add(createMockRemoteNode())
         targetNeighbors.add(createMockRemoteNode())
         targetNeighbors.add(createMockRemoteNode())
         const req = StreamHandshakeRequest.create({
             randomGraphId: 'random-graph',
-            senderId,
-            requestId: 'requestId',
-            senderDescriptor: {
-                kademliaId: senderId,
-                type: NodeType.NODEJS
-            }
+            requestId: 'requestId'
         })
-        const res = await handshakerServer.handshake(req, {} as any)
+        const res = await handshakerServer.handshake(req, {
+            incomingSourceDescriptor: createMockPeerDescriptor()
+        } as any)
         expect(res.accepted).toEqual(true)
         expect(res.interleaveTargetDescriptor).toBeDefined()
     })
 
     it('unaccepted handshake', async () => {
-        const senderId = hexToBinary('0x1111')
         ongoingHandshakes.add('0x2222' as NodeID)
         ongoingHandshakes.add('0x3333' as NodeID)
         ongoingHandshakes.add('0x4444' as NodeID)
         ongoingHandshakes.add('0x5555' as NodeID)
         const req = StreamHandshakeRequest.create({
             randomGraphId: 'random-graph',
-            senderId,
-            requestId: 'requestId',
-            senderDescriptor: {
-                kademliaId: senderId,
-                type: NodeType.NODEJS
-            }
+            requestId: 'requestId'
         })
-        const res = await handshakerServer.handshake(req, {} as any)
+        const res = await handshakerServer.handshake(req, {
+            incomingSourceDescriptor: createMockPeerDescriptor()
+        } as any)
         expect(res.accepted).toEqual(false)
     })
 

--- a/packages/trackerless-network/test/unit/HandshakerServer.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakerServer.test.ts
@@ -85,27 +85,29 @@ describe('HandshakerServer', () => {
     it('handshakeWithInterleaving success', async () => {
         const req: InterleaveNotice = {
             randomGraphId: 'random-graph',
-            senderId: hexToBinary('0x1111'),
             interleaveTargetDescriptor: {
                 kademliaId: hexToBinary('0x2222'),
                 type: NodeType.NODEJS
             }
 
         }
-        await handshakerServer.interleaveNotice(req, {} as any)
+        await handshakerServer.interleaveNotice(req, {
+            incomingSourceDescriptor: createMockPeerDescriptor()
+        } as any)
         expect(handshakeWithInterleaving).toHaveBeenCalledTimes(1)
     })
 
     it('handshakeWithInterleaving success', async () => {
         const req: InterleaveNotice = {
             randomGraphId: 'wrong-random-graph',
-            senderId: hexToBinary('0x1111'),
             interleaveTargetDescriptor: {
                 kademliaId: hexToBinary('0x2222'),
                 type: NodeType.NODEJS
             }
         }
-        await handshakerServer.interleaveNotice(req, {} as any)
+        await handshakerServer.interleaveNotice(req, {
+            incomingSourceDescriptor: createMockPeerDescriptor()
+        } as any)
         expect(handshakeWithInterleaving).toHaveBeenCalledTimes(0)
     })
 

--- a/packages/trackerless-network/test/unit/StreamNodeServer.test.ts
+++ b/packages/trackerless-network/test/unit/StreamNodeServer.test.ts
@@ -1,11 +1,10 @@
 import { ListeningRpcCommunicator } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
-import { hexToBinary } from '@streamr/utils'
 import { StreamNodeServer } from '../../src/logic/StreamNodeServer'
 import { LeaveStreamNotice } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { MockTransport } from '../utils/mock/Transport'
-import { createMockPeerDescriptor, createRandomNodeId, createStreamMessage } from '../utils/utils'
+import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 
 describe('StreamNodeServer', () => {
 
@@ -51,7 +50,6 @@ describe('StreamNodeServer', () => {
 
     it('Server leaveStreamNotice()', async () => {
         const leaveNotice: LeaveStreamNotice = {
-            senderId: hexToBinary(createRandomNodeId()),
             randomGraphId: 'random-graph'
         }
         await streamNodeServer.leaveStreamNotice(leaveNotice, { incomingSourceDescriptor: mockSender } as any)


### PR DESCRIPTION
Removed:
- `NeighborUpdate#senderId`
- `TemporaryConnectionRequest#senderId`
- `StreamHandshakeRequest#senderId` and `StreamHandshakeRequest#senderDescriptor`
- `InterleaveNotice#senderId`
- `LeaveStreamNotice#senderId`

The sender is read from the `ServerCallContext` instead:
```
const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
```

## Future improvements

The call context of 
```
const options: DhtRpcOptions = {
    sourceDescriptor: ownPeerDescriptor,
    targetDescriptor: this.remotePeerDescriptor,
}
```
could be created in `Remote` as most/all of subclasses of `Remove` use that? (some use use different timeouts or `notification: true`)