### PR TITLE
fix(trackerless-network): [NET-1120] Use `streamPartitionMinPropagationTargets` in proxy client

### DIFF
--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -269,6 +269,7 @@ export class StreamrNode extends EventEmitter<Events> {
             ownPeerDescriptor: this.layer0!.getPeerDescriptor(),
             streamPartId,
             connectionLocker: this.connectionLocker!,
+            minPropagationTargets: this.config.streamPartitionMinPropagationTargets,
             nodeName: this.config.nodeName,
             userId
         })

--- a/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyStreamConnectionClient.ts
@@ -48,6 +48,7 @@ interface ProxyStreamConnectionClientConfig {
     connectionLocker: ConnectionLocker
     userId: EthereumAddress
     nodeName?: string
+    minPropagationTargets?: number // TODO could be required option if we apply all defaults somewhere at higher level
 }
 
 interface ProxyDefinition {
@@ -91,7 +92,7 @@ export class ProxyStreamConnectionClient extends EventEmitter {
             markForInspection: (_senderId: NodeID, _messageId: MessageID) => {}
         })
         this.propagation = new Propagation({
-            minPropagationTargets: 2,
+            minPropagationTargets: config.minPropagationTargets ?? 2,
             sendToNeighbor: async (neighborId: NodeID, msg: StreamMessage): Promise<void> => {
                 const remote = this.targetNeighbors.getNeighborById(neighborId)
                 if (remote) {


### PR DESCRIPTION
**Given:** there is a proxied stream which receives messages from a proxy`
**When:**` a message is received 
**Then:**  this node should propagate it to `n` others nodes, where `n `is defined by `streamPartitionMinPropagationTargets` client config option.

It used hardcoded value of `2` instead.

## Future improvements

- The client provides defaults for each config option (or it at least should, haven't checked). So it would make sense that there wouldn't be internal default values in each components. We already do most of the default value handling in `createConfigWithDefaults`, but could maybe move all defaults to that function (or even higher level).