### PR TITLE
fix(network): NET 994 re-enable `multiple nodes can join without configured entrypoints simultaneously`

### DIFF
--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -50,9 +50,9 @@ describe('inspect', () => {
             inspectedNodes.push(node)
         }))
         await Promise.all([
-            publisherNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }),
-            inspectorNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }),
-            ...inspectedNodes.map((node) => node.joinStreamPart(streamPartId, { minCount: 4, timeout: 5000 }))
+            publisherNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }),
+            inspectorNode.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }),
+            ...inspectedNodes.map((node) => node.joinStreamPart(streamPartId, { minCount: 4, timeout: 15000 }))
         ])
         sequenceNumber = 0
     }, 30000)

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -119,7 +119,7 @@ describe('stream without default entrypoints', () => {
 
     it('nodes store themselves as entrypoints on streamPart if number of entrypoints is low', async () => {
         for (let i = 0; i < 10; i++) {
-            await nodes[i].join(STREAM_PART_ID, { minCount: (i > 0) ? 1 : 0, timeout: 5000 })
+            await nodes[i].join(STREAM_PART_ID, { minCount: (i > 0) ? 1 : 0, timeout: 15000 })
         }
         await waitForCondition(async () => {
             const entryPointData = await nodes[15].stack.getLayer0DhtNode().getDataFromDht(streamPartIdToDataKey(STREAM_PART_ID))

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -102,11 +102,10 @@ describe('stream without default entrypoints', () => {
         ])
     })
 
-    // TODO: can't this test make pass
-    /*it('multiple nodes can join without configured entrypoints simultaneously', async () => {
+    it('multiple nodes can join without configured entrypoints simultaneously', async () => {
         const numOfSubscribers = 8
         await Promise.all(range(numOfSubscribers).map(async (i) => {
-            await nodes[i].joinAndWaitForNeighbors(STREAM_ID, undefined, 4)
+            await nodes[i].join(STREAM_PART_ID, { minCount: 4, timeout: 15000 })
             nodes[i].addMessageListener((_msg) => {
                 numOfReceivedMessages += 1
             })
@@ -115,7 +114,7 @@ describe('stream without default entrypoints', () => {
             waitForCondition(() => numOfReceivedMessages === numOfSubscribers, 15000),
             nodes[9].broadcast(streamMessage)
         ])
-    }, 45000)*/
+    }, 45000)
 
     it('nodes store themselves as entrypoints on streamPart if number of entrypoints is low', async () => {
         for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
## Summary

Re-enable previously flaky test case `multiple nodes can join without configured entrypoints simultaneously` in `integration/stream-without-default-entrypoints.test.ts`
