### PR TITLE
refactor(dht): Remove `LockResponse#reason`

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -277,7 +277,6 @@ message UnlockRequest {
 
 message LockResponse {
   bool accepted = 1;
-  optional bool reason = 2;
 }
 
 enum DisconnectMode {

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -536,10 +536,6 @@ export interface LockResponse {
      * @generated from protobuf field: bool accepted = 1;
      */
     accepted: boolean;
-    /**
-     * @generated from protobuf field: optional bool reason = 2;
-     */
-    reason?: boolean;
 }
 /**
  * @generated from protobuf message dht.DisconnectNotice
@@ -1119,8 +1115,7 @@ export const UnlockRequest = new UnlockRequest$Type();
 class LockResponse$Type extends MessageType$<LockResponse> {
     constructor() {
         super("dht.LockResponse", [
-            { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 2, name: "reason", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+            { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -536,10 +536,6 @@ export interface LockResponse {
      * @generated from protobuf field: bool accepted = 1;
      */
     accepted: boolean;
-    /**
-     * @generated from protobuf field: optional bool reason = 2;
-     */
-    reason?: boolean;
 }
 /**
  * @generated from protobuf message dht.DisconnectNotice
@@ -1119,8 +1115,7 @@ export const UnlockRequest = new UnlockRequest$Type();
 class LockResponse$Type extends MessageType$<LockResponse> {
     constructor() {
         super("dht.LockResponse", [
-            { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 2, name: "reason", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+            { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }


### PR DESCRIPTION
Removed the `reason` field from `LockResponse` RPC entity. The field was not used, and it also seemed to have incorrect type (`bool` instead of a `string`)