### PR TITLE
test(broker): [NET-1158, NET-1162] Nonce handling in `generateWalletWithGasAndTokens`

### DIFF
--- a/packages/broker/test/integration/plugins/operator/contractUtils.ts
+++ b/packages/broker/test/integration/plugins/operator/contractUtils.ts
@@ -6,7 +6,7 @@ import { config as CHAIN_CONFIG } from '@streamr/config'
 import type { Operator, OperatorFactory, Sponsorship, SponsorshipFactory } from '@streamr/network-contracts'
 import { TestToken, operatorABI, operatorFactoryABI, sponsorshipABI, sponsorshipFactoryABI, tokenABI } from '@streamr/network-contracts'
 import { fastPrivateKey } from '@streamr/test-utils'
-import { Logger, TheGraphClient, toEthereumAddress } from '@streamr/utils'
+import { Logger, TheGraphClient, toEthereumAddress, retry } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { OperatorServiceConfig } from '../../../../src/plugins/operator/OperatorPlugin'
 import { range } from 'lodash'
@@ -201,13 +201,23 @@ export async function generateWalletWithGasAndTokens(opts?: GenerateWalletWithGa
     const token = (opts?.chainConfig !== undefined)
         ? new Contract(opts.chainConfig.contracts.DATA, tokenABI, adminWallet) as unknown as TestToken
         : getTokenContract().connect(adminWallet)
-    await (await token.mint(newWallet.address, parseEther('1000000'), {
-        nonce: await adminWallet.getTransactionCount()
-    })).wait()
-    await (await adminWallet.sendTransaction({
-        to: newWallet.address,
-        value: parseEther('1')
-    })).wait()
+    await retry(
+        async () => {
+            await (await token.mint(newWallet.address, parseEther('1000000'), {
+                nonce: await adminWallet.getTransactionCount()
+            })).wait()
+            await (await adminWallet.sendTransaction({
+                to: newWallet.address,
+                value: parseEther('1')
+            })).wait()
+        },
+        (message: string, error: any) => {
+            logger.debug(message, { error })
+        },
+        'Token minting',
+        10,
+        100
+    )
     return newWallet.connect(provider)
 }
 

--- a/packages/broker/test/integration/plugins/operator/contractUtils.ts
+++ b/packages/broker/test/integration/plugins/operator/contractUtils.ts
@@ -203,9 +203,7 @@ export async function generateWalletWithGasAndTokens(opts?: GenerateWalletWithGa
         : getTokenContract().connect(adminWallet)
     await retry(
         async () => {
-            await (await token.mint(newWallet.address, parseEther('1000000'), {
-                nonce: await adminWallet.getTransactionCount()
-            })).wait()
+            await (await token.mint(newWallet.address, parseEther('1000000'))).wait()
             await (await adminWallet.sendTransaction({
                 to: newWallet.address,
                 value: parseEther('1')

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -39,6 +39,7 @@ import { TheGraphClient, GraphQLQuery, FetchResponse } from './TheGraphClient'
 import { Heap } from './Heap'
 import { executeSafePromise } from './executeSafePromise'
 import { binaryToHex, binaryToUtf8, hexToBinary, utf8ToBinary, areEqualBinaries } from './binaryUtils'
+import { retry } from './retry'
 
 export {
     BrandedString,
@@ -90,7 +91,8 @@ export {
     binaryToUtf8,
     hexToBinary,
     utf8ToBinary,
-    areEqualBinaries
+    areEqualBinaries,
+    retry
 }
 
 export {

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -2,7 +2,7 @@ import { wait } from './wait'
 
 export const retry = async <T>(
     task: () => Promise<T>,
-    onFailure: (message: string, error: any) => void,
+    onRetryableFailure: (message: string, error: any) => void,
     description: string,
     maxCount: number,
     delay: number,
@@ -14,7 +14,7 @@ export const retry = async <T>(
         } catch (err: any) {
             if (i < (maxCount - 1)) {
                 const message = `${description} failed, retrying in ${delay} ms`
-                onFailure(message, err)
+                onRetryableFailure(message, err)
             }
         }
         await wait(delay)

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -1,0 +1,23 @@
+import { wait } from './wait'
+
+export const retry = async <T>(
+    task: () => Promise<T>,
+    onFailure: (message: string, error: any) => void,
+    description: string,
+    maxCount: number,
+    delay: number,
+): Promise<T> => {
+    for (let i = 0; i < maxCount; i++) {
+        try {
+            const result = await task()
+            return result
+        } catch (err: any) {
+            if (i < (maxCount - 1)) {
+                const message = `${description} failed, retrying in ${delay} ms`
+                onFailure(message, err)
+            }
+        }
+        await wait(delay)
+    }
+    throw new Error(`${description} failed after ${maxCount} attempts`)
+}

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -15,9 +15,9 @@ export const retry = async <T>(
             if (i < (maxCount - 1)) {
                 const message = `${description} failed, retrying in ${delay} ms`
                 onRetryableFailure(message, err)
+                await wait(delay)
             }
         }
-        await wait(delay)
     }
     throw new Error(`${description} failed after ${maxCount} attempts`)
 }

--- a/packages/utils/test/retry.test.ts
+++ b/packages/utils/test/retry.test.ts
@@ -1,0 +1,71 @@
+import { retry } from '../src/retry'
+
+describe('retry', () => {
+
+    it('first success', async () => {
+        const task = jest.fn().mockResolvedValue(123)
+        const onRetryableFailure = jest.fn()
+        const result = await retry(
+            task,
+            onRetryableFailure,
+            'foobar',
+            4,
+            10
+        )
+        expect(result).toBe(123)
+        expect(task).toHaveBeenCalledTimes(1)
+        expect(onRetryableFailure).not.toHaveBeenCalled()
+    })
+
+    it('non-first success', async () => {
+        const error = new Error('mock-error')
+        const task = jest.fn()
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error)
+            .mockResolvedValue(123)
+        const onRetryableFailure = jest.fn()
+        const result = await retry(
+            task,
+            onRetryableFailure,
+            'foobar',
+            4,
+            10
+        )
+        expect(result).toBe(123)
+        expect(task).toHaveBeenCalledTimes(3)
+        expect(onRetryableFailure).toHaveBeenCalledTimes(2)
+        for (let i = 1; i <= 2; i++) {
+            expect(onRetryableFailure).toHaveBeenNthCalledWith(1, 'foobar failed, retrying in 10 ms', error)
+            expect(onRetryableFailure).toHaveBeenNthCalledWith(2, 'foobar failed, retrying in 10 ms', error)
+        }
+    })
+
+    it('all fail', async () => {
+        const error = new Error('mock-error')
+        const task = jest.fn().mockRejectedValue(error)
+        const onRetryableFailure = jest.fn()
+        await expect(() => retry(
+            task,
+            onRetryableFailure,
+            'foobar',
+            4,
+            10
+        )).rejects.toThrow('foobar failed after 4 attempts')
+        expect(task).toHaveBeenCalledTimes(4)
+        expect(onRetryableFailure).toHaveBeenCalledTimes(3)
+        for (let i = 1; i <= 4; i++) {
+            expect(onRetryableFailure).toHaveBeenNthCalledWith(1, 'foobar failed, retrying in 10 ms', error)
+            expect(onRetryableFailure).toHaveBeenNthCalledWith(2, 'foobar failed, retrying in 10 ms', error)
+        }
+    })
+
+    it('no tasks', async () => {
+        await expect(() => retry(
+            undefined as any,
+            undefined as any,
+            'foobar',
+            0,
+            10
+        )).rejects.toThrow('foobar failed after 0 attempts')
+    })
+})


### PR DESCRIPTION
Add a `retry` utility to `@streamr/utils` and use it in Broker's `generateWalletWithGasAndTokens` test utility. There is only one adminWallet and therefore it is possible that multiple callers execute a transaction concurrently for that wallet. 

Also remove redundant explicit nonce handling in that method (if no `nonce` is defined, the functionality which we implemented is the default functionality).
