### PR TITLE
Update testnets.md

### DIFF
--- a/docs/docs/streamr-testnets/testnets.md
+++ b/docs/docs/streamr-testnets/testnets.md
@@ -16,7 +16,7 @@ The 1.0 testnets will be launched with the technical parameters set out in: [SIP
 3. [Delegate](../streamr-network/network-roles/delegators.md) your `DATA` tokens onto other Operators
 
 ## Current node software version
-Use node version: `100.0.0-pretestnet.3`. Do not use the `latest` tag release.
+Use node version: `v100.0.0-pretestnet.3`. Do not use the `latest` tag release.
 
 ## Schedules
 Keep a close eye on this page as these dates may change based on the findings of each testnet.


### PR DESCRIPTION
## Summary

Prepended a missing `v` to `100.0.0-pretestnet.3`: `v100.0.0-pretestnet.3`. 

If node operators paste the string without the `v` prepended e.g. as such: `sudo docker run -p 32200:32200 --name streamr --restart unless-stopped -d -v $(cd ~/.streamrDocker && pwd):/home/streamr/.streamr streamr/broker-node:100.0.0-pretestnet.3` instead of `sudo docker run -p 32200:32200 --name streamr --restart unless-stopped -d -v $(cd ~/.streamrDocker && pwd):/home/streamr/.streamr streamr/broker-node:v100.0.0-pretestnet.3`, updating the Docker container image will fail.

## Limitations and future improvements

Perhaps add detailed update instructions to the testnets FAQ :)
