### PR TITLE
refactor(dht): `isBrowserEnvironment`

### DIFF
--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -115,8 +115,8 @@ module.exports = (env, argv) => {
                 '@streamr/dht': path.resolve('../dht/src/exports.ts'),
                 [path.resolve(__dirname, '../dht/src/connection/WebRTC/NodeWebRtcConnection.ts')]:
                     path.resolve(__dirname, '../dht/src/connection/WebRTC/BrowserWebRtcConnection.ts'),
-                [path.resolve(__dirname, '../dht/src/helpers/browser/isNodeJS.ts')]:
-                    path.resolve(__dirname, '../dht/src/helpers/browser/isBrowser.ts'),
+                [path.resolve(__dirname, '../dht/src/helpers/browser/isBrowserEnvironment.ts')]:
+                    path.resolve(__dirname, '../dht/src/helpers/browser/isBrowserEnvironment_override.ts'),
                 // swap out ServerPersistence for BrowserPersistence
                 [path.resolve('./src/utils/persistence/ServerPersistence.ts')]: (
                     path.resolve('./src/utils/persistence/BrowserPersistence.ts')

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -42,7 +42,7 @@ import { IceServer } from '../connection/WebRTC/WebRtcConnector'
 import { registerExternalApiRpcMethods } from './registerExternalApiRpcMethods'
 import { RemoteExternalApi } from './RemoteExternalApi'
 import { UUID } from '../helpers/UUID'
-import { isNodeJS } from '../helpers/browser/isNodeJS'
+import { isBrowserEnvironment } from '../helpers/browser/isBrowserEnvironment'
 import { sample } from 'lodash'
 
 export interface DhtNodeEvents {
@@ -142,7 +142,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     } else {
         kademliaId = hexToBinary(peerId!)
     }
-    const nodeType = isNodeJS() ? NodeType.NODEJS : NodeType.BROWSER
+    const nodeType = isBrowserEnvironment() ? NodeType.BROWSER : NodeType.NODEJS 
     const ret: PeerDescriptor = { kademliaId, type: nodeType }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
@@ -190,7 +190,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         logger.trace(`Starting new Streamr Network DHT Node with serviceId ${this.config.serviceId}`)
         this.started = true
 
-        if (!isNodeJS()) {
+        if (isBrowserEnvironment()) {
             this.config.websocketPortRange = undefined
             if (this.config.peerDescriptor) {
                 this.config.peerDescriptor.websocket = undefined

--- a/packages/dht/src/helpers/browser/isBrowser.ts
+++ b/packages/dht/src/helpers/browser/isBrowser.ts
@@ -1,1 +1,0 @@
-export const isNodeJS = (): boolean => false

--- a/packages/dht/src/helpers/browser/isBrowserEnvironment.ts
+++ b/packages/dht/src/helpers/browser/isBrowserEnvironment.ts
@@ -1,0 +1,1 @@
+export const isBrowserEnvironment = (): boolean => false

--- a/packages/dht/src/helpers/browser/isBrowserEnvironment_override.ts
+++ b/packages/dht/src/helpers/browser/isBrowserEnvironment_override.ts
@@ -1,0 +1,3 @@
+// webpack overwrites the isBrowserEnvironment.ts with this file when it creates the browser bundle
+
+export const isBrowserEnvironment = (): boolean => true

--- a/packages/dht/src/helpers/browser/isNodeJS.ts
+++ b/packages/dht/src/helpers/browser/isNodeJS.ts
@@ -1,1 +1,0 @@
-export const isNodeJS = (): boolean => true


### PR DESCRIPTION
Inverted `isNodeJS()` helper method to `isBrowserEnvironent()`. 

It is better to check the exceptional case (that we are in the browser environment), and assume that anything else is NodeJS (which is kind of approximation, e.g. Deno is not Node).

## Future improvements

The override is done only in client's webpack build, and not in `dht's` and `trackerless-network`'s karma.config.js (which override the `NodeWebRtcConnection` -> `BrowserWebRtcConnection`). Therefore browser tests currently use `NODEJS` as their node type instead of `BROWSER` node type. (NET-1143)