### PR TITLE
refactor(dht): Rename `ExternalApiRpc#findData`

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -48,7 +48,7 @@ service ConnectionLockRpc {
 }
 
 service ExternalApiRpc {
-  rpc findData (FindDataRequest) returns (FindDataResponse);
+  rpc externalFindData (ExternalFindDataRequest) returns (ExternalFindDataResponse);
   rpc externalStoreData (ExternalStoreDataRequest) returns (ExternalStoreDataResponse);
 }
 
@@ -289,11 +289,11 @@ message DisconnectNotice {
 message DisconnectNoticeResponse {
 }
 
-message FindDataRequest {
+message ExternalFindDataRequest {
   bytes kademliaId = 1;
 }
 
-message FindDataResponse {
+message ExternalFindDataResponse {
   repeated DataEntry dataEntries = 1;
   optional string error = 2;
 }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -622,7 +622,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.config.serviceId,
             toProtoRpcClient(new ExternalApiRpcClient(this.rpcCommunicator!.getRpcClientTransport()))
         )
-        return await rpcRemote.findData(idToFind)
+        return await rpcRemote.externalFindData(idToFind)
     }
 
     public getRpcCommunicator(): RoutingRpcCommunicator {

--- a/packages/dht/src/dht/ExternalApiRpcRemote.ts
+++ b/packages/dht/src/dht/ExternalApiRpcRemote.ts
@@ -1,19 +1,19 @@
 import { Any } from '../proto/google/protobuf/any'
-import { DataEntry, ExternalStoreDataRequest, FindDataRequest, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
+import { DataEntry, ExternalStoreDataRequest, ExternalFindDataRequest, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { IExternalApiRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
 import { Remote } from './contact/Remote'
 
 export class ExternalApiRpcRemote extends Remote<IExternalApiRpcClient> {
 
-    async findData(idToFind: Uint8Array): Promise<DataEntry[]> {
-        const request: FindDataRequest = {
+    async externalFindData(idToFind: Uint8Array): Promise<DataEntry[]> {
+        const request: ExternalFindDataRequest = {
             kademliaId: idToFind
         }
         const options = this.formDhtRpcOptions({
             timeout: 10000
         })
         try {
-            const data = await this.getClient().findData(request, options)
+            const data = await this.getClient().externalFindData(request, options)
             return data.dataEntries
         } catch (err) {
             return []

--- a/packages/dht/src/dht/registerExternalApiRpcMethods.ts
+++ b/packages/dht/src/dht/registerExternalApiRpcMethods.ts
@@ -21,7 +21,6 @@ export const registerExternalApiRpcMethods = (thisNode: DhtNode): void => {
     )
 }
 
-// IDhtNodeRpc method for external findRecursive calls
 const externalFindData = async (thisNode: DhtNode, request: ExternalFindDataRequest, context: ServerCallContext): Promise<ExternalFindDataResponse> => {
     const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
     const result = await thisNode.startRecursiveFind(request.kademliaId, true, senderPeerDescriptor)
@@ -35,7 +34,6 @@ const externalFindData = async (thisNode: DhtNode, request: ExternalFindDataRequ
     }
 }
 
-// IDhtNodeRpc method for external storeData calls
 const externalStoreData = async (thisNode: DhtNode, request: ExternalStoreDataRequest): Promise<ExternalStoreDataResponse> => {
     const result = await thisNode.storeDataToDht(request.key, request.data!)
     return ExternalStoreDataResponse.create({

--- a/packages/dht/src/dht/registerExternalApiRpcMethods.ts
+++ b/packages/dht/src/dht/registerExternalApiRpcMethods.ts
@@ -1,15 +1,15 @@
 import { DhtNode } from '../dht/DhtNode'
-import { ExternalStoreDataRequest, ExternalStoreDataResponse, FindDataRequest, FindDataResponse } from '../proto/packages/dht/protos/DhtRpc'
+import { ExternalStoreDataRequest, ExternalStoreDataResponse, ExternalFindDataRequest, ExternalFindDataResponse } from '../proto/packages/dht/protos/DhtRpc'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 
 export const registerExternalApiRpcMethods = (thisNode: DhtNode): void => {
     const rpcCommunicator = thisNode.getRpcCommunicator()
     rpcCommunicator.registerRpcMethod(
-        FindDataRequest, 
-        FindDataResponse, 
-        'findData', 
-        (req: FindDataRequest, context: ServerCallContext) => findData(thisNode, req, context),
+        ExternalFindDataRequest, 
+        ExternalFindDataResponse, 
+        'externalFindData', 
+        (req: ExternalFindDataRequest, context: ServerCallContext) => externalFindData(thisNode, req, context),
         { timeout: 10000 }
     )
     rpcCommunicator.registerRpcMethod(
@@ -22,13 +22,13 @@ export const registerExternalApiRpcMethods = (thisNode: DhtNode): void => {
 }
 
 // IDhtNodeRpc method for external findRecursive calls
-const findData = async (thisNode: DhtNode, findDataRequest: FindDataRequest, context: ServerCallContext): Promise<FindDataResponse> => {
+const externalFindData = async (thisNode: DhtNode, request: ExternalFindDataRequest, context: ServerCallContext): Promise<ExternalFindDataResponse> => {
     const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-    const result = await thisNode.startRecursiveFind(findDataRequest.kademliaId, true, senderPeerDescriptor)
+    const result = await thisNode.startRecursiveFind(request.kademliaId, true, senderPeerDescriptor)
     if (result.dataEntries) {
-        return FindDataResponse.create({ dataEntries: result.dataEntries })
+        return ExternalFindDataResponse.create({ dataEntries: result.dataEntries })
     } else {
-        return FindDataResponse.create({ 
+        return ExternalFindDataResponse.create({ 
             dataEntries: [],
             error: 'Could not find data with the given key' 
         })

--- a/packages/dht/src/dht/registerExternalApiRpcMethods.ts
+++ b/packages/dht/src/dht/registerExternalApiRpcMethods.ts
@@ -1,5 +1,10 @@
 import { DhtNode } from '../dht/DhtNode'
-import { ExternalStoreDataRequest, ExternalStoreDataResponse, ExternalFindDataRequest, ExternalFindDataResponse } from '../proto/packages/dht/protos/DhtRpc'
+import { 
+    ExternalStoreDataRequest,
+    ExternalStoreDataResponse,
+    ExternalFindDataRequest,
+    ExternalFindDataResponse
+} from '../proto/packages/dht/protos/DhtRpc'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 
@@ -21,7 +26,11 @@ export const registerExternalApiRpcMethods = (thisNode: DhtNode): void => {
     )
 }
 
-const externalFindData = async (thisNode: DhtNode, request: ExternalFindDataRequest, context: ServerCallContext): Promise<ExternalFindDataResponse> => {
+const externalFindData = async (
+    thisNode: DhtNode,
+    request: ExternalFindDataRequest,
+    context: ServerCallContext
+): Promise<ExternalFindDataResponse> => {
     const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
     const result = await thisNode.startRecursiveFind(request.kademliaId, true, senderPeerDescriptor)
     if (result.dataEntries) {
@@ -34,7 +43,10 @@ const externalFindData = async (thisNode: DhtNode, request: ExternalFindDataRequ
     }
 }
 
-const externalStoreData = async (thisNode: DhtNode, request: ExternalStoreDataRequest): Promise<ExternalStoreDataResponse> => {
+const externalStoreData = async (
+    thisNode: DhtNode,
+    request: ExternalStoreDataRequest
+): Promise<ExternalStoreDataResponse> => {
     const result = await thisNode.storeDataToDht(request.key, request.data!)
     return ExternalStoreDataResponse.create({
         storers: result

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -4,8 +4,8 @@
 import { ExternalApiRpc } from "./DhtRpc";
 import type { ExternalStoreDataResponse } from "./DhtRpc";
 import type { ExternalStoreDataRequest } from "./DhtRpc";
-import type { FindDataResponse } from "./DhtRpc";
-import type { FindDataRequest } from "./DhtRpc";
+import type { ExternalFindDataResponse } from "./DhtRpc";
+import type { ExternalFindDataRequest } from "./DhtRpc";
 import { ConnectionLockRpc } from "./DhtRpc";
 import type { DisconnectNoticeResponse } from "./DhtRpc";
 import type { DisconnectNotice } from "./DhtRpc";
@@ -352,9 +352,9 @@ export class ConnectionLockRpcClient implements IConnectionLockRpcClient, Servic
  */
 export interface IExternalApiRpcClient {
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(input: FindDataRequest, options?: RpcOptions): UnaryCall<FindDataRequest, FindDataResponse>;
+    externalFindData(input: ExternalFindDataRequest, options?: RpcOptions): UnaryCall<ExternalFindDataRequest, ExternalFindDataResponse>;
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);
      */
@@ -370,11 +370,11 @@ export class ExternalApiRpcClient implements IExternalApiRpcClient, ServiceInfo 
     constructor(private readonly _transport: RpcTransport) {
     }
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(input: FindDataRequest, options?: RpcOptions): UnaryCall<FindDataRequest, FindDataResponse> {
+    externalFindData(input: ExternalFindDataRequest, options?: RpcOptions): UnaryCall<ExternalFindDataRequest, ExternalFindDataResponse> {
         const method = this.methods[0], opt = this._transport.mergeOptions(options);
-        return stackIntercept<FindDataRequest, FindDataResponse>("unary", this._transport, method, opt, input);
+        return stackIntercept<ExternalFindDataRequest, ExternalFindDataResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -3,8 +3,8 @@
 // tslint:disable
 import { ExternalStoreDataResponse } from "./DhtRpc";
 import { ExternalStoreDataRequest } from "./DhtRpc";
-import { FindDataResponse } from "./DhtRpc";
-import { FindDataRequest } from "./DhtRpc";
+import { ExternalFindDataResponse } from "./DhtRpc";
+import { ExternalFindDataRequest } from "./DhtRpc";
 import { DisconnectNoticeResponse } from "./DhtRpc";
 import { DisconnectNotice } from "./DhtRpc";
 import { UnlockRequest } from "./DhtRpc";
@@ -144,9 +144,9 @@ export interface IConnectionLockRpc<T = ServerCallContext> {
  */
 export interface IExternalApiRpc<T = ServerCallContext> {
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(request: FindDataRequest, context: T): Promise<FindDataResponse>;
+    externalFindData(request: ExternalFindDataRequest, context: T): Promise<ExternalFindDataResponse>;
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);
      */

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -576,18 +576,18 @@ export interface DisconnectNotice {
 export interface DisconnectNoticeResponse {
 }
 /**
- * @generated from protobuf message dht.FindDataRequest
+ * @generated from protobuf message dht.ExternalFindDataRequest
  */
-export interface FindDataRequest {
+export interface ExternalFindDataRequest {
     /**
      * @generated from protobuf field: bytes kademliaId = 1;
      */
     kademliaId: Uint8Array;
 }
 /**
- * @generated from protobuf message dht.FindDataResponse
+ * @generated from protobuf message dht.ExternalFindDataResponse
  */
-export interface FindDataResponse {
+export interface ExternalFindDataResponse {
     /**
      * @generated from protobuf field: repeated dht.DataEntry dataEntries = 1;
      */
@@ -1165,30 +1165,30 @@ class DisconnectNoticeResponse$Type extends MessageType$<DisconnectNoticeRespons
  */
 export const DisconnectNoticeResponse = new DisconnectNoticeResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class FindDataRequest$Type extends MessageType$<FindDataRequest> {
+class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
     constructor() {
-        super("dht.FindDataRequest", [
+        super("dht.ExternalFindDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
 }
 /**
- * @generated MessageType for protobuf message dht.FindDataRequest
+ * @generated MessageType for protobuf message dht.ExternalFindDataRequest
  */
-export const FindDataRequest = new FindDataRequest$Type();
+export const ExternalFindDataRequest = new ExternalFindDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class FindDataResponse$Type extends MessageType$<FindDataResponse> {
+class ExternalFindDataResponse$Type extends MessageType$<ExternalFindDataResponse> {
     constructor() {
-        super("dht.FindDataResponse", [
+        super("dht.ExternalFindDataResponse", [
             { no: 1, name: "dataEntries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry },
             { no: 2, name: "error", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }
 /**
- * @generated MessageType for protobuf message dht.FindDataResponse
+ * @generated MessageType for protobuf message dht.ExternalFindDataResponse
  */
-export const FindDataResponse = new FindDataResponse$Type();
+export const ExternalFindDataResponse = new ExternalFindDataResponse$Type();
 /**
  * @generated ServiceType for protobuf service dht.DhtNodeRpc
  */
@@ -1246,6 +1246,6 @@ export const ConnectionLockRpc = new ServiceType("dht.ConnectionLockRpc", [
  * @generated ServiceType for protobuf service dht.ExternalApiRpc
  */
 export const ExternalApiRpc = new ServiceType("dht.ExternalApiRpc", [
-    { name: "findData", options: {}, I: FindDataRequest, O: FindDataResponse },
+    { name: "externalFindData", options: {}, I: ExternalFindDataRequest, O: ExternalFindDataResponse },
     { name: "externalStoreData", options: {}, I: ExternalStoreDataRequest, O: ExternalStoreDataResponse }
 ]);

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -4,8 +4,8 @@
 import { ExternalApiRpc } from "./DhtRpc";
 import type { ExternalStoreDataResponse } from "./DhtRpc";
 import type { ExternalStoreDataRequest } from "./DhtRpc";
-import type { FindDataResponse } from "./DhtRpc";
-import type { FindDataRequest } from "./DhtRpc";
+import type { ExternalFindDataResponse } from "./DhtRpc";
+import type { ExternalFindDataRequest } from "./DhtRpc";
 import { ConnectionLockRpc } from "./DhtRpc";
 import type { DisconnectNoticeResponse } from "./DhtRpc";
 import type { DisconnectNotice } from "./DhtRpc";
@@ -352,9 +352,9 @@ export class ConnectionLockRpcClient implements IConnectionLockRpcClient, Servic
  */
 export interface IExternalApiRpcClient {
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(input: FindDataRequest, options?: RpcOptions): UnaryCall<FindDataRequest, FindDataResponse>;
+    externalFindData(input: ExternalFindDataRequest, options?: RpcOptions): UnaryCall<ExternalFindDataRequest, ExternalFindDataResponse>;
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);
      */
@@ -370,11 +370,11 @@ export class ExternalApiRpcClient implements IExternalApiRpcClient, ServiceInfo 
     constructor(private readonly _transport: RpcTransport) {
     }
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(input: FindDataRequest, options?: RpcOptions): UnaryCall<FindDataRequest, FindDataResponse> {
+    externalFindData(input: ExternalFindDataRequest, options?: RpcOptions): UnaryCall<ExternalFindDataRequest, ExternalFindDataResponse> {
         const method = this.methods[0], opt = this._transport.mergeOptions(options);
-        return stackIntercept<FindDataRequest, FindDataResponse>("unary", this._transport, method, opt, input);
+        return stackIntercept<ExternalFindDataRequest, ExternalFindDataResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -3,8 +3,8 @@
 // tslint:disable
 import { ExternalStoreDataResponse } from "./DhtRpc";
 import { ExternalStoreDataRequest } from "./DhtRpc";
-import { FindDataResponse } from "./DhtRpc";
-import { FindDataRequest } from "./DhtRpc";
+import { ExternalFindDataResponse } from "./DhtRpc";
+import { ExternalFindDataRequest } from "./DhtRpc";
 import { DisconnectNoticeResponse } from "./DhtRpc";
 import { DisconnectNotice } from "./DhtRpc";
 import { UnlockRequest } from "./DhtRpc";
@@ -144,9 +144,9 @@ export interface IConnectionLockRpc<T = ServerCallContext> {
  */
 export interface IExternalApiRpc<T = ServerCallContext> {
     /**
-     * @generated from protobuf rpc: findData(dht.FindDataRequest) returns (dht.FindDataResponse);
+     * @generated from protobuf rpc: externalFindData(dht.ExternalFindDataRequest) returns (dht.ExternalFindDataResponse);
      */
-    findData(request: FindDataRequest, context: T): Promise<FindDataResponse>;
+    externalFindData(request: ExternalFindDataRequest, context: T): Promise<ExternalFindDataResponse>;
     /**
      * @generated from protobuf rpc: externalStoreData(dht.ExternalStoreDataRequest) returns (dht.ExternalStoreDataResponse);
      */

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -576,18 +576,18 @@ export interface DisconnectNotice {
 export interface DisconnectNoticeResponse {
 }
 /**
- * @generated from protobuf message dht.FindDataRequest
+ * @generated from protobuf message dht.ExternalFindDataRequest
  */
-export interface FindDataRequest {
+export interface ExternalFindDataRequest {
     /**
      * @generated from protobuf field: bytes kademliaId = 1;
      */
     kademliaId: Uint8Array;
 }
 /**
- * @generated from protobuf message dht.FindDataResponse
+ * @generated from protobuf message dht.ExternalFindDataResponse
  */
-export interface FindDataResponse {
+export interface ExternalFindDataResponse {
     /**
      * @generated from protobuf field: repeated dht.DataEntry dataEntries = 1;
      */
@@ -1165,30 +1165,30 @@ class DisconnectNoticeResponse$Type extends MessageType$<DisconnectNoticeRespons
  */
 export const DisconnectNoticeResponse = new DisconnectNoticeResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class FindDataRequest$Type extends MessageType$<FindDataRequest> {
+class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
     constructor() {
-        super("dht.FindDataRequest", [
+        super("dht.ExternalFindDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
 }
 /**
- * @generated MessageType for protobuf message dht.FindDataRequest
+ * @generated MessageType for protobuf message dht.ExternalFindDataRequest
  */
-export const FindDataRequest = new FindDataRequest$Type();
+export const ExternalFindDataRequest = new ExternalFindDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class FindDataResponse$Type extends MessageType$<FindDataResponse> {
+class ExternalFindDataResponse$Type extends MessageType$<ExternalFindDataResponse> {
     constructor() {
-        super("dht.FindDataResponse", [
+        super("dht.ExternalFindDataResponse", [
             { no: 1, name: "dataEntries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry },
             { no: 2, name: "error", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }
 /**
- * @generated MessageType for protobuf message dht.FindDataResponse
+ * @generated MessageType for protobuf message dht.ExternalFindDataResponse
  */
-export const FindDataResponse = new FindDataResponse$Type();
+export const ExternalFindDataResponse = new ExternalFindDataResponse$Type();
 /**
  * @generated ServiceType for protobuf service dht.DhtNodeRpc
  */
@@ -1246,6 +1246,6 @@ export const ConnectionLockRpc = new ServiceType("dht.ConnectionLockRpc", [
  * @generated ServiceType for protobuf service dht.ExternalApiRpc
  */
 export const ExternalApiRpc = new ServiceType("dht.ExternalApiRpc", [
-    { name: "findData", options: {}, I: FindDataRequest, O: FindDataResponse },
+    { name: "externalFindData", options: {}, I: ExternalFindDataRequest, O: ExternalFindDataResponse },
     { name: "externalStoreData", options: {}, I: ExternalStoreDataRequest, O: ExternalStoreDataResponse }
 ]);


### PR DESCRIPTION
Rename RPC method and messages:
- `ExternalApiRpc#findData` -> `externalFindData`
- `FindDataRequest` -> `ExternalFindDataRequest`
- `FindDataResponse` -> `ExternalFindDataResponse`