### PR TITLE
test(broker): Fix flaky "OperatorPlugin accepts proxy connections" test

### DIFF
--- a/packages/broker/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -6,6 +6,7 @@ import { ProxyDirection, StreamPermission } from 'streamr-client'
 import { Broker, createBroker } from '../../../../src/broker'
 import { createClient, createTestStream, formConfig, startBroker } from '../../../utils'
 import { delegate, deploySponsorshipContract, generateWalletWithGasAndTokens, setupOperatorContract, sponsor, stake } from './contractUtils'
+import { wait } from '@streamr/utils'
 
 describe('OperatorPlugin', () => {
 
@@ -53,6 +54,9 @@ describe('OperatorPlugin', () => {
                 }
             }
         })
+        // wait for a while so that MaintainTopologyService has time to handle addStakedStreams
+        // events emitted during Broker start
+        await wait(500)
         const brokerDescriptor = await broker.getStreamrClient().getPeerDescriptor()
         await subscriber.setProxies({ id: stream.id }, [brokerDescriptor], ProxyDirection.SUBSCRIBE)
         const subscription = await subscriber.subscribe(stream.id)

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -174,7 +174,13 @@ export class ProxyStreamConnectionClient extends EventEmitter implements IStream
             this.targetNeighbors.add(remote)
             this.propagation.onNeighborJoined(nodeId)
             logger.info('Open proxy connection', {
-                nodeId
+                nodeId,
+                streamPartId: this.config.streamPartId
+            })
+        } else {
+            logger.warn('Unable to open proxy connection', {
+                nodeId,
+                streamPartId: this.config.streamPartId
             })
         }
     }

--- a/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/RemoteProxyServer.ts
@@ -23,7 +23,7 @@ export class RemoteProxyServer extends Remote<IProxyConnectionRpcClient> {
             const res = await this.client.requestConnection(request, options)
             return res.accepted
         } catch (err) {
-            logger.warn(`ProxyConnectionRequest failed with error: ${err}`)
+            logger.debug(`ProxyConnectionRequest failed with error: ${err}`)
             return false
         }
     }


### PR DESCRIPTION
Add waiting so that events can be handled and therefore the Broker is ready to accept proxy connections.

Also added warning about failed proxy connections.