### PR TITLE
refactor(dht): `WebsocketServer` actions

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -30,8 +30,10 @@ import { WebsocketServerStartError } from '../../helpers/errors'
 import { AutoCertifierClientFacade } from './AutoCertifierClientFacade'
 const logger = new Logger(module)
 
-export const connectivityMethodToWebsocketUrl = (ws: ConnectivityMethod): string => {
-    return (ws.tls ? 'wss://' : 'ws://') + ws.host + ':' + ws.port
+export type Action = 'connectivityRequest' | 'connectivityProbe'
+
+export const connectivityMethodToWebsocketUrl = (ws: ConnectivityMethod, action?: Action): string => {
+    return (ws.tls ? 'wss://' : 'ws://') + ws.host + ':' + ws.port + ((action !== undefined) ? '?action=' + action : '')
 }
 
 const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
@@ -143,19 +145,14 @@ export class WebsocketConnector {
     public async start(): Promise<void> {
         if (!this.abortController.signal.aborted && this.websocketServer) {
             this.websocketServer.on('connected', (connection: IConnection) => {
-
                 const serverSocket = connection as unknown as ServerWebsocket
-                if (serverSocket.resourceURL &&
-                    serverSocket.resourceURL.query) {
-                    const query = serverSocket.resourceURL.query as unknown as ParsedUrlQuery
-                    if (query.connectivityRequest) {
-                        logger.trace('Received connectivity request connection from ' + serverSocket.getRemoteAddress())
-                        this.connectivityChecker!.listenToIncomingConnectivityRequests(serverSocket)
-                    } else if (query.connectivityProbe) {
-                        logger.trace('Received connectivity probe connection from ' + serverSocket.getRemoteAddress())
-                    } else {
-                        this.attachHandshaker(connection)
-                    }
+                const query = serverSocket.resourceURL.query as unknown as (ParsedUrlQuery | null)
+                const action = query?.action as (Action | undefined)
+                logger.trace('WebSocket client connected', { action, remoteAddress: serverSocket.getRemoteAddress() })
+                if (action === 'connectivityRequest') {
+                    this.connectivityChecker!.listenToIncomingConnectivityRequests(serverSocket)
+                } else if (action === 'connectivityProbe') {
+                    // no-op
                 } else {
                     this.attachHandshaker(connection)
                 }
@@ -190,7 +187,7 @@ export class WebsocketConnector {
                         }
                         return preconfiguredConnectivityResponse
                     } else {
-                        // Do real connectivity checking     
+                        // Do real connectivity checking
                         return await this.connectivityChecker!.sendConnectivityRequest(entryPoint, selfSigned)
                     }
                 }


### PR DESCRIPTION
Refactor handling of `WebsocketServer` requests.

Also small change to the URL query parameter format:
- previously pattern like this `ws://foobar.com?connectivityRequest=true` 
- now the pattern like this: `ws://foobar.com?action=connectivityRequest`

## Open questions

There are three possible ways to open the connections: the default connection which starts with a handshake, and two actions `connectivityRequest`/`connectivityProbe`.  The idea is that when an action is executed, the server does a task and sends a response as a WebSocket message. After that message has been received the recipient is expected to close the socket connection.

But actually the `connectivityProbe` doesn't do anything. It just opens a connection which doesn't listen to messages, and doesn't send any message. 

Would it make sense to have just two modes/actions: `defaultRpc` (or something) and `connectivityRequest`. I.e. the `connectivityProbe` wouldn't be a mode as it doesn't do anything.

