### PR TITLE
refactor(dht): Do not expose `DhtPeer`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -555,8 +555,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return undefined
     }
 
-    public getNeighborList(): SortedContactList<DhtPeer> {
-        return this.neighborList!
+    public getClosestContacts(maxCount?: number): PeerDescriptor[] {
+        return this.neighborList!.getClosestContacts(maxCount).map((c) => c.getPeerDescriptor())
     }
 
     public getNodeId(): PeerID {

--- a/packages/dht/src/exports.ts
+++ b/packages/dht/src/exports.ts
@@ -7,7 +7,6 @@ export { PeerDescriptor, Message, NodeType, DataEntry } from './proto/packages/d
 export { ITransport } from './transport/ITransport'
 export { ConnectionManager, ConnectionLocker, PortRange, TlsCertificate } from './connection/ConnectionManager'
 export { PeerID, PeerIDKey } from './helpers/PeerID'
-export { DhtPeer } from './dht/DhtPeer'
 export { UUID } from './helpers/UUID'
 export { DhtRpcOptions } from './rpc-protocol/DhtRpcOptions'
 export { protoClasses } from './helpers/protoClasses'

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { Simulator } from '../../src/connection/Simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
+import { PeerID } from '../../src/exports'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { execSync } from 'child_process'
@@ -70,7 +71,7 @@ describe('Kademlia correctness', () => {
                 groundTruthString += groundTruth[i + ''][j].name + ','
             }
 
-            const kademliaNeighbors = nodes[i].getNeighborList().getContactIds()
+            const kademliaNeighbors = nodes[i].getClosestContacts().map((p) => PeerID.fromValue(p.kademliaId))
 
             let kadString = 'kademliaNeighbors: '
             kademliaNeighbors.forEach((neighbor) => {

--- a/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
@@ -1,6 +1,6 @@
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { isSamePeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 
 describe('Layer0-Layer1', () => {
     const epPeerDescriptor: PeerDescriptor = {
@@ -76,14 +76,14 @@ describe('Layer0-Layer1', () => {
             stream2Node1.joinDht([epPeerDescriptor]),
             stream2Node2.joinDht([epPeerDescriptor])
         ])
-        expect(stream1Node1.getNeighborList().getSize()).toEqual(1)
-        expect(stream1Node2.getNeighborList().getSize()).toEqual(1)
-        expect(stream2Node1.getNeighborList().getSize()).toEqual(1)
-        expect(stream2Node2.getNeighborList().getSize()).toEqual(1)
+        expect(stream1Node1.getClosestContacts()).toHaveLength(1)
+        expect(stream1Node2.getClosestContacts()).toHaveLength(1)
+        expect(stream2Node1.getClosestContacts()).toHaveLength(1)
+        expect(stream2Node2.getClosestContacts()).toHaveLength(1)
 
-        expect(stream1Node1.getNeighborList().getContactIds()[0].equals(peerIdFromPeerDescriptor(node1.getPeerDescriptor()))).toEqual(true)
-        expect(stream1Node2.getNeighborList().getContactIds()[0].equals(peerIdFromPeerDescriptor(epPeerDescriptor))).toEqual(true)
-        expect(stream2Node1.getNeighborList().getContactIds()[0].equals(peerIdFromPeerDescriptor(node2.getPeerDescriptor()))).toEqual(true)
-        expect(stream2Node2.getNeighborList().getContactIds()[0].equals(peerIdFromPeerDescriptor(epPeerDescriptor))).toEqual(true)
+        expect(isSamePeerDescriptor(stream1Node1.getClosestContacts()[0], node1.getPeerDescriptor())).toBe(true)
+        expect(isSamePeerDescriptor(stream1Node2.getClosestContacts()[0], epPeerDescriptor)).toBe(true)
+        expect(isSamePeerDescriptor(stream2Node1.getClosestContacts()[0], node2.getPeerDescriptor())).toBe(true)
+        expect(isSamePeerDescriptor(stream2Node2.getClosestContacts()[0], epPeerDescriptor)).toBe(true)
     })
 })

--- a/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
@@ -1,6 +1,6 @@
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { isSamePeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { isSamePeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 
 describe('Layer0-Layer1', () => {
     const epPeerDescriptor: PeerDescriptor = {

--- a/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
@@ -39,7 +39,7 @@ describe('Mock connection Dht joining with latencies', () => {
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 2)
-            expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 2)
+            expect(node.getClosestContacts().length).toBeGreaterThanOrEqual(node.getK() - 2)
         })
         expect(entryPoint.getBucketSize()).toBeGreaterThanOrEqual(entryPoint.getK() - 2)
     }, 60 * 1000)

--- a/packages/dht/test/integration/DhtWithMockConnections.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnections.test.ts
@@ -39,7 +39,7 @@ describe('Mock IConnection DHT Joining', () => {
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 2)
-            expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 2)
+            expect(node.getClosestContacts().length).toBeGreaterThanOrEqual(node.getK() - 2)
         })
         expect(entryPoint.getBucketSize()).toBeGreaterThanOrEqual(entryPoint.getK() - 2)
     }, 60000)

--- a/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithRealConnectionLatencies.test.ts
@@ -40,7 +40,7 @@ describe('Mock connection Dht joining with real latencies', () => {
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
         nodes.forEach((node) => {
             expect(node.getBucketSize()).toBeGreaterThanOrEqual(node.getK() - 3)
-            expect(node.getNeighborList().getSize()).toBeGreaterThanOrEqual(node.getK() - 3)
+            expect(node.getClosestContacts().length).toBeGreaterThanOrEqual(node.getK() - 3)
         })
         expect(entryPoint.getBucketSize()).toBeGreaterThanOrEqual(entryPoint.getK())
     }, 60 * 1000)

--- a/packages/trackerless-network/src/logic/ILayer1.ts
+++ b/packages/trackerless-network/src/logic/ILayer1.ts
@@ -1,4 +1,4 @@
-import { PeerDescriptor, SortedContactList, DhtPeer } from '@streamr/dht'
+import { PeerDescriptor } from '@streamr/dht'
 
 export interface ILayer1Events {
     newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
@@ -15,7 +15,7 @@ export interface ILayer1 {
     off<T extends keyof ILayer1Events>(eventName: T, listener: (peerDescriptor: PeerDescriptor, peers: PeerDescriptor[]) => void): void
     
     removeContact: (peerDescriptor: PeerDescriptor, removeFromOpenInternetPeers?: boolean) => void
-    getNeighborList: () => SortedContactList<DhtPeer>
+    getClosestContacts: (maxCount?: number) => PeerDescriptor[]
     getKBucketPeers: () => PeerDescriptor[]
     getBucketSize: () => number
     joinDht: (entryPoints: PeerDescriptor[], doRandomJoin?: boolean, retry?: boolean) => Promise<void>

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'eventemitter3'
 import {
     PeerDescriptor,
-    DhtPeer,
     ListeningRpcCommunicator,
     ITransport,
     ConnectionLocker
@@ -256,8 +255,8 @@ export class RandomGraphNode extends EventEmitter<Events> {
 
     private getNeighborCandidatesFromLayer1(): PeerDescriptor[] {
         const uniqueNodes = new Set<PeerDescriptor>()
-        this.config.layer1.getNeighborList().getClosestContacts(this.config.nodeViewSize).forEach((contact: DhtPeer) => {
-            uniqueNodes.add(contact.getPeerDescriptor())
+        this.config.layer1.getClosestContacts(this.config.nodeViewSize).forEach((peer: PeerDescriptor) => {
+            uniqueNodes.add(peer)
         })
         this.config.layer1.getKBucketPeers().forEach((peer: PeerDescriptor) => {
             uniqueNodes.add(peer)

--- a/packages/trackerless-network/test/utils/mock/MockLayer1.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer1.ts
@@ -19,8 +19,8 @@ export class MockLayer1 extends EventEmitter implements ILayer1 {
 
     }
 
-    getNeighborList(): SortedContactList<DhtPeer> {
-        return this.neighborList
+    getClosestContacts(maxCount?: number): PeerDescriptor[] {
+        return this.neighborList.getClosestContacts(maxCount).map((c) => c.getPeerDescriptor())
     }
 
     getKBucketPeers(): PeerDescriptor[] {

--- a/packages/trackerless-network/test/utils/mock/MockLayer1.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer1.ts
@@ -1,4 +1,4 @@
-import { DhtPeer, PeerDescriptor, PeerID, PeerIDKey, SortedContactList } from '@streamr/dht'
+import { PeerDescriptor } from '@streamr/dht'
 import { EventEmitter } from 'eventemitter3'
 import { NodeID } from '../../../src/identifiers'
 import { ILayer1 } from '../../../src/logic/ILayer1'
@@ -7,20 +7,18 @@ import { createMockPeerDescriptor } from '../utils'
 export class MockLayer1 extends EventEmitter implements ILayer1 {
     
     private readonly kbucketPeers: PeerDescriptor[] = []
-    private readonly neighborList: SortedContactList<DhtPeer>
 
-    constructor(nodeId: NodeID) {
+    constructor(_nodeId: NodeID) {
         super()
-        this.neighborList = new SortedContactList(PeerID.fromKey(nodeId as string as PeerIDKey), 10)
     }
 
     // eslint-disable-next-line class-methods-use-this
     removeContact(_peerDescriptor: PeerDescriptor, _removeFromOpenInternetPeers?: boolean): void {
-
     }
 
-    getClosestContacts(maxCount?: number): PeerDescriptor[] {
-        return this.neighborList.getClosestContacts(maxCount).map((c) => c.getPeerDescriptor())
+    // eslint-disable-next-line class-methods-use-this
+    getClosestContacts(_maxCount?: number): PeerDescriptor[] {
+        return []
     }
 
     getKBucketPeers(): PeerDescriptor[] {


### PR DESCRIPTION
We consider `DhtPeer` as an internal class, which should not be visible to the `trackerless-network` (see comment https://github.com/streamr-dev/network/pull/1933#discussion_r1350757070). Therefore removed the class from exports.

Changed `DhtNode#getNeighborList` to return `PeerDescriptor[]` instead of `DhtPeer` and renamed it to `getClosestContacts`. Now all methods of `ILayer1` interface operate on `PeerDescriptor`.

Also removed `MockLayer1#neighborList` as the field was not written by any method.
