### PR TITLE
refactor(dht, trackerless-network): Unify transport naming

### DIFF
--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -58,7 +58,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         logger.trace(`Creating WebSocketConnector`)
         this.webSocketConnector = new WebSocketConnector({
             protocolVersion: ConnectionManager.PROTOCOL_VERSION,
-            rpcTransport: this.config.transport!,
+            transport: this.config.transport!,
             // TODO should we use canConnect also for WebRtcConnector? (NET-1142)
             canConnect: (peerDescriptor: PeerDescriptor) => canConnect(peerDescriptor),
             onIncomingConnection,
@@ -70,7 +70,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         })
         logger.trace(`Creating WebRTCConnector`)
         this.webrtcConnector = new WebRtcConnector({
-            rpcTransport: this.config.transport!,
+            transport: this.config.transport!,
             protocolVersion: ConnectionManager.PROTOCOL_VERSION,
             iceServers: this.config.iceServers,
             allowPrivateAddresses: this.config.webrtcAllowPrivateAddresses,

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -24,7 +24,7 @@ export interface ConnectorFacade {
 const logger = new Logger(module)
 
 export interface DefaultConnectorFacadeConfig {
-    transportLayer: ITransport
+    transport: ITransport
     websocketHost?: string
     websocketPortRange?: PortRange
     entryPoints?: PeerDescriptor[]
@@ -58,7 +58,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         logger.trace(`Creating WebSocketConnector`)
         this.webSocketConnector = new WebSocketConnector({
             protocolVersion: ConnectionManager.PROTOCOL_VERSION,
-            rpcTransport: this.config.transportLayer!,
+            rpcTransport: this.config.transport!,
             // TODO should we use canConnect also for WebRtcConnector? (NET-1142)
             canConnect: (peerDescriptor: PeerDescriptor) => canConnect(peerDescriptor),
             onIncomingConnection,
@@ -70,7 +70,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         })
         logger.trace(`Creating WebRTCConnector`)
         this.webrtcConnector = new WebRtcConnector({
-            rpcTransport: this.config.transportLayer!,
+            rpcTransport: this.config.transport!,
             protocolVersion: ConnectionManager.PROTOCOL_VERSION,
             iceServers: this.config.iceServers,
             allowPrivateAddresses: this.config.webrtcAllowPrivateAddresses,

--- a/packages/dht/src/connection/WebRTC/WebRtcConnector.ts
+++ b/packages/dht/src/connection/WebRTC/WebRtcConnector.ts
@@ -37,7 +37,7 @@ export const replaceInternalIpWithExternalIp = (candidate: string, ip: string): 
 }
 
 export interface WebRtcConnectorConfig {
-    rpcTransport: ITransport
+    transport: ITransport
     protocolVersion: string
     iceServers?: IceServer[]
     allowPrivateAddresses?: boolean
@@ -77,7 +77,7 @@ export class WebRtcConnector implements IWebRtcConnectorService {
         this.allowPrivateAddresses = config.allowPrivateAddresses || true
         this.onIncomingConnection = onIncomingConnection
 
-        this.rpcCommunicator = new ListeningRpcCommunicator(WebRtcConnector.WEBRTC_CONNECTOR_SERVICE_ID, config.rpcTransport, {
+        this.rpcCommunicator = new ListeningRpcCommunicator(WebRtcConnector.WEBRTC_CONNECTOR_SERVICE_ID, config.transport, {
             rpcRequestTimeout: 15000
         })
         this.rpcCommunicator.registerRpcNotification(RtcOffer, 'rtcOffer',

--- a/packages/dht/src/connection/WebSocket/WebSocketConnector.ts
+++ b/packages/dht/src/connection/WebSocket/WebSocketConnector.ts
@@ -42,7 +42,7 @@ const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
 
 interface WebSocketConnectorConfig {
     protocolVersion: string
-    rpcTransport: ITransport
+    transport: ITransport
     canConnect: (peerDescriptor: PeerDescriptor, _ip: string, port: number) => boolean
     onIncomingConnection: (connection: ManagedConnection) => boolean
     portRange?: PortRange
@@ -83,7 +83,7 @@ export class WebSocketConnector implements IWebSocketConnectorService {
 
         this.canConnectFunction = config.canConnect.bind(this)
 
-        this.rpcCommunicator = new ListeningRpcCommunicator(WebSocketConnector.WEBSOCKET_CONNECTOR_SERVICE_ID, config.rpcTransport, {
+        this.rpcCommunicator = new ListeningRpcCommunicator(WebSocketConnector.WEBSOCKET_CONNECTOR_SERVICE_ID, config.transport, {
             rpcRequestTimeout: 15000
         })
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -70,7 +70,7 @@ export interface DhtNodeOptions {
     storeMaxTtl?: number
     networkConnectivityTimeout?: number
 
-    transportLayer?: ITransport
+    transport?: ITransport
     peerDescriptor?: PeerDescriptor
     entryPoints?: PeerDescriptor[]
     websocketHost?: string
@@ -106,7 +106,7 @@ export class DhtNodeConfig {
     metricsContext = new MetricsContext()
     peerId = new UUID().toHex()
 
-    transportLayer?: ITransport
+    transport?: ITransport
     peerDescriptor?: PeerDescriptor
     entryPoints?: PeerDescriptor[]
     websocketHost?: string
@@ -163,7 +163,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private openInternetPeers?: SortedContactList<RemoteDhtNode>
     private randomPeers?: RandomContactList<RemoteDhtNode>
     private rpcCommunicator?: RoutingRpcCommunicator
-    private transportLayer?: ITransport
+    private transport?: ITransport
     private ownPeerDescriptor?: PeerDescriptor
     public router?: Router
     public dataStore?: DataStore
@@ -198,16 +198,16 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 this.config.peerDescriptor.websocket = undefined
             }
         }
-        // If transportLayer is given, do not create a ConnectionManager
-        if (this.config.transportLayer) {
-            this.transportLayer = this.config.transportLayer
-            this.ownPeerDescriptor = this.transportLayer.getPeerDescriptor()
-            if (this.config.transportLayer instanceof ConnectionManager) {
-                this.connectionManager = this.config.transportLayer
+        // If transport is given, do not create a ConnectionManager
+        if (this.config.transport) {
+            this.transport = this.config.transport
+            this.ownPeerDescriptor = this.transport.getPeerDescriptor()
+            if (this.config.transport instanceof ConnectionManager) {
+                this.connectionManager = this.config.transport
             }
         } else {
             const connectorFacadeConfig: DefaultConnectorFacadeConfig = {
-                transportLayer: this,
+                transport: this,
                 entryPoints: this.config.entryPoints,
                 iceServers: this.config.iceServers,
                 webrtcAllowPrivateAddresses: this.config.webrtcAllowPrivateAddresses,
@@ -240,16 +240,16 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             })
             await connectionManager.start()
             this.connectionManager = connectionManager
-            this.transportLayer = connectionManager
+            this.transport = connectionManager
         }
 
         this.rpcCommunicator = new RoutingRpcCommunicator(
             this.config.serviceId,
-            this.transportLayer.send,
+            this.transport.send,
             { rpcRequestTimeout: this.config.rpcRequestTimeout }
         )
 
-        this.transportLayer.on('message', (message: Message) => this.handleMessage(message))
+        this.transport.on('message', (message: Message) => this.handleMessage(message))
 
         this.bindDefaultServerMethods()
         this.initKBuckets(peerIdFromPeerDescriptor(this.ownPeerDescriptor!))
@@ -346,13 +346,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.openInternetPeers.on('newContact', (newContact: RemoteDhtNode, activeContacts: RemoteDhtNode[]) =>
             this.emit('newOpenInternetContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
-        this.transportLayer!.on('connected', (peerDescriptor: PeerDescriptor) => this.onTransportConnected(peerDescriptor))
+        this.transport!.on('connected', (peerDescriptor: PeerDescriptor) => this.onTransportConnected(peerDescriptor))
 
-        this.transportLayer!.on('disconnected', (peerDescriptor: PeerDescriptor, disonnectionType: DisconnectionType) => {
+        this.transport!.on('disconnected', (peerDescriptor: PeerDescriptor, disonnectionType: DisconnectionType) => {
             this.onTransportDisconnected(peerDescriptor, disonnectionType)
         })
 
-        this.transportLayer!.getAllConnectionPeerDescriptors().forEach((peer) => {
+        this.transport!.getAllConnectionPeerDescriptors().forEach((peer) => {
             const remoteDhtNode = new RemoteDhtNode(
                 this.ownPeerDescriptor!,
                 peer,
@@ -682,7 +682,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getTransport(): ITransport {
-        return this.transportLayer!
+        return this.transport!
     }
 
     public getPeerDescriptor(): PeerDescriptor {
@@ -752,7 +752,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.connectionManager) {
             await this.connectionManager.stop()
         }
-        this.transportLayer = undefined
+        this.transport = undefined
         this.connectionManager = undefined
         this.connections.clear()
         this.removeAllListeners()

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -19,7 +19,7 @@ const logger = new Logger(module)
 
 export interface RecursiveFindSessionConfig {
     serviceId: string
-    rpcTransport: ITransport
+    transport: ITransport
     kademliaIdToFind: Uint8Array
     ownPeerId: PeerID
     waitedRoutingPathCompletions: number
@@ -28,7 +28,7 @@ export interface RecursiveFindSessionConfig {
 
 export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvents> implements IRecursiveFindSessionService {
     private readonly serviceId: string
-    private readonly rpcTransport: ITransport
+    private readonly transport: ITransport
     private readonly kademliaIdToFind: Uint8Array
     private readonly ownPeerId: PeerID
     private readonly waitedRoutingPathCompletions: number
@@ -45,13 +45,13 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
     constructor(config: RecursiveFindSessionConfig) {
         super()
         this.serviceId = config.serviceId
-        this.rpcTransport = config.rpcTransport
+        this.transport = config.transport
         this.kademliaIdToFind = config.kademliaIdToFind
         this.ownPeerId = config.ownPeerId
         this.waitedRoutingPathCompletions = config.waitedRoutingPathCompletions
         this.results = new SortedContactList(PeerID.fromValue(this.kademliaIdToFind), 10, undefined, true)
         this.mode = config.mode
-        this.rpcCommunicator = new ListeningRpcCommunicator(this.serviceId, this.rpcTransport, {
+        this.rpcCommunicator = new ListeningRpcCommunicator(this.serviceId, this.transport, {
             rpcRequestTimeout: 15000
         })
         this.rpcCommunicator.registerRpcNotification(RecursiveFindReport, 'reportRecursiveFindResult',

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -88,7 +88,7 @@ export class RecursiveFinder implements IRecursiveFinder {
         const sessionId = v4()
         const recursiveFindSession = new RecursiveFindSession({
             serviceId: sessionId,
-            rpcTransport: this.sessionTransport,
+            transport: this.sessionTransport,
             kademliaIdToFind: idToFind,
             ownPeerId: peerIdFromPeerDescriptor(this.ownPeerDescriptor),
             waitedRoutingPathCompletions: this.connections.size > 1 ? 2 : 1,

--- a/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
@@ -35,11 +35,11 @@ describe('Layer0-Layer1', () => {
         await node1.start()
         await node2.start()
 
-        stream1Node1 = new DhtNode({ transportLayer: epDhtNode, serviceId: STREAM_ID1 })
-        stream1Node2 = new DhtNode({ transportLayer: node1, serviceId: STREAM_ID1 })
+        stream1Node1 = new DhtNode({ transport: epDhtNode, serviceId: STREAM_ID1 })
+        stream1Node2 = new DhtNode({ transport: node1, serviceId: STREAM_ID1 })
 
-        stream2Node1 = new DhtNode({ transportLayer: epDhtNode, serviceId: STREAM_ID2 })
-        stream2Node2 = new DhtNode({ transportLayer: node2, serviceId: STREAM_ID2 })
+        stream2Node1 = new DhtNode({ transport: epDhtNode, serviceId: STREAM_ID2 })
+        stream2Node2 = new DhtNode({ transport: node2, serviceId: STREAM_ID2 })
 
         await Promise.all([
             stream1Node1.start(),

--- a/packages/dht/test/end-to-end/Layer0WebRTC-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0WebRTC-Layer1.test.ts
@@ -54,31 +54,31 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         layer1EntryPoint = new DhtNode({
             peerId: binaryToHex(entrypointDescriptor.kademliaId),
-            transportLayer: layer0EntryPoint,
+            transport: layer0EntryPoint,
             serviceId: 'layer1'
         })
 
         layer1Node1 = new DhtNode({
             peerId: layer0Node1Id,
-            transportLayer: layer0Node1,
+            transport: layer0Node1,
             serviceId: 'layer1'
         })
 
         layer1Node2 = new DhtNode({
             peerId: layer0Node2Id,
-            transportLayer: layer0Node2,
+            transport: layer0Node2,
             serviceId: 'layer1'
         })
 
         layer1Node3 = new DhtNode({
             peerId: layer0Node3Id,
-            transportLayer: layer0Node3,
+            transport: layer0Node3,
             serviceId: 'layer1'
         })
 
         layer1Node4 = new DhtNode({
             peerId: layer0Node4Id,
-            transportLayer: layer0Node4,
+            transport: layer0Node4,
             serviceId: 'layer1'
         })
 

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebRTC.test.ts
@@ -25,7 +25,7 @@ describe('Layer1 Scale', () => {
         await epLayer0Node.start()
         await epLayer0Node.joinDht([epPeerDescriptor])
 
-        epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
+        epLayer1Node = new DhtNode({ transport: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
         await epLayer1Node.start()
         await epLayer1Node.joinDht([epPeerDescriptor])
 
@@ -37,7 +37,7 @@ describe('Layer1 Scale', () => {
             await node.start()
             layer0Nodes.push(node)
             const layer1 = new DhtNode({
-                transportLayer: node,
+                transport: node,
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getPeerDescriptor(),
                 serviceId: STREAM_ID,

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -27,7 +27,7 @@ describe('Layer1 Scale', () => {
         await epLayer0Node.start()
         await epLayer0Node.joinDht([epPeerDescriptor])
 
-        epLayer1Node = new DhtNode({ transportLayer: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
+        epLayer1Node = new DhtNode({ transport: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
         await epLayer1Node.start()
         await epLayer1Node.joinDht([epPeerDescriptor])
 
@@ -39,7 +39,7 @@ describe('Layer1 Scale', () => {
             await node.start()
             layer0Nodes.push(node)
             const layer1 = new DhtNode({
-                transportLayer: node,
+                transport: node,
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getPeerDescriptor(),
                 serviceId: STREAM_ID

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -7,10 +7,10 @@ import { ITransport } from '../../src/exports'
 import { PeerID } from '../../src/helpers/PeerID'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 
-const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transportLayer: ITransport) => {
+const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transport: ITransport) => {
     return new ConnectionManager({
         createConnectorFacade: () => new DefaultConnectorFacade({
-            transportLayer,
+            transport,
             createOwnPeerDescriptor: () => ownPeerDescriptor
         }),
         metricsContext: new MetricsContext()

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -68,7 +68,7 @@ describe('ConnectionManager', () => {
     it('Can start alone', async () => {
 
         const connectionManager = createConnectionManager({
-            transportLayer: mockTransport,
+            transport: mockTransport,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 9991, max: 9991 },
         })
@@ -83,7 +83,7 @@ describe('ConnectionManager', () => {
     it('Throws an async exception if fails to connect to entrypoints', async () => {
 
         const connectionManager = createConnectionManager({
-            transportLayer: mockTransport,
+            transport: mockTransport,
             websocketPortRange: { min: 9992, max: 9992 },
             entryPoints: [
                 { kademliaId: Uint8Array.from([1, 2, 3]), type: NodeType.NODEJS, websocket: { host: '127.0.0.1', port: 12345, tls: false } }
@@ -97,7 +97,7 @@ describe('ConnectionManager', () => {
 
     it('Can probe connectivity in open internet', async () => {
         const connectionManager1 = createConnectionManager({
-            transportLayer: mockTransport,
+            transport: mockTransport,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 9993, max: 9993 }
         })
@@ -107,7 +107,7 @@ describe('ConnectionManager', () => {
         expect(createOwnPeerDescriptor.mock.calls[0][0].openInternet).toEqual(true)
 
         const connectionManager2 = createConnectionManager({
-            transportLayer: mockConnectorTransport2,
+            transport: mockConnectorTransport2,
             websocketPortRange: { min: 9994, max: 9994 },
             entryPoints: [
                 { kademliaId: Uint8Array.from([1, 2, 3]), type: NodeType.NODEJS, websocket: { host: '127.0.0.1', port: 9993, tls: false } }
@@ -124,7 +124,7 @@ describe('ConnectionManager', () => {
 
     it('Can send data to other connectionmanager over websocket', async () => {
         const connectionManager1 = createConnectionManager({
-            transportLayer: mockConnectorTransport1,
+            transport: mockConnectorTransport1,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 9995, max: 9995 }
         })
@@ -134,7 +134,7 @@ describe('ConnectionManager', () => {
         expect(createOwnPeerDescriptor.mock.calls[0][0].openInternet).toEqual(true)
 
         const connectionManager2 = createConnectionManager({
-            transportLayer: mockConnectorTransport2,
+            transport: mockConnectorTransport2,
             websocketPortRange: { min: 9996, max: 9996 },
             entryPoints: [
                 connectionManager1.getPeerDescriptor()
@@ -185,7 +185,7 @@ describe('ConnectionManager', () => {
 
     it('Can disconnect websockets', async () => {
         const connectionManager1 = createConnectionManager({ 
-            transportLayer: mockConnectorTransport1,
+            transport: mockConnectorTransport1,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 9997, max: 9997 }
         })
@@ -195,7 +195,7 @@ describe('ConnectionManager', () => {
         expect(createOwnPeerDescriptor.mock.calls[0][0].openInternet).toEqual(true)
 
         const connectionManager2 = createConnectionManager({
-            transportLayer: mockConnectorTransport2,
+            transport: mockConnectorTransport2,
             websocketPortRange: { min: 9999, max: 9999 },
             entryPoints: [
                 connectionManager1.getPeerDescriptor()
@@ -309,7 +309,7 @@ describe('ConnectionManager', () => {
 
     it('Cannot send to own WebSocketServer if kademliaIds do not match', async () => {
         const connectionManager1 = createConnectionManager({
-            transportLayer: mockTransport,
+            transport: mockTransport,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 10001, max: 10001 }
         })

--- a/packages/dht/test/integration/RpcErrors.test.ts
+++ b/packages/dht/test/integration/RpcErrors.test.ts
@@ -12,10 +12,10 @@ import { NodeType, PeerDescriptor, PingRequest, PingResponse } from '../../src/p
 import { DefaultConnectorFacade } from '../../src/connection/ConnectorFacade'
 import { MetricsContext } from '@streamr/utils'
 
-const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transportLayer: ITransport) => {
+const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transport: ITransport) => {
     return new ConnectionManager({
         createConnectorFacade: () => new DefaultConnectorFacade({
-            transportLayer,
+            transport,
             createOwnPeerDescriptor: () => ownPeerDescriptor
         }),
         metricsContext: new MetricsContext()

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -116,12 +116,12 @@ describe('SimultaneousConnections', () => {
         beforeEach(async () => {
             const websocketPortRange = { min: 43432, max: 43433 }
             connectionManager1 = createConnectionManager(wsPeer1, {
-                transportLayer: simulatorTransport1,
+                transport: simulatorTransport1,
                 websocketPortRange,
                 entryPoints: [wsPeer1]
             })
             connectionManager2 = createConnectionManager(wsPeer2, {
-                transportLayer: simulatorTransport2,
+                transport: simulatorTransport2,
                 websocketPortRange,
                 entryPoints: [wsPeer1]
             })
@@ -191,12 +191,12 @@ describe('SimultaneousConnections', () => {
 
         beforeEach(async () => {
             connectionManager1 = createConnectionManager(wsPeer1, {
-                transportLayer: simulatorTransport1,
+                transport: simulatorTransport1,
                 websocketPortRange: { min: 43432, max: 43432 },
                 entryPoints: [wsPeer1]
             })
             connectionManager2 = createConnectionManager(wsPeer2, {
-                transportLayer: simulatorTransport2
+                transport: simulatorTransport2
             })
             await connectionManager1.start()
             await connectionManager2.start()
@@ -259,10 +259,10 @@ describe('SimultaneousConnections', () => {
 
         beforeEach(async () => {
             connectionManager1 = createConnectionManager(wrtcPeer1, {
-                transportLayer: simulatorTransport1,
+                transport: simulatorTransport1,
             })
             connectionManager2 = createConnectionManager(wrtcPeer2, {
-                transportLayer: simulatorTransport2,
+                transport: simulatorTransport2,
             })
             await connectionManager1.start()
             await connectionManager2.start()

--- a/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebRtcConnectionManagement.test.ts
@@ -10,10 +10,10 @@ import { SimulatorTransport } from '../../src/connection/Simulator/SimulatorTran
 import { DefaultConnectorFacade } from '../../src/connection/ConnectorFacade'
 import { MetricsContext } from '@streamr/utils'
 
-const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transportLayer: ITransport) => {
+const createConnectionManager = (ownPeerDescriptor: PeerDescriptor, transport: ITransport) => {
     return new ConnectionManager({
         createConnectorFacade: () => new DefaultConnectorFacade({
-            transportLayer,
+            transport,
             createOwnPeerDescriptor: () => ownPeerDescriptor
         }),
         metricsContext: new MetricsContext()

--- a/packages/dht/test/integration/WebSocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebSocketConnectionManagement.test.ts
@@ -55,12 +55,12 @@ describe('WebSocket Connection Management', () => {
         await connectorTransport2.start()
 
         const config1 = createConfig(wsServerConnectorPeerDescriptor, {
-            transportLayer: connectorTransport1,
+            transport: connectorTransport1,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 12223, max: 12223 }
         })
         const config2 = createConfig(noWsServerConnectorPeerDescriptor, {
-            transportLayer: connectorTransport2
+            transport: connectorTransport2
         })
 
         wsServerManager = new ConnectionManager(config1)

--- a/packages/dht/test/unit/WebSocketConnector.test.ts
+++ b/packages/dht/test/unit/WebSocketConnector.test.ts
@@ -17,7 +17,7 @@ describe('WebSocketConnector', () => {
     describe('isPossibleToFormConnection', () => {
 
         const connector = new WebSocketConnector({
-            rpcTransport: new MockTransport(),
+            transport: new MockTransport(),
             canConnect: () => {}
         } as any)
 

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -64,7 +64,7 @@ export const createMockConnectionDhtNode = async (stringId: string,
 
     const node = new DhtNode({
         peerDescriptor: peerDescriptor,
-        transportLayer: mockConnectionManager,
+        transport: mockConnectionManager,
         numberOfNodesPerKBucket: K ? K : 8,
         maxConnections: maxConnections,
         dhtJoinTimeout
@@ -82,7 +82,7 @@ export const createMockConnectionLayer1Node = async (stringId: string, layer0Nod
     }
 
     const node = new DhtNode({
-        peerDescriptor: descriptor, transportLayer: layer0Node,
+        peerDescriptor: descriptor, transport: layer0Node,
         serviceId: serviceId ? serviceId : 'layer1', numberOfNodesPerKBucket: 8
     })
     await node.start()

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -194,7 +194,7 @@ export class StreamrNode extends EventEmitter<Events> {
 
     private createLayer1Node = (streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): ILayer1 => {
         return new DhtNode({
-            transportLayer: this.layer0!,
+            transport: this.layer0!,
             serviceId: 'layer1::' + streamPartId,
             peerDescriptor: this.layer0!.getPeerDescriptor(),
             entryPoints,

--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -24,13 +24,13 @@ describe('inspect', () => {
     let publishInterval: NodeJS.Timeout
 
     const initiateNode = async (peerDescriptor: PeerDescriptor, simulator: Simulator): Promise<NetworkStack> => {
-        const transportLayer = new SimulatorTransport(peerDescriptor, simulator)
-        await transportLayer.start()
+        const transport = new SimulatorTransport(peerDescriptor, simulator)
+        await transport.start()
         const node = new NetworkStack({
             layer0: {
                 entryPoints: [publisherDescriptor],
                 peerDescriptor,
-                transportLayer
+                transport
             }
         })
         await node.start()

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -41,14 +41,14 @@ describe('NetworkNode', () => {
             layer0: {
                 entryPoints: [pd1],
                 peerDescriptor: pd1,
-                transportLayer: transport1
+                transport: transport1
             }
         })
         node2 = createNetworkNode({
             layer0: {
                 entryPoints: [pd1],
                 peerDescriptor: pd2,
-                transportLayer: transport2
+                transport: transport2
             }
         })
 

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -28,12 +28,12 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         await Promise.all(cms.map((cm) => cm.start()))
 
         dhtEntryPoint = new DhtNode({
-            transportLayer: entrypointCm,
+            transport: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
         dhtNodes = range(numOfNodes).map((i) => new DhtNode({
-            transportLayer: cms[i],
+            transport: cms[i],
             peerDescriptor: peerDescriptors[i],
             serviceId: streamPartId
         }))

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -44,13 +44,13 @@ describe('RandomGraphNode-DhtNode', () => {
         await Promise.all(cms.map((cm) => cm.start()))
 
         dhtEntryPoint = new DhtNode({
-            transportLayer: entrypointCm,
+            transport: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
 
         dhtNodes = range(numOfNodes).map((i) => new DhtNode({
-            transportLayer: cms[i],
+            transport: cms[i],
             peerDescriptor: peerDescriptors[i],
             serviceId: streamPartId
         }))

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -50,12 +50,12 @@ describe('StreamrNode', () => {
         transport2 = new SimulatorTransport(peerDescriptor2, simulator)
         await transport2.start()
         layer01 = new DhtNode({
-            transportLayer: transport1,
+            transport: transport1,
             peerDescriptor: peerDescriptor1,
             entryPoints: [peerDescriptor1]
         })
         layer02 = new DhtNode({
-            transportLayer: transport2,
+            transport: transport2,
             peerDescriptor: peerDescriptor2,
             entryPoints: [peerDescriptor1]
         })

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -46,7 +46,7 @@ describe('Joining stream parts on offline nodes', () => {
         const entryPointTransport = new SimulatorTransport(entryPointPeerDescriptor, simulator)
         entryPoint = new NetworkStack({
             layer0: {
-                transportLayer: entryPointTransport,
+                transport: entryPointTransport,
                 peerDescriptor: entryPointPeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -54,7 +54,7 @@ describe('Joining stream parts on offline nodes', () => {
         const node1Transport = new SimulatorTransport(node1PeerDescriptor, simulator)
         node1 = new NetworkStack({
             layer0: {
-                transportLayer: node1Transport,
+                transport: node1Transport,
                 peerDescriptor: node1PeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -62,7 +62,7 @@ describe('Joining stream parts on offline nodes', () => {
         const node2Transport = new SimulatorTransport(node2PeerDescriptor, simulator)
         node2 = new NetworkStack({
             layer0: {
-                transportLayer: node2Transport,
+                transport: node2Transport,
                 peerDescriptor: node2PeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -50,7 +50,7 @@ describe('stream without default entrypoints', () => {
         await entryPointTransport.start()
         entrypoint = createNetworkNode({
             layer0: {
-                transportLayer: entryPointTransport,
+                transport: entryPointTransport,
                 peerDescriptor: entryPointPeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -63,7 +63,7 @@ describe('stream without default entrypoints', () => {
             const node = createNetworkNode({
                 layer0: {
                     peerDescriptor,
-                    transportLayer: transport,
+                    transport: transport,
                     entryPoints: [entryPointPeerDescriptor]
                 }
             })

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -63,7 +63,7 @@ describe('stream without default entrypoints', () => {
             const node = createNetworkNode({
                 layer0: {
                     peerDescriptor,
-                    transport: transport,
+                    transport,
                     entryPoints: [entryPointPeerDescriptor]
                 }
             })

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -32,7 +32,7 @@ export const createMockRandomGraphNodeAndDhtNode = async (
     const mockCm = new SimulatorTransport(ownPeerDescriptor, simulator)
     await mockCm.start()
     const dhtNode = new DhtNode({
-        transportLayer: mockCm,
+        transport: mockCm,
         peerDescriptor: ownPeerDescriptor,
         numberOfNodesPerKBucket: 4,
         entryPoints: [entryPointDescriptor]
@@ -111,7 +111,7 @@ export const createNetworkNodeWithSimulator = (
         layer0: {
             peerDescriptor,
             entryPoints,
-            transportLayer: transport,
+            transport: transport,
             maxConnections: 25,
             storeHighestTtl: 120000,
             storeMaxTtl: 120000

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -111,7 +111,7 @@ export const createNetworkNodeWithSimulator = (
         layer0: {
             peerDescriptor,
             entryPoints,
-            transport: transport,
+            transport,
             maxConnections: 25,
             storeHighestTtl: 120000,
             storeMaxTtl: 120000


### PR DESCRIPTION
Rename usages of `ITransport`:
- `transportLayer` -> `transport`
- `rpcTransport` -> `transport`
