### PR TITLE
fix(DHT): Websocket server clean up fix

### DIFF
--- a/packages/dht/src/connection/WebSocket/ServerWebSocket.ts
+++ b/packages/dht/src/connection/WebSocket/ServerWebSocket.ts
@@ -67,7 +67,6 @@ export class ServerWebSocket extends EventEmitter<ConnectionEvents> implements I
         this.socket = undefined
 
         this.emit('disconnected', disconnectionType, reasonCode, description)
-        this.removeAllListeners()
     }
 
     public send(data: Uint8Array): void {


### PR DESCRIPTION
## Summary

Removed a line calling `ServerWebSocket#RemoveAllListeners` to avoid cases where a connection remains in the ConnectionManager's state as the `disconnected` event was never seen
