### PR TITLE
refactor(trackerless-network): Rename `P2PTransport`

### DIFF
--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -41,7 +41,7 @@ export interface Events {
 export interface StrictRandomGraphNodeConfig {
     streamPartId: StreamPartID
     layer1: ILayer1
-    P2PTransport: ITransport
+    transport: ITransport
     connectionLocker: ConnectionLocker
     ownPeerDescriptor: PeerDescriptor
     nodeViewSize: number
@@ -126,7 +126,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
             this.abortController.signal
         )   
         addManagedEventListener<any, any>(
-            this.config.P2PTransport as any,
+            this.config.transport as any,
             'disconnected',
             (peerDescriptor: PeerDescriptor) => this.onNodeDisconnected(peerDescriptor),
             this.abortController.signal

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -59,7 +59,7 @@ export interface StreamrNodeConfig {
 
 // TODO rename class?
 export class StreamrNode extends EventEmitter<Events> {
-    private P2PTransport?: ITransport
+    private transport?: ITransport
     private connectionLocker?: ConnectionLocker
     private layer0?: ILayer0
     private readonly metricsContext: MetricsContext
@@ -89,7 +89,7 @@ export class StreamrNode extends EventEmitter<Events> {
         logger.info(`Starting new StreamrNode with id ${getNodeIdFromPeerDescriptor(startedAndJoinedLayer0.getPeerDescriptor())}`)
         this.started = true
         this.layer0 = startedAndJoinedLayer0
-        this.P2PTransport = transport
+        this.transport = transport
         this.connectionLocker = connectionLocker
         cleanUp = () => this.destroy()
     }
@@ -104,9 +104,9 @@ export class StreamrNode extends EventEmitter<Events> {
         this.streamParts.clear()
         this.removeAllListeners()
         await this.layer0!.stop()
-        await this.P2PTransport!.stop()
+        await this.transport!.stop()
         this.layer0 = undefined
-        this.P2PTransport = undefined
+        this.transport = undefined
         this.connectionLocker = undefined
     }
 
@@ -207,7 +207,7 @@ export class StreamrNode extends EventEmitter<Events> {
     private createRandomGraphNode = (streamPartId: StreamPartID, layer1: ILayer1) => {
         return createRandomGraphNode({
             streamPartId,
-            P2PTransport: this.P2PTransport!,
+            transport: this.transport!,
             layer1,
             connectionLocker: this.connectionLocker!,
             ownPeerDescriptor: this.layer0!.getPeerDescriptor(),
@@ -255,7 +255,7 @@ export class StreamrNode extends EventEmitter<Events> {
 
     private createProxyClient(streamPartId: StreamPartID): ProxyClient {
         return new ProxyClient({
-            P2PTransport: this.P2PTransport!,
+            transport: this.transport!,
             ownPeerDescriptor: this.layer0!.getPeerDescriptor(),
             streamPartId,
             connectionLocker: this.connectionLocker!,

--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -28,7 +28,7 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
     const ownNodeId = getNodeIdFromPeerDescriptor(config.ownPeerDescriptor)
     const rpcCommunicator = config.rpcCommunicator ?? new ListeningRpcCommunicator(
         formStreamPartDeliveryServiceId(config.streamPartId),
-        config.P2PTransport
+        config.transport
     )
     const numOfTargetNeighbors = config.numOfTargetNeighbors ?? 4
     const maxNumberOfContacts = config.maxNumberOfContacts ?? 20

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -43,7 +43,7 @@ export const retry = async <T>(task: () => Promise<T>, description: string, abor
 }
 
 interface ProxyClientConfig {
-    P2PTransport: ITransport
+    transport: ITransport
     ownPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     connectionLocker: ConnectionLocker
@@ -76,7 +76,7 @@ export class ProxyClient extends EventEmitter {
     constructor(config: ProxyClientConfig) {
         super()
         this.config = config
-        this.rpcCommunicator = new ListeningRpcCommunicator(formStreamPartDeliveryServiceId(config.streamPartId), config.P2PTransport)
+        this.rpcCommunicator = new ListeningRpcCommunicator(formStreamPartDeliveryServiceId(config.streamPartId), config.transport)
         this.targetNeighbors = new NodeList(getNodeIdFromPeerDescriptor(this.config.ownPeerDescriptor), 1000)
         this.deliveryRpcLocal = new DeliveryRpcLocal({
             ownPeerDescriptor: this.config.ownPeerDescriptor,
@@ -241,7 +241,7 @@ export class ProxyClient extends EventEmitter {
     async start(): Promise<void> {
         this.registerDefaultServerMethods()
         addManagedEventListener<any, any>(
-            this.config.P2PTransport as any,
+            this.config.transport as any,
             'disconnected',
             (peerDescriptor: PeerDescriptor) => this.onNodeDisconnected(peerDescriptor),
             this.abortController.signal

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -43,7 +43,7 @@ describe('random graph with real connections', () => {
             {
                 streamPartId,
                 layer1: epDhtNode,
-                P2PTransport: epDhtNode.getTransport(),
+                transport: epDhtNode.getTransport(),
                 connectionLocker: epDhtNode.getTransport() as ConnectionManager,
                 ownPeerDescriptor: epPeerDescriptor
             }
@@ -51,28 +51,28 @@ describe('random graph with real connections', () => {
         randomGraphNode2 = createRandomGraphNode({
             streamPartId,
             layer1: dhtNode1,
-            P2PTransport: dhtNode1.getTransport(),
+            transport: dhtNode1.getTransport(),
             connectionLocker: dhtNode1.getTransport() as ConnectionManager,
             ownPeerDescriptor: dhtNode1.getPeerDescriptor()
         })
         randomGraphNode3 = createRandomGraphNode({
             streamPartId,
             layer1: dhtNode2,
-            P2PTransport: dhtNode2.getTransport(),
+            transport: dhtNode2.getTransport(),
             connectionLocker: dhtNode2.getTransport() as ConnectionManager,
             ownPeerDescriptor: dhtNode2.getPeerDescriptor()
         })
         randomGraphNode4 = createRandomGraphNode({
             streamPartId,
             layer1: dhtNode3,
-            P2PTransport: dhtNode3.getTransport(),
+            transport: dhtNode3.getTransport(),
             connectionLocker: dhtNode3.getTransport() as ConnectionManager,
             ownPeerDescriptor: dhtNode3.getPeerDescriptor()
         })
         randomGraphNode5 = createRandomGraphNode({
             streamPartId,
             layer1: dhtNode4,
-            P2PTransport: dhtNode4.getTransport(),
+            transport: dhtNode4.getTransport(),
             connectionLocker: dhtNode4.getTransport() as ConnectionManager,
             ownPeerDescriptor: dhtNode4.getPeerDescriptor()
         })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -40,14 +40,14 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         graphNodes = range(numOfNodes).map((i) => createRandomGraphNode({
             streamPartId,
             layer1: dhtNodes[i],
-            P2PTransport: cms[i],
+            transport: cms[i],
             connectionLocker: cms[i],
             ownPeerDescriptor: peerDescriptors[i]
         }))
         entryPointRandomGraphNode = createRandomGraphNode({
             streamPartId,
             layer1: dhtEntryPoint,
-            P2PTransport: entrypointCm,
+            transport: entrypointCm,
             connectionLocker: entrypointCm,
             ownPeerDescriptor: entrypointDescriptor
         })

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -58,7 +58,7 @@ describe('RandomGraphNode-DhtNode', () => {
         graphNodes = range(numOfNodes).map((i) => createRandomGraphNode({
             streamPartId,
             layer1: dhtNodes[i],
-            P2PTransport: cms[i],
+            transport: cms[i],
             connectionLocker: cms[i],
             ownPeerDescriptor: peerDescriptors[i],
             neighborUpdateInterval: 2000
@@ -67,7 +67,7 @@ describe('RandomGraphNode-DhtNode', () => {
         entryPointRandomGraphNode = createRandomGraphNode({
             streamPartId,
             layer1: dhtEntryPoint,
-            P2PTransport: entrypointCm,
+            transport: entrypointCm,
             connectionLocker: entrypointCm,
             ownPeerDescriptor: entrypointDescriptor,
             neighborUpdateInterval: 2000

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -33,7 +33,7 @@ describe('RandomGraphNode', () => {
             targetNeighbors,
             randomNodeView,
             nearbyNodeView,
-            P2PTransport: new MockTransport(),
+            transport: new MockTransport(),
             ownPeerDescriptor: peerDescriptor,
             layer1,
             connectionLocker: mockConnectionLocker,

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -39,7 +39,7 @@ export const createMockRandomGraphNodeAndDhtNode = async (
     })
     const randomGraphNode = createRandomGraphNode({
         streamPartId,
-        P2PTransport: mockCm,
+        transport: mockCm,
         layer1: dhtNode,
         connectionLocker: mockCm,
         ownPeerDescriptor


### PR DESCRIPTION
Rename the `P2PTransport` field from multiple classes. It contains `ITransport` object and should be therefore name just as `transport`. (Other similar cases were already renamed in https://github.com/streamr-dev/network/pull/2005)