### PR TITLE
fix(DHT): NET-1027 enable skipped integation/Store.test.ts test case

### DIFF
--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -55,8 +55,7 @@ describe('Storing data in DHT', () => {
         expect(successfulStorers.length).toBeGreaterThan(4)
     }, 90000)
 
-    // TODO: flaky test, fix in NET-1027
-    it.skip('Storing and getting data works', async () => {
+    it('Storing and getting data works', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
         const data = Any.pack(entrypointDescriptor, PeerDescriptor)


### PR DESCRIPTION
## Summary

Re-enabled `integration/Store.test.ts` `Storing and getting data works` after it passed locally 200 times