### PR TITLE
refactor(dht): [NET-1130] Remove `nodeName`

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -148,7 +148,6 @@ message PeerDescriptor {
   ConnectivityMethod websocket = 5;
   optional bool openInternet = 6;
   optional uint32 region = 7;
-  optional string nodeName = 8;
 }
 
 message ConnectivityMethod {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -76,7 +76,6 @@ export interface DhtNodeOptions {
     websocketPortRange?: PortRange
     peerId?: string
 
-    nodeName?: string
     rpcRequestTimeout?: number
     iceServers?: IceServer[]
     webrtcAllowPrivateAddresses?: boolean
@@ -110,7 +109,6 @@ export class DhtNodeConfig {
     entryPoints?: PeerDescriptor[]
     websocketHost?: string
     websocketPortRange?: PortRange
-    nodeName?: string
     rpcRequestTimeout?: number
     iceServers?: IceServer[]
     webrtcAllowPrivateAddresses?: boolean

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -25,7 +25,6 @@ import {
     Logger,
     MetricsContext,
     hexToBinary,
-    binaryToHex,
     waitForCondition
 } from '@streamr/utils'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
@@ -138,7 +137,7 @@ const logger = new Logger(module)
 
 export type Events = TransportEvents & DhtNodeEvents
 
-export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string, nodeName?: string): PeerDescriptor => {
+export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string): PeerDescriptor => {
     let kademliaId: Uint8Array
     if (msg) {
         kademliaId = peerId ? hexToBinary(peerId) : PeerID.fromIp(msg.host).value
@@ -146,7 +145,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
         kademliaId = hexToBinary(peerId!)
     }
     const nodeType = isNodeJS() ? NodeType.NODEJS : NodeType.BROWSER
-    const ret: PeerDescriptor = { kademliaId, nodeName: nodeName ? nodeName : binaryToHex(kademliaId), type: nodeType }
+    const ret: PeerDescriptor = { kademliaId, type: nodeType }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
         ret.openInternet = true
@@ -449,9 +448,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.config.peerDescriptor) {
             this.ownPeerDescriptor = this.config.peerDescriptor
         } else {
-            this.ownPeerDescriptor = createPeerDescriptor(connectivityResponse,
-                this.config.peerId,
-                this.config.nodeName)
+            this.ownPeerDescriptor = createPeerDescriptor(connectivityResponse, this.config.peerId)
         }
         return this.ownPeerDescriptor
     }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -26,7 +26,6 @@ interface DiscoverySessionConfig {
     parallelism: number
     noProgressLimit: number
     newContactListener?: (dhtPeer: DhtPeer) => void
-    nodeName?: string
 }
 
 export class DiscoverySession {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -72,14 +72,12 @@ export class PeerDiscovery {
             rpcCommunicator: this.config.rpcCommunicator,
             parallelism: this.config.parallelism,
             noProgressLimit: this.config.joinNoProgressLimit,
-            newContactListener: (newPeer: DhtPeer) => this.config.addContact(newPeer.getPeerDescriptor()),
-            nodeName: this.config.ownPeerDescriptor.nodeName
+            newContactListener: (newPeer: DhtPeer) => this.config.addContact(newPeer.getPeerDescriptor())
         }
         const session = new DiscoverySession(sessionOptions)
         const randomSession = doRandomJoin ? new DiscoverySession({
             ...sessionOptions,
-            targetId: crypto.randomBytes(8),
-            nodeName: this.config.ownPeerDescriptor.nodeName + '-random'
+            targetId: crypto.randomBytes(8)
         }) : null
         this.ongoingDiscoverySessions.set(session.sessionId, session)
         if (randomSession) {

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -253,10 +253,6 @@ export interface PeerDescriptor {
      * @generated from protobuf field: optional uint32 region = 7;
      */
     region?: number;
-    /**
-     * @generated from protobuf field: optional string nodeName = 8;
-     */
-    nodeName?: string;
 }
 /**
  * @generated from protobuf message dht.ConnectivityMethod
@@ -1019,8 +1015,7 @@ class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
             { no: 4, name: "tcp", kind: "message", T: () => ConnectivityMethod },
             { no: 5, name: "websocket", kind: "message", T: () => ConnectivityMethod },
             { no: 6, name: "openInternet", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
-            { no: 7, name: "region", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
-            { no: 8, name: "nodeName", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 7, name: "region", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
 }

--- a/packages/dht/test/benchmark/RecursiveFind.test.ts
+++ b/packages/dht/test/benchmark/RecursiveFind.test.ts
@@ -32,7 +32,7 @@ describe('Recursive find correctness', () => {
 
         nodes = []
         const entryPointId = '0'
-        entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, Uint8Array.from(dhtIds[0].data), undefined, entryPointId)
+        entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, Uint8Array.from(dhtIds[0].data), undefined)
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
@@ -43,7 +43,7 @@ describe('Recursive find correctness', () => {
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
 
-            const node = await createMockConnectionDhtNode(nodeId, simulator, Uint8Array.from(dhtIds[i].data), undefined, nodeId)
+            const node = await createMockConnectionDhtNode(nodeId, simulator, Uint8Array.from(dhtIds[i].data), undefined)
             nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }

--- a/packages/dht/test/benchmark/RecursiveFind.test.ts
+++ b/packages/dht/test/benchmark/RecursiveFind.test.ts
@@ -37,8 +37,7 @@ describe('Recursive find correctness', () => {
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
 
         for (let i = 1; i < NUM_NODES; i++) {

--- a/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
@@ -19,15 +19,15 @@ describe('Layer0 with WebRTC connections', () => {
 
     beforeEach(async () => {
 
-        epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor, nodeName: 'entrypoint', numberOfNodesPerKBucket: 8 })
+        epDhtNode = new DhtNode({ peerDescriptor: epPeerDescriptor, numberOfNodesPerKBucket: 8 })
         await epDhtNode.start()
 
         await epDhtNode.joinDht([epPeerDescriptor])
 
-        node1 = new DhtNode({ nodeName: 'Peer0', entryPoints: [epPeerDescriptor] })
-        node2 = new DhtNode({ nodeName: 'Peer1', entryPoints: [epPeerDescriptor] })
-        node3 = new DhtNode({ nodeName: 'Peer2', entryPoints: [epPeerDescriptor] })
-        node4 = new DhtNode({ nodeName: 'Peer3', entryPoints: [epPeerDescriptor] })
+        node1 = new DhtNode({ entryPoints: [epPeerDescriptor] })
+        node2 = new DhtNode({ entryPoints: [epPeerDescriptor] })
+        node3 = new DhtNode({ entryPoints: [epPeerDescriptor] })
+        node4 = new DhtNode({ entryPoints: [epPeerDescriptor] })
 
         await Promise.all([
             node1.start(),

--- a/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer0WebRTC.test.ts
@@ -8,7 +8,6 @@ import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/Dh
 describe('Layer0 with WebRTC connections', () => {
     const epPeerDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString('entrypoint').value,
-        nodeName: 'entrypoint',
         type: NodeType.NODEJS,
         websocket: { host: '127.0.0.1', port: 10029, tls: false }
     }

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
@@ -33,7 +33,7 @@ describe('Layer1 Scale', () => {
         layer1Nodes = []
 
         for (let i = 1; i < NUM_OF_NODES; i++) {
-            const node = new DhtNode({ nodeName: `${i}`, entryPoints: [epPeerDescriptor] })
+            const node = new DhtNode({ entryPoints: [epPeerDescriptor] })
             await node.start()
             layer0Nodes.push(node)
             const layer1 = new DhtNode({

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
@@ -6,8 +6,7 @@ describe('Layer1 Scale', () => {
     const epPeerDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString('0').value,
         type: NodeType.NODEJS,
-        websocket: { host: '127.0.0.1', port: 43228, tls: false },
-        nodeName: 'entrypoint'
+        websocket: { host: '127.0.0.1', port: 43228, tls: false }
     }
 
     const STREAM_ID = 'stream'

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -6,8 +6,7 @@ describe('Layer1 Scale', () => {
     const epPeerDescriptor: PeerDescriptor = {
         kademliaId: PeerID.fromString('entrypoint').value,
         type: NodeType.NODEJS,
-        websocket: { host: '127.0.0.1', port: 43225, tls: false },
-        nodeName: 'entrypoint'
+        websocket: { host: '127.0.0.1', port: 43225, tls: false }
     }
 
     const STREAM_ID = 'stream'

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -23,11 +23,11 @@ describe('Layer1 Scale', () => {
     const websocketPortRange = { min: 62200, max: 62200 + NUM_OF_NODES }
 
     beforeEach(async () => {
-        epLayer0Node = new DhtNode({ peerDescriptor: epPeerDescriptor, nodeName: 'entrypoint' })
+        epLayer0Node = new DhtNode({ peerDescriptor: epPeerDescriptor })
         await epLayer0Node.start()
         await epLayer0Node.joinDht([epPeerDescriptor])
 
-        epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID, nodeName: 'entrypoint' })
+        epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
         await epLayer1Node.start()
         await epLayer1Node.joinDht([epPeerDescriptor])
 
@@ -35,11 +35,10 @@ describe('Layer1 Scale', () => {
         layer1Nodes = []
 
         for (let i = 0; i < NUM_OF_NODES; i++) {
-            const node = new DhtNode({ nodeName: `${i}`, websocketPortRange, entryPoints: [epPeerDescriptor] })
+            const node = new DhtNode({ websocketPortRange, entryPoints: [epPeerDescriptor] })
             await node.start()
             layer0Nodes.push(node)
             const layer1 = new DhtNode({
-                nodeName: `${i}`,
                 transportLayer: node,
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getPeerDescriptor(),

--- a/packages/dht/test/end-to-end/WebSocketConnectionRequest.test.ts
+++ b/packages/dht/test/end-to-end/WebSocketConnectionRequest.test.ts
@@ -22,8 +22,8 @@ describe('WebSocket IConnection Requests', () => {
 
         await epDhtNode.joinDht([epPeerDescriptor])
 
-        node1 = new DhtNode({ nodeName: 'node1', websocketPortRange: { min: 10022, max: 10022 }, entryPoints: [epPeerDescriptor] })
-        node2 = new DhtNode({ nodeName: 'node2', entryPoints: [epPeerDescriptor] })
+        node1 = new DhtNode({ websocketPortRange: { min: 10022, max: 10022 }, entryPoints: [epPeerDescriptor] })
+        node2 = new DhtNode({ entryPoints: [epPeerDescriptor] })
         await node1.start()
         await node2.start()
     })

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -9,12 +9,10 @@ describe('Connection Locking', () => {
 
     const mockPeerDescriptor1: PeerDescriptor = {
         kademliaId: PeerID.fromString('mock1').value,
-        nodeName: 'mock1',
         type: NodeType.NODEJS
     }
     const mockPeerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('mock2').value,
-        nodeName: 'mock2',
         type: NodeType.NODEJS
     }
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -14,23 +14,19 @@ describe('ConnectionManager', () => {
 
     const mockPeerDescriptor1: PeerDescriptor = {
         kademliaId: PeerID.fromString('tester1').value,
-        nodeName: 'tester1',
         type: NodeType.NODEJS
     }
     const mockPeerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('tester2').value,
-        nodeName: 'tester2',
         type: NodeType.NODEJS
     }
 
     const mockPeerDescriptor3: PeerDescriptor = {
         kademliaId: PeerID.fromString('tester3').value,
-        nodeName: 'tester3',
         type: NodeType.NODEJS
     }
     const mockPeerDescriptor4: PeerDescriptor = {
         kademliaId: PeerID.fromString('tester4').value,
-        nodeName: 'tester4',
         type: NodeType.NODEJS
     }
     const simulator = new Simulator()

--- a/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnectionLatencies.test.ts
@@ -16,8 +16,7 @@ describe('Mock connection Dht joining with latencies', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: '0'
+            type: NodeType.NODEJS
         }
         for (let i = 1; i < 100; i++) {
             const nodeId = `${i}`

--- a/packages/dht/test/integration/DhtWithMockConnections.test.ts
+++ b/packages/dht/test/integration/DhtWithMockConnections.test.ts
@@ -16,8 +16,7 @@ describe('Mock IConnection DHT Joining', () => {
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: '0'
+            type: NodeType.NODEJS
         }
         for (let i = 1; i < 100; i++) {
             const nodeId = `${i}`

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -12,8 +12,7 @@ describe('Layer1', () => {
 
     const entryPoint0Descriptor = {
         kademliaId: PeerID.fromString(layer0EntryPointId).value,
-        type: NodeType.NODEJS,
-        nodeName: layer0EntryPointId
+        type: NodeType.NODEJS
     }
 
     let layer0EntryPoint: DhtNode

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -37,7 +37,6 @@ describe('Layer1', () => {
                 undefined,
                 undefined,
                 undefined,
-                undefined,
                 60000
             )
             nodes.push(node)

--- a/packages/dht/test/integration/MigrateData.test.ts
+++ b/packages/dht/test/integration/MigrateData.test.ts
@@ -48,8 +48,7 @@ describe('Migrating data from node to node in DHT', () => {
 
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
 
         nodes.push(entryPoint)

--- a/packages/dht/test/integration/MigrateData.test.ts
+++ b/packages/dht/test/integration/MigrateData.test.ts
@@ -42,7 +42,7 @@ describe('Migrating data from node to node in DHT', () => {
         nodes = []
         const entryPointId = '0'
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
-            Uint8Array.from(dhtIds[0].data), K, entryPointId, MAX_CONNECTIONS)
+            Uint8Array.from(dhtIds[0].data), K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         nodesById.set(entryPoint.getNodeId().toKey(), entryPoint)
 
@@ -57,7 +57,7 @@ describe('Migrating data from node to node in DHT', () => {
             const nodeId = `${i}`
 
             const node = await createMockConnectionDhtNode(nodeId, simulator,
-                Uint8Array.from(dhtIds[i].data), K, nodeId, MAX_CONNECTIONS)
+                Uint8Array.from(dhtIds[i].data), K, MAX_CONNECTIONS)
             nodesById.set(node.getNodeId().toKey(), node)
             nodes.push(node)
         }

--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -52,8 +52,7 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         entryPointDescriptor = {
             kademliaId: layer0EntryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: layer0EntryPointId
+            type: NodeType.NODEJS
         }
 
         await layer0EntryPoint.joinDht([entryPointDescriptor])

--- a/packages/dht/test/integration/RecursiveFind.test.ts
+++ b/packages/dht/test/integration/RecursiveFind.test.ts
@@ -17,7 +17,7 @@ describe('Recursive find correctness', () => {
     beforeEach(async () => {
         nodes = []
         const entryPointId = '0'
-        entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, undefined, K, entryPointId)
+        entryPoint = await createMockConnectionDhtNode(entryPointId, simulator, undefined, K)
         nodes.push(entryPoint)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
@@ -25,7 +25,7 @@ describe('Recursive find correctness', () => {
         }
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
-            const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, nodeId, 20, 60000)
+            const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, 20, 60000)
             nodes.push(node)
         }
         await entryPoint.joinDht([entrypointDescriptor])

--- a/packages/dht/test/integration/RecursiveFind.test.ts
+++ b/packages/dht/test/integration/RecursiveFind.test.ts
@@ -21,8 +21,7 @@ describe('Recursive find correctness', () => {
         nodes.push(entryPoint)
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -33,7 +33,6 @@ describe('Route Message With Mock Connections', () => {
 
         entryPointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            nodeName: 'entrypoint',
             type: NodeType.NODEJS
         }
 

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -25,8 +25,7 @@ describe('Scaling down a Dht network', () => {
 
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
 
         for (let i = 1; i < NUM_NODES; i++) {

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -20,7 +20,7 @@ describe('Scaling down a Dht network', () => {
         nodes = []
         const entryPointId = '0'
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
-            undefined, K, entryPointId, MAX_CONNECTIONS)
+            undefined, K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
 
         entrypointDescriptor = {
@@ -30,7 +30,7 @@ describe('Scaling down a Dht network', () => {
 
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
-            const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, nodeId, MAX_CONNECTIONS)
+            const node = await createMockConnectionDhtNode(nodeId, simulator, undefined, K, MAX_CONNECTIONS)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -14,14 +14,12 @@ describe('SimultaneousConnections', () => {
 
     const peerDescriptor1 = {
         kademliaId: PeerID.fromString('mock1').value,
-        type: NodeType.NODEJS,
-        nodeName: 'mock1'
+        type: NodeType.NODEJS
     }
 
     const peerDescriptor2 = {
         kademliaId: PeerID.fromString('mock2').value,
-        type: NodeType.NODEJS,
-        nodeName: 'mock2'
+        type: NodeType.NODEJS
     }
 
     const baseMsg: Message = {
@@ -84,7 +82,6 @@ describe('SimultaneousConnections', () => {
 
         const wsPeer1: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock1').value,
-            nodeName: 'mock1WebSocket',
             type: NodeType.NODEJS,
             websocket: {
                 host: '127.0.0.1',
@@ -95,7 +92,6 @@ describe('SimultaneousConnections', () => {
 
         const wsPeer2: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock2').value,
-            nodeName: 'mock2WebSocket',
             type: NodeType.NODEJS,
             websocket: {
                 host: '127.0.0.1',
@@ -169,7 +165,6 @@ describe('SimultaneousConnections', () => {
 
         const wsPeer1: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock1').value,
-            nodeName: 'mock1WebSocketServer',
             type: NodeType.NODEJS,
             websocket: {
                 host: '127.0.0.1',
@@ -180,7 +175,6 @@ describe('SimultaneousConnections', () => {
 
         const wsPeer2: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock2').value,
-            nodeName: 'mock2WebSocketClient',
             type: NodeType.NODEJS
         }
 
@@ -246,13 +240,11 @@ describe('SimultaneousConnections', () => {
 
         const wrtcPeer1: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock1').value,
-            nodeName: 'mock1WebRTC',
             type: NodeType.NODEJS
         }
 
         const wrtcPeer2: PeerDescriptor = {
             kademliaId: PeerID.fromString('mock2').value,
-            nodeName: 'mock2WebRTC',
             type: NodeType.NODEJS
         }
 

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -24,7 +24,7 @@ describe('Storing data in DHT', () => {
         nodes = []
         const entryPointId = '0'
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
-            undefined, K, entryPointId, MAX_CONNECTIONS)
+            undefined, K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
@@ -35,7 +35,7 @@ describe('Storing data in DHT', () => {
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
             const node = await createMockConnectionDhtNode(nodeId, simulator, 
-                undefined, K, nodeId, MAX_CONNECTIONS, 60000)
+                undefined, K, MAX_CONNECTIONS, 60000)
             nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -29,8 +29,7 @@ describe('Storing data in DHT', () => {
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -24,7 +24,7 @@ describe('Storing data in DHT', () => {
         nodes = []
         const entryPointId = '0'
         entryPoint = await createMockConnectionDhtNode(entryPointId, simulator,
-            undefined, K, entryPointId, MAX_CONNECTIONS)
+            undefined, K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
@@ -35,7 +35,7 @@ describe('Storing data in DHT', () => {
         for (let i = 1; i < NUM_NODES; i++) {
             const nodeId = `${i}`
             const node = await createMockConnectionDhtNode(nodeId, simulator, 
-                undefined, K, nodeId, MAX_CONNECTIONS, 60000)
+                undefined, K, MAX_CONNECTIONS, 60000)
             nodeIndicesById[node.getNodeId().toKey()] = i
             nodes.push(node)
         }

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -29,8 +29,7 @@ describe('Storing data in DHT', () => {
         nodeIndicesById[entryPoint.getNodeId().toKey()] = 0
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS,
-            nodeName: entryPointId
+            type: NodeType.NODEJS
         }
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -48,8 +48,8 @@ describe('Storing data in DHT with two peers', () => {
 
         const successfulStorers1 = await otherNode.storeDataToDht(dataKey1.value, data1)
         const successfulStorers2 = await entryPoint.storeDataToDht(dataKey2.value, data2)
-        expect(successfulStorers1[0].nodeName).toEqual(entryPoint.getPeerDescriptor().nodeName)
-        expect(successfulStorers2[0].nodeName).toEqual(otherNode.getPeerDescriptor().nodeName)
+        expect(successfulStorers1[0].kademliaId).toStrictEqual(entryPoint.getPeerDescriptor().kademliaId)
+        expect(successfulStorers2[0].kademliaId).toStrictEqual(otherNode.getPeerDescriptor().kademliaId)
 
         const foundData1 = await otherNode.getDataFromDht(dataKey1.value)
         const foundData2 = await entryPoint.getDataFromDht(dataKey2.value)
@@ -63,7 +63,7 @@ describe('Storing data in DHT with two peers', () => {
         const dataKey = PeerID.fromString('data-to-store')
         const data = Any.pack(entryPoint.getPeerDescriptor(), PeerDescriptor)
         const successfulStorers = await entryPoint.storeDataToDht(dataKey.value, data)
-        expect(successfulStorers[0].nodeName).toEqual(entryPoint.getPeerDescriptor().nodeName)
+        expect(successfulStorers[0].kademliaId).toStrictEqual(entryPoint.getPeerDescriptor().kademliaId)
 
         const foundData = await entryPoint.getDataFromDht(dataKey.value)
         expect(isSamePeerDescriptor(entryPoint.getPeerDescriptor(), Any.unpack(foundData.dataEntries![0]!.data!, PeerDescriptor))).toBeTrue()

--- a/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
@@ -17,13 +17,11 @@ describe('WebRTC Connection Management', () => {
 
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: PeerID.fromString('peer1').value,
-        nodeName: 'peer1',
         type: NodeType.NODEJS,
     }
 
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('peer2').value,
-        nodeName: 'peer2',
         type: NodeType.NODEJS,
     }
 

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -13,13 +13,11 @@ describe('LocalDataStore', () => {
     let localDataStore: LocalDataStore
     const storer1: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS,
-        nodeName: 'storer1'
+        type: NodeType.NODEJS
     }
     const storer2: PeerDescriptor = {
         kademliaId: new Uint8Array([3, 2, 1]),
-        type: NodeType.NODEJS,
-        nodeName: 'storer2'
+        type: NodeType.NODEJS
     }
     const data1 = Any.pack(storer1, PeerDescriptor)
     const data2 = Any.pack(storer2, PeerDescriptor)

--- a/packages/dht/test/unit/RecursiveFinder.test.ts
+++ b/packages/dht/test/unit/RecursiveFinder.test.ts
@@ -28,13 +28,11 @@ describe('RecursiveFinder', () => {
     const peerId1 = PeerID.fromString('peerid')
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: peerId1.value,
-        type: NodeType.NODEJS,
-        nodeName: 'peerid'
+        type: NodeType.NODEJS
     }
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('destination').value,
-        type: NodeType.NODEJS,
-        nodeName: 'destination'
+        type: NodeType.NODEJS
     }
     const recursiveFindRequest = createRecursiveFindRequest(FindMode.NODE)
     const message: Message = {

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -11,12 +11,11 @@ describe('Router', () => {
     const peerId = PeerID.fromString('router')
     const peerDescriptor1: PeerDescriptor = {
         kademliaId: peerId.value,
-        type: NodeType.NODEJS,
-        nodeName: 'router'
+        type: NodeType.NODEJS
     }
     const peerDescriptor2: PeerDescriptor = {
         kademliaId: PeerID.fromString('destination').value,
-        type: NodeType.NODEJS,
+        type: NodeType.NODEJS
     }
     const rpcWrapper = createWrappedClosestPeersRequest(peerDescriptor1, peerDescriptor2)
     const message: Message = {

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -60,8 +60,7 @@ export const createMockConnectionDhtNode = async (stringId: string,
     const peerDescriptor: PeerDescriptor = {
         kademliaId: id.value,
         type: NodeType.NODEJS,
-        region: getRandomRegion(),
-        nodeName: nodeName ? nodeName : stringId
+        region: getRandomRegion()
     }
 
     const mockConnectionManager = new ConnectionManager({
@@ -87,7 +86,6 @@ export const createMockConnectionLayer1Node = async (stringId: string, layer0Nod
     const descriptor: PeerDescriptor = {
         kademliaId: id.value,
         type: NodeType.NODEJS,
-        nodeName: stringId
     }
 
     const node = new DhtNode({

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -46,7 +46,6 @@ export const createMockConnectionDhtNode = async (stringId: string,
     simulator: Simulator,
     binaryId?: Uint8Array,
     K?: number,
-    nodeName?: string,
     maxConnections = 80,
     dhtJoinTimeout = 45000
 ): Promise<DhtNode> => {
@@ -71,7 +70,6 @@ export const createMockConnectionDhtNode = async (stringId: string,
     const node = new DhtNode({
         peerDescriptor: peerDescriptor,
         transportLayer: mockConnectionManager,
-        nodeName: nodeName,
         numberOfNodesPerKBucket: K ? K : 8,
         maxConnections: maxConnections,
         dhtJoinTimeout
@@ -90,7 +88,7 @@ export const createMockConnectionLayer1Node = async (stringId: string, layer0Nod
 
     const node = new DhtNode({
         peerDescriptor: descriptor, transportLayer: layer0Node,
-        serviceId: serviceId ? serviceId : 'layer1', numberOfNodesPerKBucket: 8, nodeName: stringId
+        serviceId: serviceId ? serviceId : 'layer1', numberOfNodesPerKBucket: 8
     })
     await node.start()
     return node

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -32,7 +32,6 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
         })
         this.streamrNode = new StreamrNode({
             ...options.networkNode,
-            nodeName: options.networkNode?.nodeName ?? options.layer0?.nodeName,
             metricsContext: this.metricsContext
         })
     }

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -54,7 +54,6 @@ export interface StreamrNodeConfig {
     metricsContext?: MetricsContext
     streamPartitionNumOfNeighbors?: number
     streamPartitionMinPropagationTargets?: number
-    nodeName?: string
     acceptProxyConnections?: boolean
 }
 
@@ -204,8 +203,7 @@ export class StreamrNode extends EventEmitter<Events> {
             entryPoints,
             numberOfNodesPerKBucket: 4,
             rpcRequestTimeout: 5000,
-            dhtJoinTimeout: 20000,
-            nodeName: this.config.nodeName + ':layer1'
+            dhtJoinTimeout: 20000
         })
     }
 

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -231,10 +231,6 @@ export interface PeerDescriptor {
      * @generated from protobuf field: optional uint32 region = 7;
      */
     region?: number;
-    /**
-     * @generated from protobuf field: optional string nodeName = 8;
-     */
-    nodeName?: string;
 }
 /**
  * @generated from protobuf message dht.ConnectivityMethod
@@ -972,8 +968,7 @@ class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
             { no: 4, name: "tcp", kind: "message", T: () => ConnectivityMethod },
             { no: 5, name: "websocket", kind: "message", T: () => ConnectivityMethod },
             { no: 6, name: "openInternet", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
-            { no: 7, name: "region", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
-            { no: 8, name: "nodeName", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+            { no: 7, name: "region", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -28,8 +28,7 @@ const prepareLayer0 = async () => {
     nodes = []
     simulator = new Simulator(LatencyType.REAL)
     const peerDescriptor = createMockPeerDescriptor({
-        region: getRandomRegion(),
-        nodeName: 'entrypoint'
+        region: getRandomRegion()
     })
     layer0Ep = peerDescriptor
     const entryPoint = createNetworkNodeWithSimulator(peerDescriptor, simulator, [peerDescriptor])
@@ -42,8 +41,7 @@ const prepareLayer0 = async () => {
 const prepareStream = async (streamId: string) => {
     console.log('Preparing stream ')
     const peerDescriptor = createMockPeerDescriptor({
-        region: getRandomRegion(),
-        nodeName: streamId
+        region: getRandomRegion()
     })
     const streamPartId = toStreamPartID(toStreamID(streamId), 0)
     const streamPublisher = createNetworkNodeWithSimulator(peerDescriptor, simulator, [layer0Ep])
@@ -61,10 +59,9 @@ const shutdownNetwork = async () => {
     simulator.stop()
 }
 
-const measureJoiningTime = async (count: number) => {
+const measureJoiningTime = async () => {
     const peerDescriptor = createMockPeerDescriptor({
-        region: getRandomRegion(),
-        nodeName: `${count}`
+        region: getRandomRegion()
     })
     console.log('starting node with id ', getNodeIdFromPeerDescriptor(peerDescriptor))
 
@@ -121,7 +118,7 @@ const run = async () => {
     
     fs.writeSync(logFile, 'Network size' + '\t' + 'Time to receive first message time (ms)' + '\n')
     for (let i = 0; i < numNodes; i++) {
-        const time = await measureJoiningTime(i)
+        const time = await measureJoiningTime()
         console.log(`Time to receive first message for ${i + 1} nodes network: ${time}ms`)
         fs.writeSync(logFile, `${i + 1}` + '\t' + `${Math.round(time)}\n`)
     }

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -29,7 +29,6 @@ const createMessage = (streamPartId: StreamPartID): StreamMessage => {
 describe('proxy and full node', () => {
 
     const proxyNodeDescriptor = createMockPeerDescriptor({
-        nodeName: 'proxyNode',
         websocket: { host: '127.0.0.1', port: 23135, tls: false }
     })
     const proxiedNodeDescriptor = createMockPeerDescriptor()

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -47,11 +47,9 @@ describe('Proxy connections', () => {
 
     beforeEach(async () => {
         const proxyNodeDescriptor1 = createMockPeerDescriptor({
-            nodeName: 'proxyNode',
             websocket: { host: '127.0.0.1', port: 23132, tls: false }
         })
         const proxyNodeDescriptor2 = createMockPeerDescriptor({
-            nodeName: 'proxyNode',
             websocket: { host: '127.0.0.1', port: 23133, tls: false }
         })
         const proxiedNodeDescriptor = createMockPeerDescriptor()

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -14,7 +14,6 @@ import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('proxy group key exchange', () => {
     const proxyNodeDescriptor = createMockPeerDescriptor({
-        nodeName: 'proxyNode',
         websocket: { host: '127.0.0.1', port: 23134, tls: false }
     })
     const publisherDescriptor = createMockPeerDescriptor()

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -37,7 +37,6 @@ describe('Full node network with WebSocket connections only', () => {
                 layer0: {
                     entryPoints: [epPeerDescriptor],
                     websocketPortRange: { min: 15556 + i, max: 15556 + i },
-                    nodeName: `${i}`,
                     numberOfNodesPerKBucket: 4
                 }
             })

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -10,7 +10,6 @@ describe('Full node network with WebSocket connections only', () => {
 
     const NUM_OF_NODES = 48
     const epPeerDescriptor = createMockPeerDescriptor({
-        nodeName: 'entrypoint',
         websocket: { host: '127.0.0.1', port: 15555, tls: false }
     })
     const streamPartId = StreamPartIDUtils.parse('websocket-network#0')

--- a/packages/trackerless-network/test/integration/NetworkStack.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStack.test.ts
@@ -13,8 +13,7 @@ describe('NetworkStack', () => {
     const streamPartId = StreamPartIDUtils.parse('stream1#0')
 
     const epDescriptor = createMockPeerDescriptor({
-        websocket: { host: '127.0.0.1', port: 32222, tls: false },
-        nodeName: 'entrypoint'
+        websocket: { host: '127.0.0.1', port: 32222, tls: false }
     })
 
     beforeEach(async () => {

--- a/packages/trackerless-network/test/integration/NetworkStack.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStack.test.ts
@@ -20,15 +20,13 @@ describe('NetworkStack', () => {
         stack1 = new NetworkStack({
             layer0: {
                 peerDescriptor: epDescriptor,
-                entryPoints: [epDescriptor],
-                nodeName: 'entrypoint'
+                entryPoints: [epDescriptor]
             }
         })
         stack2 = new NetworkStack({
             layer0: {
                 websocketPortRange: { min: 32223, max: 32223 },
-                entryPoints: [epDescriptor],
-                nodeName: 'node2'
+                entryPoints: [epDescriptor]
             }
         })
 

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -17,13 +17,11 @@ describe('RandomGraphNode-DhtNode', () => {
 
     const streamPartId = StreamPartIDUtils.parse('stream#0')
     const entrypointDescriptor = createMockPeerDescriptor({
-        nodeName: 'entrypoint',
         region: getRandomRegion()
     })
 
-    const peerDescriptors: PeerDescriptor[] = range(numOfNodes).map((i) => {
+    const peerDescriptors: PeerDescriptor[] = range(numOfNodes).map(() => {
         return createMockPeerDescriptor({
-            nodeName: `node${i}`,
             region: getRandomRegion()
         })
     })

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -12,31 +12,26 @@ describe('Joining streams on offline nodes', () => {
 
     const entryPointPeerDescriptor: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 2, 3]),
-        nodeName: 'entrypoint',
         type: NodeType.NODEJS
     }
 
     const node1PeerDescriptor: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 1, 1]),
-        nodeName: 'node1',
         type: NodeType.NODEJS
     }
 
     const node2PeerDescriptor: PeerDescriptor = {
         kademliaId: new Uint8Array([2, 2, 2]),
-        nodeName: 'node2',
         type: NodeType.NODEJS
     }
 
     const offlineDescriptor1: PeerDescriptor = {
         kademliaId: new Uint8Array([3, 3, 3]),
-        nodeName: 'offline',
         type: NodeType.NODEJS
     }
 
     const offlineDescriptor2: PeerDescriptor = {
         kademliaId: new Uint8Array([4, 4, 4]),
-        nodeName: 'offline',
         type: NodeType.NODEJS
     }
 

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -22,7 +22,6 @@ describe('stream without default entrypoints', () => {
     let numOfReceivedMessages: number
     const entryPointPeerDescriptor: PeerDescriptor = {
         kademliaId: new Uint8Array([1, 2, 3]),
-        nodeName: 'entrypoint',
         type: NodeType.NODEJS
     }
 
@@ -57,10 +56,8 @@ describe('stream without default entrypoints', () => {
             }
         })
         await entrypoint.start()
-        await Promise.all(range(20).map(async (i) => {
-            const peerDescriptor = createMockPeerDescriptor({
-                nodeName: `${i}`
-            })
+        await Promise.all(range(20).map(async () => {
+            const peerDescriptor = createMockPeerDescriptor()
             const transport = new SimulatorTransport(peerDescriptor, simulator)
             const node = createNetworkNode({
                 layer0: {

--- a/packages/trackerless-network/test/unit/StreamPartEntrypointDiscovery.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartEntrypointDiscovery.test.ts
@@ -17,12 +17,8 @@ describe('StreamPartEntryPointDiscovery', () => {
     let entryPointDiscoveryWithoutData: StreamPartEntryPointDiscovery
     let storeCalled: number
 
-    const peerDescriptor = createMockPeerDescriptor({
-        nodeName: 'fake'
-    })
-    const deletedPeerDescriptor = createMockPeerDescriptor({
-        nodeName: 'deleted'
-    })
+    const peerDescriptor = createMockPeerDescriptor()
+    const deletedPeerDescriptor = createMockPeerDescriptor()
 
     const fakeData: DataEntry = {
         data: Any.pack(peerDescriptor, PeerDescriptor),


### PR DESCRIPTION
Removed `DhtNode#nodeName` and `PeerDescriptor#nodeName`. It is no longer used after these PRs:
- https://github.com/streamr-dev/network/pull/1962
- https://github.com/streamr-dev/network/pull/1967