### PR TITLE
fix(dht): [NET-1099] Incorrect event payload `SortedContactList#onContactRemoved`

### DIFF
--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -56,13 +56,14 @@ export class SortedContactList<Contact extends IContact> extends EventEmitter<Ev
                 this.contactIds.sort(this.compareIds)
             } else if (this.compareIds(this.contactIds[this.maxSize - 1], contact.getPeerId()) > 0) {
                 const removed = this.contactIds.pop()
+                const removedDescriptor = this.contactsById.get(removed!.toKey())!.contact.getPeerDescriptor()
                 this.contactsById.delete(removed!.toKey())
                 this.contactsById.set(contact.getPeerId().toKey(), new ContactState(contact))
                 this.contactIds.push(contact.getPeerId())
                 this.contactIds.sort(this.compareIds)
                 this.emit(
                     'contactRemoved',
-                    contact.getPeerDescriptor(),
+                    removedDescriptor,
                     this.getClosestContacts().map((contact: Contact) => contact.getPeerDescriptor())
                 )
             }

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -103,12 +103,14 @@ describe('SortedContactList', () => {
 
     it('cannot exceed maxSize', async () => {
         const list = new SortedContactList(id0, 3)
+        const onContactRemoved = jest.fn()
+        list.on('contactRemoved', onContactRemoved)
+        list.addContact(peer1)
         list.addContact(peer4)
         list.addContact(peer3)
         list.addContact(peer2)
-        list.addContact(peer1)
         expect(list.getSize()).toEqual(3)
-        expect(list.getContact(id4)).toBeFalsy()
+        expect(onContactRemoved).toBeCalledWith(descriptor4, [descriptor1, descriptor2, descriptor3])
     })
 
     it('removing contacts', async () => {
@@ -123,17 +125,5 @@ describe('SortedContactList', () => {
         expect(list.getContactIds()).toEqual(list.getContactIds().sort(list.compareIds))
         const ret = list.removeContact(PeerID.fromValue(Buffer.from([0, 0, 0, 6])))
         expect(ret).toEqual(false)
-    })
-
-    it('max size', () => {
-        const list = new SortedContactList(id0, 3)
-        const onContactRemoved = jest.fn()
-        list.on('contactRemoved', onContactRemoved)
-        list.addContact(peer1)
-        list.addContact(peer4)
-        list.addContact(peer3)
-        list.addContact(peer2)
-        expect(list.getSize()).toEqual(3)
-        expect(onContactRemoved).toBeCalledWith(descriptor4, [descriptor1, descriptor2, descriptor3])
     })
 })

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -124,4 +124,16 @@ describe('SortedContactList', () => {
         const ret = list.removeContact(PeerID.fromValue(Buffer.from([0, 0, 0, 6])))
         expect(ret).toEqual(false)
     })
+
+    it('max size', () => {
+        const list = new SortedContactList(id0, 3)
+        const onContactRemoved = jest.fn()
+        list.on('contactRemoved', onContactRemoved)
+        list.addContact(peer1)
+        list.addContact(peer4)
+        list.addContact(peer3)
+        list.addContact(peer2)
+        expect(list.getSize()).toEqual(3)
+        expect(onContactRemoved).toBeCalledWith(descriptor4, [descriptor1, descriptor2, descriptor3])
+    })
 })


### PR DESCRIPTION
The event payload of `contactRemoved` was incorrect when it is emitted from `SortedContactList#addContact`. The first argument should be the removed contact but is the added contact.

That parameter is currently not used in any of the event listeners. Maybe good to keep the parameter for consistency, as similar parameter is also `newContact` event.