### PR TITLE
chore(utils): make executeSafePromise exit on error

### DIFF
--- a/packages/utils/src/executeSafePromise.ts
+++ b/packages/utils/src/executeSafePromise.ts
@@ -10,8 +10,13 @@ const logger = new Logger(module)
 export const executeSafePromise = async <T>(createPromise: () => Promise<T>): Promise<T> => {
     try {
         return await createPromise()
-    } catch (error: any) {
-        logger.fatal('Assertion failure!', { message: error?.message, stack: error?.stack })
-        process.exit(1)
+    } catch (err: any) {
+        logger.fatal('Assertion failure!', { message: err?.message, err })
+        if (process.exit !== undefined) {
+            process.exit(1)
+        } else {
+            // cause an unhandled promise rejection on purpose
+            throw new Error('executeSafePromise: Assertion failure!', err)
+        }
     }
 }

--- a/packages/utils/src/executeSafePromise.ts
+++ b/packages/utils/src/executeSafePromise.ts
@@ -2,11 +2,16 @@ import { Logger } from './Logger'
 
 const logger = new Logger(module)
 
+/**
+ * Execute a promise that should never reject. If it does, log the error and exit the process.
+ * To be used in places where we want to "annotate" that the intention of a promise is never
+ * to reject (unless something is really wrong).
+ */
 export const executeSafePromise = async <T>(createPromise: () => Promise<T>): Promise<T> => {
     try {
         return await createPromise()
     } catch (error: any) {
-        logger.error('Assertion failure!', { message: error?.message, stack: error?.stack })
-        return new Promise(() => {}) as any  // never resolves
+        logger.fatal('Assertion failure!', { message: error?.message, stack: error?.stack })
+        process.exit(1)
     }
 }


### PR DESCRIPTION
## Summary

Make utility function `executeSafePromise` invoke process.exit on rejection when in Node.js. When in browser cause an unhandled promise rejection. Also change log level to `fatal`.


## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
