### PR TITLE
feat(broker): Add logging for `MaintainTopologyService`

### DIFF
--- a/packages/broker/src/plugins/operator/MaintainTopologyService.ts
+++ b/packages/broker/src/plugins/operator/MaintainTopologyService.ts
@@ -66,13 +66,14 @@ export class MaintainTopologyService {
         const [id, partition] = StreamPartIDUtils.getStreamIDAndPartition(streamPartId)
         let subscription: Subscription
         try {
+            logger.info(`Join stream partition ${streamPartId}`)
             subscription = await this.streamrClient.subscribe({
                 id,
                 partition,
                 raw: true
             })
         } catch (err) {
-            logger.warn('Failed to subscribe', { streamPartId, reason: err?.reason })
+            logger.warn(`Failed to join stream partition ${streamPartId}`, { reason: err?.reason })
             return
         }
         this.subscriptions.set(streamPartId, subscription)
@@ -82,9 +83,10 @@ export class MaintainTopologyService {
         const subscription = this.subscriptions.get(streamPartId)
         this.subscriptions.delete(streamPartId)
         try {
+            logger.info(`Leave stream partition ${streamPartId}`)
             await subscription?.unsubscribe()
         } catch (err) {
-            logger.warn('Failed to unsubscribe', { streamPartId, reason: err?.reason })
+            logger.warn(`Failed to leave stream partition ${streamPartId}`, { reason: err?.reason })
         }
     })
 


### PR DESCRIPTION
Write a line to the log when `MaintainTopologyService` joins or leaves a stream.