### PR TITLE
refactor(dht): Remove redundant `ownPeerId`

### DIFF
--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -8,7 +8,7 @@ import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { DhtRpcServiceClient } from '../../proto/packages/dht/protos/DhtRpc.client'
 import { SortedContactList } from '../contact/SortedContactList'
 import { RemoteDhtNode } from '../RemoteDhtNode'
-import { keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { isSamePeerDescriptor, keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 
 const logger = new Logger(module)
 
@@ -19,6 +19,7 @@ interface DiscoverySessionEvents {
 interface DiscoverySessionConfig {
     bucket: KBucket<RemoteDhtNode>
     neighborList: SortedContactList<RemoteDhtNode>
+    // TODO what this is? always peerIdFromPeerDescriptor(ownPeerDescriptor).value
     targetId: Uint8Array
     ownPeerDescriptor: PeerDescriptor
     serviceId: string
@@ -37,11 +38,9 @@ export class DiscoverySession {
     private noProgressCounter = 0
     private ongoingClosestPeersRequests: Set<string> = new Set()
     private readonly config: DiscoverySessionConfig
-    private readonly ownPeerId: PeerID
 
     constructor(config: DiscoverySessionConfig) {
         this.config = config
-        this.ownPeerId = peerIdFromPeerDescriptor(config.ownPeerDescriptor)
     }
 
     private addNewContacts(contacts: PeerDescriptor[]): void {
@@ -49,13 +48,13 @@ export class DiscoverySession {
             return
         }
         contacts.forEach((contact) => {
-            const remoteDhtNode = new RemoteDhtNode(
-                this.config.ownPeerDescriptor,
-                contact,
-                toProtoRpcClient(new DhtRpcServiceClient(this.config.rpcCommunicator.getRpcClientTransport())),
-                this.config.serviceId
-            )
-            if (!remoteDhtNode.getPeerId().equals(this.ownPeerId)) {
+            if (!isSamePeerDescriptor(contact, this.config.ownPeerDescriptor)) {
+                const remoteDhtNode = new RemoteDhtNode(
+                    this.config.ownPeerDescriptor,
+                    contact,
+                    toProtoRpcClient(new DhtRpcServiceClient(this.config.rpcCommunicator.getRpcClientTransport())),
+                    this.config.serviceId
+                )
                 if (this.config.newContactListener) {
                     this.config.newContactListener(remoteDhtNode)
                 }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -19,7 +19,6 @@ interface DiscoverySessionEvents {
 interface DiscoverySessionConfig {
     bucket: KBucket<RemoteDhtNode>
     neighborList: SortedContactList<RemoteDhtNode>
-    // TODO what this is? always peerIdFromPeerDescriptor(ownPeerDescriptor).value
     targetId: Uint8Array
     ownPeerDescriptor: PeerDescriptor
     serviceId: string

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -76,6 +76,7 @@ export class PeerDiscovery {
         const session = new DiscoverySession(sessionOptions)
         const randomSession = doRandomJoin ? new DiscoverySession({
             ...sessionOptions,
+            // TODO why 8 bytes? (are we generating a random "kademliaId" here?)
             targetId: crypto.randomBytes(8)
         }) : null
         this.ongoingDiscoverySessions.set(session.sessionId, session)

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -1,20 +1,19 @@
 import { DiscoverySession } from './DiscoverySession'
 import { RemoteDhtNode } from '../RemoteDhtNode'
 import crypto from 'crypto'
-import { isSamePeerDescriptor, keyFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { isSamePeerDescriptor, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { Logger, scheduleAtInterval, setAbortableTimeout } from '@streamr/utils'
 import KBucket from 'k-bucket'
 import { SortedContactList } from '../contact/SortedContactList'
 import { ConnectionManager } from '../../connection/ConnectionManager'
-import { PeerID, PeerIDKey } from '../../helpers/PeerID'
+import { PeerIDKey } from '../../helpers/PeerID'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { RandomContactList } from '../contact/RandomContactList'
 
 interface PeerDiscoveryConfig {
     rpcCommunicator: RoutingRpcCommunicator
     ownPeerDescriptor: PeerDescriptor
-    ownPeerId: PeerID
     bucket: KBucket<RemoteDhtNode>
     connections: Map<PeerIDKey, RemoteDhtNode>
     neighborList: SortedContactList<RemoteDhtNode>
@@ -61,12 +60,12 @@ export class PeerDiscovery {
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
         this.config.addContact(entryPointDescriptor)
-        const closest = this.config.bucket.closest(this.config.ownPeerId.value, this.config.getClosestContactsLimit)
+        const closest = this.config.bucket.closest(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value, this.config.getClosestContactsLimit)
         this.config.neighborList.addContacts(closest)
         const sessionOptions = {
             bucket: this.config.bucket,
             neighborList: this.config.neighborList,
-            targetId: this.config.ownPeerId.value,
+            targetId: peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value,
             ownPeerDescriptor: this.config.ownPeerDescriptor,
             serviceId: this.config.serviceId,
             rpcCommunicator: this.config.rpcCommunicator,
@@ -139,7 +138,8 @@ export class PeerDiscovery {
         if (this.stopped) {
             return
         }
-        await Promise.allSettled(this.config.bucket.closest(this.config.ownPeerId.value, this.config.parallelism).map(async (peer: RemoteDhtNode) => {
+        const nodes = this.config.bucket.closest(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value, this.config.parallelism)
+        await Promise.allSettled(nodes.map(async (peer: RemoteDhtNode) => {
             const contacts = await peer.getClosestPeers(this.config.ownPeerDescriptor.kademliaId)
             contacts.forEach((contact) => {
                 this.config.addContact(contact)

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -21,7 +21,7 @@ export interface RecursiveFindSessionConfig {
     serviceId: string
     rpcTransport: ITransport
     kademliaIdToFind: Uint8Array
-    ownPeerID: PeerID
+    ownPeerId: PeerID
     waitedRoutingPathCompletions: number
     mode: FindMode
 }
@@ -30,7 +30,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
     private readonly serviceId: string
     private readonly rpcTransport: ITransport
     private readonly kademliaIdToFind: Uint8Array
-    private readonly ownPeerID: PeerID
+    private readonly ownPeerId: PeerID
     private readonly waitedRoutingPathCompletions: number
     private readonly rpcCommunicator: ListeningRpcCommunicator
     private readonly mode: FindMode
@@ -47,7 +47,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
         this.serviceId = config.serviceId
         this.rpcTransport = config.rpcTransport
         this.kademliaIdToFind = config.kademliaIdToFind
-        this.ownPeerID = config.ownPeerID
+        this.ownPeerId = config.ownPeerId
         this.waitedRoutingPathCompletions = config.waitedRoutingPathCompletions
         this.results = new SortedContactList(PeerID.fromValue(this.kademliaIdToFind), 10, undefined, true)
         this.mode = config.mode
@@ -101,7 +101,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
     private addKnownHops(routingPath: PeerDescriptor[]) {
         routingPath.forEach((desc) => {
             const newPeerId = PeerID.fromValue(desc.kademliaId)
-            if (!this.ownPeerID.equals(newPeerId)) {
+            if (!this.ownPeerId.equals(newPeerId)) {
                 this.allKnownHops.add(newPeerId.toKey())
             }
         })
@@ -109,7 +109,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
 
     private setHopAsReported(desc: PeerDescriptor) {
         const newPeerId = PeerID.fromValue(desc.kademliaId)
-        if (!this.ownPeerID.equals(newPeerId)) {
+        if (!this.ownPeerId.equals(newPeerId)) {
             this.reportedHops.add(newPeerId.toKey())
         }
         if (this.isFindCompleted()) {

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -90,7 +90,7 @@ export class RecursiveFinder implements IRecursiveFinder {
             serviceId: sessionId,
             rpcTransport: this.sessionTransport,
             kademliaIdToFind: idToFind,
-            ownPeerID: peerIdFromPeerDescriptor(this.ownPeerDescriptor),
+            ownPeerId: peerIdFromPeerDescriptor(this.ownPeerDescriptor),
             waitedRoutingPathCompletions: this.connections.size > 1 ? 2 : 1,
             mode: findMode
         })

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -1,9 +1,9 @@
 import { Message, PeerDescriptor, RouteMessageAck, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
-import { keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { isSamePeerDescriptor, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { RoutingMode, RoutingSession, RoutingSessionEvents } from './RoutingSession'
 import { Logger, executeSafePromise, raceEvents3, withTimeout } from '@streamr/utils'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
-import { PeerID, PeerIDKey } from '../../helpers/PeerID'
+import { PeerIDKey } from '../../helpers/PeerID'
 import { DuplicateDetector } from './DuplicateDetector'
 import { ConnectionManager } from '../../connection/ConnectionManager'
 import { RemoteDhtNode } from '../RemoteDhtNode'
@@ -28,7 +28,6 @@ export enum RoutingErrors {
 export interface RouterConfig {
     rpcCommunicator: RoutingRpcCommunicator
     ownPeerDescriptor: PeerDescriptor
-    ownPeerId: PeerID
     connections: Map<PeerIDKey, RemoteDhtNode>
     addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     serviceId: string
@@ -57,7 +56,6 @@ const logger = new Logger(module)
 export class Router implements IRouter {
     private readonly rpcCommunicator: RoutingRpcCommunicator
     private readonly ownPeerDescriptor: PeerDescriptor
-    private readonly ownPeerId: PeerID
     private readonly connections: Map<PeerIDKey, RemoteDhtNode>
     private readonly addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     private readonly serviceId: string
@@ -70,7 +68,6 @@ export class Router implements IRouter {
     constructor(config: RouterConfig) {
         this.rpcCommunicator = config.rpcCommunicator
         this.ownPeerDescriptor = config.ownPeerDescriptor
-        this.ownPeerId = config.ownPeerId
         this.connections = config.connections
         this.addContact = config.addContact
         this.serviceId = config.serviceId
@@ -140,7 +137,7 @@ export class Router implements IRouter {
             })
             session.start()
         } catch (e) {
-            if (peerIdFromPeerDescriptor(routedMessage.sourcePeer!).equals(this.ownPeerId)) {
+            if (isSamePeerDescriptor(routedMessage.sourcePeer!, this.ownPeerDescriptor)) {
                 logger.warn(
                     `Failed to send (routeMessage: ${this.serviceId}) to ${keyFromPeerDescriptor(routedMessage.destinationPeer!)}: ${e}`
                 )
@@ -161,7 +158,7 @@ export class Router implements IRouter {
             this.ownPeerDescriptor,
             routedMessage,
             this.connections,
-            this.ownPeerId.equals(peerIdFromPeerDescriptor(routedMessage.sourcePeer!)) ? 2 : 1,
+            isSamePeerDescriptor(this.ownPeerDescriptor, routedMessage.sourcePeer!) ? 2 : 1,
             mode,
             undefined,
             excludedPeers
@@ -209,7 +206,7 @@ export class Router implements IRouter {
         logger.trace(`Processing received routeMessage ${routedMessage.requestId}`)
         this.addContact(routedMessage.sourcePeer!, true)
         this.addToDuplicateDetector(routedMessage.requestId)
-        if (this.ownPeerId.equals(peerIdFromPeerDescriptor(routedMessage.destinationPeer!))) {
+        if (isSamePeerDescriptor(this.ownPeerDescriptor, routedMessage.destinationPeer!)) {
             logger.trace(`routing message targeted to self ${routedMessage.requestId}`)
             this.setForwardingEntries(routedMessage)
             this.connectionManager?.handleMessage(routedMessage.message!)
@@ -221,7 +218,7 @@ export class Router implements IRouter {
 
     private setForwardingEntries(routedMessage: RouteMessageWrapper): void {
         const reachableThroughWithoutSelf = routedMessage.reachableThrough.filter((peer) => {
-            return !peerIdFromPeerDescriptor(peer).equals(this.ownPeerId)
+            return !isSamePeerDescriptor(peer, this.ownPeerDescriptor)
         })
         
         if (reachableThroughWithoutSelf.length > 0) {
@@ -253,7 +250,7 @@ export class Router implements IRouter {
         logger.trace(`Processing received forward routeMessage ${forwardMessage.requestId}`)
         this.addContact(forwardMessage.sourcePeer!, true)
         this.addToDuplicateDetector(forwardMessage.requestId)
-        if (this.ownPeerId.equals(peerIdFromPeerDescriptor(forwardMessage.destinationPeer!))) {
+        if (isSamePeerDescriptor(this.ownPeerDescriptor, forwardMessage.destinationPeer!)) {
             return this.forwardToDestination(forwardMessage)
         } else {
             return this.doRouteMessage(forwardMessage, RoutingMode.FORWARD)
@@ -263,7 +260,7 @@ export class Router implements IRouter {
     private forwardToDestination(routedMessage: RouteMessageWrapper): RouteMessageAck {
         logger.trace(`Forwarding found message targeted to self ${routedMessage.requestId}`)
         const forwardedMessage = routedMessage.message!
-        if (this.ownPeerId.equals(peerIdFromPeerDescriptor(forwardedMessage.targetDescriptor!))) {
+        if (isSamePeerDescriptor(this.ownPeerDescriptor, forwardedMessage.targetDescriptor!)) {
             this.connectionManager?.handleMessage(forwardedMessage)
             return createRouteMessageAck(routedMessage)
         }

--- a/packages/dht/test/unit/RecursiveFinder.test.ts
+++ b/packages/dht/test/unit/RecursiveFinder.test.ts
@@ -25,9 +25,8 @@ describe('RecursiveFinder', () => {
     let recursiveFinder: RecursiveFinder
     let connections: Map<PeerIDKey, RemoteDhtNode>
 
-    const peerId1 = PeerID.fromString('peerid')
     const peerDescriptor1: PeerDescriptor = {
-        kademliaId: peerId1.value,
+        kademliaId: PeerID.fromString('peerid').value,
         type: NodeType.NODEJS
     }
     const peerDescriptor2: PeerDescriptor = {
@@ -59,7 +58,6 @@ describe('RecursiveFinder', () => {
         connections = new Map()
         recursiveFinder = new RecursiveFinder({
             ownPeerDescriptor: peerDescriptor1,
-            ownPeerId: peerId1,
             router: new MockRouter(),
             connections,
             serviceId: 'RecursiveFinder',

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -48,7 +48,6 @@ describe('Router', () => {
         connections = new Map()
         router = new Router({
             ownPeerDescriptor: peerDescriptor1,
-            ownPeerId: peerId,
             rpcCommunicator: mockRpcCommunicator,
             addContact: (_contact) => {},
             serviceId: 'router',


### PR DESCRIPTION
Simplify state in some classes by removing redundant `ownPeerId` field. The same information is available also from a separate `ownPeerDescriptor` field.