### PR TITLE
refactor(dht, trackerless-network): Convert arrow method to class methods

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -356,14 +356,14 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         }
     }
 
-    private onConnected = (connection: ManagedConnection) => {
+    private onConnected(connection: ManagedConnection) {
         const peerDescriptor = connection.getPeerDescriptor()!
         this.emit('connected', peerDescriptor)
         logger.trace(keyFromPeerDescriptor(peerDescriptor) + ' onConnected() ' + connection.connectionType)
         this.onConnectionCountChange()
     }
 
-    private onDisconnected = (connection: ManagedConnection, disconnectionType: DisconnectionType) => {
+    private onDisconnected(connection: ManagedConnection, disconnectionType: DisconnectionType) {
         logger.trace(keyOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()) + ' onDisconnected() ' + disconnectionType)
 
         const peerIdKey = keyFromPeerDescriptor(connection.getPeerDescriptor()!)

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -403,7 +403,7 @@ export class ConnectionManager extends EventEmitter<Events> implements ITranspor
         if (connection.isHandshakeCompleted()) {
             this.onConnected(connection)
         } else {
-            connection.once('handshakeCompleted', ()=> {
+            connection.once('handshakeCompleted', () => {
                 this.onConnected(connection)
             })
         }

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -25,10 +25,10 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
         super()
         this.localPeerDescriptor = localPeerDescriptor
         this.connection = connection
-        this.connection.on('data', this.onData)
+        this.connection.on('data', (data: Uint8Array) => this.onData(data))
     }
 
-    private onData = (data: Uint8Array) => {
+    private onData(data: Uint8Array) {
         try {
             const message = Message.fromBinary(data)
             if (message.body.oneofKind === 'handshakeRequest') {

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -165,7 +165,7 @@ export class ManagedConnection extends EventEmitter<Events> {
         return this.peerDescriptor
     }
 
-    private onHandshakeCompleted = (peerDescriptor: PeerDescriptor) => {
+    private onHandshakeCompleted(peerDescriptor: PeerDescriptor) {
         this.lastUsed = Date.now()
 
         this.setPeerDescriptor(peerDescriptor)

--- a/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
@@ -229,7 +229,7 @@ export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
         return managedConnection
     }
 
-    private onServerSocketHandshakeRequest = (peerDescriptor: PeerDescriptor, serverWebsocket: IConnection) => {
+    private onServerSocketHandshakeRequest(peerDescriptor: PeerDescriptor, serverWebsocket: IConnection) {
 
         const peerId = peerIdFromPeerDescriptor(peerDescriptor)
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -287,7 +287,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
     }
 
-    private initKBuckets = (selfId: PeerID) => {
+    private initKBuckets(selfId: PeerID) {
         this.bucket = new KBucket<DhtNodeRpcRemote>({
             localNodeId: selfId.value,
             numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
@@ -414,7 +414,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
     }
 
-    private generatePeerDescriptorCallBack = (connectivityResponse: ConnectivityResponse) => {
+    private generatePeerDescriptorCallBack(connectivityResponse: ConnectivityResponse) {
         if (this.config.peerDescriptor) {
             this.localPeerDescriptor = this.config.peerDescriptor
         } else {

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -105,7 +105,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         )
     }
 
-    private onRequestFailed = (peerId: PeerID) => {
+    private onRequestFailed(peerId: PeerID) {
         logger.trace('onRequestFailed() sessionId: ' + this.sessionId)
         if (this.stopped) {
             return
@@ -125,7 +125,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    private emitFailure = () => {
+    private emitFailure() {
         if (this.successfulHopCounter >= 1) {
             this.emit('partialSuccess', this.sessionId)
 
@@ -134,7 +134,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    private onRequestSucceeded = () => {
+    private onRequestSucceeded() {
         logger.trace('onRequestSucceeded() sessionId: ' + this.sessionId)
         if (this.stopped) {
             return
@@ -149,7 +149,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    private sendRouteMessageRequest = async (contact: RemoteContact): Promise<boolean> => {
+    private async sendRouteMessageRequest(contact: RemoteContact): Promise<boolean> {
         if (this.stopped) {
             return false
         }
@@ -171,7 +171,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    private findMoreContacts = (): RemoteContact[] => {
+    private findMoreContacts(): RemoteContact[] {
         logger.trace('findMoreContacts() sessionId: ' + this.sessionId)
         // the contents of the connections might have changed between the rounds
         // addContacts() will only add new contacts that were not there yet
@@ -181,7 +181,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         return this.contactList.getUncontactedContacts(this.parallelism)
     }
 
-    private sendMoreRequests = (uncontacted: RemoteContact[]) => {
+    private sendMoreRequests(uncontacted: RemoteContact[]) {
         logger.trace('sendMoreRequests() sessionId: ' + this.sessionId)
         if (this.stopped) {
             return

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -59,7 +59,7 @@ describe('ConnectionManager', () => {
         await mockConnectorTransport2.start()
     })
 
-    afterAll(async ()=> {
+    afterAll(async () => {
         await mockTransport.stop()
         await mockConnectorTransport1.stop()
         await mockConnectorTransport2.stop()

--- a/packages/dht/test/unit/UUID.test.ts
+++ b/packages/dht/test/unit/UUID.test.ts
@@ -32,7 +32,7 @@ describe('UUID', () => {
     })
 
     it('Throws if incorrect string is given as uuid string parameter', () => {
-        expect(()=> {new UUID('äå%')}).toThrow(TypeError)
+        expect(() => {new UUID('äå%')}).toThrow(TypeError)
     })
 
     it('Uses passed UUID as id', () => {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -193,7 +193,7 @@ export class StreamrNode extends EventEmitter<Events> {
         }
     }
 
-    private createLayer1Node = (streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): Layer1Node => {
+    private createLayer1Node(streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): Layer1Node {
         return new DhtNode({
             transport: this.layer0Node!,
             serviceId: 'layer1::' + streamPartId,
@@ -205,7 +205,7 @@ export class StreamrNode extends EventEmitter<Events> {
         })
     }
 
-    private createRandomGraphNode = (streamPartId: StreamPartID, layer1Node: Layer1Node) => {
+    private createRandomGraphNode(streamPartId: StreamPartID, layer1Node: Layer1Node) {
         return createRandomGraphNode({
             streamPartId,
             transport: this.transport!,

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -60,7 +60,7 @@ describe('NodeList', () => {
         }
     })
 
-    afterEach(async ()=> {
+    afterEach(async () => {
         // eslint-disable-next-line @typescript-eslint/prefer-for-of
         for (let i = 0; i < mockTransports.length; i++) {
             await mockTransports[i].stop()


### PR DESCRIPTION
Some class methods were implemented as arrow functions instead of normal methods. Converted those to use the standard style.