### PR TITLE
documentation url fix

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ const config = {
     title: "Streamr Docs",
     tagline:
         "Publish and subscribe to your json based real-time data powered by the decentralized Streamr network.",
-    url: "https://streamr.network/",
+    url: "https://docs.streamr.network/",
     baseUrl: "/",
     onBrokenLinks: "throw",
     onBrokenMarkdownLinks: "throw",


### PR DESCRIPTION
## Summary

Fixed the current documentation url to docusaurus config. Solves the canonical links issue & search engine indexing issues.
