### PR TITLE
refactor(trackerless-network): Divide `StreamrNode#joinStream`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -18,7 +18,6 @@ import {
     FindMode,
     DataEntry,
 } from '../proto/packages/dht/protos/DhtRpc'
-import * as Err from '../helpers/errors'
 import { DisconnectionType, ITransport, TransportEvents } from '../transport/ITransport'
 import { ConnectionManager, ConnectionManagerConfig, PortRange, TlsCertificate } from '../connection/ConnectionManager'
 import { DhtRpcServiceClient, ExternalApiServiceClient } from '../proto/packages/dht/protos/DhtRpc.client'
@@ -734,13 +733,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public async stop(): Promise<void> {
-        if (this.stopped) {
+        if (this.stopped || !this.started) {
             return
         }
         logger.trace('stop()')
-        if (!this.started) {
-            throw new Err.CouldNotStop('Cannot not stop() before start()')
-        }
         this.stopped = true
 
         if (this.entryPointDisconnectTimeout) {

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -1,6 +1,6 @@
 import { ConnectionManager, DhtNode, DhtNodeOptions, isSamePeerDescriptor } from '@streamr/dht'
 import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
-import { Logger, MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
+import { MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
 import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
 import { ProxyDirection, StreamMessage, StreamMessageType } from './proto/packages/trackerless-network/protos/NetworkRpc'
@@ -47,8 +47,6 @@ export interface NetworkStackEvents {
 
 const DEFAULT_FIRST_CONNECTION_TIMEOUT = 5000
 
-const logger = new Logger(module)
-
 export class NetworkStack extends EventEmitter<NetworkStackEvents> {
 
     private layer0DhtNode?: DhtNode
@@ -76,13 +74,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
             throw new Error(`Cannot join to ${streamPartId} as proxy connections have been set`)
         }
         await this.joinLayer0IfRequired(streamPartId)
-        setImmediate(async () => {
-            try {
-                await this.getStreamrNode().joinStream(streamPartId)
-            } catch (err) {
-                logger.warn(`Failed to join to stream ${streamPartId} with error: ${err}`)
-            }
-        })
+        this.getStreamrNode().joinStream(streamPartId)
         if (neighborRequirement !== undefined) {
             await waitForCondition(() => {
                 return this.getStreamrNode().getNeighbors(streamPartId).length >= neighborRequirement.minCount

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -30,7 +30,7 @@ export enum StreamNodeType {
     PROXY = 'proxy'
 }
 
-export interface StreamObject {
+export interface StreamObject { // TODO rename to StreamPartDelivery, maybe have "proxied: boolean" instead of StreamNodeType
     layer1?: ILayer1
     layer2: IStreamNode
     type: StreamNodeType
@@ -58,6 +58,7 @@ export interface StreamrNodeConfig {
     acceptProxyConnections?: boolean
 }
 
+// TODO rename class?
 export class StreamrNode extends EventEmitter<Events> {
     private P2PTransport?: ITransport
     private connectionLocker?: ConnectionLocker
@@ -126,18 +127,13 @@ export class StreamrNode extends EventEmitter<Events> {
 
     broadcast(msg: StreamMessage): void {
         const streamPartId = toStreamPartID(msg.messageId!.streamId as StreamID, msg.messageId!.streamPartition)
-        if (!this.streams.has(streamPartId)) {
-            this.joinStream(streamPartId)
-                .catch((err) => {
-                    logger.warn(`Failed to broadcast to stream ${streamPartId} with error: ${err}`)
-                })
-        }
+        this.joinStream(streamPartId)
         this.streams.get(streamPartId)!.layer2.broadcast(msg)
         this.metrics.broadcastMessagesPerSecond.record(1)
         this.metrics.broadcastBytesPerSecond.record(msg.content.length)
     }
 
-    leaveStream(streamPartId: StreamPartID): void {
+    leaveStream(streamPartId: StreamPartID): void { // TODO rename to leaveStreamPart
         const stream = this.streams.get(streamPartId)
         if (stream) {
             stream.layer2.stop()
@@ -147,15 +143,42 @@ export class StreamrNode extends EventEmitter<Events> {
         this.streamEntryPointDiscovery!.removeSelfAsEntryPoint(streamPartId)
     }
 
-    async joinStream(streamPartId: StreamPartID): Promise<void> {
-        if (this.streams.has(streamPartId)) {
+    joinStream(streamPartId: StreamPartID): void { // TODO rename to joinStreamPart
+        logger.debug(`Join stream part ${streamPartId}`)
+        let stream = this.streams.get(streamPartId)
+        if (stream !== undefined) {
             return
         }
-        logger.debug(`Joining stream ${streamPartId}`)
+        const layer1 = this.createLayer1Node(streamPartId, this.knownStreamEntryPoints.get(streamPartId) ?? [])
+        const layer2 = this.createRandomGraphNode(streamPartId, layer1)
+        stream = {
+            type: StreamNodeType.RANDOM_GRAPH,
+            layer1,
+            layer2
+        }
+        this.streams.set(streamPartId, stream)
+        layer2.on('message', (message: StreamMessage) => {
+            this.emit('newMessage', message)
+        })
+        setImmediate(async () => {
+            try {
+                await this.startLayersAndJoinDht(streamPartId)
+            } catch (err) {
+                logger.warn(`Failed to join to stream ${streamPartId} with error: ${err}`)
+            }
+        })
+    }
+
+    private async startLayersAndJoinDht(streamPartId: StreamPartID): Promise<void> {
+        logger.debug(`Start layers and join DHT for stream part ${streamPartId}`)
+        const stream = this.streams.get(streamPartId)!
+        if ((stream === undefined) || (stream.type !== StreamNodeType.RANDOM_GRAPH)) {
+            // leaveStream has been called (or leaveStream called, and then setProxied called)
+            return
+        }
+        await stream.layer1!.start()
+        await stream.layer2.start()
         let entryPoints = this.knownStreamEntryPoints.get(streamPartId) ?? []
-        const [layer1, layer2] = this.createStream(streamPartId, entryPoints)
-        await layer1.start()
-        await layer2.start()
         const forwardingNode = this.layer0!.isJoinOngoing() ? this.layer0!.getKnownEntryPoints()[0] : undefined
         const discoveryResult = await this.streamEntryPointDiscovery!.discoverEntryPointsFromDht(
             streamPartId,
@@ -163,26 +186,12 @@ export class StreamrNode extends EventEmitter<Events> {
             forwardingNode
         )
         entryPoints = entryPoints.concat(discoveryResult.discoveredEntryPoints)
-        await layer1.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT))
+        await stream.layer1!.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_LIMIT))
         await this.streamEntryPointDiscovery!.storeSelfAsEntryPointIfNecessary(
             streamPartId,
             discoveryResult.entryPointsFromDht,
             entryPoints.length
         )
-    }
-
-    private createStream(streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): [ILayer1, RandomGraphNode] {
-        const layer1 = this.createLayer1Node(streamPartId, entryPoints)
-        const layer2 = this.createRandomGraphNode(streamPartId, layer1)
-        this.streams.set(streamPartId, {
-            type: StreamNodeType.RANDOM_GRAPH,
-            layer1,
-            layer2
-        })
-        layer2.on('message', (message: StreamMessage) => {
-            this.emit('newMessage', message)
-        })
-        return [layer1, layer2]
     }
 
     private createLayer1Node = (streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): ILayer1 => {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -173,7 +173,7 @@ export class StreamrNode extends EventEmitter<Events> {
         logger.debug(`Start layers and join DHT for stream part ${streamPartId}`)
         const stream = this.streams.get(streamPartId)!
         if ((stream === undefined) || (stream.type !== StreamNodeType.RANDOM_GRAPH)) {
-            // leaveStream has been called (or leaveStream called, and then setProxied called)
+            // leaveStream has been called (or leaveStream called, and then setProxies called)
             return
         }
         await stream.layer1!.start()

--- a/packages/trackerless-network/test/end-to-end/inspect.test.ts
+++ b/packages/trackerless-network/test/end-to-end/inspect.test.ts
@@ -81,11 +81,9 @@ describe('inspect', () => {
         await inspectedNode.start()
         await inspectorNode.start()
 
-        await Promise.all([
-            publisherNode.stack.getStreamrNode()!.joinStream(streamPartId),
-            inspectedNode.stack.getStreamrNode()!.joinStream(streamPartId),
-            inspectorNode.stack.getStreamrNode()!.joinStream(streamPartId)
-        ])
+        publisherNode.stack.getStreamrNode()!.joinStream(streamPartId)
+        inspectedNode.stack.getStreamrNode()!.joinStream(streamPartId)
+        inspectorNode.stack.getStreamrNode()!.joinStream(streamPartId)
 
         await waitForCondition(() => 
             publisherNode.stack.getStreamrNode().getNeighbors(streamPartId).length === 2 

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -61,11 +61,11 @@ describe('proxy and full node', () => {
             }
         })
         await proxyNode.start()
-        await proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId)
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId1)
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId2)
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId3)
-        await proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId4)
+        proxyNode.stack.getStreamrNode()!.joinStream(proxyStreamId)
+        proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId1)
+        proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId2)
+        proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId3)
+        proxyNode.stack.getStreamrNode()!.joinStream(regularStreamId4)
 
         proxiedNode = createNetworkNode({
             layer0: {

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -66,7 +66,7 @@ describe('Proxy connections', () => {
         })
         await proxyNode1.start()
         proxyNode1.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
-        await proxyNode1.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
+        proxyNode1.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
         proxyNode2 = createNetworkNode({
             layer0: {
                 entryPoints: [proxyNodeDescriptor1],
@@ -78,7 +78,7 @@ describe('Proxy connections', () => {
         })
         await proxyNode2.start()
         proxyNode2.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
-        await proxyNode2.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
+        proxyNode2.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
         proxiedNode = createNetworkNode({
             layer0: {
                 entryPoints: [proxyNode1.getPeerDescriptor()],
@@ -188,7 +188,7 @@ describe('Proxy connections', () => {
         proxyNode1.leave(STREAM_PART_ID)
         await waitForCondition(() => hasConnectionToProxy(proxyNode1.getNodeId(), ProxyDirection.SUBSCRIBE))
         expect(hasConnectionFromProxy(proxyNode1)).toBe(false)
-        await proxyNode1.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
+        proxyNode1.stack.getStreamrNode()!.joinStream(STREAM_PART_ID)
         await waitForCondition(() => hasConnectionToProxy(proxyNode1.getNodeId(), ProxyDirection.SUBSCRIBE), 25000)
         // TODO why wait is needed?
         await wait(100)

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -43,7 +43,7 @@ describe('proxy group key exchange', () => {
         })
         await proxyNode.start()
         proxyNode.setStreamPartEntryPoints(streamPartId, [proxyNodeDescriptor])
-        await proxyNode.stack.getStreamrNode()!.joinStream(streamPartId)
+        proxyNode.stack.getStreamrNode()!.joinStream(streamPartId)
         publisher = createNetworkNode({
             layer0: {
                 entryPoints: [publisherDescriptor],

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -34,7 +34,7 @@ describe('Full node network with WebRTC connections', () => {
         })
         await entryPoint.start()
         entryPoint.getStreamrNode()!.setStreamPartEntryPoints(randomGraphId, [epPeerDescriptor])
-        await entryPoint.getStreamrNode()!.joinStream(randomGraphId)
+        entryPoint.getStreamrNode()!.joinStream(randomGraphId)
 
         await Promise.all(range(NUM_OF_NODES).map(async () => {
             const peerDescriptor = createMockPeerDescriptor()
@@ -47,7 +47,7 @@ describe('Full node network with WebRTC connections', () => {
             nodes.push(node)
             await node.start()
             node.getStreamrNode().setStreamPartEntryPoints(randomGraphId, [epPeerDescriptor])
-            await node.getStreamrNode().joinStream(randomGraphId)
+            node.getStreamrNode().joinStream(randomGraphId)
         }))
 
     }, 90000)

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -31,7 +31,7 @@ describe('Full node network with WebSocket connections only', () => {
         })
         await entryPoint.start()
         entryPoint.getStreamrNode()!.setStreamPartEntryPoints(randomGraphId, [epPeerDescriptor])
-        await entryPoint.getStreamrNode()!.joinStream(randomGraphId)
+        entryPoint.getStreamrNode()!.joinStream(randomGraphId)
 
         await Promise.all(range(NUM_OF_NODES).map(async (i) => {
             const node = new NetworkStack({
@@ -45,7 +45,7 @@ describe('Full node network with WebSocket connections only', () => {
             nodes.push(node)
             await node.start()
             node.getStreamrNode().setStreamPartEntryPoints(randomGraphId, [epPeerDescriptor])
-            await node.getStreamrNode().joinStream(randomGraphId)
+            node.getStreamrNode().joinStream(randomGraphId)
         }))
 
     }, 120000)

--- a/packages/trackerless-network/test/integration/NetworkStack.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStack.test.ts
@@ -48,7 +48,7 @@ describe('NetworkStack', () => {
 
     it('Can use NetworkNode pub/sub via NetworkStack', async () => {
         let receivedMessages = 0
-        await stack1.getStreamrNode().joinStream(streamPartId)
+        stack1.getStreamrNode().joinStream(streamPartId)
         stack1.getStreamrNode().on('newMessage', () => {
             receivedMessages += 1
         })

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -80,8 +80,8 @@ describe('StreamrNode', () => {
     })
 
     it('Joining stream', async () => {
-        await node1.joinStream(STREAM_PART_ID)
-        await node2.joinStream(STREAM_PART_ID)
+        node1.joinStream(STREAM_PART_ID)
+        node2.joinStream(STREAM_PART_ID)
         await waitForCondition(() => node1.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1)
         await waitForCondition(() => node2.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1)
         expect(node1.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length).toEqual(1)
@@ -89,8 +89,8 @@ describe('StreamrNode', () => {
     })
 
     it('Publishing after joining and waiting for neighbors', async () => {
-        await node1.joinStream(STREAM_PART_ID)
-        await node2.joinStream(STREAM_PART_ID)
+        node1.joinStream(STREAM_PART_ID)
+        node2.joinStream(STREAM_PART_ID)
         await waitForCondition(() => node1.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1)
         await waitForCondition(() => node2.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1)
         await Promise.all([
@@ -103,10 +103,10 @@ describe('StreamrNode', () => {
         const streamPartId2 = StreamPartIDUtils.parse('test2#0')
         node1.setStreamPartEntryPoints(streamPartId2, [peerDescriptor1])
         node2.setStreamPartEntryPoints(streamPartId2, [peerDescriptor1])
-        await node1.joinStream(STREAM_PART_ID)
-        await node1.joinStream(streamPartId2)
-        await node2.joinStream(STREAM_PART_ID)
-        await node2.joinStream(streamPartId2)
+        node1.joinStream(STREAM_PART_ID)
+        node1.joinStream(streamPartId2)
+        node2.joinStream(STREAM_PART_ID)
+        node2.joinStream(streamPartId2)
         await Promise.all([
             waitForCondition(() => node1.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1),
             waitForCondition(() => node2.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1),
@@ -127,8 +127,8 @@ describe('StreamrNode', () => {
     })
 
     it('leaving streams', async () => {
-        await node1.joinStream(STREAM_PART_ID)
-        await node2.joinStream(STREAM_PART_ID)
+        node1.joinStream(STREAM_PART_ID)
+        node2.joinStream(STREAM_PART_ID)
         await Promise.all([
             waitForCondition(() => node1.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1),
             waitForCondition(() => node2.getStream(STREAM_PART_ID)!.layer2.getTargetNeighborIds().length === 1)

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -95,7 +95,7 @@ describe('Joining streams on offline nodes', () => {
         node1.getStreamrNode().on('newMessage', () => { messageReceived = true })
         const msg = createStreamMessage(JSON.stringify({ hello: 'WORLD' }), streamPartId, randomEthereumAddress())
         node2.getStreamrNode().broadcast(msg)
-        await waitForCondition(() => messageReceived, 25000)
-    }, 30000)
+        await waitForCondition(() => messageReceived, 40000)
+    }, 60000)
 
 })

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -91,7 +91,7 @@ describe('Joining streams on offline nodes', () => {
         await entryPoint.getLayer0DhtNode().storeDataToDht(streamPartIdToDataKey(streamPartId), Any.pack(offlineDescriptor1, PeerDescriptor))
         await entryPoint.getLayer0DhtNode().storeDataToDht(streamPartIdToDataKey(streamPartId), Any.pack(offlineDescriptor2, PeerDescriptor))
         
-        await node1.getStreamrNode().joinStream(streamPartId)
+        node1.getStreamrNode().joinStream(streamPartId)
         node1.getStreamrNode().on('newMessage', () => { messageReceived = true })
         const msg = createStreamMessage(JSON.stringify({ hello: 'WORLD' }), streamPartId, randomEthereumAddress())
         node2.getStreamrNode().broadcast(msg)

--- a/packages/trackerless-network/test/unit/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/unit/StreamrNode.test.ts
@@ -41,12 +41,12 @@ describe('StreamrNode', () => {
         })
 
         it('can join streams', async () => {
-            await node.joinStream(streamPartId)
+            node.joinStream(streamPartId)
             expect(node.hasStream(streamPartId)).toEqual(true)
         })
 
         it('can leave streams', async () => {
-            await node.joinStream(streamPartId)
+            node.joinStream(streamPartId)
             expect(node.hasStream(streamPartId)).toEqual(true)
             node.leaveStream(streamPartId)
             expect(node.hasStream(streamPartId)).toEqual(false)


### PR DESCRIPTION
Divided the logic in `StreamrNode#joinStream` so that the method does the state management synchronously and the starting of layers is asynchrously (inside `setImmediate` call). Earlier the method return a `Promise`, but it was important that part of the method was called in the same tick.

As state management is no is now synchronous operation we can ensure that `this.streams` is always in consistent state (i.e. it contains all streams which we have joined or set proxies for, but other streams). After this change a call to `NetworkNode#joinStreamPart` always puts the internal state to the correct state (a stream joined). And in `StreamrNode#broadcast` we can just call `joinStream` without error-prone asynchronous management.

There is now also an additional check which ensures that `leaveStream()` has not been called before the background task starts.

The downside of this refactoring is that we can't no longer know when `StreamrNode#joinStream` operation has completed. But external components don't actually need to care about that internal state. Also the `StreamrNode` is never accessed directly by instead it is used via the `NetworkStack` class which already hide this internal state.

Also a fix for `DhtNode`: if the node has not been started, a call to `stop()` is a no-op. And increased timeout in `joining-streams-on-offline-peers.test.ts` to avoid flakiness.

## Future improvements
- rename `joinStream`/`leaveStream` to `joinStreamPart`/`leaveStreamPart` (and other similar methods?)
- rename `StreamrNode` class?
- maybe refactor `StreamrNodeType` to just a simple `proxied` boolean
- remove obsolete `IStreamNode` methods (e.g. `getTargetNeighborIds` and listeners?), and maybe the whole interface as `ProxyStreamConnectionClient` is actually not a node (may need small refactoring `StreamrNode.streams` data structure)`