### PR TITLE
refactor(dht): Remove redundant stop checks

### DIFF
--- a/packages/dht/src/connection/websocket/ServerWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ServerWebsocket.ts
@@ -33,29 +33,23 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.connectionId = new ConnectionID()
 
         socket.on('message', (message) => {
-            if (!this.stopped) {
-                logger.trace('ServerWebsocket::onMessage')
-                if (message.type === MessageType.UTF8) {
-                    logger.debug('Received string Message: ' + message.utf8Data)
-                } else if (message.type === MessageType.BINARY) {
-                    logger.trace('Received Binary Message of ' + message.binaryData.length + ' bytes')
-                    this.emit('data',
-                        new Uint8Array(message.binaryData.buffer, message.binaryData.byteOffset,
-                            message.binaryData.byteLength / Uint8Array.BYTES_PER_ELEMENT))
-                }
+            logger.trace('ServerWebsocket::onMessage')
+            if (message.type === MessageType.UTF8) {
+                logger.debug('Received string Message: ' + message.utf8Data)
+            } else if (message.type === MessageType.BINARY) {
+                logger.trace('Received Binary Message of ' + message.binaryData.length + ' bytes')
+                this.emit('data',
+                    new Uint8Array(message.binaryData.buffer, message.binaryData.byteOffset,
+                        message.binaryData.byteLength / Uint8Array.BYTES_PER_ELEMENT))
             }
         })
         socket.on('close', (reasonCode, description) => {
-            if (!this.stopped) {
-                logger.trace(' Peer ' + socket.remoteAddress + ' disconnected.')
-                this.doDisconnect('OTHER', reasonCode, description)
-            }
+            logger.trace(' Peer ' + socket.remoteAddress + ' disconnected.')
+            this.doDisconnect('OTHER', reasonCode, description)
         })
 
         socket.on('error', (error) => {
-            if (!this.stopped) {
-                this.emit('error', error.name)
-            }
+            this.emit('error', error.name)
         })
 
         this.socket = socket

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -463,7 +463,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.stopped) {
             return
         }
-        if (!this.stopped && !contact.getPeerId().equals(this.getNodeId())) {
+        if (!contact.getPeerId().equals(this.getNodeId())) {
             // Important to lock here, before the ping result is known
             this.connectionManager?.weakLockConnection(contact.getPeerDescriptor())
             if (this.connections.has(contact.getPeerId().toKey())) {


### PR DESCRIPTION
Removed redundant check  of `this.isStopped`:
- `ServerWebSocket` event listeneres: not needed because there is a `this.socket.removeAllListeners()` call
- `DhtNode#onKBucketAdded`: not needed because already guarded at the top of the method
