### PR TITLE
CI trigger: `100.0.0-pretestnet.1`

### DIFF
--- a/packages/dht/src/connection/WebRTC/WebRtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/WebRTC/WebRtcConnectorRpcLocal.ts
@@ -295,7 +295,7 @@ export class WebRtcConnectorRpcLocal implements IWebRtcConnectorRpc {
         const attempts = Array.from(this.ongoingConnectAttempts.values())
         await Promise.allSettled(attempts.map((conn) => conn.close('OTHER')))
 
-        this.rpcCommunicator.stop()
+        this.rpcCommunicator.destroy()
     }
 
     public isOffering(targetPeerDescriptor: PeerDescriptor): boolean {

--- a/packages/dht/src/connection/WebSocket/WebSocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/WebSocket/WebSocketConnectorRpcLocal.ts
@@ -261,7 +261,7 @@ export class WebSocketConnectorRpcLocal implements IWebSocketConnectorRpc {
 
     public async destroy(): Promise<void> {
         this.destroyed = true
-        this.rpcCommunicator.stop()
+        this.rpcCommunicator.destroy()
 
         const requests = Array.from(this.ongoingConnectRequests.values())
         await Promise.allSettled(requests.map((conn) => conn.close('OTHER')))

--- a/packages/dht/src/dht/find/RecursiveFindSession.ts
+++ b/packages/dht/src/dht/find/RecursiveFindSession.ts
@@ -172,6 +172,7 @@ export class RecursiveFindSession extends EventEmitter<RecursiveFindSessionEvent
             clearTimeout(this.reportFindCompletedTimeout)
             this.reportFindCompletedTimeout = undefined
         }
+        this.rpcCommunicator.destroy()
         this.emit('findCompleted', [])
     }
 }

--- a/packages/dht/src/dht/find/RecursiveFinder.ts
+++ b/packages/dht/src/dht/find/RecursiveFinder.ts
@@ -195,6 +195,7 @@ export class RecursiveFinder implements IRecursiveFinder {
                 toProtoRpcClient(new RecursiveFindSessionServiceClient(remoteCommunicator.getRpcClientTransport()))
             )
             remoteSession.sendFindResponse(routingPath, closestNodes, dataEntries, noCloserNodesFound)
+            remoteCommunicator.destroy()
         }
     }
 

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -131,6 +131,7 @@ export class Router implements IRouter {
                 } catch (e) {
                     logger.trace('raceEvents timed out for routingSession ' + session.sessionId) 
                 }
+                session.stop()
                 this.removeRoutingSession(session.sessionId) 
             })
             session.start()

--- a/packages/dht/src/transport/ListeningRpcCommunicator.ts
+++ b/packages/dht/src/transport/ListeningRpcCommunicator.ts
@@ -4,11 +4,20 @@ import { RpcCommunicatorConfig } from '@streamr/proto-rpc'
 import { Message } from '../proto/packages/dht/protos/DhtRpc'
 
 export class ListeningRpcCommunicator extends RoutingRpcCommunicator {
+    private readonly transport: ITransport
+    private readonly listener: (msg: Message) => void
+
     constructor(ownServiceId: string, transport: ITransport, config?: RpcCommunicatorConfig) {
         super(ownServiceId, transport.send, config)
-        
-        transport.on('message', (msg: Message) => {
+        this.listener = (msg: Message) => {
             this.handleMessageFromPeer(msg)
-        })
+        }
+        this.transport = transport
+        transport.on('message', this.listener) 
+    }
+
+    destroy(): void {
+        this.transport.off('message', this.listener)
+        this.stop()
     }
 }

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -274,7 +274,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         this.abortController.abort()
         this.config.proxyConnectionRpcLocal?.stop()
         this.config.targetNeighbors.getAll().map((remote) => remote.leaveStreamPartNotice())
-        this.config.rpcCommunicator.stop()
+        this.config.rpcCommunicator.destroy()
         this.removeAllListeners()
         this.config.nearbyNodeView.stop()
         this.config.targetNeighbors.stop()

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -254,7 +254,7 @@ export class ProxyClient extends EventEmitter {
             remote.leaveStreamPartNotice()
         })
         this.targetNeighbors.stop()
-        this.rpcCommunicator.stop()
+        this.rpcCommunicator.destroy()
         this.connections.clear()
         this.abortController.abort()
     }


### PR DESCRIPTION
The `ListeningRpcCommunicator` had a critical bug where it set en event
listener to the `ITransport` passed to it, but it never cleaned it up.
This caused all `ListeningRpcCommunicators` created for
RecursiveFindSessions and RecursiveFindResponses to leak. Issue likely
also existed for `RandomGraphNodes` in the trackerless-network. If a
node a stream partition the `ListeningRpcCommunicator` created for it
would leak.

`ListeningRpcCommunicator` has now a new method called `destroy` which
ensures that the listener is cleaned up.
Also after a `RoutingSession` is completed the router will call stop on
in
