### PR TITLE
refactor(utils): Compatible timer types

### DIFF
--- a/packages/utils/src/abortableTimers.ts
+++ b/packages/utils/src/abortableTimers.ts
@@ -11,8 +11,8 @@ export const setAbortableTimeout = createAbortableTimerFn(setTimeout, clearTimeo
 export const setAbortableInterval = createAbortableTimerFn(setInterval, clearInterval, false)
 
 function createAbortableTimerFn(
-    setupTimerFn: (cb: () => void, ms?: number) => NodeJS.Timer,
-    clearFn: (ref: NodeJS.Timer) => void,
+    setupTimerFn: (cb: () => void, ms?: number) => NodeJS.Timeout,
+    clearFn: (ref: NodeJS.Timeout) => void,
     removeListenerOnCb: boolean
 ): (cb: () => void, ms: number, abortSignal: AbortSignal) => void {
     return (callback, ms, abortSignal): void => {

--- a/packages/utils/test/TheGraphClient.test.ts
+++ b/packages/utils/test/TheGraphClient.test.ts
@@ -13,7 +13,7 @@ interface IndexState {
 class EmulatedTheGraphIndex {
 
     private states: IndexState[]
-    private timer: NodeJS.Timer | undefined
+    private timer: NodeJS.Timeout | undefined
 
     constructor(states: IndexState[]) {
         this.states = states


### PR DESCRIPTION
Change `NodeJS.Timer` -> `NodeJS.Timeout` 

Are needed when we'll update to latest `@types/node` type definitions: see this commit where `[Symbol.dispose]()` is added to `Timeout` for Node v20.5.0: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3866583ca9244b47878fa0ac8cfdfb23eb2ef0c5/types/node/timers.d.ts