### PR TITLE
fix(DHT): Ensure that Messages are routed to existing connections only

### DIFF
--- a/packages/dht/src/dht/routing/FindRpcRemote.ts
+++ b/packages/dht/src/dht/routing/FindRpcRemote.ts
@@ -19,7 +19,9 @@ export class FindRpcRemote extends Remote<IFindRpcClient> {
             reachableThrough: params.reachableThrough ?? [],
             routingPath: params.routingPath
         }
-        const options = this.formDhtRpcOptions()
+        const options = this.formDhtRpcOptions({
+            doNotConnect: true
+        })
         try {
             const ack = await this.getClient().routeFindRequest(message, options)
             if (ack.error.length > 0) {

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -136,7 +136,7 @@ export class Router implements IRouter {
         logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
             + `to ${getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)}`)
         const session = this.createRoutingSession(routedMessage, mode)
-        const contacts = session.getRoutablePeers()
+        const contacts = session.updateAndGetRoutablePeers()
         if (contacts.length > 0) {
             this.addRoutingSession(session)
             // eslint-disable-next-line promise/catch-or-return

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -136,7 +136,7 @@ export class Router implements IRouter {
         logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
             + `to ${getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)}`)
         const session = this.createRoutingSession(routedMessage, mode)
-        const contacts = session.findMoreContacts()
+        const contacts = session.getRoutablePeers()
         if (contacts.length > 0) {
             this.addRoutingSession(session)
             // eslint-disable-next-line promise/catch-or-return

--- a/packages/dht/src/dht/routing/RouterRpcRemote.ts
+++ b/packages/dht/src/dht/routing/RouterRpcRemote.ts
@@ -22,7 +22,9 @@ export class RouterRpcRemote extends Remote<IRouterRpcClient> {
             reachableThrough: params.reachableThrough ?? [],
             routingPath: params.routingPath
         }
-        const options = this.formDhtRpcOptions()
+        const options = this.formDhtRpcOptions({
+            doNotConnect: true
+        })
         try {
             const ack = await this.getClient().routeMessage(message, options)
             // Success signal if sent to destination and error includes duplicate
@@ -54,7 +56,9 @@ export class RouterRpcRemote extends Remote<IRouterRpcClient> {
             reachableThrough: params.reachableThrough ?? [],
             routingPath: params.routingPath
         }
-        const options = this.formDhtRpcOptions()
+        const options = this.formDhtRpcOptions({
+            doNotConnect: true
+        })
         try {
             const ack = await this.getClient().forwardMessage(message, options)
             if (ack.error.length > 0) {

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -116,7 +116,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         if (this.ongoingRequests.has(peerId.toKey())) {
             this.ongoingRequests.delete(peerId.toKey())
         }
-        const contacts = this.findMoreContacts()
+        const contacts = this.getRoutablePeers()
         if (contacts.length === 0 && this.ongoingRequests.size === 0) {
             logger.trace('routing failed, emitting routingFailed sessionId: ' + this.sessionId)
             // TODO should call this.stop() so that we do cleanup? (after the emitFailure call)
@@ -143,7 +143,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             return
         }
         this.successfulHopCounter += 1
-        const contacts = this.findMoreContacts()
+        const contacts = this.getRoutablePeers()
         if (this.successfulHopCounter >= this.parallelism || contacts.length === 0) {
             // TODO should call this.stop() so that we do cleanup? (after the routingSucceeded call)
             this.stopped = true
@@ -170,8 +170,8 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    findMoreContacts(): RemoteContact[] {
-        logger.trace('findMoreContacts() sessionId: ' + this.sessionId)
+    getRoutablePeers(): RemoteContact[] {
+        logger.trace('getRoutablePeers() sessionId: ' + this.sessionId)
         // Remove stale contacts that may have been removed from connections
         this.contactList.getAllContacts().forEach((contact) => {
             const peerId = peerIdFromPeerDescriptor(contact.getPeerDescriptor())

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -1,7 +1,7 @@
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { SortedContactList } from '../contact/SortedContactList'
 import { PeerID, PeerIDKey } from '../../helpers/PeerID'
-import { getNodeIdFromPeerDescriptor, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 import { v4 } from 'uuid'

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -116,7 +116,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         if (this.ongoingRequests.has(peerId.toKey())) {
             this.ongoingRequests.delete(peerId.toKey())
         }
-        const contacts = this.getRoutablePeers()
+        const contacts = this.updateAndGetRoutablePeers()
         if (contacts.length === 0 && this.ongoingRequests.size === 0) {
             logger.trace('routing failed, emitting routingFailed sessionId: ' + this.sessionId)
             // TODO should call this.stop() so that we do cleanup? (after the emitFailure call)
@@ -143,7 +143,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             return
         }
         this.successfulHopCounter += 1
-        const contacts = this.getRoutablePeers()
+        const contacts = this.updateAndGetRoutablePeers()
         if (this.successfulHopCounter >= this.parallelism || contacts.length === 0) {
             // TODO should call this.stop() so that we do cleanup? (after the routingSucceeded call)
             this.stopped = true
@@ -170,7 +170,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
     }
 
-    getRoutablePeers(): RemoteContact[] {
+    updateAndGetRoutablePeers(): RemoteContact[] {
         logger.trace('getRoutablePeers() sessionId: ' + this.sessionId)
         // Remove stale contacts that may have been removed from connections
         this.contactList.getAllContacts().forEach((contact) => {

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -64,7 +64,7 @@ describe('Route Message With Mock Connections', () => {
         logger.info('simulator stop called')
     }, 10000)
 
-    it.only('Happy path', async () => {
+    it('Happy path', async () => {
         const rpcWrapper = createWrappedClosestPeersRequest(sourceNode.getLocalPeerDescriptor())
         const message: Message = {
             serviceId: 'unknown',

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -64,7 +64,7 @@ describe('Route Message With Mock Connections', () => {
         logger.info('simulator stop called')
     }, 10000)
 
-    it('Happy path', async () => {
+    it.only('Happy path', async () => {
         const rpcWrapper = createWrappedClosestPeersRequest(sourceNode.getLocalPeerDescriptor())
         const message: Message = {
             serviceId: 'unknown',

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -1,0 +1,76 @@
+import { v4 } from 'uuid'
+import { RoutingSession } from '../../src/dht/routing/RoutingSession'
+import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { createWrappedClosestPeersRequest } from '../utils/utils'
+import { hexToBinary } from '@streamr/utils'
+import { PeerIDKey } from '../../src/helpers/PeerID'
+import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
+import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
+import { keyFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+
+describe('RoutingSession', () => {
+
+    let session: RoutingSession
+    let connections: Map<PeerIDKey, DhtNodeRpcRemote>
+    let rpcCommunicator: RoutingRpcCommunicator
+
+    const mockPeerDescriptor1: PeerDescriptor = {
+        kademliaId: hexToBinary('eee1'),
+        type: NodeType.NODEJS
+    }
+
+    const mockPeerDescriptor2 = {
+        kademliaId: hexToBinary('eee2'),
+        type: NodeType.NODEJS
+    }
+
+    const rpcWrapper = createWrappedClosestPeersRequest(mockPeerDescriptor1)
+    const message: Message = {
+        serviceId: 'unknown',
+        messageId: v4(),
+        messageType: MessageType.RPC,
+        body: {
+            oneofKind: 'rpcMessage',
+            rpcMessage: rpcWrapper
+        },
+        sourceDescriptor: mockPeerDescriptor1,
+        targetDescriptor: mockPeerDescriptor2
+    }
+    const routedMessage: RouteMessageWrapper = {
+        message,
+        requestId: 'REQ',
+        routingPath: [],
+        reachableThrough: [],
+        destinationPeer: mockPeerDescriptor1,
+        sourcePeer: mockPeerDescriptor2
+    }
+
+    const createMockDhtNodeRpcRemote = (destination: PeerDescriptor): DhtNodeRpcRemote => {
+        return new DhtNodeRpcRemote(mockPeerDescriptor1, destination, {} as any, 'router')
+    }
+
+    beforeEach(() => {
+        rpcCommunicator = new RoutingRpcCommunicator('mock', async () => {})
+        connections = new Map()
+        session = new RoutingSession(rpcCommunicator, mockPeerDescriptor1, routedMessage, connections, 2)
+    })
+
+    afterEach(() => {
+        rpcCommunicator.stop()
+        session.stop()
+    })
+
+    it('findMoreContacts', () => {
+        connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        const contacts = session.findMoreContacts()
+        expect(contacts.length).toBe(1)
+    })
+
+    it('findMoreContacts peer disconnects', () => {
+        connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        expect(session.findMoreContacts().length).toBe(1)
+        connections.delete(keyFromPeerDescriptor(mockPeerDescriptor2))
+        expect(session.findMoreContacts().length).toBe(0)
+    })
+
+})

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -62,15 +62,15 @@ describe('RoutingSession', () => {
 
     it('findMoreContacts', () => {
         connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
-        const contacts = session.findMoreContacts()
+        const contacts = session.getRoutablePeers()
         expect(contacts.length).toBe(1)
     })
 
     it('findMoreContacts peer disconnects', () => {
         connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
-        expect(session.findMoreContacts().length).toBe(1)
+        expect(session.getRoutablePeers().length).toBe(1)
         connections.delete(keyFromPeerDescriptor(mockPeerDescriptor2))
-        expect(session.findMoreContacts().length).toBe(0)
+        expect(session.getRoutablePeers().length).toBe(0)
     })
 
 })

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -62,15 +62,15 @@ describe('RoutingSession', () => {
 
     it('findMoreContacts', () => {
         connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
-        const contacts = session.getRoutablePeers()
+        const contacts = session.updateAndGetRoutablePeers()
         expect(contacts.length).toBe(1)
     })
 
     it('findMoreContacts peer disconnects', () => {
         connections.set(keyFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
-        expect(session.getRoutablePeers().length).toBe(1)
+        expect(session.updateAndGetRoutablePeers().length).toBe(1)
         connections.delete(keyFromPeerDescriptor(mockPeerDescriptor2))
-        expect(session.getRoutablePeers().length).toBe(0)
+        expect(session.updateAndGetRoutablePeers().length).toBe(0)
     })
 
 })


### PR DESCRIPTION
## Summary

The goal of the routing is to not open any connections for routing. Instead the message is passed over existing connections for faster propagation. This change ensures that new connections are not opened for the routing paths

Added improvements to the routing to ensure that routed messages are sent through existing connections.
Routed messages are passed through network faster as nodes will no longer attempt to open new connections in corner cases. Also if a routing node has left the network it is no longer possible to attempt to connect to it for routing. Instead the request fails fast with the doNotConnect flag and the message is then routed to another node.

## Changes
 
- Routing related RemoteRpc classes now use the doNotConnect flag
- RoutingSession removes unconnected nodes from the contactList

