### PR TITLE
fix(trackerless-network): [NET-1104] Duplicate entry points in `joinStream`

### DIFF
--- a/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/StreamEntryPointDiscovery.ts
@@ -137,13 +137,13 @@ export class StreamEntryPointDiscovery {
         entryPointsFromDht: boolean,
         currentEntrypointCount: number
     ): Promise<void> {
-        if (!this.config.streams.has(streamPartId)) {
+        if (!this.config.streams.has(streamPartId) || !entryPointsFromDht) {
             return
         }
         if (this.config.streams.get(streamPartId)!.layer1!.getBucketSize() < NETWORK_SPLIT_AVOIDANCE_LIMIT) {
             await this.storeSelfAsEntryPoint(streamPartId)
             setImmediate(() => this.avoidNetworkSplit(streamPartId))
-        } else if (entryPointsFromDht && currentEntrypointCount < ENTRYPOINT_STORE_LIMIT) {
+        } else if (currentEntrypointCount < ENTRYPOINT_STORE_LIMIT) {
             await this.storeSelfAsEntryPoint(streamPartId)
         }
     }

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -163,7 +163,7 @@ export class StreamrNode extends EventEmitter<Events> {
             forwardingNode
         )
         entryPoints = entryPoints.concat(discoveryResult.discoveredEntryPoints)
-        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT), true, entryPoints.length > 0)
+        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT), true)
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
             streamPartId,
             discoveryResult.entryPointsFromDht,

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -163,7 +163,7 @@ export class StreamrNode extends EventEmitter<Events> {
             forwardingNode
         )
         entryPoints = entryPoints.concat(discoveryResult.discoveredEntryPoints)
-        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT), true)
+        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT))
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
             streamPartId,
             discoveryResult.entryPointsFromDht,

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -152,19 +152,18 @@ export class StreamrNode extends EventEmitter<Events> {
             return
         }
         logger.debug(`Joining stream ${streamPartId}`)
-        const knownEntryPoints = this.knownStreamEntryPoints.get(streamPartId) ?? []
-        let entryPoints = knownEntryPoints.concat(knownEntryPoints)
-        const [layer1, layer2] = this.createStream(streamPartId, knownEntryPoints)
+        let entryPoints = this.knownStreamEntryPoints.get(streamPartId) ?? []
+        const [layer1, layer2] = this.createStream(streamPartId, entryPoints)
         await layer1.start()
         await layer2.start()
         const forwardingNode = this.layer0!.isJoinOngoing() ? this.layer0!.getKnownEntryPoints()[0] : undefined
         const discoveryResult = await this.streamEntryPointDiscovery!.discoverEntryPointsFromDht(
             streamPartId,
-            knownEntryPoints.length,
+            entryPoints.length,
             forwardingNode
         )
-        entryPoints = knownEntryPoints.concat(discoveryResult.discoveredEntryPoints)
-        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT), true, knownEntryPoints.length > 0)
+        entryPoints = entryPoints.concat(discoveryResult.discoveredEntryPoints)
+        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT), true, entryPoints.length > 0)
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
             streamPartId,
             discoveryResult.entryPointsFromDht,

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -1,6 +1,6 @@
 import { MessageID, MessageRef, StreamMessage, StreamMessageType, toStreamID, toStreamPartID } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
-import { hexToBinary, utf8ToBinary, waitForCondition, waitForEvent3 } from '@streamr/utils'
+import { hexToBinary, utf8ToBinary, wait, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { NodeID } from '../../src/identifiers'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
@@ -190,6 +190,8 @@ describe('Proxy connections', () => {
         expect(hasConnectionFromProxy(proxyNode1)).toBe(false)
         await proxyNode1.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
         await waitForCondition(() => hasConnectionToProxy(proxyNode1.getNodeId(), ProxyDirection.SUBSCRIBE), 25000)
+        // TODO why wait is needed?
+        await wait(100)
         expect(hasConnectionFromProxy(proxyNode1)).toBe(true)
     }, 30000)
 


### PR DESCRIPTION
Fixed a bug in `StreamrNode#joinStream`: it put duplicate entry points to the array (same items twice). Also fixed  `layer1.joinDht` call to use all entry points, not just user-defined entry points (see open questions whether that is the correct fix)

Also fixed retry-parameter for `layer1.joinDht`: as a call to `joinStream` is always the first join to the stream, it is good to have it retry it until it succeeds (or timeouts).

Also fixed a flaky test.