### PR TITLE
test(dht): Memory leak test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27904,6 +27904,7 @@
                 "@types/uuid": "^9.0.7",
                 "@types/websocket": "^1.0.3",
                 "express": "^4.17.1",
+                "jest-leak-detector": "^27.3.1",
                 "patch-package": "^8.0.0",
                 "ts-essentials": "^9.4.1",
                 "ts-node": "^10.9.1"

--- a/packages/dht/karma.config.js
+++ b/packages/dht/karma.config.js
@@ -5,7 +5,7 @@ const { createKarmaConfig, createWebpackConfig } = require('@streamr/browser-tes
 const TEST_PATHS = [
     'test/unit/**/*.ts',
     './test/integration/**/!(DhtWith*|MigrateData*).ts/',
-    'test/end-to-end/**/*.ts'
+    'test/end-to-end/**/!(memory-leak*).ts'
 ]
 
 const NodeWebrtcConnection = path.resolve(__dirname, 'src/connection/webrtc/NodeWebrtcConnection.ts')

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -54,6 +54,7 @@
     "@types/uuid": "^9.0.7",
     "@types/websocket": "^1.0.3",
     "express": "^4.17.1",
+    "jest-leak-detector": "^27.3.1",
     "patch-package": "^8.0.0",
     "ts-essentials": "^9.4.1",
     "ts-node": "^10.9.1"

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -1,0 +1,84 @@
+import LeakDetector from 'jest-leak-detector'
+import { binaryToHex, waitForCondition } from '@streamr/utils'
+import { randomBytes } from 'crypto'
+import { DhtNode } from '../../src/dht/DhtNode'
+import { Message, MessageType, NodeType } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
+
+const MESSAGE_ID = 'mock-message-id'
+
+describe('memory leak', () => {
+
+    it('send message', async () => {
+        const entryPointDescriptor = {
+            kademliaId: randomBytes(10),
+            type: NodeType.NODEJS,
+            websocket: {
+                host: '127.0.0.1',
+                port: 11224,
+                tls: false
+            }
+        }
+        let entryPoint: DhtNode | undefined = new DhtNode({
+            peerId: binaryToHex(entryPointDescriptor.kademliaId),
+            websocketHost: entryPointDescriptor.websocket!.host,
+            websocketPortRange: {
+                min: entryPointDescriptor.websocket.port,
+                max: entryPointDescriptor.websocket.port
+            },
+            entryPoints: [entryPointDescriptor]
+        })
+        await entryPoint.start()
+        await entryPoint.joinDht([entryPointDescriptor])
+        let sender: DhtNode | undefined = new DhtNode({})
+        let receiver: DhtNode | undefined = new DhtNode({})
+        /*TODO should this work? await Promise.all([
+            async () => {
+                await sender.start()
+                await sender.joinDht([entryPointDescriptor])
+            },
+            async () => {
+                await receiver.start()
+                await receiver.joinDht([entryPointDescriptor])
+            }
+        ])*/
+        await sender.start()
+        await sender.joinDht([entryPointDescriptor])
+        await receiver.start()
+        await receiver.joinDht([entryPointDescriptor])
+
+        let receivedMessage: Message | undefined = undefined
+        receiver.on('message', (msg: Message) => receivedMessage = msg)
+        const msg: Message = {
+            serviceId: 'mock-service-id',
+            targetDescriptor: receiver.getLocalPeerDescriptor(),
+            messageType: MessageType.RPC,
+            messageId: 'mock-message-id',
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            }
+        }
+        await sender.send(msg)
+        await waitForCondition(() => receivedMessage !== undefined)
+        expect(receivedMessage!.messageId).toEqual(MESSAGE_ID)
+
+        await Promise.all([
+            entryPoint.stop(),
+            sender.stop(),
+            receiver.stop()
+        ])
+
+        const detector1 = new LeakDetector(entryPoint)
+        entryPoint = undefined
+        expect(await detector1.isLeaking()).toBe(false)
+
+        const detector2 = new LeakDetector(sender)
+        sender = undefined
+        expect(await detector2.isLeaking()).toBe(false)
+
+        const detector3 = new LeakDetector(receiver)
+        receiver = undefined
+        expect(await detector3.isLeaking()).toBe(false)
+    })
+})


### PR DESCRIPTION
Add memory leak test. Sends a RPC message from a node to another.

## Open questions

- Check "`TODO should this work?`" for alternative way for initializing the sender and the receiver. Should that approach work?

## Future improvements

- More test cases