### PR TITLE
refactor(dht): Simplify handling of `DhtNode` defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27832,6 +27832,7 @@
                 "@types/websocket": "^1.0.3",
                 "express": "^4.17.1",
                 "patch-package": "^8.0.0",
+                "ts-essentials": "^9.4.1",
                 "ts-node": "^10.9.1"
             },
             "optionalDependencies": {

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -55,6 +55,7 @@
     "@types/websocket": "^1.0.3",
     "express": "^4.17.1",
     "patch-package": "^8.0.0",
+    "ts-essentials": "^9.4.1",
     "ts-node": "^10.9.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Added `StrictDhtNodeOptions` type in which ensures always contain a value. Merging default options with `@streamr/utils`
 `merge` utility function.

## Future improvements

Added these fields to `DhtNodeOptions`. Both were in the removed `DhtNodeConfig` type. Could maybe rename to have more descriptive names:
- `getClosestContactsLimit?: number`
- `storeNumberOfCopies?: number`