### PR TITLE
fix(dht, trackerless-network): Strict boolean expressions

### DIFF
--- a/packages/dht/src/connection/ConnectionLockHandler.ts
+++ b/packages/dht/src/connection/ConnectionLockHandler.ts
@@ -26,7 +26,7 @@ export class ConnectionLockHandler {
     }
 
     public isLocalLocked(id: PeerIDKey, lockId?: LockID): boolean {
-        if (!lockId) {
+        if (lockId === undefined) {
             return this.localLocks.has(id)
         } else {
             return this.localLocks.has(id) && this.localLocks.get(id)!.has(lockId)
@@ -34,7 +34,7 @@ export class ConnectionLockHandler {
     }
 
     public isRemoteLocked(id: PeerIDKey, lockId?: LockID): boolean {
-        if (!lockId) {
+        if (lockId === undefined) {
             return this.remoteLocks.has(id)
         } else {
             if (this.remoteLocks.has(id) && this.remoteLocks.get(id)!.has(lockId)) {

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -39,6 +39,7 @@ export interface DefaultConnectorFacadeConfig {
     webrtcPortRange?: PortRange
     maxMessageSize?: number
     tlsCertificate?: TlsCertificate
+    // TODO explicit default value for "websocketServerEnableTls" or make it required
     websocketServerEnableTls?: boolean
     autoCertifierUrl?: string
     autoCertifierConfigFile?: string

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -148,7 +148,7 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
             this.latencyTable = getRegionDelayMatrix()
         }
 
-        if (this.latencyType === LatencyType.FIXED && !this.fixedLatency) {
+        if ((this.latencyType === LatencyType.FIXED) && (this.fixedLatency === undefined)) {
             throw new Error('LatencyType.FIXED requires the desired latency to be given as second parameter')
         }
 

--- a/packages/dht/src/connection/simulator/SimulatorConnection.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnection.ts
@@ -85,7 +85,7 @@ export class SimulatorConnection extends Connection implements IConnection {
             logger.trace('connect() called')
 
             this.simulator.connect(this, this.targetPeerDescriptor, (error?: string) => {
-                if (error) {
+                if (error !== undefined) {
                     logger.trace(error)
                     this.doDisconnect(false)
                 } else {

--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -51,7 +51,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
         this.peerConnection = new RTCPeerConnection({ iceServers: urls })
 
         this.peerConnection.onicecandidate = (event) => {
-            if (event.candidate && event.candidate.sdpMid) {
+            if ((event.candidate !== null) && (event.candidate.sdpMid !== null)) {
                 this.emit('localCandidate', event.candidate.candidate, event.candidate.sdpMid)
             }
         }
@@ -63,14 +63,14 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
         if (isOffering) {
             this.peerConnection.onnegotiationneeded = async () => {
                 try {
-                    if (this.peerConnection) {
+                    if (this.peerConnection !== undefined) {
                         this.makingOffer = true
                         try {
                             await this.peerConnection.setLocalDescription()
                         } catch (err) {
                             logger.warn('error', { err })
                         }
-                        if (this.peerConnection.localDescription) {
+                        if (this.peerConnection.localDescription !== null) {
                             this.emit('localDescription', this.peerConnection.localDescription?.sdp, this.peerConnection.localDescription?.type)
                         }
                     }
@@ -93,7 +93,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
     }
 
     public async setRemoteDescription(description: string, type: string): Promise<void> {
-        const offerCollision = (type.toLowerCase() === RtcDescription.OFFER) && (this.makingOffer || !this.peerConnection ||
+        const offerCollision = (type.toLowerCase() === RtcDescription.OFFER) && (this.makingOffer || (this.peerConnection === undefined) ||
             this.peerConnection.signalingState != 'stable')
 
         const ignoreOffer = this.isOffering && offerCollision
@@ -106,13 +106,13 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
             logger.warn('error', { err })
         }
 
-        if (type.toLowerCase() === RtcDescription.OFFER && this.peerConnection) {
+        if ((type.toLowerCase() === RtcDescription.OFFER) && (this.peerConnection !== undefined)) {
             try {
                 await this.peerConnection.setLocalDescription()
             } catch (err) {
                 logger.warn('error', { err })
             }
-            if (this.peerConnection.localDescription) {
+            if (this.peerConnection.localDescription !== null) {
                 this.emit('localDescription', this.peerConnection.localDescription.sdp, this.peerConnection.localDescription.type)
             }
         }
@@ -148,7 +148,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
             
             this.removeAllListeners()
 
-            if (this.dataChannel) {
+            if (this.dataChannel !== undefined) {
                 try {
                     this.dataChannel.close()
                 } catch (e) {
@@ -158,7 +158,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
             this.dataChannel = undefined
 
-            if (this.peerConnection) {
+            if (this.peerConnection !== undefined) {
                 try {
                     this.peerConnection.close()
                 } catch (e) {
@@ -209,7 +209,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
     }
 
     private stopListening() {
-        if (this.dataChannel) {
+        if (this.dataChannel !== undefined) {
             this.dataChannel.onopen = null
             this.dataChannel.onclose = null
             this.dataChannel.onerror = null
@@ -217,7 +217,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
             this.dataChannel.onmessage = null
         }
 
-        if (this.peerConnection) {
+        if (this.peerConnection !== undefined) {
             this.peerConnection.onicecandidate = null
             this.peerConnection.onicegatheringstatechange = null
             this.peerConnection.onnegotiationneeded = null

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -161,7 +161,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
         if (!this.closed) {
             logger.trace(
                 `Closing Node WebRTC Connection to ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`
-                + `${reason ? `, reason: ${reason}` : ''}`
+                + `${(reason !== undefined) ? `, reason: ${reason}` : ''}`
             )
 
             this.closed = true

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -178,7 +178,7 @@ export class WebrtcConnector {
         )
 
         connection.on('localCandidate', (candidate: string, mid: string) => {
-            if (this.config.externalIp) {
+            if (this.config.externalIp !== undefined) {
                 candidate = replaceInternalIpWithExternalIp(candidate, this.config.externalIp)
                 logger.debug(`onLocalCandidate injected external ip ${candidate} ${mid}`)
             }

--- a/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
@@ -123,7 +123,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
     private isIceCandidateAllowed(candidate: string): boolean {
         if (!this.config.allowPrivateAddresses) {
             const address = getAddressFromIceCandidate(candidate)
-            if (address && isPrivateIPv4(address)) {
+            if ((address !== undefined) && isPrivateIPv4(address)) {
                 return false
             }
         }

--- a/packages/dht/src/connection/webrtc/iceServerAsString.ts
+++ b/packages/dht/src/connection/webrtc/iceServerAsString.ts
@@ -9,7 +9,7 @@ export function iceServerAsString({ url, port, username, password, tcp }: IceSer
         return `${protocol}:${hostname}:${port}`
     }
     if (username !== undefined && password !== undefined) {
-        return `${protocol}:${username}:${password}@${hostname}:${port}${tcp ? '?transport=tcp' : ''}`
+        return `${protocol}:${username}:${password}@${hostname}:${port}${(tcp !== undefined) ? '?transport=tcp' : ''}`
     }
     throw new Error(`username (${username}) and password (${password}) must be supplied together`)
 }

--- a/packages/dht/src/connection/websocket/ClientWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ClientWebsocket.ts
@@ -23,6 +23,7 @@ export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.connectionId = new ConnectionID()
     }
 
+    // TODO explicit default value for "selfSigned" or make it required
     public connect(address: string, selfSigned?: boolean): void {
         if (!this.destroyed) {
             this.socket = new Websocket(address, undefined, undefined, undefined, { rejectUnauthorized: !selfSigned })

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -123,7 +123,7 @@ export type Events = TransportEvents & DhtNodeEvents
 export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string): PeerDescriptor => {
     let kademliaId: Uint8Array
     if (msg) {
-        kademliaId = peerId ? hexToBinary(peerId) : PeerID.fromIp(msg.host).value
+        kademliaId = (peerId !== undefined) ? hexToBinary(peerId) : PeerID.fromIp(msg.host).value
     } else {
         kademliaId = hexToBinary(peerId!)
     }
@@ -296,7 +296,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcRequestTimeout: this.config.rpcRequestTimeout
         })
         this.bindRpcLocalMethods()
-        if (this.connectionManager! && this.config.entryPoints && this.config.entryPoints.length > 0 
+        if ((this.connectionManager !== undefined) && (this.config.entryPoints !== undefined) && this.config.entryPoints.length > 0
             && !areEqualPeerDescriptors(this.config.entryPoints[0], this.localPeerDescriptor!)) {
             this.connectToEntryPoint(this.config.entryPoints[0])
         }
@@ -573,7 +573,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 this.config.serviceId,
                 this.config.rpcRequestTimeout
             )
-            if (!this.bucket!.get(contact.kademliaId) && !this.neighborList!.getContact(peerIdFromPeerDescriptor(contact))) {
+            if ((this.bucket!.get(contact.kademliaId) === null) && (this.neighborList!.getContact(peerIdFromPeerDescriptor(contact)) === undefined)) {
                 this.neighborList!.addContact(rpcRemote)
                 if (setActive) {
                     const peerId = peerIdFromPeerDescriptor(contact)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -542,7 +542,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
         for (const contactId of this.neighborList!.getContactIds()) {
             if (!this.bucket!.get(contactId.value) && this.neighborList!.isActive(contactId)) {
-                return this.neighborList!.getContact(contactId).contact
+                return this.neighborList!.getContact(contactId)!.contact
             }
         }
         return undefined

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -35,8 +35,8 @@ export class ContactList<C extends { getPeerId: () => PeerID }> extends EventEmi
         this.defaultContactQueryLimit = defaultContactQueryLimit
     }
 
-    public getContact(id: PeerID): ContactState<C> {
-        return this.contactsById.get(id.toKey())!
+    public getContact(id: PeerID): ContactState<C> | undefined {
+        return this.contactsById.get(id.toKey())
     }
 
     public getSize(): number {

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -60,6 +60,7 @@ export class DiscoverySession {
                 if (this.config.newContactListener) {
                     this.config.newContactListener(rpcRemote)
                 }
+                // TODO better check (currently this condition is always true)
                 if (!this.config.neighborList.getContact(rpcRemote.getPeerId())) {
                     this.config.neighborList.addContact(rpcRemote)
                 }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -60,8 +60,7 @@ export class DiscoverySession {
                 if (this.config.newContactListener) {
                     this.config.newContactListener(rpcRemote)
                 }
-                // TODO better check (currently this condition is always true)
-                if (!this.config.neighborList.getContact(rpcRemote.getPeerId())) {
+                if (this.config.neighborList.getContact(rpcRemote.getPeerId()) !== undefined) {
                     this.config.neighborList.addContact(rpcRemote)
                 }
             }

--- a/packages/dht/src/dht/find/FindSession.ts
+++ b/packages/dht/src/dht/find/FindSession.ts
@@ -89,6 +89,7 @@ export class FindSession extends EventEmitter<FindSessionEvents> {
         routingPath: PeerDescriptor[],
         nodes: PeerDescriptor[],
         dataEntries: DataEntry[],
+        // TODO explicit default value for "noCloserNodesFound or make it required
         noCloserNodesFound?: boolean
     ): void {
         this.addKnownHops(routingPath)
@@ -164,6 +165,7 @@ export class FindSession extends EventEmitter<FindSessionEvents> {
 
     public getResults = (): FindResult => ({
         closestNodes: this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()),
+        // TODO better check (currently this condition is always true)
         dataEntries: (this.foundData && this.foundData.size > 0) ? Array.from(this.foundData.values()) : undefined
     })
 

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -117,6 +117,7 @@ export class Finder implements IFinder {
             session.doSendFindResponse(
                 [this.localPeerDescriptor],
                 [this.localPeerDescriptor],
+                // TODO better check (currently this condition is always true)
                 data ? Array.from(data.values()) : [],
                 true
             )

--- a/packages/dht/src/dht/routing/RouterRpcLocal.ts
+++ b/packages/dht/src/dht/routing/RouterRpcLocal.ts
@@ -20,7 +20,8 @@ const logger = new Logger(module)
 export const createRouteMessageAck = (routedMessage: RouteMessageWrapper, error?: string): RouteMessageAck => {
     const ack: RouteMessageAck = {
         requestId: routedMessage.requestId,
-        error: error ? error : ''
+        // TODO if there is no error, can we just leave the field out?
+        error: (error !== undefined) ? error : ''
     }
     return ack
 }

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -57,7 +57,7 @@ export class LocalDataStore {
 
     public markAsDeleted(id: Uint8Array, storer: PeerID): boolean {
         const dataKey = PeerID.fromValue(id).toKey()
-        if (!this.store.get(dataKey)?.has(storer.toKey())) {
+        if (this.store.get(dataKey)?.has(storer.toKey()) === undefined) {
             return false
         }
         const storedEntry = this.store.get(dataKey)!.get(storer.toKey())

--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -14,7 +14,7 @@ export class PeerID {
     private readonly key: PeerIDKey  // precompute often-used form of data
 
     protected constructor({ ip, value, stringValue }: { ip?: string, value?: Uint8Array, stringValue?: string } = {}) {
-        if (ip) {
+        if (ip !== undefined) {
             this.data = new Uint8Array(20)
             const ipNum = this.ip2Int(ip)
             const view = new DataView(this.data.buffer)
@@ -23,7 +23,7 @@ export class PeerID {
             this.data.set((new UUID()).value, 4)
         } else if (value) {
             this.data = new Uint8Array(value.slice(0))
-        } else if (stringValue) {
+        } else if (stringValue !== undefined) {
             const ab = PeerID.textEncoder.encode(stringValue) //toUTF8Array(stringValue)
             this.data = ab
         } else {

--- a/packages/dht/src/helpers/UUID.ts
+++ b/packages/dht/src/helpers/UUID.ts
@@ -5,7 +5,7 @@ export class UUID {
     private buf: Uint8Array
 
     constructor(other?: (UUID | Uint8Array | string)) {
-        if (!other) {
+        if (other === undefined) {
             this.buf = new Uint8Array(16)
             v4(null, this.buf)
         } else if (other.constructor === UUID) {

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -38,6 +38,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
                 targetDescriptor
             }
 
+            // TODO is it possible to have explicit default values for "doNotConnect" and "doNotMindStopped"?
             if (msg.header.response || callContext && callContext.doNotConnect && callContext.doNotMindStopped ) {
                 return this.sendFn(message, true, true)
             } else if (msg.header.response || callContext && callContext.doNotConnect) {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -225,6 +225,7 @@ export class StreamrNode extends EventEmitter<Events> {
         userId: EthereumAddress,
         connectionCount?: number
     ): Promise<void> {
+        // TODO explicit default value for "acceptProxyConnections" or make it required
         if (this.config.acceptProxyConnections) {
             throw new Error('cannot set proxies when acceptProxyConnections=true')
         }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -98,6 +98,7 @@ export class Handshaker implements IHandshaker {
         const results = await Promise.allSettled(
             Array.from(targets.values()).map(async (target: HandshakeRpcRemote, i) => {
                 const otherNode = i === 0 ? targets[1] : targets[0]
+                // TODO better check (currently this condition is always true)
                 const otherNodeId = otherNode ? getNodeIdFromPeerDescriptor(otherNode.getPeerDescriptor()) : undefined
                 return this.handshakeWithTarget(target, otherNodeId)
             })


### PR DESCRIPTION
Use strict boolean expressions, i.e. `if (foo !== undefined)` instead of `if (foo)`. 

Some expressions were fixed and some issues were annotated with TODO comments.

## Background

There has been several problems related to boolean expression which handle nullable values in checks/assertions:
- currently we have some boolean expressions which are unintentionally always `true`
  - see "`better check (currently this condition is always true)`" comments added in this PR
- there was recently a problem when we used nullable `HandshakeError` enum https://github.com/streamr-dev/network/pull/1904
  - in many enums on one of the values is `0`, and therefore lenient `null` checks can incorrectly ignore the value
 - the `MigrateData` test is broken https://github.com/streamr-dev/network/pull/2088

## Future improvements

- These warnings were found with https://typescript-eslint.io/rules/strict-boolean-expressions/ `eslint` rule. We could enable the rule if we add TypeScript support to our `eslint` setup (see https://github.com/streamr-dev/network/pull/1171). 
- Could also  run the `eslint` rule with `allowString=false` and `allowNumber=false` to get some more potential places to fix?
- Could also change some `if` statements which use objects to have explicit undefined check (i.e. `if (obj)` to `if (obj !== undefined`)) 
  - use `if \([!a-zA-Z0-9.]+\)` regexp to find those