### PR TITLE
fix(DHT): NET-1123 fixed browser connection attempts to clear text ws servers

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -142,7 +142,8 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     } else {
         kademliaId = hexToBinary(peerId!)
     }
-    const ret: PeerDescriptor = { kademliaId, nodeName: nodeName ? nodeName : binaryToHex(kademliaId), type: NodeType.NODEJS }
+    const nodeType = isNodeJS() ? NodeType.NODEJS : NodeType.BROWSER
+    const ret: PeerDescriptor = { kademliaId, nodeName: nodeName ? nodeName : binaryToHex(kademliaId), type: nodeType }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
         ret.openInternet = true


### PR DESCRIPTION
## Summary

Fixed attempted connections from the browser to clear text WS servers.

- Browser nodes now appropriately assign their type as `BROWSER`.
- If Browser type is detected in the PeerDescriptor on either side and the other side has a clear text ws server default to WebRTC connections.
- If WS server has local address allow browser to connect to them for testing