### PR TITLE
refactor(dht): Extract `WebsocketConnector`

### DIFF
--- a/packages/dht/src/connection/ConnectivityChecker.ts
+++ b/packages/dht/src/connection/ConnectivityChecker.ts
@@ -10,7 +10,7 @@ import { ClientWebsocket } from './websocket/ClientWebsocket'
 import { v4 } from 'uuid'
 import { NatType } from './ConnectionManager'
 import { ServerWebsocket } from './websocket/ServerWebsocket'
-import { connectivityMethodToWebsocketUrl } from './websocket/WebsocketConnectorRpcLocal'
+import { connectivityMethodToWebsocketUrl } from './websocket/WebsocketConnector'
 
 const logger = new Logger(module)
 

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -9,7 +9,7 @@ import { ManagedConnection } from './ManagedConnection'
 import { Simulator } from './simulator/Simulator'
 import { SimulatorConnector } from './simulator/SimulatorConnector'
 import { IceServer, WebrtcConnector } from './webrtc/WebrtcConnector'
-import { WebsocketConnectorRpcLocal } from './websocket/WebsocketConnectorRpcLocal'
+import { WebsocketConnector } from './websocket/WebsocketConnector'
 
 export interface ConnectorFacade {
     createConnection: (peerDescriptor: PeerDescriptor) => ManagedConnection
@@ -44,7 +44,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
 
     private readonly config: DefaultConnectorFacadeConfig
     private localPeerDescriptor?: PeerDescriptor
-    private websocketConnector?: WebsocketConnectorRpcLocal
+    private websocketConnector?: WebsocketConnector
     private webrtcConnector?: WebrtcConnector
 
     constructor(config: DefaultConnectorFacadeConfig) {
@@ -56,7 +56,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         canConnect: (peerDescriptor: PeerDescriptor) => boolean
     ): Promise<void> {
         logger.trace(`Creating WebsocketConnectorRpcLocal`)
-        this.websocketConnector = new WebsocketConnectorRpcLocal({
+        this.websocketConnector = new WebsocketConnector({
             transport: this.config.transport!,
             // TODO should we use canConnect also for WebrtcConnector? (NET-1142)
             canConnect: (peerDescriptor: PeerDescriptor) => canConnect(peerDescriptor),

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -1,0 +1,280 @@
+import { ClientWebsocket } from './ClientWebsocket'
+import { IConnection, ConnectionType } from '../IConnection'
+import { ITransport } from '../../transport/ITransport'
+import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
+import { WebsocketConnectorRpcLocal } from './WebsocketConnectorRpcLocal'
+import { WebsocketConnectorRpcRemote } from './WebsocketConnectorRpcRemote'
+import {
+    ConnectivityMethod,
+    ConnectivityResponse,
+    NodeType,
+    PeerDescriptor,
+    WebsocketConnectionRequest,
+    WebsocketConnectionResponse
+} from '../../proto/packages/dht/protos/DhtRpc'
+import { WebsocketConnectorRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
+import { Logger, binaryToHex, wait } from '@streamr/utils'
+import { ManagedConnection } from '../ManagedConnection'
+import { WebsocketServer } from './WebsocketServer'
+import { ConnectivityChecker } from '../ConnectivityChecker'
+import { NatType, PortRange, TlsCertificate } from '../ConnectionManager'
+import { PeerIDKey } from '../../helpers/PeerID'
+import { ServerWebsocket } from './ServerWebsocket'
+import { toProtoRpcClient } from '@streamr/proto-rpc'
+import { Handshaker } from '../Handshaker'
+import { keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { ParsedUrlQuery } from 'querystring'
+import { range, sample } from 'lodash'
+import { isPrivateIPv4 } from '../../helpers/AddressTools'
+import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
+
+const logger = new Logger(module)
+
+export const connectivityMethodToWebsocketUrl = (ws: ConnectivityMethod): string => {
+    return (ws.tls ? 'wss://' : 'ws://') + ws.host + ':' + ws.port
+}
+
+const canOpenConnectionFromBrowser = (websocketServer: ConnectivityMethod) => {
+    const hasPrivateAddress = ((websocketServer.host === 'localhost') || isPrivateIPv4(websocketServer.host))
+    return websocketServer.tls || hasPrivateAddress
+}
+
+const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
+
+interface WebsocketConnectorConfig {
+    transport: ITransport
+    canConnect: (peerDescriptor: PeerDescriptor) => boolean
+    onIncomingConnection: (connection: ManagedConnection) => boolean
+    portRange?: PortRange
+    maxMessageSize?: number
+    host?: string
+    entrypoints?: PeerDescriptor[]
+    tlsCertificate?: TlsCertificate
+}
+
+export class WebsocketConnector {
+
+    private static readonly WEBSOCKET_CONNECTOR_SERVICE_ID = 'system/websocket-connector'
+    private readonly rpcCommunicator: ListeningRpcCommunicator
+    private readonly websocketServer?: WebsocketServer
+    private connectivityChecker?: ConnectivityChecker
+    private readonly ongoingConnectRequests: Map<PeerIDKey, ManagedConnection> = new Map()
+    private onIncomingConnection: (connection: ManagedConnection) => boolean
+    private host?: string
+    private readonly entrypoints?: PeerDescriptor[]
+    private readonly tlsCertificate?: TlsCertificate
+    private selectedPort?: number
+    private localPeerDescriptor?: PeerDescriptor
+    private connectingConnections: Map<PeerIDKey, ManagedConnection> = new Map()
+    private destroyed = false
+
+    constructor(config: WebsocketConnectorConfig) {
+        this.websocketServer = config.portRange ? new WebsocketServer({
+            portRange: config.portRange!,
+            tlsCertificate: config.tlsCertificate,
+            maxMessageSize: config.maxMessageSize
+        }) : undefined
+        this.onIncomingConnection = config.onIncomingConnection
+        this.host = config.host
+        this.entrypoints = config.entrypoints
+        this.tlsCertificate = config.tlsCertificate
+        this.rpcCommunicator = new ListeningRpcCommunicator(WebsocketConnector.WEBSOCKET_CONNECTOR_SERVICE_ID, config.transport, {
+            rpcRequestTimeout: 15000
+        })
+        this.registerLocalRpcMethods(config)
+    }
+
+    private registerLocalRpcMethods(config: WebsocketConnectorConfig) {
+        const rpcLocal = new WebsocketConnectorRpcLocal({
+            canConnect: (peerDescriptor: PeerDescriptor) => config.canConnect(peerDescriptor),
+            connect: (targetPeerDescriptor: PeerDescriptor) => this.connect(targetPeerDescriptor),
+            onIncomingConnection: (connection: ManagedConnection) => config.onIncomingConnection(connection)
+        })
+        this.rpcCommunicator.registerRpcMethod(
+            WebsocketConnectionRequest,
+            WebsocketConnectionResponse,
+            'requestConnection',
+            async (req: WebsocketConnectionRequest, context: ServerCallContext) => {
+                if (!this.destroyed) {
+                    return rpcLocal.requestConnection(req, context)
+                } else {
+                    return { accepted: false }
+                }
+            }
+        )
+    }
+
+    private attachHandshaker(connection: IConnection) {
+        const handshaker = new Handshaker(this.localPeerDescriptor!, connection)
+        handshaker.once('handshakeRequest', (peerDescriptor: PeerDescriptor) => {
+            this.onServerSocketHandshakeRequest(peerDescriptor, connection)
+        })
+    }
+
+    public async start(): Promise<void> {
+        if (!this.destroyed && this.websocketServer) {
+            this.websocketServer.on('connected', (connection: IConnection) => {
+
+                const serverSocket = connection as unknown as ServerWebsocket
+                if (serverSocket.resourceURL &&
+                    serverSocket.resourceURL.query) {
+                    const query = serverSocket.resourceURL.query as unknown as ParsedUrlQuery
+                    if (query.connectivityRequest) {
+                        logger.trace('Received connectivity request connection from ' + serverSocket.getRemoteAddress())
+                        this.connectivityChecker!.listenToIncomingConnectivityRequests(serverSocket)
+                    } else if (query.connectivityProbe) {
+                        logger.trace('Received connectivity probe connection from ' + serverSocket.getRemoteAddress())
+                    } else {
+                        this.attachHandshaker(connection)
+                    }
+                } else {
+                    this.attachHandshaker(connection)
+                }
+            })
+            const port = await this.websocketServer.start()
+            this.selectedPort = port
+            this.connectivityChecker = new ConnectivityChecker(this.selectedPort, this.tlsCertificate !== undefined, this.host)
+        }
+    }
+
+    public async checkConnectivity(): Promise<ConnectivityResponse> {
+        // TODO: this could throw if the server is not running
+        const noServerConnectivityResponse: ConnectivityResponse = {
+            host: '127.0.0.1',
+            natType: NatType.UNKNOWN
+        }
+        if (this.destroyed) {
+            return noServerConnectivityResponse
+        }
+        for (const reattempt of range(ENTRY_POINT_CONNECTION_ATTEMPTS)) {
+            const entryPoint = sample(this.entrypoints)!
+            try {
+                if (!this.websocketServer) {
+                    return noServerConnectivityResponse
+                } else {
+                    if (!this.entrypoints || this.entrypoints.length === 0) {
+                        // return connectivity info given in config
+                        const preconfiguredConnectivityResponse: ConnectivityResponse = {
+                            host: this.host!,
+                            natType: NatType.OPEN_INTERNET,
+                            websocket: { host: this.host!, port: this.selectedPort!, tls: this.tlsCertificate !== undefined }
+                        }
+                        return preconfiguredConnectivityResponse
+                    } else {
+                        // Do real connectivity checking
+                        return await this.connectivityChecker!.sendConnectivityRequest(entryPoint)
+                    }
+                }
+            } catch (err) {
+                if (reattempt < ENTRY_POINT_CONNECTION_ATTEMPTS) {
+                    const error = `Failed to connect to entrypoint with id ${binaryToHex(entryPoint.kademliaId)} `
+                        + `and URL ${connectivityMethodToWebsocketUrl(entryPoint.websocket!)}`
+                    logger.error(error, { error: err })
+                    await wait(2000)
+                }
+            }
+        }
+        throw Error(`Failed to connect to the entrypoints after ${ENTRY_POINT_CONNECTION_ATTEMPTS} attempts`)
+    }
+
+    public isPossibleToFormConnection(targetPeerDescriptor: PeerDescriptor): boolean {
+        if (this.localPeerDescriptor!.websocket !== undefined) {
+            return (targetPeerDescriptor.type !== NodeType.BROWSER) || canOpenConnectionFromBrowser(this.localPeerDescriptor!.websocket)
+        } else if (targetPeerDescriptor.websocket !== undefined) {
+            return (this.localPeerDescriptor!.type !== NodeType.BROWSER) || canOpenConnectionFromBrowser(targetPeerDescriptor.websocket)
+        } else {
+            return false
+        }
+    }
+
+    public connect(targetPeerDescriptor: PeerDescriptor): ManagedConnection {
+        const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
+        const existingConnection = this.connectingConnections.get(peerKey)
+        if (existingConnection) {
+            return existingConnection
+        }
+
+        if (this.localPeerDescriptor!.websocket && !targetPeerDescriptor.websocket) {
+            return this.requestConnectionFromPeer(this.localPeerDescriptor!, targetPeerDescriptor)
+        } else {
+            const socket = new ClientWebsocket()
+
+            const url = connectivityMethodToWebsocketUrl(targetPeerDescriptor.websocket!)
+
+            const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_CLIENT, socket, undefined)
+            managedConnection.setPeerDescriptor(targetPeerDescriptor)
+
+            this.connectingConnections.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+
+            const delFunc = () => {
+                if (this.connectingConnections.has(peerKey)) {
+                    this.connectingConnections.delete(peerKey)
+                }
+                socket.off('disconnected', delFunc)
+                managedConnection.off('handshakeCompleted', delFunc)
+            }
+            socket.on('disconnected', delFunc)
+            managedConnection.on('handshakeCompleted', delFunc)
+
+            socket.connect(url)
+
+            return managedConnection
+        }
+    }
+
+    private requestConnectionFromPeer(localPeerDescriptor: PeerDescriptor, targetPeerDescriptor: PeerDescriptor): ManagedConnection {
+        setImmediate(() => {
+            const remoteConnector = new WebsocketConnectorRpcRemote(
+                localPeerDescriptor,
+                targetPeerDescriptor,
+                toProtoRpcClient(new WebsocketConnectorRpcClient(this.rpcCommunicator.getRpcClientTransport()))
+            )
+            remoteConnector.requestConnection(localPeerDescriptor.websocket!.host, localPeerDescriptor.websocket!.port)
+        })
+        const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_SERVER)
+        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(keyFromPeerDescriptor(targetPeerDescriptor)))
+        managedConnection.setPeerDescriptor(targetPeerDescriptor)
+        this.ongoingConnectRequests.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+        return managedConnection
+    }
+
+    private onServerSocketHandshakeRequest(peerDescriptor: PeerDescriptor, serverWebsocket: IConnection) {
+
+        const peerId = peerIdFromPeerDescriptor(peerDescriptor)
+
+        if (this.ongoingConnectRequests.has(peerId.toKey())) {
+            const ongoingConnectReguest = this.ongoingConnectRequests.get(peerId.toKey())!
+            ongoingConnectReguest.attachImplementation(serverWebsocket)
+            ongoingConnectReguest.acceptHandshake()
+            this.ongoingConnectRequests.delete(peerId.toKey())
+        } else {
+            const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_SERVER, undefined, serverWebsocket)
+
+            managedConnection.setPeerDescriptor(peerDescriptor)
+
+            if (this.onIncomingConnection(managedConnection)) {
+                managedConnection.acceptHandshake()
+            } else {
+                managedConnection.rejectHandshake('Duplicate connection')
+                managedConnection.destroy()
+            }
+        }
+    }
+
+    public setLocalPeerDescriptor(localPeerDescriptor: PeerDescriptor): void {
+        this.localPeerDescriptor = localPeerDescriptor
+    }
+
+    public async destroy(): Promise<void> {
+        this.destroyed = true
+        this.rpcCommunicator.destroy()
+
+        const requests = Array.from(this.ongoingConnectRequests.values())
+        await Promise.allSettled(requests.map((conn) => conn.close('OTHER')))
+
+        const attempts = Array.from(this.connectingConnections.values())
+        await Promise.allSettled(attempts.map((conn) => conn.close('OTHER')))
+        this.connectivityChecker?.destroy()
+        await this.websocketServer?.stop()
+    }
+}

--- a/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
@@ -1,292 +1,41 @@
-import { ClientWebsocket } from './ClientWebsocket'
-import { IConnection, ConnectionType } from '../IConnection'
-import { ITransport } from '../../transport/ITransport'
-import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
-import { WebsocketConnectorRpcRemote } from './WebsocketConnectorRpcRemote'
+import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import {
-    ConnectivityMethod,
-    ConnectivityResponse,
-    NodeType,
     PeerDescriptor,
     WebsocketConnectionRequest,
     WebsocketConnectionResponse
 } from '../../proto/packages/dht/protos/DhtRpc'
-import { WebsocketConnectorRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
-import { Logger, binaryToHex, wait } from '@streamr/utils'
 import { IWebsocketConnectorRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
-import { ManagedConnection } from '../ManagedConnection'
-import { WebsocketServer } from './WebsocketServer'
-import { ConnectivityChecker } from '../ConnectivityChecker'
-import { NatType, PortRange, TlsCertificate } from '../ConnectionManager'
-import { PeerIDKey } from '../../helpers/PeerID'
-import { ServerWebsocket } from './ServerWebsocket'
-import { toProtoRpcClient } from '@streamr/proto-rpc'
-import { Handshaker } from '../Handshaker'
-import { keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
-import { ParsedUrlQuery } from 'querystring'
-import { range, sample } from 'lodash'
-import { isPrivateIPv4 } from '../../helpers/AddressTools'
-import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
-
-const logger = new Logger(module)
-
-export const connectivityMethodToWebsocketUrl = (ws: ConnectivityMethod): string => {
-    return (ws.tls ? 'wss://' : 'ws://') + ws.host + ':' + ws.port
-}
-
-const canOpenConnectionFromBrowser = (websocketServer: ConnectivityMethod) => {
-    const hasPrivateAddress = ((websocketServer.host === 'localhost') || isPrivateIPv4(websocketServer.host))
-    return websocketServer.tls || hasPrivateAddress
-}
-
-const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
+import { ManagedConnection } from '../ManagedConnection'
 
 interface WebsocketConnectorRpcLocalConfig {
-    transport: ITransport
     canConnect: (peerDescriptor: PeerDescriptor) => boolean
+    connect: (targetPeerDescriptor: PeerDescriptor) => ManagedConnection
     onIncomingConnection: (connection: ManagedConnection) => boolean
-    portRange?: PortRange
-    maxMessageSize?: number
-    host?: string
-    entrypoints?: PeerDescriptor[]
-    tlsCertificate?: TlsCertificate
 }
 
 export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
 
-    private static readonly WEBSOCKET_CONNECTOR_SERVICE_ID = 'system/websocket-connector'
-    private readonly rpcCommunicator: ListeningRpcCommunicator
-    private readonly canConnectFunction: (peerDescriptor: PeerDescriptor) => boolean
-    private readonly websocketServer?: WebsocketServer
-    private connectivityChecker?: ConnectivityChecker
-    private readonly ongoingConnectRequests: Map<PeerIDKey, ManagedConnection> = new Map()
-    private onIncomingConnection: (connection: ManagedConnection) => boolean
-    private host?: string
-    private readonly entrypoints?: PeerDescriptor[]
-    private readonly tlsCertificate?: TlsCertificate
-    private selectedPort?: number
-    private localPeerDescriptor?: PeerDescriptor
-    private connectingConnections: Map<PeerIDKey, ManagedConnection> = new Map()
-    private destroyed = false
+    private readonly config: WebsocketConnectorRpcLocalConfig
 
     constructor(config: WebsocketConnectorRpcLocalConfig) {
-        this.websocketServer = config.portRange ? new WebsocketServer({
-            portRange: config.portRange!,
-            tlsCertificate: config.tlsCertificate,
-            maxMessageSize: config.maxMessageSize
-        }) : undefined
-        this.onIncomingConnection = config.onIncomingConnection
-        this.host = config.host
-        this.entrypoints = config.entrypoints
-        this.tlsCertificate = config.tlsCertificate
-
-        this.canConnectFunction = config.canConnect.bind(this)
-
-        this.rpcCommunicator = new ListeningRpcCommunicator(WebsocketConnectorRpcLocal.WEBSOCKET_CONNECTOR_SERVICE_ID, config.transport, {
-            rpcRequestTimeout: 15000
-        })
-
-        this.rpcCommunicator.registerRpcMethod(
-            WebsocketConnectionRequest,
-            WebsocketConnectionResponse,
-            'requestConnection',
-            (req: WebsocketConnectionRequest, context: ServerCallContext) => this.requestConnection(req, context)
-        )
+        this.config = config
     }
 
-    private attachHandshaker(connection: IConnection) {
-        const handshaker = new Handshaker(this.localPeerDescriptor!, connection)
-        handshaker.once('handshakeRequest', (peerDescriptor: PeerDescriptor) => {
-            this.onServerSocketHandshakeRequest(peerDescriptor, connection)
-        })
-    }
-
-    public async start(): Promise<void> {
-        if (!this.destroyed && this.websocketServer) {
-            this.websocketServer.on('connected', (connection: IConnection) => {
-
-                const serverSocket = connection as unknown as ServerWebsocket
-                if (serverSocket.resourceURL &&
-                    serverSocket.resourceURL.query) {
-                    const query = serverSocket.resourceURL.query as unknown as ParsedUrlQuery
-                    if (query.connectivityRequest) {
-                        logger.trace('Received connectivity request connection from ' + serverSocket.getRemoteAddress())
-                        this.connectivityChecker!.listenToIncomingConnectivityRequests(serverSocket)
-                    } else if (query.connectivityProbe) {
-                        logger.trace('Received connectivity probe connection from ' + serverSocket.getRemoteAddress())
-                    } else {
-                        this.attachHandshaker(connection)
-                    }
-                } else {
-                    this.attachHandshaker(connection)
-                }
-            })
-            const port = await this.websocketServer.start()
-            this.selectedPort = port
-            this.connectivityChecker = new ConnectivityChecker(this.selectedPort, this.tlsCertificate !== undefined, this.host)
-        }
-    }
-
-    public async checkConnectivity(): Promise<ConnectivityResponse> {
-        // TODO: this could throw if the server is not running
-        const noServerConnectivityResponse: ConnectivityResponse = {
-            host: '127.0.0.1',
-            natType: NatType.UNKNOWN
-        }
-        if (this.destroyed) {
-            return noServerConnectivityResponse
-        }
-        for (const reattempt of range(ENTRY_POINT_CONNECTION_ATTEMPTS)) {
-            const entryPoint = sample(this.entrypoints)!
-            try {
-                if (!this.websocketServer) {
-                    return noServerConnectivityResponse
-                } else {
-                    if (!this.entrypoints || this.entrypoints.length === 0) {
-                        // return connectivity info given in config
-                        const preconfiguredConnectivityResponse: ConnectivityResponse = {
-                            host: this.host!,
-                            natType: NatType.OPEN_INTERNET,
-                            websocket: { host: this.host!, port: this.selectedPort!, tls: this.tlsCertificate !== undefined }
-                        }
-                        return preconfiguredConnectivityResponse
-                    } else {
-                        // Do real connectivity checking
-                        return await this.connectivityChecker!.sendConnectivityRequest(entryPoint)
-                    }
-                }
-            } catch (err) {
-                if (reattempt < ENTRY_POINT_CONNECTION_ATTEMPTS) {
-                    const error = `Failed to connect to entrypoint with id ${binaryToHex(entryPoint.kademliaId)} `
-                        + `and URL ${connectivityMethodToWebsocketUrl(entryPoint.websocket!)}`
-                    logger.error(error, { error: err })
-                    await wait(2000)
-                }
-            }
-        }
-        throw Error(`Failed to connect to the entrypoints after ${ENTRY_POINT_CONNECTION_ATTEMPTS} attempts`)
-    }
-
-    public isPossibleToFormConnection(targetPeerDescriptor: PeerDescriptor): boolean {
-        if (this.localPeerDescriptor!.websocket !== undefined) {
-            return (targetPeerDescriptor.type !== NodeType.BROWSER) || canOpenConnectionFromBrowser(this.localPeerDescriptor!.websocket)
-        } else if (targetPeerDescriptor.websocket !== undefined) {
-            return (this.localPeerDescriptor!.type !== NodeType.BROWSER) || canOpenConnectionFromBrowser(targetPeerDescriptor.websocket)
-        } else {
-            return false
-        }
-    }
-
-    public connect(targetPeerDescriptor: PeerDescriptor): ManagedConnection {
-        const peerKey = keyFromPeerDescriptor(targetPeerDescriptor)
-        const existingConnection = this.connectingConnections.get(peerKey)
-        if (existingConnection) {
-            return existingConnection
-        }
-
-        if (this.localPeerDescriptor!.websocket && !targetPeerDescriptor.websocket) {
-            return this.requestConnectionFromPeer(this.localPeerDescriptor!, targetPeerDescriptor)
-        } else {
-            const socket = new ClientWebsocket()
-
-            const url = connectivityMethodToWebsocketUrl(targetPeerDescriptor.websocket!)
-
-            const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_CLIENT, socket, undefined)
-            managedConnection.setPeerDescriptor(targetPeerDescriptor)
-
-            this.connectingConnections.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
-
-            const delFunc = () => {
-                if (this.connectingConnections.has(peerKey)) {
-                    this.connectingConnections.delete(peerKey)
-                }
-                socket.off('disconnected', delFunc)
-                managedConnection.off('handshakeCompleted', delFunc)
-            }
-            socket.on('disconnected', delFunc)
-            managedConnection.on('handshakeCompleted', delFunc)
-
-            socket.connect(url)
-
-            return managedConnection
-        }
-    }
-
-    private requestConnectionFromPeer(localPeerDescriptor: PeerDescriptor, targetPeerDescriptor: PeerDescriptor): ManagedConnection {
-        setImmediate(() => {
-            const remoteConnector = new WebsocketConnectorRpcRemote(
-                localPeerDescriptor,
-                targetPeerDescriptor,
-                toProtoRpcClient(new WebsocketConnectorRpcClient(this.rpcCommunicator.getRpcClientTransport()))
-            )
-            remoteConnector.requestConnection(localPeerDescriptor.websocket!.host, localPeerDescriptor.websocket!.port)
-        })
-        const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_SERVER)
-        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(keyFromPeerDescriptor(targetPeerDescriptor)))
-        managedConnection.setPeerDescriptor(targetPeerDescriptor)
-        this.ongoingConnectRequests.set(keyFromPeerDescriptor(targetPeerDescriptor), managedConnection)
-        return managedConnection
-    }
-
-    private onServerSocketHandshakeRequest(peerDescriptor: PeerDescriptor, serverWebsocket: IConnection) {
-
-        const peerId = peerIdFromPeerDescriptor(peerDescriptor)
-
-        if (this.ongoingConnectRequests.has(peerId.toKey())) {
-            const ongoingConnectReguest = this.ongoingConnectRequests.get(peerId.toKey())!
-            ongoingConnectReguest.attachImplementation(serverWebsocket)
-            ongoingConnectReguest.acceptHandshake()
-            this.ongoingConnectRequests.delete(peerId.toKey())
-        } else {
-            const managedConnection = new ManagedConnection(this.localPeerDescriptor!, ConnectionType.WEBSOCKET_SERVER, undefined, serverWebsocket)
-
-            managedConnection.setPeerDescriptor(peerDescriptor)
-
-            if (this.onIncomingConnection(managedConnection)) {
-                managedConnection.acceptHandshake()
-            } else {
-                managedConnection.rejectHandshake('Duplicate connection')
-                managedConnection.destroy()
-            }
-        }
-    }
-
-    public setLocalPeerDescriptor(localPeerDescriptor: PeerDescriptor): void {
-        this.localPeerDescriptor = localPeerDescriptor
-    }
-
-    public async destroy(): Promise<void> {
-        this.destroyed = true
-        this.rpcCommunicator.destroy()
-
-        const requests = Array.from(this.ongoingConnectRequests.values())
-        await Promise.allSettled(requests.map((conn) => conn.close('OTHER')))
-
-        const attempts = Array.from(this.connectingConnections.values())
-        await Promise.allSettled(attempts.map((conn) => conn.close('OTHER')))
-        this.connectivityChecker?.destroy()
-        await this.websocketServer?.stop()
-    }
-
-    // IWebsocketConnectorRpc implementation
     public async requestConnection(_request: WebsocketConnectionRequest, context: ServerCallContext): Promise<WebsocketConnectionResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        if (!this.destroyed && this.canConnectFunction(senderPeerDescriptor)) {
+        if (this.config.canConnect(senderPeerDescriptor)) {
             setImmediate(() => {
+                /* TODO is this needed?
                 if (this.destroyed) {
                     return
-                }
-                const connection = this.connect(senderPeerDescriptor)
-                this.onIncomingConnection(connection)
+                }*/
+                const connection = this.config.connect(senderPeerDescriptor)
+                this.config.onIncomingConnection(connection)
             })
-            const res: WebsocketConnectionResponse = {
-                accepted: true
-            }
-            return res
-        }
-        return {
-            accepted: false
+            return { accepted: true }
+        } else {
+            return { accepted: false }
         }
     }
 }

--- a/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
@@ -12,6 +12,7 @@ interface WebsocketConnectorRpcLocalConfig {
     canConnect: (peerDescriptor: PeerDescriptor) => boolean
     connect: (targetPeerDescriptor: PeerDescriptor) => ManagedConnection
     onIncomingConnection: (connection: ManagedConnection) => boolean
+    abortSignal: AbortSignal
 }
 
 export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
@@ -26,6 +27,9 @@ export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         if (this.config.canConnect(senderPeerDescriptor)) {
             setImmediate(() => {
+                if (this.config.abortSignal.aborted) {
+                    return
+                }
                 const connection = this.config.connect(senderPeerDescriptor)
                 this.config.onIncomingConnection(connection)
             })

--- a/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
@@ -26,10 +26,6 @@ export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         if (this.config.canConnect(senderPeerDescriptor)) {
             setImmediate(() => {
-                /* TODO is this needed?
-                if (this.destroyed) {
-                    return
-                }*/
                 const connection = this.config.connect(senderPeerDescriptor)
                 this.config.onIncomingConnection(connection)
             })

--- a/packages/dht/test/unit/WebsocketConnector.test.ts
+++ b/packages/dht/test/unit/WebsocketConnector.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { WebsocketConnectorRpcLocal } from '../../src/connection/websocket/WebsocketConnectorRpcLocal'
+import { WebsocketConnector } from '../../src/connection/websocket/WebsocketConnector'
 import { ConnectivityMethod, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import crypto from 'crypto'
 import { MockTransport } from '../utils/mock/Transport'
@@ -12,11 +12,11 @@ const createMockPeerDescriptor = (nodeType: NodeType, websocket?: ConnectivityMe
     }
 }
 
-describe('WebsocketConnectorRpcLocal', () => {
+describe('WebsocketConnector', () => {
 
     describe('isPossibleToFormConnection', () => {
 
-        const connector = new WebsocketConnectorRpcLocal({
+        const connector = new WebsocketConnector({
             transport: new MockTransport(),
             canConnect: () => {}
         } as any)


### PR DESCRIPTION
Extract `WebsocketConnector` from `WebsocketConnectorRpcLocal`.

## Small changes

- removed redundant `this.destroyed` check (the state is checked just before executing the method)
- use `abortController`