### PR TITLE
fix(DHT): Fix external store storer PeerDescriptor

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -60,8 +60,9 @@ service ExternalApiRpc {
 message StoreDataRequest {
   bytes kademliaId = 1;
   google.protobuf.Any data = 2;
-  uint32 ttl = 3;
+  PeerDescriptor storer = 3;
   google.protobuf.Timestamp storerTime = 4;
+  uint32 ttl = 5;
 }
 
 message StoreDataResponse {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -423,7 +423,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             startFind: (idToFind: Uint8Array, fetchData: boolean, excludedPeer: PeerDescriptor) => {
                 return this.startFind(idToFind, fetchData, excludedPeer)
             },
-            storeDataToDht: (key: Uint8Array, data: Any) => this.storeDataToDht(key, data)
+            storeDataToDht: (key: Uint8Array, data: Any, externalStorer?: PeerDescriptor) => this.storeDataToDht(key, data, externalStorer)
         })
         this.rpcCommunicator!.registerRpcMethod(
             ExternalFindDataRequest,
@@ -436,7 +436,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ExternalStoreDataRequest,
             ExternalStoreDataResponse,
             'externalStoreData',
-            (req: ExternalStoreDataRequest) => externalApiRpcLocal.externalStoreData(req),
+            (req: ExternalStoreDataRequest, context: ServerCallContext) => externalApiRpcLocal.externalStoreData(req, context),
             { timeout: 10000 }
         )
     }
@@ -626,11 +626,11 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.finder!.startFind(idToFind, fetchData, excludedPeer)
     }
 
-    public async storeDataToDht(key: Uint8Array, data: Any): Promise<PeerDescriptor[]> {
+    public async storeDataToDht(key: Uint8Array, data: Any, externalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
         if (this.peerDiscovery!.isJoinOngoing() && this.config.entryPoints && this.config.entryPoints.length > 0) {
             return this.storeDataViaPeer(key, data, sample(this.config.entryPoints)!)
         }
-        return this.storeRpcLocal!.storeDataToDht(key, data)
+        return this.storeRpcLocal!.storeDataToDht(key, data, externalStorer)
     }
 
     public async storeDataViaPeer(key: Uint8Array, data: Any, peer: PeerDescriptor): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -423,7 +423,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             startFind: (idToFind: Uint8Array, fetchData: boolean, excludedPeer: PeerDescriptor) => {
                 return this.startFind(idToFind, fetchData, excludedPeer)
             },
-            storeDataToDht: (key: Uint8Array, data: Any, externalStorer?: PeerDescriptor) => this.storeDataToDht(key, data, externalStorer)
+            storeDataToDht: (key: Uint8Array, data: Any, originalStorer?: PeerDescriptor) => this.storeDataToDht(key, data, originalStorer)
         })
         this.rpcCommunicator!.registerRpcMethod(
             ExternalFindDataRequest,
@@ -626,11 +626,11 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.finder!.startFind(idToFind, fetchData, excludedPeer)
     }
 
-    public async storeDataToDht(key: Uint8Array, data: Any, externalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
+    public async storeDataToDht(key: Uint8Array, data: Any, originalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
         if (this.peerDiscovery!.isJoinOngoing() && this.config.entryPoints && this.config.entryPoints.length > 0) {
             return this.storeDataViaPeer(key, data, sample(this.config.entryPoints)!)
         }
-        return this.storeRpcLocal!.storeDataToDht(key, data, externalStorer)
+        return this.storeRpcLocal!.storeDataToDht(key, data, originalStorer)
     }
 
     public async storeDataViaPeer(key: Uint8Array, data: Any, peer: PeerDescriptor): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -630,7 +630,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.peerDiscovery!.isJoinOngoing() && this.config.entryPoints && this.config.entryPoints.length > 0) {
             return this.storeDataViaPeer(key, data, sample(this.config.entryPoints)!)
         }
-        return this.storeRpcLocal!.storeDataToDht(key, data, originalStorer)
+        return this.storeRpcLocal!.storeDataToDht(key, data, originalStorer ?? this.localPeerDescriptor!)
     }
 
     public async storeDataViaPeer(key: Uint8Array, data: Any, peer: PeerDescriptor): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/ExternalApiRpcLocal.ts
+++ b/packages/dht/src/dht/ExternalApiRpcLocal.ts
@@ -13,7 +13,7 @@ import { Any } from '../proto/google/protobuf/any'
 
 interface ExternalApiRpcLocalConfig {
     startFind: (idToFind: Uint8Array, fetchData: boolean, excludedPeer: PeerDescriptor) => Promise<FindResult>
-    storeDataToDht: (key: Uint8Array, data: Any, originalStorer?: PeerDescriptor) => Promise<PeerDescriptor[]>
+    storeDataToDht: (key: Uint8Array, data: Any, storer: PeerDescriptor) => Promise<PeerDescriptor[]>
 }
 
 export class ExternalApiRpcLocal implements IExternalApiRpc {

--- a/packages/dht/src/dht/ExternalApiRpcLocal.ts
+++ b/packages/dht/src/dht/ExternalApiRpcLocal.ts
@@ -13,7 +13,7 @@ import { Any } from '../proto/google/protobuf/any'
 
 interface ExternalApiRpcLocalConfig {
     startFind: (idToFind: Uint8Array, fetchData: boolean, excludedPeer: PeerDescriptor) => Promise<FindResult>
-    storeDataToDht: (key: Uint8Array, data: Any, externalStorer?: PeerDescriptor) => Promise<PeerDescriptor[]>
+    storeDataToDht: (key: Uint8Array, data: Any, originalStorer?: PeerDescriptor) => Promise<PeerDescriptor[]>
 }
 
 export class ExternalApiRpcLocal implements IExternalApiRpc {

--- a/packages/dht/src/dht/ExternalApiRpcLocal.ts
+++ b/packages/dht/src/dht/ExternalApiRpcLocal.ts
@@ -13,7 +13,7 @@ import { Any } from '../proto/google/protobuf/any'
 
 interface ExternalApiRpcLocalConfig {
     startFind: (idToFind: Uint8Array, fetchData: boolean, excludedPeer: PeerDescriptor) => Promise<FindResult>
-    storeDataToDht: (key: Uint8Array, data: Any) => Promise<PeerDescriptor[]>
+    storeDataToDht: (key: Uint8Array, data: Any, externalStorer?: PeerDescriptor) => Promise<PeerDescriptor[]>
 }
 
 export class ExternalApiRpcLocal implements IExternalApiRpc {
@@ -30,8 +30,9 @@ export class ExternalApiRpcLocal implements IExternalApiRpc {
         return ExternalFindDataResponse.create({ entries: result.dataEntries ?? [] })
     }
 
-    async externalStoreData(request: ExternalStoreDataRequest): Promise<ExternalStoreDataResponse> {
-        const result = await this.config.storeDataToDht(request.key, request.data!)
+    async externalStoreData(request: ExternalStoreDataRequest, context: ServerCallContext): Promise<ExternalStoreDataResponse> {
+        const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
+        const result = await this.config.storeDataToDht(request.key, request.data!, senderPeerDescriptor)
         return ExternalStoreDataResponse.create({
             storers: result
         })

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -150,7 +150,7 @@ export class StoreRpcLocal implements IStoreRpc {
         }
     }
 
-    public async storeDataToDht(key: Uint8Array, data: Any, externalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
+    public async storeDataToDht(key: Uint8Array, data: Any, originalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
         logger.debug(`Storing data to DHT ${this.serviceId}`)
         const result = await this.finder.startFind(key)
         const closestNodes = result.closestNodes
@@ -161,7 +161,7 @@ export class StoreRpcLocal implements IStoreRpc {
             if (areEqualPeerDescriptors(this.localPeerDescriptor, closestNodes[i])) {
                 this.localDataStore.storeEntry({
                     kademliaId: key, 
-                    storer: externalStorer ?? this.localPeerDescriptor,
+                    storer: originalStorer ?? this.localPeerDescriptor,
                     ttl, 
                     storedAt: Timestamp.now(), 
                     data,

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -150,7 +150,7 @@ export class StoreRpcLocal implements IStoreRpc {
         }
     }
 
-    public async storeDataToDht(key: Uint8Array, data: Any): Promise<PeerDescriptor[]> {
+    public async storeDataToDht(key: Uint8Array, data: Any, externalStorer?: PeerDescriptor): Promise<PeerDescriptor[]> {
         logger.debug(`Storing data to DHT ${this.serviceId}`)
         const result = await this.finder.startFind(key)
         const closestNodes = result.closestNodes
@@ -161,7 +161,7 @@ export class StoreRpcLocal implements IStoreRpc {
             if (areEqualPeerDescriptors(this.localPeerDescriptor, closestNodes[i])) {
                 this.localDataStore.storeEntry({
                     kademliaId: key, 
-                    storer: this.localPeerDescriptor,
+                    storer: externalStorer ?? this.localPeerDescriptor,
                     ttl, 
                     storedAt: Timestamp.now(), 
                     data,

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -22,13 +22,17 @@ export interface StoreDataRequest {
      */
     data?: Any;
     /**
-     * @generated from protobuf field: uint32 ttl = 3;
+     * @generated from protobuf field: dht.PeerDescriptor storer = 3;
      */
-    ttl: number;
+    storer?: PeerDescriptor;
     /**
      * @generated from protobuf field: google.protobuf.Timestamp storerTime = 4;
      */
     storerTime?: Timestamp;
+    /**
+     * @generated from protobuf field: uint32 ttl = 5;
+     */
+    ttl: number;
 }
 /**
  * @generated from protobuf message dht.StoreDataResponse
@@ -681,8 +685,9 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
         super("dht.StoreDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "data", kind: "message", T: () => Any },
-            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp }
+            { no: 3, name: "storer", kind: "message", T: () => PeerDescriptor },
+            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp },
+            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
 }

--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -1,6 +1,6 @@
 import { DhtNode } from '../../src/dht/DhtNode'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
-import { createMockConnectionDhtNode } from '../utils/utils'
+import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { PeerID } from '../../src/helpers/PeerID'
@@ -42,12 +42,13 @@ describe('DhtNodeExternalApi', () => {
     })
 
     it('external store data happy path', async () => {
-        const data = Any.pack(remote.getLocalPeerDescriptor(), PeerDescriptor)
+        const storedPeerDescriptor = createMockPeerDescriptor()
+        const data = Any.pack(storedPeerDescriptor, PeerDescriptor)
         const key = PeerID.fromString('key').value 
 
         await remote.storeDataViaPeer(key, data, dhtNode1.getLocalPeerDescriptor())
         const foundData = await remote.findDataViaPeer(key, dhtNode1.getLocalPeerDescriptor())
-        expect(Any.unpack(foundData[0].data!, PeerDescriptor)).toEqual(remote.getLocalPeerDescriptor())
+        expect(areEqualPeerDescriptors(Any.unpack(foundData[0].data!, PeerDescriptor), storedPeerDescriptor)).toEqual(true)
         expect(areEqualPeerDescriptors(foundData[0].storer!, remote.getLocalPeerDescriptor())).toEqual(true)
     })
   

--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -4,6 +4,7 @@ import { createMockConnectionDhtNode } from '../utils/utils'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { PeerID } from '../../src/helpers/PeerID'
+import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
 
 describe('DhtNodeExternalApi', () => {
 
@@ -41,12 +42,14 @@ describe('DhtNodeExternalApi', () => {
     })
 
     it('external store data happy path', async () => {
-        const data = Any.pack(dhtNode1.getLocalPeerDescriptor(), PeerDescriptor)
+        const data = Any.pack(remote.getLocalPeerDescriptor(), PeerDescriptor)
         const key = PeerID.fromString('key').value 
 
         await remote.storeDataViaPeer(key, data, dhtNode1.getLocalPeerDescriptor())
         const foundData = await remote.findDataViaPeer(key, dhtNode1.getLocalPeerDescriptor())
-        expect(Any.unpack(foundData[0].data!, PeerDescriptor)).toEqual(dhtNode1.getLocalPeerDescriptor())
+        console.log(foundData[0].storer!.kademliaId, Any.unpack(foundData[0].data!, PeerDescriptor).kademliaId)
+        expect(Any.unpack(foundData[0].data!, PeerDescriptor)).toEqual(remote.getLocalPeerDescriptor())
+        expect(areEqualPeerDescriptors(foundData[0].storer!, remote.getLocalPeerDescriptor())).toEqual(true)
     })
   
 })

--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -47,7 +47,6 @@ describe('DhtNodeExternalApi', () => {
 
         await remote.storeDataViaPeer(key, data, dhtNode1.getLocalPeerDescriptor())
         const foundData = await remote.findDataViaPeer(key, dhtNode1.getLocalPeerDescriptor())
-        console.log(foundData[0].storer!.kademliaId, Any.unpack(foundData[0].data!, PeerDescriptor).kademliaId)
         expect(Any.unpack(foundData[0].data!, PeerDescriptor)).toEqual(remote.getLocalPeerDescriptor())
         expect(areEqualPeerDescriptors(foundData[0].storer!, remote.getLocalPeerDescriptor())).toEqual(true)
     })

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -1,7 +1,7 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
+import { createMockConnectionDhtNode, createMockPeerDescriptor, waitConnectionManagersReadyForTesting } from '../utils/utils'
 import { PeerID } from '../../src/helpers/PeerID'
 import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { Any } from '../../src/proto/google/protobuf/any'
@@ -47,7 +47,8 @@ describe('Storing data in DHT', () => {
     it('Storing data works', async () => {
         const storingNodeIndex = 34
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
         const successfulStorers = await nodes[storingNodeIndex].storeDataToDht(dataKey.value, data)
         expect(successfulStorers.length).toBeGreaterThan(4)
     }, 90000)
@@ -55,15 +56,16 @@ describe('Storing data in DHT', () => {
     it('Storing and getting data works', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
         const successfulStorers = await storingNode.storeDataToDht(dataKey.value, data)
         expect(successfulStorers.length).toBeGreaterThan(4)
 
         const fetchingNode = getRandomNode()
         const results = await fetchingNode.getDataFromDht(dataKey.value)
         results.forEach((entry) => {
-            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
-            expect(areEqualPeerDescriptors(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+            const foundData = Any.unpack(entry.data!, PeerDescriptor)
+            expect(areEqualPeerDescriptors(foundData, storedData)).toBeTrue()
         })
     }, 90000)
 })

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -68,4 +68,22 @@ describe('Storing data in DHT', () => {
             expect(areEqualPeerDescriptors(foundData, storedData)).toBeTrue()
         })
     }, 90000)
+
+    it('storing with explicit storer PeerDescriptor', async () => {
+        const storingNode = getRandomNode()
+        const dataKey = PeerID.fromString('3232323e12r31r3')
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
+        const requestor = createMockPeerDescriptor()
+        const successfulStorers = await storingNode.storeDataToDht(dataKey.value, data, requestor)
+        expect(successfulStorers.length).toBeGreaterThan(4)
+
+        const fetchingNode = getRandomNode()
+        const results = await fetchingNode.getDataFromDht(dataKey.value)
+        results.forEach((entry) => {
+            const foundData = Any.unpack(entry.data!, PeerDescriptor)
+            expect(areEqualPeerDescriptors(foundData, storedData)).toBeTrue()
+            expect(areEqualPeerDescriptors(entry.storer!, requestor)).toBeTrue()
+        })
+    })
 })

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -1,7 +1,7 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
+import { createMockConnectionDhtNode, createMockPeerDescriptor, waitConnectionManagersReadyForTesting } from '../utils/utils'
 import { PeerID } from '../../src/helpers/PeerID'
 import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { Any } from '../../src/proto/google/protobuf/any'
@@ -47,7 +47,8 @@ describe('Storing data in DHT', () => {
     it('Data can be deleted', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
         const successfulStorers = await storingNode.storeDataToDht(dataKey.value, data)
         expect(successfulStorers.length).toBeGreaterThan(4)
         await storingNode.deleteDataFromDht(dataKey.value)
@@ -57,14 +58,15 @@ describe('Storing data in DHT', () => {
         results.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(entry.deleted).toBeTrue()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
         })
     }, 90000)
 
     it('Data can be deleted and re-stored', async () => {
         const storingNode = getRandomNode()
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
         const successfulStorers1 = await storingNode.storeDataToDht(dataKey.value, data)
         expect(successfulStorers1.length).toBeGreaterThan(4)
         await storingNode.deleteDataFromDht(dataKey.value)
@@ -74,7 +76,7 @@ describe('Storing data in DHT', () => {
         results1.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(entry.deleted).toBeTrue()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
         })
 
         const successfulStorers2 = await storingNode.storeDataToDht(dataKey.value, data)
@@ -84,7 +86,7 @@ describe('Storing data in DHT', () => {
         results2.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(entry.deleted).toBeFalse()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, entrypointDescriptor)).toBeTrue()
+            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
         })
     }, 90000)
 })

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -1,4 +1,4 @@
-import { createMockConnectionDhtNode } from '../utils/utils'
+import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { PeerID } from '../../src/helpers/PeerID'
@@ -41,10 +41,12 @@ describe('Storing data in DHT with two peers', () => {
     })
 
     it('Node can store on two peer DHT', async () => {
+        const storedData1 = createMockPeerDescriptor()
+        const storedData2 = createMockPeerDescriptor()
         const dataKey1 = PeerID.fromString('node0-stored-data')
-        const data1 = Any.pack(otherNode.getLocalPeerDescriptor(), PeerDescriptor)
         const dataKey2 = PeerID.fromString('other-node-stored-data')
-        const data2 = Any.pack(entryPoint.getLocalPeerDescriptor(), PeerDescriptor)
+        const data1 = Any.pack(storedData1, PeerDescriptor)
+        const data2 = Any.pack(storedData2, PeerDescriptor)
 
         const successfulStorers1 = await otherNode.storeDataToDht(dataKey1.value, data1)
         const successfulStorers2 = await entryPoint.storeDataToDht(dataKey2.value, data2)
@@ -53,19 +55,20 @@ describe('Storing data in DHT with two peers', () => {
 
         const foundData1 = await otherNode.getDataFromDht(dataKey1.value)
         const foundData2 = await entryPoint.getDataFromDht(dataKey2.value)
-        expect(areEqualPeerDescriptors(otherNode.getLocalPeerDescriptor(), Any.unpack(foundData1[0]!.data!, PeerDescriptor))).toBeTrue()
-        expect(areEqualPeerDescriptors(entryPoint.getLocalPeerDescriptor(), Any.unpack(foundData2[0]!.data!, PeerDescriptor))).toBeTrue()
+        expect(areEqualPeerDescriptors(storedData1, Any.unpack(foundData1[0]!.data!, PeerDescriptor))).toBeTrue()
+        expect(areEqualPeerDescriptors(storedData2, Any.unpack(foundData2[0]!.data!, PeerDescriptor))).toBeTrue()
     })
 
     it('Can store on one peer DHT', async () => {
         await otherNode.stop()
         await waitForCondition(() => entryPoint.getBucketSize() === 0)
         const dataKey = PeerID.fromString('data-to-store')
-        const data = Any.pack(entryPoint.getLocalPeerDescriptor(), PeerDescriptor)
+        const storedData = createMockPeerDescriptor()
+        const data = Any.pack(storedData, PeerDescriptor)
         const successfulStorers = await entryPoint.storeDataToDht(dataKey.value, data)
         expect(successfulStorers[0].kademliaId).toStrictEqual(entryPoint.getLocalPeerDescriptor().kademliaId)
 
         const foundData = await entryPoint.getDataFromDht(dataKey.value)
-        expect(areEqualPeerDescriptors(entryPoint.getLocalPeerDescriptor(), Any.unpack(foundData[0]!.data!, PeerDescriptor))).toBeTrue()
+        expect(areEqualPeerDescriptors(storedData, Any.unpack(foundData[0]!.data!, PeerDescriptor))).toBeTrue()
     }, 60000)
 })

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -30,9 +30,17 @@ import { Empty } from '../../src/proto/google/protobuf/empty'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { wait, waitForCondition } from '@streamr/utils'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
+import { createRandomKademliaId } from '../../src/helpers/kademliaId'
 
 export const generateId = (stringId: string): Uint8Array => {
     return PeerID.fromString(stringId).value
+}
+
+export const createMockPeerDescriptor = (): PeerDescriptor => {
+    return {
+        kademliaId: createRandomKademliaId(),
+        type: NodeType.NODEJS,
+    }  
 }
 
 export const createMockConnectionDhtNode = async (

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -22,13 +22,17 @@ export interface StoreDataRequest {
      */
     data?: Any;
     /**
-     * @generated from protobuf field: uint32 ttl = 3;
+     * @generated from protobuf field: dht.PeerDescriptor storer = 3;
      */
-    ttl: number;
+    storer?: PeerDescriptor;
     /**
      * @generated from protobuf field: google.protobuf.Timestamp storerTime = 4;
      */
     storerTime?: Timestamp;
+    /**
+     * @generated from protobuf field: uint32 ttl = 5;
+     */
+    ttl: number;
 }
 /**
  * @generated from protobuf message dht.StoreDataResponse
@@ -681,8 +685,9 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
         super("dht.StoreDataRequest", [
             { no: 1, name: "kademliaId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "data", kind: "message", T: () => Any },
-            { no: 3, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp }
+            { no: 3, name: "storer", kind: "message", T: () => PeerDescriptor },
+            { no: 4, name: "storerTime", kind: "message", T: () => Timestamp },
+            { no: 5, name: "ttl", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
         ]);
     }
 }


### PR DESCRIPTION
## Summary

When storing data with the external store operation, the incorrect PeerDescriptor was assigned for the storer. This could create scenarios where the external node used to run the store operation would set itself as the storer of data. When multiple request would be handled for the same keys to store data the stored would be overwritten. Additionally, the original storer would not be able to delete the data with its own PeerDescriptor

## Future improvements

- Stop using setStreamPartEntryPoints in trackerless-network tests. There could be an explicit test that tests the feature but by the default behaviour should be used in all other tests