### PR TITLE
refactor: Unify throw type

### DIFF
--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -180,7 +180,7 @@ export class AutoCertifierClient extends EventEmitter<AutoCertifierClientEvents>
         if (this.ongoingSessions.has(request.sessionId)) {
             return { sessionId: request.sessionId }
         } else {
-            throw `Session not found ${request.sessionId}`
+            throw new Error(`Session not found ${request.sessionId}`)
         }
     }
 }

--- a/packages/broker/src/plugins/storage/BucketManager.ts
+++ b/packages/broker/src/plugins/storage/BucketManager.ts
@@ -252,7 +252,7 @@ export class BucketManager {
                 query = GET_LAST_BUCKETS_TO_TIMESTAMP
                 params = [streamId, partition, toTimestamp]
             } else {
-                throw TypeError(`Not correct combination of fromTimestamp (${fromTimestamp}) and toTimestamp (${toTimestamp})`)
+                throw new TypeError(`Not correct combination of fromTimestamp (${fromTimestamp}) and toTimestamp (${toTimestamp})`)
             }
             return this.getBucketsFromDatabase(query, params, streamId, partition)
         }

--- a/packages/broker/test/integration/plugins/storage/BatchManager.test.ts
+++ b/packages/broker/test/integration/plugins/storage/BatchManager.test.ts
@@ -137,7 +137,7 @@ describe('BatchManager', () => {
         expect(batch.retries).toEqual(0)
 
         const mockBatch = jest.fn().mockImplementation(() => {
-            throw Error('Throw not inserted')
+            throw new Error('Throw not inserted')
         })
         batchManager.cassandraClient.batch = mockBatch
 
@@ -158,7 +158,7 @@ describe('BatchManager', () => {
         const batch = batchManager.batches[bucketId]
 
         const mockBatch = jest.fn().mockImplementation(() => {
-            throw Error('Throw not inserted')
+            throw new Error('Throw not inserted')
         })
         batchManager.cassandraClient.batch = mockBatch
 

--- a/packages/dht/src/connection/ConnectivityChecker.ts
+++ b/packages/dht/src/connection/ConnectivityChecker.ts
@@ -22,10 +22,10 @@ export const connectAsync = async ({ url, selfSigned, timeoutMs = 1000 }:
         socket, ['connected', 'error'],
         timeoutMs)
     } catch (e) {
-        throw (new Err.ConnectionFailed('WebSocket connection timed out'))
+        throw new Err.ConnectionFailed('WebSocket connection timed out')
     }
     if (result.winnerName === 'error') {
-        throw (new Err.ConnectionFailed('Could not open WebSocket connection'))
+        throw new Err.ConnectionFailed('Could not open WebSocket connection')
     }
     return socket
 }

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -185,7 +185,7 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
 
             if (sourceRegion === undefined || targetRegion === undefined || sourceRegion > 15 || targetRegion > 15) {
                 logger.error('invalid region index given to Simulator')
-                throw ('invalid region index given to Simulator')
+                throw new Error('invalid region index given to Simulator')
             }
 
             latency = this.latencyTable![sourceRegion][targetRegion]

--- a/packages/dht/src/dht/store/StoreRpcRemote.ts
+++ b/packages/dht/src/dht/store/StoreRpcRemote.ts
@@ -18,9 +18,7 @@ export class StoreRpcRemote extends RpcRemote<IStoreRpcClient> {
         } catch (err) {
             const to = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
             const from = getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor())
-            throw Error(
-                `Could not store data to ${to} from ${from} ${err}`
-            )
+            throw new Error(`Could not store data to ${to} from ${from} ${err}`)
         }
     }
 
@@ -29,9 +27,7 @@ export class StoreRpcRemote extends RpcRemote<IStoreRpcClient> {
         try {
             return await this.getClient().deleteData(request, options)
         } catch (err) {
-            throw Error(
-                `Could not call delete data to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} ${err}`
-            )
+            throw new Error(`Could not call delete data to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} ${err}`)
         }
     }
 

--- a/packages/dht/test/benchmark/kademlia-simulation/KademliaSimulation.ts
+++ b/packages/dht/test/benchmark/kademlia-simulation/KademliaSimulation.ts
@@ -17,7 +17,7 @@ export class KademliaSimulation {
 
     constructor() {
         if (!fs.existsSync('test/data/nodeids.json')) {
-            throw ('Cannot find test/data/nodeids.json, please run "npm run prepare-kademlia-simulation first"')
+            throw new Error('Cannot find test/data/nodeids.json, please run "npm run prepare-kademlia-simulation first"')
         }
         this.dhtIds = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
         this.groundTruth = JSON.parse(fs.readFileSync('test/data/orderedneighbors.json').toString())

--- a/packages/dht/test/utils/mock/Router.ts
+++ b/packages/dht/test/utils/mock/Router.ts
@@ -30,7 +30,7 @@ export class MockRouter implements IRouter {
 
     // eslint-disable-next-line class-methods-use-this
     send(): Promise<void> {
-        throw Error('Not implemented')
+        throw new Error('Not implemented')
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -283,9 +283,9 @@ async function waitReadyForTesting(connectionManager: ConnectionManager, limit: 
     } catch (err) {
         if (connectionManager.getNumberOfLocalLockedConnections() > 0
             && connectionManager.getNumberOfRemoteLockedConnections() > 0) {
-            throw Error('Connections are still locked')
+            throw new Error('Connections are still locked')
         } else if (connectionManager.getAllConnectionPeerDescriptors().length > limit) {
-            throw Error(`ConnectionManager has more than ${limit}`)
+            throw new Error(`ConnectionManager has more than ${limit}`)
         }
     }
 }

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -122,7 +122,7 @@ export class ProxyClient extends EventEmitter {
     ): Promise<void> {
         logger.trace('Setting proxies', { streamPartId: this.config.streamPartId, peerDescriptors: nodes, direction, userId, connectionCount })
         if (connectionCount !== undefined && connectionCount > nodes.length) {
-            throw Error('Cannot set connectionCount above the size of the configured array of nodes')
+            throw new Error('Cannot set connectionCount above the size of the configured array of nodes')
         }
         const nodesIds = new Map<NodeID, PeerDescriptor>()
         nodes.forEach((peerDescriptor) => {


### PR DESCRIPTION
When we throw an error, it is now always an instance of `Error`.

We also use the `new` keyword when we construct new `Error` instances. That doesn't change the functionality, as it s ok to construct an Error without the `new` keyword. But unified style is easier to understand (as there is no specific reason to not to use the different construction style).