### PR TITLE
NET-1110: hotfix: add msg handler to MaintainTopologyService

### DIFF
--- a/packages/broker/src/plugins/operator/MaintainTopologyService.ts
+++ b/packages/broker/src/plugins/operator/MaintainTopologyService.ts
@@ -27,10 +27,6 @@ export class MaintainTopologyService {
                 partition,
                 raw: true
             }, () => {})
-
-            subscription.on('error', (err) => {
-                logger.error(`Subscription error: ${err}`)
-            })
         } catch (err) {
             logger.warn(`Failed to join stream partition ${streamPartId}`, { reason: err?.reason })
             return

--- a/packages/broker/src/plugins/operator/MaintainTopologyService.ts
+++ b/packages/broker/src/plugins/operator/MaintainTopologyService.ts
@@ -28,9 +28,9 @@ export class MaintainTopologyService {
                 raw: true
             }, () => {})
 
-			subscription.on('error', (err) => {
-				logger.error(`Subscription error: ${err}`)
-			})
+            subscription.on('error', (err) => {
+                logger.error(`Subscription error: ${err}`)
+            })
         } catch (err) {
             logger.warn(`Failed to join stream partition ${streamPartId}`, { reason: err?.reason })
             return

--- a/packages/broker/src/plugins/operator/MaintainTopologyService.ts
+++ b/packages/broker/src/plugins/operator/MaintainTopologyService.ts
@@ -26,7 +26,11 @@ export class MaintainTopologyService {
                 id,
                 partition,
                 raw: true
-            })
+            }, () => {})
+
+			subscription.on('error', (err) => {
+				logger.error(`Subscription error: ${err}`)
+			})
         } catch (err) {
             logger.warn(`Failed to join stream partition ${streamPartId}`, { reason: err?.reason })
             return

--- a/packages/broker/test/unit/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/broker/test/unit/plugins/operator/MaintainTopologyService.test.ts
@@ -29,7 +29,7 @@ function setUpFixturesAndMocks(streamrClient: MockProxy<StreamrClient>): Record<
     for (const streamPartId of ALL_STREAM_PARTS) {
         result[streamPartId] = { unsubscribe: jest.fn() }
     }
-    streamrClient.subscribe.mockImplementation(async (opts) => {
+    streamrClient.subscribe.mockImplementation(async (opts, msgHandler) => {
         if ((opts as any).id === STREAM_NOT_EXIST) {
             throw new Error('non-existing stream')
         }
@@ -63,8 +63,8 @@ describe('MaintainTopologyService', () => {
 
         await waitForCondition(() => streamrClient.subscribe.mock.calls.length >= 2)
         expect(streamrClient.subscribe).toHaveBeenCalledTimes(2)
-        expect(streamrClient.subscribe).toBeCalledWith(formRawSubscriptionParam(SP1))
-        expect(streamrClient.subscribe).toBeCalledWith(formRawSubscriptionParam(SP2))
+        expect(streamrClient.subscribe.mock.calls[0][0]).toEqual(formRawSubscriptionParam(SP1))
+        expect(streamrClient.subscribe.mock.calls[1][0]).toEqual(formRawSubscriptionParam(SP2))
     })
 
     it('handles "assigned" event given non-existing stream (does not crash)', async () => {

--- a/packages/broker/test/unit/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/broker/test/unit/plugins/operator/MaintainTopologyService.test.ts
@@ -29,7 +29,7 @@ function setUpFixturesAndMocks(streamrClient: MockProxy<StreamrClient>): Record<
     for (const streamPartId of ALL_STREAM_PARTS) {
         result[streamPartId] = { unsubscribe: jest.fn() }
     }
-    streamrClient.subscribe.mockImplementation(async (opts, msgHandler) => {
+    streamrClient.subscribe.mockImplementation(async (opts) => {
         if ((opts as any).id === STREAM_NOT_EXIST) {
             throw new Error('non-existing stream')
         }


### PR DESCRIPTION
Add a msg handler to the `streamrClient.subscribe` call in `MaintainTopologyService`, because without it, message pipeline buffers get full and prevent other subscriptions for the same streams from getting messages.