### PR TITLE
fix(network): [NET-1033, NET-1107] Flaky network browser tests

### DIFF
--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -50,9 +50,9 @@ describe('inspect', () => {
             inspectedNodes.push(node)
         }))
         await Promise.all([
-            publisherNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }),
-            inspectorNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }),
-            ...inspectedNodes.map((node) => node.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }))
+            publisherNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }),
+            inspectorNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }),
+            ...inspectedNodes.map((node) => node.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }))
         ])
         sequenceNumber = 0
     }, 30000)

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -119,7 +119,7 @@ describe('stream without default entrypoints', () => {
 
     it('nodes store themselves as entrypoints on streamPart if number of entrypoints is low', async () => {
         for (let i = 0; i < 10; i++) {
-            await nodes[i].join(STREAM_PART_ID, { minCount: (i > 0) ? 1 : 0, timeout: 5000 })
+            await nodes[i].join(STREAM_PART_ID, { minCount: (i > 0) ? 1 : 0, timeout: 15000 })
         }
         await waitForCondition(async () => {
             const entryPointData = await nodes[15].stack.getLayer0DhtNode().getDataFromDht(streamPartIdToDataKey(STREAM_PART_ID))


### PR DESCRIPTION
## Summary

Fix flaky browser test cases `nodes store themselves as entrypoints on streamPart if number of entrypoints is low` and `integration/Inspect.test.ts` `beforeEach` by giving the nodes more time to recover from network splits. Increased flakyness observed after [db1b8fe](https://github.com/streamr-dev/network/pull/1546/commits/db1b8fe4267f1e957e2d65fda7983b7bbdbc43b8) as the `waitForConnections` logic was changed from waiting for n connection events in a stream to waiting for n connections to exists in a stream
- The previous logic before PR https://github.com/streamr-dev/network/pull/1880 was that we waited from n `targetNeighborConnected` events, but as connections may also close while we wait, this didn't always wait for all connections correctly. Therefore the waiting may take longer than previously.
