### PR TITLE
fix(dht, trackerless-network): Fix some TypeScript `eslint` warnings

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -141,6 +141,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             addRemoteLocked: (id: PeerIDKey, serviceId: string) => this.locks.addRemoteLocked(id, serviceId),
             removeRemoteLocked: (id: PeerIDKey, serviceId: string) => this.locks.removeRemoteLocked(id, serviceId),
             closeConnection: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean, reason?: string) => {
+                // TODO should we have some handling for this floating promise?
                 this.closeConnection(peerDescriptor, gracefulLeave, reason)
             },
             getLocalPeerDescriptor: () => this.getLocalPeerDescriptor()
@@ -213,6 +214,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             } else {
                 logger.trace('handshake of connection not completed, force-closing')
                 const eventReceived = waitForEvent3<ManagedConnectionEvents>(peer, 'disconnected', 2000)
+                // TODO should we have some handling for this floating promise?
                 peer.close(true)
                 try {
                     await eventReceived
@@ -522,6 +524,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             })
                 .catch((e) => {
                     logger.trace('force-closing connection after timeout ' + e)
+                    // TODO should we have some handling for this floating promise?
                     connection.close(true)
                 })
                 .finally(() => {

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -385,7 +385,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 + ' onDisconnected() did nothing, no such connection in connectionManager')
             if (storedConnection) {
                 logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor())
-                + ' connectionIds do not match ' + storedConnection.connectionId + ' ' + connection.connectionId)
+                + ' connectionIds do not match ' + storedConnection.connectionId.toString() + ' ' + connection.connectionId.toString())
             }
         }
 

--- a/packages/dht/src/connection/ConnectivityChecker.ts
+++ b/packages/dht/src/connection/ConnectivityChecker.ts
@@ -77,10 +77,12 @@ export class ConnectivityChecker {
         const responseAwaiter = () => {
             return new Promise((resolve: (res: ConnectivityResponse) => void, reject) => {
                 const timeoutId = setTimeout(() => {
+                    // TODO should we have some handling for this floating promise?
                     outgoingConnection.close(false)
                     reject(new Err.ConnectivityResponseTimeout('timeout'))
                 }, ConnectivityChecker.CONNECTIVITY_CHECKER_TIMEOUT)
                 const listener = (bytes: Uint8Array) => {
+                    // TODO should we have some handling for this floating promise?
                     outgoingConnection.close(false)
                     try {
                         const message: Message = Message.fromBinary(bytes)

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -64,7 +64,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
     ): Promise<void> {
         logger.trace(`Creating WebsocketConnectorRpcLocal`)
         const webSocketConnectorConfig = {
-            transport: this.config.transport!,
+            transport: this.config.transport,
             // TODO should we use canConnect also for WebrtcConnector? (NET-1142)
             canConnect: (peerDescriptor: PeerDescriptor) => canConnect(peerDescriptor),
             onNewConnection,
@@ -81,7 +81,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         this.websocketConnector = new WebsocketConnector(webSocketConnectorConfig)
         logger.trace(`Creating WebRtcConnectorRpcLocal`)
         this.webrtcConnector = new WebrtcConnector({
-            transport: this.config.transport!,
+            transport: this.config.transport,
             iceServers: this.config.iceServers,
             allowPrivateAddresses: this.config.webrtcAllowPrivateAddresses,
             bufferThresholdLow: this.config.webrtcDatachannelBufferThresholdLow,
@@ -102,8 +102,8 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         this.setLocalPeerDescriptor(localPeerDescriptor)
         if (localPeerDescriptor.websocket && !this.config.tlsCertificate && this.config.websocketServerEnableTls) {
             try {
-                await this.websocketConnector!.autoCertify()
-                const connectivityResponse = await this.websocketConnector!.checkConnectivity(false)
+                await this.websocketConnector.autoCertify()
+                const connectivityResponse = await this.websocketConnector.checkConnectivity(false)
                 const autocertifiedLocalPeerDescriptor = this.config.createLocalPeerDescriptor(connectivityResponse)
                 if (autocertifiedLocalPeerDescriptor.websocket !== undefined) {
                     this.setLocalPeerDescriptor(autocertifiedLocalPeerDescriptor)

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -85,6 +85,7 @@ export class ManagedConnection extends EventEmitter<Events> {
 
             this.handshaker.once('handshakeFailed', (error) => {
                 if (error === HandshakeError.INVALID_TARGET_PEER_DESCRIPTOR) {
+                    // TODO should we have some handling for this floating promise?
                     this.close(false)
                 } else {
                     logger.trace(getNodeIdOrUnknownFromPeerDescriptor(this.remotePeerDescriptor) + ' handshakeFailed: ' + error)

--- a/packages/dht/src/connection/connectivityRequestHandler.ts
+++ b/packages/dht/src/connection/connectivityRequestHandler.ts
@@ -56,6 +56,7 @@ const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, co
         }
     }
     if (outgoingConnection) {
+        // TODO should we have some handling for this floating promise?
         outgoingConnection.close(false)
         logger.trace('Connectivity test produced positive result, communicating reply to the requester ' + host + ':' + connectivityRequest.port)
         connectivityResponseMessage = {

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -313,6 +313,7 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
         this.simulatorTimeout = setTimeout(this.executeQueuedOperations, timeDifference)
        
         if (Simulator.clock) {
+            // TODO should we have some handling for this floating promise?
             Simulator.clock.runAllAsync()
         }
     }

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -259,6 +259,7 @@ export class WebsocketConnector {
                 targetPeerDescriptor,
                 toProtoRpcClient(new WebsocketConnectorRpcClient(this.rpcCommunicator.getRpcClientTransport()))
             )
+            // TODO should we have some handling for this floating promise?
             remoteConnector.requestConnection(localPeerDescriptor.websocket!.host, localPeerDescriptor.websocket!.port)
         })
         const managedConnection = new ManagedConnection(

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -79,7 +79,7 @@ export class WebsocketConnector {
 
     constructor(config: WebsocketConnectorConfig) {
         this.websocketServer = config.portRange ? new WebsocketServer({
-            portRange: config.portRange!,
+            portRange: config.portRange,
             tlsCertificate: config.tlsCertificate,
             maxMessageSize: config.maxMessageSize,
             enableTls: config.serverEnableTls
@@ -136,7 +136,7 @@ export class WebsocketConnector {
             updateCertificate: (certificate: string, privateKey: string) => this.websocketServer!.updateCertificate(certificate, privateKey)
         })
         logger.trace(`AutoCertifying subdomain...`)
-        await this.autoCertifierClient!.start()
+        await this.autoCertifierClient.start()
     }
 
     private setHost(hostName: string): void {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -492,6 +492,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             && this.config.entryPoints.length > 0
         ) {
             setImmediate(async () => {
+                // TODO should we catch possible promise rejection?
                 await Promise.all(this.config.entryPoints!.map((entryPoint) => 
                     this.peerDiscovery!.rejoinDht(entryPoint)
                 )) 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -609,7 +609,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             return
         }
         const reachableThrough = this.peerDiscovery!.isJoinOngoing() ? this.config.entryPoints ?? [] : []
-        await this.router!.send(msg, reachableThrough)
+        this.router!.send(msg, reachableThrough)
     }
 
     public async joinDht(entryPointDescriptors: PeerDescriptor[], doAdditionalRandomPeerDiscovery?: boolean, retry?: boolean): Promise<void> {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -95,6 +95,7 @@ export class PeerDiscovery {
             if (!this.isStopped()) {
                 if (this.config.bucket.count() === 0) {
                     if (retry) {
+                        // TODO should we catch possible promise rejection?
                         setAbortableTimeout(() => this.rejoinDht(entryPointDescriptor), 1000, this.abortController.signal)
                     }
                 } else {
@@ -118,6 +119,7 @@ export class PeerDiscovery {
         } catch (err) {
             logger.warn(`Rejoining DHT ${this.config.serviceId} failed`)
             if (!this.isStopped()) {
+                // TODO should we catch possible promise rejection?
                 setAbortableTimeout(() => this.rejoinDht(entryPoint), 5000, this.abortController.signal)
             }
         } finally {

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -34,7 +34,7 @@ interface ForwardingTableEntry {
 
 export interface IRouter {
     doRouteMessage(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RouteMessageAck
-    send(msg: Message, reachableThrough: PeerDescriptor[]): Promise<void>
+    send(msg: Message, reachableThrough: PeerDescriptor[]): void
     isMostLikelyDuplicate(requestId: string): boolean
     addToDuplicateDetector(requestId: string): void
     addRoutingSession(session: RoutingSession): void
@@ -96,7 +96,7 @@ export class Router implements IRouter {
 
     }
 
-    public async send(msg: Message, reachableThrough: PeerDescriptor[]): Promise<void> {
+    public send(msg: Message, reachableThrough: PeerDescriptor[]): void {
         msg.sourceDescriptor = this.localPeerDescriptor
         const targetPeerDescriptor = msg.targetDescriptor!
         const forwardingEntry = this.forwardingTable.get(keyFromPeerDescriptor(targetPeerDescriptor))

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -137,6 +137,7 @@ export class Router implements IRouter {
             // eslint-disable-next-line promise/catch-or-return
             logger.trace('starting to raceEvents from routingSession: ' + session.sessionId)
             let eventReceived: Promise<unknown>
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             executeSafePromise(async () => {
                 eventReceived = raceEvents3<RoutingSessionEvents>(
                     session,

--- a/packages/dht/src/dht/routing/getPreviousPeer.ts
+++ b/packages/dht/src/dht/routing/getPreviousPeer.ts
@@ -2,5 +2,5 @@ import { last } from 'lodash'
 import { PeerDescriptor, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
 
 export const getPreviousPeer = (routeMessage: RouteMessageWrapper): PeerDescriptor | undefined => {
-    return last(routeMessage.routingPath!)
+    return last(routeMessage.routingPath)
 }

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -54,6 +54,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
         if (message.serviceId == this.ownServiceId && message.body.oneofKind === 'rpcMessage') {
             const context = new DhtCallContext()
             context.incomingSourceDescriptor = message.sourceDescriptor
+            // TODO should we have some handling for this floating promise?
             this.handleIncomingMessage(message.body.rpcMessage, context)
         }
     }

--- a/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
@@ -128,6 +128,7 @@ export class EntryPointDiscovery {
             await this.keepSelfAsEntryPoint()
         }
         if (possibleNetworkSplitDetected) {
+            // TODO should we catch possible promise rejection?
             setImmediate(() => this.avoidNetworkSplit())
         }
     }

--- a/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
@@ -161,10 +161,10 @@ export class EntryPointDiscovery {
         await exponentialRunOff(async () => {
             const rediscoveredEntrypoints = await this.discoverEntryPoints()
             await this.config.layer1Node.joinDht(rediscoveredEntrypoints, false, false)
-            if (this.config.layer1Node!.getBucketSize() < NETWORK_SPLIT_AVOIDANCE_LIMIT) {
+            if (this.config.layer1Node.getBucketSize() < NETWORK_SPLIT_AVOIDANCE_LIMIT) {
                 // Filter out nodes that are not in the k-bucket, assumed to be offline
                 const nodesToAvoid = rediscoveredEntrypoints
-                    .filter((peer) => !this.config.layer1Node!.getKBucketPeers().includes(peer))
+                    .filter((peer) => !this.config.layer1Node.getKBucketPeers().includes(peer))
                     .map((peer) => getNodeIdFromPeerDescriptor(peer))
                 nodesToAvoid.forEach((node) => this.networkSplitAvoidedNodes.add(node))
                 throw new Error(`Network split is still possible`)

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -305,7 +305,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
     private getPropagationTargets(msg: StreamMessage): NodeID[] {
         let propagationTargets = this.config.targetNeighbors.getIds()
         if (this.config.proxyConnectionRpcLocal) {
-            propagationTargets = propagationTargets.concat(this.config.proxyConnectionRpcLocal!.getPropagationTargets(msg))
+            propagationTargets = propagationTargets.concat(this.config.proxyConnectionRpcLocal.getPropagationTargets(msg))
         }
         propagationTargets = propagationTargets.filter((target) => !this.config.inspector.isInspected(target ))
         propagationTargets = propagationTargets.concat(this.config.temporaryConnectionRpcLocal.getNodes().getIds())

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -314,6 +314,7 @@ export class StreamrNode extends EventEmitter<Events> {
 
 [`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `unhandledRejection`, `SIGTERM`].forEach((term) => {
     process.on(term, async () => {
+        // TODO should we catch possible promise rejection?
         await cleanUp()
         process.exit()
     })

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
@@ -34,6 +34,7 @@ export class NeighborFinder implements INeighborFinder {
         }
         const newExcludes = await this.config.doFindNeighbors(excluded)
         if (this.config.targetNeighbors.size() < this.config.minCount && newExcludes.length < this.config.nearbyNodeView.size()) {
+            // TODO should we catch possible promise rejection?
             setAbortableTimeout(() => this.findNeighbors(newExcludes), INTERVAL, this.abortController.signal)
         } else {
             this.running = false
@@ -49,6 +50,7 @@ export class NeighborFinder implements INeighborFinder {
             return
         }
         this.running = true
+        // TODO should we catch possible promise rejection?
         setAbortableTimeout(() => this.findNeighbors(excluded), INITIAL_WAIT, this.abortController.signal)
     }
 

--- a/packages/trackerless-network/src/logic/propagation/Propagation.ts
+++ b/packages/trackerless-network/src/logic/propagation/Propagation.ts
@@ -65,6 +65,7 @@ export class Propagation {
 
     private sendAndAwaitThenMark({ message, source, handledNeighbors }: PropagationTask, neighborId: NodeID): void {
         if (!handledNeighbors.has(neighborId) && neighborId !== source) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             (async () => {
                 try {
                     await this.sendToNeighbor(neighborId, message)

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -86,6 +86,7 @@ export class ProxyClient extends EventEmitter {
             onLeaveNotice: (senderId: NodeID) => {
                 const contact = this.targetNeighbors.get(senderId)
                 if (contact) {
+                    // TODO should we catch possible promise rejection?
                     setImmediate(() => this.onNodeDisconnected(contact.getPeerDescriptor()))
                 }
             },
@@ -243,6 +244,7 @@ export class ProxyClient extends EventEmitter {
         addManagedEventListener<any, any>(
             this.config.transport as any,
             'disconnected',
+            // TODO should we catch possible promise rejection?
             (peerDescriptor: PeerDescriptor) => this.onNodeDisconnected(peerDescriptor),
             this.abortController.signal
         )

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -123,7 +123,7 @@ export class ProxyClient extends EventEmitter {
         if (connectionCount !== undefined && connectionCount > nodes.length) {
             throw Error('Cannot set connectionCount above the size of the configured array of nodes')
         }
-        const nodesIds = new Map()
+        const nodesIds = new Map<NodeID, PeerDescriptor>()
         nodes.forEach((peerDescriptor) => {
             nodesIds.set(getNodeIdFromPeerDescriptor(peerDescriptor), peerDescriptor)
         })


### PR DESCRIPTION
Needs https://github.com/streamr-dev/network/pull/2107 so that Broker tests pass?

Fixed or annotated with TODO comments these `eslint` warnings:
- `@typescript-eslint/require-await`
- `@typescript-eslint/no-unnecessary-type-assertion`
- `@typescript-eslint/no-floating-promises`
- `@typescript-eslint/no-unsafe-assignment`
- `@typescript-eslint/restrict-plus-operands`
- `@typescript-eslint/no-misused-promises`

These warnings were found with TypeScript eslint

## Future improvements

- Currently our `eslint` doesn't use TypeScript, and therefore these rules aren't used when we run `npm run eslint.` We should enable most of these rules when we add TypeScript support to our eslint setup (see https://github.com/streamr-dev/network/pull/1171).