### PR TITLE
refactor(dht): Simplify `RouteMessageAck` handling

### DIFF
--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -230,7 +230,15 @@ export class Finder implements IFinder {
         const closestPeersToDestination = this.getClosestConnections(routedMessage.destinationPeer!.kademliaId, 5)
         const data = this.findLocalData(idToFind.value, findRequest!.fetchData)
         if (areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.destinationPeer!)) {
-            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, true)
+            // TODO this is also very similar case to what we do at line 255, could simplify the code paths?
+            this.sendFindResponse(
+                routedMessage.routingPath,
+                routedMessage.sourcePeer!,
+                findRequest!.sessionId,
+                closestPeersToDestination,
+                data,
+                true
+            )
             return createRouteMessageAck(routedMessage)
         } else {
             const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
@@ -244,7 +252,14 @@ export class Finder implements IFinder {
                     && getPreviousPeer(routedMessage) 
                     && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
                 )
-            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, noCloserContactsFound)
+            this.sendFindResponse(
+                routedMessage.routingPath,
+                routedMessage.sourcePeer!,
+                findRequest!.sessionId,
+                closestPeersToDestination,
+                data,
+                noCloserContactsFound
+            )
             return ack
         }
     }

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -239,9 +239,7 @@ export class Finder implements IFinder {
             logger.trace(`routeFindRequest Node found no candidates`)
             this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId,
                 closestPeersToDestination, data, true)
-        } else if (ack.error) {
-            return ack
-        } else {
+        } else if (ack.error === undefined) {
             const noCloserContactsFound = (
                 closestPeersToDestination.length > 0
                 && getPreviousPeer(routedMessage)

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -232,20 +232,21 @@ export class Finder implements IFinder {
         if (areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.destinationPeer!)) {
             this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, true)
             return createRouteMessageAck(routedMessage)
+        } else {
+            const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
+            if (ack.error === RouteMessageError.NO_TARGETS) {
+                // TODO can we remove this, is the info already logged in Router:166
+                logger.trace(`routeFindRequest Node found no candidates`)
+            }
+            const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
+                (
+                    closestPeersToDestination.length > 0 
+                    && getPreviousPeer(routedMessage) 
+                    && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
+                )
+            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, noCloserContactsFound)
+            return ack
         }
-        const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
-        if (ack.error === RouteMessageError.NO_TARGETS) {
-            // TODO can we remove this, is the info already logged in Router:166
-            logger.trace(`routeFindRequest Node found no candidates`)
-        }
-        const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
-            (
-                closestPeersToDestination.length > 0 
-                && getPreviousPeer(routedMessage) 
-                && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
-            )
-        this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, noCloserContactsFound)
-        return ack
     }
 
     private getClosestConnections(kademliaId: Uint8Array, limit: number): PeerDescriptor[] {

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -242,26 +242,24 @@ export class Finder implements IFinder {
             return createRouteMessageAck(routedMessage)
         } else {
             const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
-            if (ack.error === RouteMessageError.NO_TARGETS) {
-                // TODO can we remove this, is the info already logged in Router:166
-                logger.trace(`routeFindRequest Node found no candidates`)
-            }
-            const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
-                (
-                    closestPeersToDestination.length > 0 
-                    && getPreviousPeer(routedMessage) 
-                    && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
+            if ((ack.error === undefined) || (ack.error === RouteMessageError.NO_TARGETS)) {
+                const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
+                    (
+                        closestPeersToDestination.length > 0 
+                        && getPreviousPeer(routedMessage) 
+                        && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
+                    )
+                this.sendFindResponse(
+                    routedMessage.routingPath,
+                    routedMessage.sourcePeer!,
+                    findRequest!.sessionId,
+                    closestPeersToDestination,
+                    data,
+                    noCloserContactsFound
                 )
-            this.sendFindResponse(
-                routedMessage.routingPath,
-                routedMessage.sourcePeer!,
-                findRequest!.sessionId,
-                closestPeersToDestination,
-                data,
-                noCloserContactsFound
-            )
+            }
             return ack
-        }
+        }    
     }
 
     private getClosestConnections(kademliaId: Uint8Array, limit: number): PeerDescriptor[] {

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -230,24 +230,22 @@ export class Finder implements IFinder {
         const closestPeersToDestination = this.getClosestConnections(routedMessage.destinationPeer!.kademliaId, 5)
         const data = this.findLocalData(idToFind.value, findRequest!.fetchData)
         if (areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.destinationPeer!)) {
-            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId,
-                closestPeersToDestination, data, true)
+            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, true)
             return createRouteMessageAck(routedMessage)
         }
         const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
+        let noCloserContactsFound
         if (ack.error === RouteMessageError.NO_TARGETS) {
             logger.trace(`routeFindRequest Node found no candidates`)
-            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId,
-                closestPeersToDestination, data, true)
+            noCloserContactsFound = true
         } else if (ack.error === undefined) {
-            const noCloserContactsFound = (
+            noCloserContactsFound = (
                 closestPeersToDestination.length > 0
                 && getPreviousPeer(routedMessage)
                 && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
             )
-            this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId,
-                closestPeersToDestination, data, noCloserContactsFound)
         }
+        this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, noCloserContactsFound)
         return ack
     }
 

--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -234,17 +234,16 @@ export class Finder implements IFinder {
             return createRouteMessageAck(routedMessage)
         }
         const ack = this.router.doRouteMessage(routedMessage, RoutingMode.FIND, excludedPeer)
-        let noCloserContactsFound
         if (ack.error === RouteMessageError.NO_TARGETS) {
+            // TODO can we remove this, is the info already logged in Router:166
             logger.trace(`routeFindRequest Node found no candidates`)
-            noCloserContactsFound = true
-        } else if (ack.error === undefined) {
-            noCloserContactsFound = (
-                closestPeersToDestination.length > 0
-                && getPreviousPeer(routedMessage)
+        }
+        const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
+            (
+                closestPeersToDestination.length > 0 
+                && getPreviousPeer(routedMessage) 
                 && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], idToFind)
             )
-        }
         this.sendFindResponse(routedMessage.routingPath, routedMessage.sourcePeer!, findRequest!.sessionId, closestPeersToDestination, data, noCloserContactsFound)
         return ack
     }

--- a/packages/dht/test/unit/Finder.test.ts
+++ b/packages/dht/test/unit/Finder.test.ts
@@ -50,8 +50,8 @@ describe('Finder', () => {
         requestId: 'REQ',
         routingPath: [],
         reachableThrough: [],
-        destinationPeer: peerDescriptor1,
-        sourcePeer: peerDescriptor2
+        sourcePeer: peerDescriptor1,
+        destinationPeer: peerDescriptor2
     }
     const rpcCommunicator = new FakeRpcCommunicator()
 


### PR DESCRIPTION
Simplified `Finder#doRouteFindRequest`.

Added unit test. Also fixed a test setup: the source and destination peers were incorrectly swapped in `routedMessage`.
