### PR TITLE
fix(trackerless-network): [NET-1106] Proxy connections counted as neighbors

### DIFF
--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -23,7 +23,7 @@ export interface NetworkNodeStub {
     leave: (streamPartId: StreamPartID) => void
     broadcast: (streamMessage: StreamMessage) => Promise<void>
     getStreamParts: () => StreamPartID[]
-    getNeighborsForStreamPart: (streamPartId: StreamPartID) => ReadonlyArray<NodeID>
+    getNeighbors: (streamPartId: StreamPartID) => ReadonlyArray<NodeID>
     getPeerDescriptor: () => PeerDescriptor
     getMetricsContext: () => MetricsContext
     getDiagnosticInfo: () => Record<string, unknown>

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -158,7 +158,7 @@ describe('Group Key Persistence', () => {
             })
             const node2 = await subscriber2.getNode()
             await until(async () => {
-                return node2.getNeighborsForStreamPart(toStreamPartID(stream.id, DEFAULT_PARTITION)).length >= 1
+                return node2.getNeighbors(toStreamPartID(stream.id, DEFAULT_PARTITION)).length >= 1
             })
 
             await Promise.all([

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -58,12 +58,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
         throw new Error('not implemented')
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    getNeighbors(): string[] {
-        throw new Error('not implemented')
-    }
-
-    getNeighborsForStreamPart(streamPartId: StreamPartID): ReadonlyArray<NodeID> {
+    getNeighbors(streamPartId: StreamPartID): ReadonlyArray<NodeID> {
         const allNodes = this.network.getNodes()
         return allNodes
             .filter((node) => (node.id !== this.id))

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -84,10 +84,8 @@ export class NetworkNode {
         this.stack.getStreamrNode().leaveStream(streamPartId)
     }
 
-    getNeighborsForStreamPart(streamPartId: StreamPartID): ReadonlyArray<NodeID> {
-        return this.hasStreamPart(streamPartId)
-            ? this.stack.getStreamrNode().getStream(streamPartId)!.layer2.getTargetNeighborIds()
-            : []
+    getNeighbors(streamPartId: StreamPartID): ReadonlyArray<NodeID> {
+        return this.stack.getStreamrNode().getNeighbors(streamPartId)
     }
 
     hasStreamPart(streamPartId: StreamPartID): boolean {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -297,7 +297,10 @@ export class StreamrNode extends EventEmitter<Events> {
     }
 
     getNeighbors(streamPartId: StreamPartID): NodeID[] {
-        return this.streams.get(streamPartId)?.layer2.getTargetNeighborIds() ?? []
+        const stream = this.streams.get(streamPartId)
+        return (stream?.type == StreamNodeType.RANDOM_GRAPH)
+            ? stream.layer2.getTargetNeighborIds()
+            : []
     }
 
     getStreamParts(): StreamPartID[] {


### PR DESCRIPTION
Fixed `getNeighors` to exclude proxy connections. (Neighbors are the connected nearby-nodes if a node is part of that network. A client which uses a proxy is not part of that stream-network, it just connects to it.)

Also renamed `NetworkNode#getNeighborsForStreamPart` -> `getNeighbors(streamPart)` and it now just delegates to the existing getNeighbors method in `StreamrNode`.