### PR TITLE
refactor(dht): Simplify `ConnectionManager#send` peers

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -246,7 +246,6 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         if (this.state === ConnectionManagerState.STOPPED && !doNotMindStopped) {
             return
         }
-
         const peerDescriptor = message.targetDescriptor!
         if (this.isConnectionToSelf(peerDescriptor)) {
             throw new Err.CannotConnectToSelf('Cannot send to self')

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -254,8 +254,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         logger.trace(`Sending message to: ${keyFromPeerDescriptor(peerDescriptor)}`)
         message = {
             ...message,
-            targetDescriptor: message.targetDescriptor || peerDescriptor,
-            sourceDescriptor: message.sourceDescriptor || this.getLocalPeerDescriptor(),
+            sourceDescriptor: this.getLocalPeerDescriptor()
         }
         const peerIdKey = keyFromPeerDescriptor(peerDescriptor)
         let connection = this.connections.get(peerIdKey)


### PR DESCRIPTION
Simplify message construction:
- `sourcePeerDescriptor` should always be `getLocalPeerDescriptor()`
- `targetPeerDescriptor` is already analyzed at line `249`

## Future improvements

- Could change the method signature to `Omit<Message, 'sourcePeerDescriptor'>`?