### PR TITLE
test(trackerless-network): Update deprecated jest config

### DIFF
--- a/packages/trackerless-network/jest.config.js
+++ b/packages/trackerless-network/jest.config.js
@@ -5,10 +5,14 @@ module.exports = {
     // Preset ts-jest
     preset: 'ts-jest',
 
-    globals: {
-        'ts-jest': {
-            babelConfig: false,
-        }
+    transform: {
+        '^.+\\.ts$': [
+            'ts-jest',
+            {
+                tsconfig: 'tsconfig.jest.json',
+                babelConfig: false
+            }
+        ]
     },
 
     // Automatically clear mock calls and instances between every test

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.jest.json",
     "compilerOptions": {
-        "outDir": "dist"
+        "outDir": "dist",
+        "noImplicitOverride": false
     },
     "include": [
         "src/**/*",


### PR DESCRIPTION
Updated `trackerless-network`'s `jest.config.js` which uses deprecated `globals` definition. Jest printed a warning:

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```

Other related changes:
-  defined the tsconfig like we do in the default root-level `jest.config.js`: https://github.com/streamr-dev/network/blob/ea6725052e0b5753bdd23af0b68503fb190e2362/jest.config.js#L9
- added `noImplicitOverride` definition to the `tsconfig.jest.ts` so that it matches the `tsconfig.node.json`: https://github.com/streamr-dev/network/blob/ea6725052e0b5753bdd23af0b68503fb190e2362/packages/trackerless-network/tsconfig.jest.json#L5