### PR TITLE
refactor(dht): Remove obsolete `setActive` parameters

### DIFF
--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -19,6 +19,7 @@ export interface Events<C> {
 export class ContactList<C extends { getPeerId: () => PeerID }> extends EventEmitter<Events<C>> {
 
     protected contactsById: Map<PeerIDKey, ContactState<C>> = new Map()
+    // TODO move this to SortedContactList
     protected contactIds: PeerID[] = []
     protected ownId: PeerID
     protected maxSize: number

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -20,7 +20,7 @@ interface PeerDiscoveryConfig {
     serviceId: ServiceID
     parallelism: number
     joinTimeout: number
-    addContact: (contact: PeerDescriptor, setActive?: boolean) => void
+    addContact: (contact: PeerDescriptor) => void
     connectionManager?: ConnectionManager
     rpcRequestTimeout?: number
 }

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -37,7 +37,7 @@ interface FinderConfig {
     localPeerDescriptor: PeerDescriptor
     serviceId: ServiceID
     localDataStore: LocalDataStore
-    addContact: (contact: PeerDescriptor, setActive?: boolean) => void
+    addContact: (contact: PeerDescriptor) => void
     isPeerCloserToIdThanSelf: (peer1: PeerDescriptor, compareToId: PeerID) => boolean
 }
 
@@ -77,7 +77,7 @@ export class Finder implements IFinder {
     private registerLocalRpcMethods(config: FinderConfig) {
         const rpcLocal = new FindRpcLocal({
             doRouteFindRequest: (routedMessage: RouteMessageWrapper) => this.doRouteFindRequest(routedMessage),
-            addContact: (contact: PeerDescriptor, setActive?: boolean) => config.addContact(contact, setActive),
+            addContact: (contact: PeerDescriptor) => config.addContact(contact),
             isMostLikelyDuplicate: (requestId: string) => this.router.isMostLikelyDuplicate(requestId),
             addToDuplicateDetector: (requestId: string) => this.router.addToDuplicateDetector(requestId)
         })

--- a/packages/dht/test/unit/Finder.test.ts
+++ b/packages/dht/test/unit/Finder.test.ts
@@ -64,7 +64,7 @@ describe('Finder', () => {
             serviceId: 'Finder',
             localDataStore: new LocalDataStore(),
             sessionTransport: new MockTransport(),
-            addContact: (_contact, _setActive) => {},
+            addContact: () => {},
             isPeerCloserToIdThanSelf: (_peer1, _compareToId) => true,
             rpcCommunicator: rpcCommunicator as any
         })


### PR DESCRIPTION
Removed obsolete `setActive` parameter from `PeerDiscovery#addContact` and `Finder#addContact` callbacks.

## Open questions

- is "active" state needed in practice?
- what is "contacted" flag of `ContactState`