### PR TITLE
fix(DHT): Disable WS TLS after failed post-autocertification connectivity checks

### DIFF
--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -161,7 +161,7 @@ export class AutoCertifierClient extends EventEmitter<AutoCertifierClientEvents>
         }
         // TODO: use async fs methods?
         const oldSubdomain = JSON.parse(fs.readFileSync(this.configFile, 'utf8')) as CertifiedSubdomain
-        logger.info('updateSubdomainIp() called for ' + JSON.stringify(oldSubdomain))
+        logger.info('updateSubdomainIp() called for ' + oldSubdomain.fqdn)
         const sessionId = await this.restClient.createSession()
         this.ongoingSessions.add(sessionId)
         await this.restClient.updateSubdomainIp(

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -9,7 +9,7 @@ import { ManagedConnection } from './ManagedConnection'
 import { Simulator } from './simulator/Simulator'
 import { SimulatorConnector } from './simulator/SimulatorConnector'
 import { IceServer, WebrtcConnector } from './webrtc/WebrtcConnector'
-import { WebsocketConnector } from './websocket/WebsocketConnector'
+import { WebsocketConnector, WebsocketConnectorConfig } from './websocket/WebsocketConnector'
 
 export interface ConnectorFacade {
     createConnection: (peerDescriptor: PeerDescriptor) => ManagedConnection
@@ -106,25 +106,36 @@ export class DefaultConnectorFacade implements ConnectorFacade {
                 const connectivityResponse = await this.websocketConnector!.checkConnectivity(false)
                 localPeerDescriptor = this.config.createLocalPeerDescriptor(connectivityResponse)
                 this.localPeerDescriptor = localPeerDescriptor
-                if (localPeerDescriptor.websocket === undefined) {
-                    logger.warn('ConnectivityCheck failed after autocertification, websocket server connectivity disabled')
-                }
                 this.websocketConnector!.setLocalPeerDescriptor(localPeerDescriptor)
+                if (localPeerDescriptor.websocket === undefined) {
+                    logger.warn('ConnectivityCheck failed after autocertification, disabling websocket server TLS')
+                    await this.restartWebsocketConnector({
+                        ...webSocketConnectorConfig,
+                        serverEnableTls: false
+                    })
+                }
             } catch (err) {
                 logger.warn('Failed to autocertify, disabling websocket server TLS')
-                await this.websocketConnector.destroy()
-                this.websocketConnector = new WebsocketConnector({
+                await this.restartWebsocketConnector({
                     ...webSocketConnectorConfig,
-                    serverEnableTls: false,
+                    serverEnableTls: false
                 })
-                await this.websocketConnector.start()
-                const connectivityResponse = await this.websocketConnector.checkConnectivity(false)
-                localPeerDescriptor = this.config.createLocalPeerDescriptor(connectivityResponse)
-                this.localPeerDescriptor = localPeerDescriptor
-                this.websocketConnector.setLocalPeerDescriptor(localPeerDescriptor)
             }
         }
         this.webrtcConnector.setLocalPeerDescriptor(localPeerDescriptor)
+    }
+    
+    async restartWebsocketConnector(webSocketConnectorConfig: WebsocketConnectorConfig): Promise<void> {
+        await this.websocketConnector!.destroy()
+        this.websocketConnector = new WebsocketConnector({
+            ...webSocketConnectorConfig,
+            serverEnableTls: false,
+        })
+        await this.websocketConnector.start()
+        const connectivityResponse = await this.websocketConnector.checkConnectivity(false)
+        const localPeerDescriptor = this.config.createLocalPeerDescriptor(connectivityResponse)
+        this.localPeerDescriptor = localPeerDescriptor
+        this.websocketConnector.setLocalPeerDescriptor(localPeerDescriptor)
     }
 
     createConnection(peerDescriptor: PeerDescriptor): ManagedConnection {

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -36,7 +36,7 @@ export const connectivityMethodToWebsocketUrl = (ws: ConnectivityMethod): string
 
 const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
 
-interface WebsocketConnectorConfig {
+export interface WebsocketConnectorConfig {
     transport: ITransport
     canConnect: (peerDescriptor: PeerDescriptor) => boolean
     onIncomingConnection: (connection: ManagedConnection) => boolean


### PR DESCRIPTION
## Summary

If the connectivity checks fail after autocertification, the WS server is now restarted with TLS disabled.

## Other changes

No longer log the full content of the autocertifier config file when doing updateSubdomainIp() in AutocertifierClient