### PR TITLE
refactor(trackerless-network): Remove obsolete methods

### DIFF
--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -122,7 +122,7 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
         await readinessListener.waitUntilReady(timeout)
     }
 
-    async joinLayer0IfRequired(streamPartId: StreamPartID): Promise<void> {
+    private async joinLayer0IfRequired(streamPartId: StreamPartID): Promise<void> {
         if (this.streamrNode!.isProxiedStreamPart(streamPartId)) {
             return
         }

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -96,7 +96,7 @@ export class NodeList extends EventEmitter<Events> {
         return included[included.length - 1]
     }
 
-    getNodes(): RemoteRandomGraphNode[] {
+    getAll(): RemoteRandomGraphNode[] {
         return Array.from(this.nodes.values())
     }
 

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -66,7 +66,7 @@ export class NodeList extends EventEmitter<Events> {
         return Array.from(this.nodes.keys())
     }
 
-    getNeighborById(id: NodeID): RemoteRandomGraphNode | undefined {
+    get(id: NodeID): RemoteRandomGraphNode | undefined {
         return this.nodes.get(id)
     }
 

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -85,9 +85,9 @@ export class RandomGraphNode extends EventEmitter<Events> {
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: NodeID) => this.broadcast(message, previousNode),
             onLeaveNotice: (senderId: NodeID) => {
-                const contact = this.config.nearbyNodeView.getNeighborById(senderId)
-                || this.config.randomNodeView.getNeighborById(senderId)
-                || this.config.targetNeighbors.getNeighborById(senderId)
+                const contact = this.config.nearbyNodeView.get(senderId)
+                || this.config.randomNodeView.get(senderId)
+                || this.config.targetNeighbors.get(senderId)
                 || this.config.proxyConnectionServer?.getConnection(senderId )?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -279,7 +279,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         this.stopped = true
         this.abortController.abort()
         this.config.proxyConnectionServer?.stop()
-        this.config.targetNeighbors.getNodes().map((remote) => remote.leaveStreamPartNotice())
+        this.config.targetNeighbors.getAll().map((remote) => remote.leaveStreamPartNotice())
         this.config.rpcCommunicator.stop()
         this.removeAllListeners()
         this.config.nearbyNodeView.stop()

--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -45,7 +45,7 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
     const propagation = config.propagation ?? new Propagation({
         minPropagationTargets,
         sendToNeighbor: async (neighborId: NodeID, msg: StreamMessage): Promise<void> => {
-            const remote = targetNeighbors.getNeighborById(neighborId) ?? temporaryConnectionServer.getNodes().getNeighborById(neighborId)
+            const remote = targetNeighbors.get(neighborId) ?? temporaryConnectionServer.getNodes().get(neighborId)
             const proxyConnection = proxyConnectionServer?.getConnection(neighborId)
             if (remote) {
                 await remote.sendData(msg)

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
@@ -9,8 +9,8 @@ interface FindNeighborsSessionConfig {
     N: number
 }
 
-const INITIAL_TIMEOUT = 100
-const INTERVAL_TIMEOUT = 250
+const INITIAL_WAIT = 100
+const INTERVAL = 250
 
 export interface INeighborFinder {
     start(excluded?: NodeID[]): void
@@ -34,7 +34,7 @@ export class NeighborFinder implements INeighborFinder {
         }
         const newExcludes = await this.config.doFindNeighbors(excluded)
         if (this.config.targetNeighbors.size() < this.config.N && newExcludes.length < this.config.nearbyNodeView.size()) {
-            setAbortableTimeout(() => this.findNeighbors(newExcludes), INTERVAL_TIMEOUT, this.abortController.signal)
+            setAbortableTimeout(() => this.findNeighbors(newExcludes), INTERVAL, this.abortController.signal)
         } else {
             this.running = false
         }
@@ -49,7 +49,7 @@ export class NeighborFinder implements INeighborFinder {
             return
         }
         this.running = true
-        setAbortableTimeout(() => this.findNeighbors(excluded), INITIAL_TIMEOUT, this.abortController.signal)
+        setAbortableTimeout(() => this.findNeighbors(excluded), INITIAL_WAIT, this.abortController.signal)
     }
 
     stop(): void {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -50,8 +50,8 @@ export class NeighborUpdateManager implements INeighborUpdateManager {
 
     private async updateNeighborInfo(): Promise<void> {
         logger.trace(`Updating neighbor info to nodes`)
-        const neighborDescriptors = this.config.targetNeighbors.getNodes().map((neighbor) => neighbor.getPeerDescriptor())
-        await Promise.allSettled(this.config.targetNeighbors.getNodes().map(async (neighbor) => {
+        const neighborDescriptors = this.config.targetNeighbors.getAll().map((neighbor) => neighbor.getPeerDescriptor())
+        await Promise.allSettled(this.config.targetNeighbors.getAll().map(async (neighbor) => {
             const res = await this.createRemote(neighbor.getPeerDescriptor()).updateNeighbors(neighborDescriptors)
             if (res.removeMe) {
                 this.config.targetNeighbors.remove(neighbor.getPeerDescriptor())

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManagerServer.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManagerServer.ts
@@ -49,14 +49,14 @@ export class NeighborUpdateManagerServer implements INeighborUpdateRpc {
             this.config.neighborFinder.start()
             const response: NeighborUpdate = {
                 randomGraphId: this.config.randomGraphId,
-                neighborDescriptors: this.config.targetNeighbors.getNodes().map((neighbor) => neighbor.getPeerDescriptor()),
+                neighborDescriptors: this.config.targetNeighbors.getAll().map((neighbor) => neighbor.getPeerDescriptor()),
                 removeMe: false
             }
             return response
         } else {
             const response: NeighborUpdate = {
                 randomGraphId: this.config.randomGraphId,
-                neighborDescriptors: this.config.targetNeighbors.getNodes().map((neighbor) => neighbor.getPeerDescriptor()),
+                neighborDescriptors: this.config.targetNeighbors.getAll().map((neighbor) => neighbor.getPeerDescriptor()),
                 removeMe: true
             }
             return response

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -220,10 +220,6 @@ export class ProxyStreamConnectionClient extends EventEmitter {
         this.propagation.feedUnseenMessage(msg, this.targetNeighbors.getIds(), previousNode ?? null)
     }
 
-    getTargetNeighborIds(): NodeID[] {
-        return this.targetNeighbors.getIds()
-    }
-
     hasProxyConnection(nodeId: NodeID, direction: ProxyDirection): boolean {
         return this.connections.has(nodeId) && this.connections.get(nodeId) === direction
     }

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -82,7 +82,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: NodeID) => this.broadcast(message, previousNode),
             onLeaveNotice: (senderId: NodeID) => {
-                const contact = this.targetNeighbors.getNeighborById(senderId)
+                const contact = this.targetNeighbors.get(senderId)
                 if (contact) {
                     setImmediate(() => this.onNodeDisconnected(contact.getPeerDescriptor()))
                 }
@@ -93,7 +93,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
         this.propagation = new Propagation({
             minPropagationTargets: 2,
             sendToNeighbor: async (neighborId: NodeID, msg: StreamMessage): Promise<void> => {
-                const remote = this.targetNeighbors.getNeighborById(neighborId)
+                const remote = this.targetNeighbors.get(neighborId)
                 if (remote) {
                     await remote.sendData(msg)
                 } else {
@@ -201,7 +201,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
             logger.info('Close proxy connection', {
                 nodeId
             })
-            const server = this.targetNeighbors.getNeighborById(nodeId)
+            const server = this.targetNeighbors.get(nodeId)
             server?.leaveStreamPartNotice()
             this.removeConnection(nodeId)
         }

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -228,7 +228,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
         return this.definition!.direction
     }
 
-    async onNodeDisconnected(peerDescriptor: PeerDescriptor): Promise<void> {
+    private async onNodeDisconnected(peerDescriptor: PeerDescriptor): Promise<void> {
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
         if (this.connections.has(nodeId)) {
             this.config.connectionLocker.unlockConnection(peerDescriptor, 'proxy-stream-connection-client')

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -252,7 +252,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
     }
 
     stop(): void {
-        this.targetNeighbors.getNodes().map((remote) => {
+        this.targetNeighbors.getAll().map((remote) => {
             this.config.connectionLocker.unlockConnection(remote.getPeerDescriptor(), 'proxy-stream-connection-client')
             remote.leaveStreamPartNotice()
         })

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -220,7 +220,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
         this.propagation.feedUnseenMessage(msg, this.targetNeighbors.getIds(), previousNode ?? null)
     }
 
-    hasProxyConnection(nodeId: NodeID, direction: ProxyDirection): boolean {
+    hasConnection(nodeId: NodeID, direction: ProxyDirection): boolean {
         return this.connections.has(nodeId) && this.connections.get(nodeId) === direction
     }
 

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionServer.ts
@@ -66,14 +66,6 @@ export class ProxyStreamConnectionServer extends EventEmitter<Events> implements
         this.removeAllListeners()
     }
 
-    getConnectedNodeIds(): NodeID[] {
-        return Array.from(this.connections.keys())
-    }
-
-    getConnections(): ProxyConnection[] {
-        return Array.from(this.connections.values())
-    }
-
     getPropagationTargets(msg: StreamMessage): NodeID[] {
         if (msg.messageType === StreamMessageType.GROUP_KEY_REQUEST) {
             try {

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -42,7 +42,7 @@ describe('Proxy connections', () => {
     
     const hasConnectionToProxy = (proxyNodeId: NodeID, direction: ProxyDirection): boolean => {
         const client = (proxiedNode.stack.getStreamrNode()!.getStream(STREAM_PART_ID) as { client: ProxyStreamConnectionClient }).client
-        return client.hasProxyConnection(proxyNodeId, direction)
+        return client.hasConnection(proxyNodeId, direction)
     }
 
     beforeEach(async () => {

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -68,8 +68,8 @@ describe('RandomGraphNode', () => {
         const peerDescriptor2 = createMockPeerDescriptor()
         layer1.emit('newContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => nearbyNodeView.size() === 2)
-        expect(nearbyNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(nearbyNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
+        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
     })
 
     it('Adds Random Nodes from layer1 newRandomContact event to randomNodeView', async () => {
@@ -77,8 +77,8 @@ describe('RandomGraphNode', () => {
         const peerDescriptor2 = createMockPeerDescriptor()
         layer1.emit('newRandomContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => randomNodeView.size() === 2)
-        expect(randomNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(randomNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
+        expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
     })
 
     it('Adds Nodes from layer1 KBucket to nearbyNodeView if its size is below nodeViewSize', async () => {
@@ -87,8 +87,8 @@ describe('RandomGraphNode', () => {
         layer1.addNewRandomPeerToKBucket()
         layer1.emit('newContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => nearbyNodeView.size() === 3)
-        expect(nearbyNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(nearbyNodeView.getNeighborById(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
+        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
     })
 
 })


### PR DESCRIPTION
Remove obsolete methods:
- `ProxyStreamConnectionClient#getTargetNeighborIds`
- `ProxyStreamConnectionServer#getConnectedNodeIds`, `getConnections`

Rename:
- `ProxyStreamConnectionClient#hasProxyConnection `-> `hasConnection`
- `NodeList#getNeighbordById` -> `get`
- `NodeList#getNodes` -> `getAll`

Change to private visibility:
- `NetworkStack#joinLayer0IfRequired`
- `ProxyStreamConnectionClient#onNodeDisconnected`

## Possible future improvements

- These methods are used only in tests: `RandomGraphNode#hasProxyConnection`, `RandomGraphNode#getNumberOfOutgoingHandshakes`, `StreamrNode#getStream`. Maybe could use other public methods or test consequences in the tests instead?
