### PR TITLE
fix(network): NET-1090 fix flaky `integration/RandomGraphNode-Layer1Node-Latencies.test.ts` test case in browser

### DIFF
--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -84,7 +84,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         await Promise.all(range(4).map((i) => {
             return waitForCondition(() => {
                 return graphNodes[i].getTargetNeighborIds().length >= 4
-            }, 10000, 2000)
+            }, 15000, 2000)
         }))
         range(4).map((i) => {
             expect(graphNodes[i].getNearbyNodeView().getIds().length).toBeGreaterThanOrEqual(4)


### PR DESCRIPTION
## Summary

Fix flaky test case in the browser. Was only flaky in CI.