### PR TITLE
refactor(dht): Simplify `DuplicateDetector`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -420,7 +420,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
                 + message.sourceDescriptor?.nodeName + ' ' + message.serviceId + ' ' + message.messageId)
             return
         }
-        this.messageDuplicateDetector.add(message.messageId, message.sourceDescriptor!.nodeName!, message)
+        this.messageDuplicateDetector.add(message.messageId)
         if (message.serviceId === this.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else {

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -252,7 +252,7 @@ export class RecursiveFinder implements IRecursiveFinder {
     async findRecursively(routedMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
         if (this.stopped) {
             return createRouteMessageAck(routedMessage, 'findRecursively() service is not running')
-        } else if (this.router.checkDuplicate(routedMessage.requestId)) {
+        } else if (this.router.isMostLikelyDuplicate(routedMessage.requestId)) {
             return createRouteMessageAck(routedMessage, 'message given to findRecursively() service is likely a duplicate')
         }
         const senderKey = keyFromPeerDescriptor(routedMessage.previousPeer || routedMessage.sourcePeer!)

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -258,7 +258,7 @@ export class RecursiveFinder implements IRecursiveFinder {
         const senderKey = keyFromPeerDescriptor(routedMessage.previousPeer || routedMessage.sourcePeer!)
         logger.trace(`Node ${this.ownPeerId.toKey()} received findRecursively call from ${senderKey}`)
         this.addContact(routedMessage.sourcePeer!, true)
-        this.router.addToDuplicateDetector(routedMessage.requestId, keyFromPeerDescriptor(routedMessage.sourcePeer!))
+        this.router.addToDuplicateDetector(routedMessage.requestId)
         return this.doFindRecursevily(routedMessage)
     }
 

--- a/packages/dht/src/dht/routing/DuplicateDetector.ts
+++ b/packages/dht/src/dht/routing/DuplicateDetector.ts
@@ -1,6 +1,4 @@
-import { Message } from '../../proto/packages/dht/protos/DhtRpc'
-
-type QueueEntry = [timestamp: number, value: string, senderId: string, message?: Message]
+type QueueEntry = [timestamp: number, value: string]
 
 export class DuplicateDetector {
 
@@ -17,13 +15,9 @@ export class DuplicateDetector {
         this.maxAge = maxAgeInSeconds * 1000
     }
 
-    public add(value: string, senderId: string, message?: Message): void {
+    public add(value: string): void {
         this.values.add(value)
-        if (message) {
-            this.queue.push([Date.now(), value, senderId, message])
-        } else {
-            this.queue.push([Date.now(), value, senderId])
-        }
+        this.queue.push([Date.now(), value])
         this.cleanUp()
     }
 
@@ -49,5 +43,4 @@ export class DuplicateDetector {
         this.values.clear()
         this.queue = []
     }
-
 }

--- a/packages/dht/src/dht/routing/DuplicateDetector.ts
+++ b/packages/dht/src/dht/routing/DuplicateDetector.ts
@@ -1,6 +1,6 @@
 import { Message } from '../../proto/packages/dht/protos/DhtRpc'
 
-type QueueEntry = [timeStamp: number, value: string, senderId: string, message?: Message]
+type QueueEntry = [timestamp: number, value: string, senderId: string, message?: Message]
 
 export class DuplicateDetector {
 

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -45,7 +45,7 @@ interface IRouterFunc {
     doRouteMessage(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RouteMessageAck
     send(msg: Message, reachableThrough: PeerDescriptor[]): Promise<void>
     checkDuplicate(messageId: string): boolean
-    addToDuplicateDetector(messageId: string, senderId: string, message?: Message): void
+    addToDuplicateDetector(messageId: string): void
     addRoutingSession(session: RoutingSession): void
     removeRoutingSession(sessionId: string): void
     stop(): void
@@ -173,8 +173,8 @@ export class Router implements IRouter {
         return this.routerDuplicateDetector.isMostLikelyDuplicate(messageId)
     }
 
-    public addToDuplicateDetector(messageId: string, senderId: string, message?: Message): void {
-        this.routerDuplicateDetector.add(messageId, senderId, message)
+    public addToDuplicateDetector(messageId: string): void {
+        this.routerDuplicateDetector.add(messageId)
     }
 
     public addRoutingSession(session: RoutingSession): void {
@@ -209,7 +209,7 @@ export class Router implements IRouter {
         }
         logger.trace(`Processing received routeMessage ${routedMessage.requestId}`)
         this.addContact(routedMessage.sourcePeer!, true)
-        this.addToDuplicateDetector(routedMessage.requestId, keyFromPeerDescriptor(routedMessage.sourcePeer!))
+        this.addToDuplicateDetector(routedMessage.requestId)
         if (this.ownPeerId.equals(peerIdFromPeerDescriptor(routedMessage.destinationPeer!))) {
             logger.trace(`${this.ownPeerDescriptor.nodeName} routing message targeted to self ${routedMessage.requestId}`)
             this.setForwardingEntries(routedMessage)
@@ -253,7 +253,7 @@ export class Router implements IRouter {
         }
         logger.trace(`Processing received forward routeMessage ${forwardMessage.requestId}`)
         this.addContact(forwardMessage.sourcePeer!, true)
-        this.addToDuplicateDetector(forwardMessage.requestId, keyFromPeerDescriptor(forwardMessage.sourcePeer!))
+        this.addToDuplicateDetector(forwardMessage.requestId)
         if (this.ownPeerId.equals(peerIdFromPeerDescriptor(forwardMessage.destinationPeer!))) {
             return this.forwardToDestination(forwardMessage)
         } else {

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -44,7 +44,7 @@ interface ForwardingTableEntry {
 interface IRouterFunc {
     doRouteMessage(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RouteMessageAck
     send(msg: Message, reachableThrough: PeerDescriptor[]): Promise<void>
-    checkDuplicate(messageId: string): boolean
+    isMostLikelyDuplicate(messageId: string): boolean
     addToDuplicateDetector(messageId: string): void
     addRoutingSession(session: RoutingSession): void
     removeRoutingSession(sessionId: string): void
@@ -169,7 +169,7 @@ export class Router implements IRouter {
         )
     }
 
-    public checkDuplicate(messageId: string): boolean {
+    public isMostLikelyDuplicate(messageId: string): boolean {
         return this.routerDuplicateDetector.isMostLikelyDuplicate(messageId)
     }
 

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -44,8 +44,8 @@ interface ForwardingTableEntry {
 interface IRouterFunc {
     doRouteMessage(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RouteMessageAck
     send(msg: Message, reachableThrough: PeerDescriptor[]): Promise<void>
-    isMostLikelyDuplicate(messageId: string): boolean
-    addToDuplicateDetector(messageId: string): void
+    isMostLikelyDuplicate(requestId: string): boolean
+    addToDuplicateDetector(requestId: string): void
     addRoutingSession(session: RoutingSession): void
     removeRoutingSession(sessionId: string): void
     stop(): void
@@ -169,12 +169,12 @@ export class Router implements IRouter {
         )
     }
 
-    public isMostLikelyDuplicate(messageId: string): boolean {
-        return this.routerDuplicateDetector.isMostLikelyDuplicate(messageId)
+    public isMostLikelyDuplicate(requestId: string): boolean {
+        return this.routerDuplicateDetector.isMostLikelyDuplicate(requestId)
     }
 
-    public addToDuplicateDetector(messageId: string): void {
-        this.routerDuplicateDetector.add(messageId)
+    public addToDuplicateDetector(requestId: string): void {
+        this.routerDuplicateDetector.add(requestId)
     }
 
     public addRoutingSession(session: RoutingSession): void {

--- a/packages/dht/test/unit/DuplicateDetector.test.ts
+++ b/packages/dht/test/unit/DuplicateDetector.test.ts
@@ -3,25 +3,24 @@ import { DuplicateDetector } from '../../src/dht/routing/DuplicateDetector'
 describe('Duplicate Detector', () => {
     let detector: DuplicateDetector
     const maxLimit = 10
-    const senderId = 'sender'
     beforeEach(async () => {
         detector = new DuplicateDetector(maxLimit, 100)
     })
 
     it('detects duplicates', async () => {
-        detector.add('test', senderId)
+        detector.add('test')
         expect(detector.size()).toEqual(1)
         expect(detector.isMostLikelyDuplicate('test')).toEqual(true)
     })
 
     it('resets on resetLimit', () => {
         for (let i = 0; i < maxLimit; i++) {
-            detector.add(`test${i}`, senderId)
+            detector.add(`test${i}`)
         }
         for (let i = 0; i < maxLimit; i++) {
             expect(detector.isMostLikelyDuplicate(`test${i}`)).toEqual(true)
         }
-        detector.add('test10', senderId)
+        detector.add('test10')
         expect(detector.size()).toEqual(10)
         expect(detector.isMostLikelyDuplicate('test0')).toEqual(false)
         expect(detector.isMostLikelyDuplicate('test10')).toEqual(true)

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -4,7 +4,6 @@ import { PeerID, PeerIDKey } from '../../src/helpers/PeerID'
 import { DhtPeer } from '../../src/dht/DhtPeer'
 import { createWrappedClosestPeersRequest, createMockRoutingRpcCommunicator } from '../utils/utils'
 import { v4 } from 'uuid'
-import { keyFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 
 describe('Router', () => {
     let router: Router
@@ -99,7 +98,7 @@ describe('Router', () => {
     })
 
     it('route server on duplicate message', async () => {
-        router.addToDuplicateDetector(routedMessage.requestId, keyFromPeerDescriptor(peerDescriptor2))
+        router.addToDuplicateDetector(routedMessage.requestId)
         const ack = await router.routeMessage(routedMessage, {} as any)
         expect(ack.error).toEqual('message given to routeMessage() service is likely a duplicate')
     })
@@ -116,7 +115,7 @@ describe('Router', () => {
     })
 
     it('forward server on duplicate message', async () => {
-        router.addToDuplicateDetector(routedMessage.requestId, keyFromPeerDescriptor(peerDescriptor2))
+        router.addToDuplicateDetector(routedMessage.requestId)
         const ack = await router.forwardMessage(routedMessage, {} as any)
         expect(ack.error).toEqual('message given to forwardMessage() service is likely a duplicate')
     })

--- a/packages/dht/test/utils/mock/Router.ts
+++ b/packages/dht/test/utils/mock/Router.ts
@@ -16,7 +16,7 @@ export class MockRouter implements IRouter {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    addToDuplicateDetector(_messageId: string, _senderId: string, _message?: Message): void {
+    addToDuplicateDetector(_messageId: string): void {
         return
     }
 

--- a/packages/dht/test/utils/mock/Router.ts
+++ b/packages/dht/test/utils/mock/Router.ts
@@ -21,7 +21,7 @@ export class MockRouter implements IRouter {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    checkDuplicate(_messageId: string): boolean {
+    isMostLikelyDuplicate(_messageId: string): boolean {
         return false
     }
 


### PR DESCRIPTION
The `DuplicateDetector` didn't use `senderId` or `message` data in any way. Simplified the class by removing those fields from parameters and data structures. 

Also renamed some fields.