### PR TITLE
refactor(dht): Rename some `DhtNode` options

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -71,7 +71,7 @@ export interface DhtNodeOptions {
     storeHighestTtl?: number
     storeMaxTtl?: number
     networkConnectivityTimeout?: number
-    storeNumberOfCopies?: number  // TODO better name?
+    storageRedundancyFactor?: number
 
     transport?: ITransport
     peerDescriptor?: PeerDescriptor
@@ -105,7 +105,7 @@ type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
     'storeHighestTtl' |
     'storeMaxTtl' |
     'networkConnectivityTimeout' |
-    'storeNumberOfCopies' |
+    'storageRedundancyFactor' |
     'metricsContext' |
     'peerId'>
 
@@ -165,7 +165,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             storeHighestTtl: 60000,
             storeMaxTtl: 60000,
             networkConnectivityTimeout: 10000,
-            storeNumberOfCopies: 5,
+            storageRedundancyFactor: 5,
             metricsContext: new MetricsContext(),
             peerId: new UUID().toHex(),
             ...conf  // TODO use merge() if we don't want that explicit undefined values override defaults?
@@ -283,7 +283,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             serviceId: this.config.serviceId,
             highestTtl: this.config.storeHighestTtl,
             maxTtl: this.config.storeMaxTtl,
-            numberOfCopies: this.config.storeNumberOfCopies,
+            redundancyFactor: this.config.storageRedundancyFactor,
             localDataStore: this.localDataStore,
             dhtNodeEmitter: this,
             getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -65,7 +65,7 @@ export interface DhtNodeOptions {
     maxNeighborListSize?: number
     numberOfNodesPerKBucket?: number
     joinNoProgressLimit?: number
-    getClosestContactsLimit?: number  // TODO better name?
+    peerDiscoveryQueryBatchSize?: number
     dhtJoinTimeout?: number
     metricsContext?: MetricsContext
     storeHighestTtl?: number
@@ -100,7 +100,7 @@ type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
     'numberOfNodesPerKBucket' |
     'joinNoProgressLimit' |
     'dhtJoinTimeout' |
-    'getClosestContactsLimit' |
+    'peerDiscoveryQueryBatchSize' |
     'maxConnections' |
     'storeHighestTtl' |
     'storeMaxTtl' |
@@ -160,7 +160,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             numberOfNodesPerKBucket: 8,
             joinNoProgressLimit: 4,
             dhtJoinTimeout: 60000,
-            getClosestContactsLimit: 5,
+            peerDiscoveryQueryBatchSize: 5,
             maxConnections: 80,
             storeHighestTtl: 60000,
             storeMaxTtl: 60000,
@@ -250,7 +250,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             randomPeers: this.randomPeers!,
             openInternetPeers: this.openInternetPeers!,
             joinNoProgressLimit: this.config.joinNoProgressLimit,
-            getClosestContactsLimit: this.config.getClosestContactsLimit,
+            peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             joinTimeout: this.config.dhtJoinTimeout,
             serviceId: this.config.serviceId,
             parallelism: this.config.joinParallelism,
@@ -492,7 +492,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 this.emit(
                     'newKbucketContact',
                     contact.getPeerDescriptor(),
-                    this.neighborList!.getClosestContacts(this.config.getClosestContactsLimit).map((peer) => peer.getPeerDescriptor())
+                    this.neighborList!.getClosestContacts(this.config.peerDiscoveryQueryBatchSize).map((peer) => peer.getPeerDescriptor())
                 )
             } else {    // open connection by pinging
                 logger.trace('starting ping ' + keyFromPeerDescriptor(contact.getPeerDescriptor()))
@@ -502,7 +502,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                         this.emit(
                             'newKbucketContact',
                             contact.getPeerDescriptor(),
-                            this.neighborList!.getClosestContacts(this.config.getClosestContactsLimit).map((peer) => peer.getPeerDescriptor())
+                            this.neighborList!.getClosestContacts(this.config.peerDiscoveryQueryBatchSize).map((peer) => peer.getPeerDescriptor())
                         )
                     } else {
                         logger.trace('ping failed ' + keyFromPeerDescriptor(contact.getPeerDescriptor()))
@@ -740,7 +740,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private async getClosestPeers(request: ClosestPeersRequest, context: ServerCallContext): Promise<ClosestPeersResponse> {
         this.addNewContact((context as DhtCallContext).incomingSourceDescriptor!)
         const response = {
-            peers: this.getClosestPeerDescriptors(request.kademliaId, this.config.getClosestContactsLimit),
+            peers: this.getClosestPeerDescriptors(request.kademliaId, this.config.peerDiscoveryQueryBatchSize),
             requestId: request.requestId
         }
         return response

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -20,7 +20,7 @@ interface PeerDiscoveryConfig {
     randomPeers: RandomContactList<RemoteDhtNode>
     openInternetPeers: SortedContactList<RemoteDhtNode>
     joinNoProgressLimit: number
-    getClosestContactsLimit: number
+    peerDiscoveryQueryBatchSize: number
     serviceId: string
     parallelism: number
     joinTimeout: number
@@ -59,7 +59,7 @@ export class PeerDiscovery {
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
         this.config.addContact(entryPointDescriptor)
-        const closest = this.config.bucket.closest(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value, this.config.getClosestContactsLimit)
+        const closest = this.config.bucket.closest(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value, this.config.peerDiscoveryQueryBatchSize)
         this.config.neighborList.addContacts(closest)
         const sessions = [this.createSession(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value)]
         if (doAdditionalRandomPeerDiscovery) {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -59,9 +59,10 @@ export class PeerDiscovery {
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
         this.config.addContact(entryPointDescriptor)
-        const closest = this.config.bucket.closest(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value, this.config.peerDiscoveryQueryBatchSize)
+        const targetId = peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value
+        const closest = this.config.bucket.closest(targetId, this.config.peerDiscoveryQueryBatchSize)
         this.config.neighborList.addContacts(closest)
-        const sessions = [this.createSession(peerIdFromPeerDescriptor(this.config.ownPeerDescriptor).value)]
+        const sessions = [this.createSession(targetId)]
         if (doAdditionalRandomPeerDiscovery) {
             sessions.push(this.createSession(createRandomKademliaId()))
         }

--- a/packages/dht/src/dht/store/DataStore.ts
+++ b/packages/dht/src/dht/store/DataStore.ts
@@ -30,7 +30,7 @@ interface DataStoreConfig {
     serviceId: string
     maxTtl: number
     highestTtl: number
-    numberOfCopies: number
+    redundancyFactor: number
     dhtNodeEmitter: EventEmitter<Events>
     getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => RemoteDhtNode[]
 }
@@ -46,7 +46,7 @@ export class DataStore implements IStoreService {
     private readonly serviceId: string
     private readonly maxTtl: number
     private readonly highestTtl: number
-    private readonly numberOfCopies: number
+    private readonly redundancyFactor: number
     private readonly dhtNodeEmitter: EventEmitter<Events>
     private readonly getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => RemoteDhtNode[]
 
@@ -58,7 +58,7 @@ export class DataStore implements IStoreService {
         this.serviceId = config.serviceId
         this.maxTtl = config.maxTtl
         this.highestTtl = config.highestTtl
-        this.numberOfCopies = config.numberOfCopies
+        this.redundancyFactor = config.redundancyFactor
         this.dhtNodeEmitter = config.dhtNodeEmitter
         this.getNodesClosestToIdFromBucket = config.getNodesClosestToIdFromBucket
         this.rpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData',
@@ -114,10 +114,10 @@ export class DataStore implements IStoreService {
             }
         }
 
-        // if new node is within the storeNumberOfCopies closest nodes to the data
+        // if new node is within the storageRedundancyFactor closest nodes to the data
         // do migrate data to it
 
-        if (index < this.numberOfCopies) {
+        if (index < this.redundancyFactor) {
             this.localDataStore.setStale(dataId, dataEntry.storer!, false)
             return true
         } else {
@@ -150,7 +150,7 @@ export class DataStore implements IStoreService {
         const successfulNodes: PeerDescriptor[] = []
         const ttl = this.highestTtl // ToDo: make TTL decrease according to some nice curve
         const storerTime = Timestamp.now()
-        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.numberOfCopies; i++) {
+        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.redundancyFactor; i++) {
             if (areEqualPeerDescriptors(this.ownPeerDescriptor, closestNodes[i])) {
                 this.localDataStore.storeEntry({
                     kademliaId: key, 
@@ -188,8 +188,8 @@ export class DataStore implements IStoreService {
 
     private selfIsOneOfClosestPeers(dataId: Uint8Array): boolean {
         const ownPeerId = PeerID.fromValue(this.ownPeerDescriptor.kademliaId)
-        const closestPeers = this.getNodesClosestToIdFromBucket(dataId, this.numberOfCopies)
-        const sortedList = new SortedContactList<Contact>(ownPeerId, this.numberOfCopies, undefined, true)
+        const closestPeers = this.getNodesClosestToIdFromBucket(dataId, this.redundancyFactor)
+        const sortedList = new SortedContactList<Contact>(ownPeerId, this.redundancyFactor, undefined, true)
         sortedList.addContact(new Contact(this.ownPeerDescriptor))
         closestPeers.forEach((con) => sortedList.addContact(new Contact(con.getPeerDescriptor())))
         return sortedList.getClosestContacts().some((node) => node.getPeerId().equals(ownPeerId))
@@ -200,7 +200,7 @@ export class DataStore implements IStoreService {
         const result = await this.recursiveFinder.startRecursiveFind(key)
         const closestNodes = result.closestNodes
         const successfulNodes: PeerDescriptor[] = []
-        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.numberOfCopies; i++) {
+        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.redundancyFactor; i++) {
             if (areEqualPeerDescriptors(this.ownPeerDescriptor, closestNodes[i])) {
                 this.localDataStore.markAsDeleted(key, peerIdFromPeerDescriptor(this.ownPeerDescriptor))
                 successfulNodes.push(closestNodes[i])
@@ -283,7 +283,7 @@ export class DataStore implements IStoreService {
         const incomingPeerId = PeerID.fromValue(incomingPeer.kademliaId)
         const closestToData = this.getNodesClosestToIdFromBucket(dataEntry.kademliaId, 10)
 
-        const sortedList = new SortedContactList<Contact>(dataId, this.numberOfCopies, undefined, true)
+        const sortedList = new SortedContactList<Contact>(dataId, this.redundancyFactor, undefined, true)
         sortedList.addContact(new Contact(this.ownPeerDescriptor))
 
         closestToData.forEach((con) => {
@@ -307,7 +307,7 @@ export class DataStore implements IStoreService {
                 })
             }
         } else {
-            // if we are the closest to the data, migrate to all storeNumberOfCopies nearest
+            // if we are the closest to the data, migrate to all storageRedundancyFactor nearest
             sortedList.getAllContacts().forEach((contact) => {
                 const contactPeerId = PeerID.fromValue(contact.getPeerDescriptor().kademliaId)
                 if (!incomingPeerId.equals(contactPeerId) && !ownPeerId.equals(contactPeerId)) {


### PR DESCRIPTION
Renamed:
- `storeNumberOfCopies` -> `storageRedundancyFactor`
- `getClosestContactsLimit` -> `peerDiscoveryQueryBatchSize`

Some of the usages of `getClosestContactsLimit` will be removed in https://linear.app/streamr/issue/NET-1157/remove-4-unused-events-from-the-dhtnode