### PR TITLE
test(dht): Use random regions in `ScaleDownDht` test

### DIFF
--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -4,6 +4,7 @@ import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/Dh
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { Logger } from '@streamr/utils'
+import { getRandomRegion } from '../../src/connection/simulator/pings'
 
 const logger = new Logger(module)
 
@@ -25,7 +26,8 @@ describe('Scaling down a Dht network', () => {
 
         entrypointDescriptor = {
             kademliaId: entryPoint.getNodeId().value,
-            type: NodeType.NODEJS
+            type: NodeType.NODEJS,
+            region: getRandomRegion()
         }
 
         for (let i = 1; i < NUM_NODES; i++) {


### PR DESCRIPTION
Each peer descriptor needs to contain `region` field in a peer descriptor when `Simulator.REAL` latency type is used.

Before this fix the test printed multiple `invalid region index given to Simulator` errors. Maybe the test functionality was also affected by that error.