### PR TITLE
refactor(dht): Extract `PeerManager`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -301,8 +301,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ownPeerId: this.getNodeId(),
             connectionManager: this.connectionManager!,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
-            createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
-            removeContact: (contact: PeerDescriptor) => this.removeContact(contact)
+            createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor)
         })
         this.peerManager.on('contactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) => {
             this.emit('contactRemoved', peerDescriptor, activeContacts)
@@ -428,14 +427,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public removeContact(contact: PeerDescriptor): void {
-        if (!this.started || this.stopped) {
+        if (!this.started) {  // the stopped state is checked in PeerManager
             return
         }
-        logger.trace(`Removing contact ${getNodeIdFromPeerDescriptor(contact)}`)
-        const peerId = peerIdFromPeerDescriptor(contact)
-        this.peerManager!.bucket!.remove(peerId.value)
-        this.peerManager!.neighborList!.removeContact(peerId)
-        this.peerManager!.randomPeers!.removeContact(peerId)
+        this.peerManager!.removeContact(contact)
     }
 
     public async send(msg: Message): Promise<void> {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -97,7 +97,7 @@ export interface DhtNodeOptions {
     autoCertifierConfigFile?: string
 }
 
-type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions, 
+type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
     'serviceId' |
     'joinParallelism' |
     'maxNeighborListSize' |
@@ -124,7 +124,7 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
     } else {
         kademliaId = hexToBinary(peerId!)
     }
-    const nodeType = isBrowserEnvironment() ? NodeType.BROWSER : NodeType.NODEJS 
+    const nodeType = isBrowserEnvironment() ? NodeType.BROWSER : NodeType.NODEJS
     const ret: PeerDescriptor = { kademliaId, type: nodeType }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
@@ -212,12 +212,12 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             // If own PeerDescriptor is given in config, create a ConnectionManager with ws server
             if (this.config.peerDescriptor?.websocket) {
                 connectorFacadeConfig.websocketHost = this.config.peerDescriptor.websocket.host
-                connectorFacadeConfig.websocketPortRange = { 
+                connectorFacadeConfig.websocketPortRange = {
                     min: this.config.peerDescriptor.websocket.port,
                     max: this.config.peerDescriptor.websocket.port
                 }
             // If websocketPortRange is given, create ws server using it, websocketHost can be undefined
-            } else if (this.config.websocketPortRange) { 
+            } else if (this.config.websocketPortRange) {
                 connectorFacadeConfig.websocketHost = this.config.websocketHost
                 connectorFacadeConfig.websocketPortRange = this.config.websocketPortRange
             }
@@ -322,9 +322,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ) {
                 setImmediate(async () => {
                     // TODO should we catch possible promise rejection?
-                    await Promise.all(this.config.entryPoints!.map((entryPoint) => 
+                    await Promise.all(this.config.entryPoints!.map((entryPoint) =>
                         this.peerDiscovery!.rejoinDht(entryPoint)
-                    )) 
+                    ))
                 })
             }
         })
@@ -367,7 +367,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.rpcCommunicator!.registerRpcMethod(
             ExternalFindDataRequest,
             ExternalFindDataResponse,
-            'externalFindData', 
+            'externalFindData',
             (req: ExternalFindDataRequest, context: ServerCallContext) => externalApiRpcLocal.externalFindData(req, context),
             { timeout: 10000 }
         )
@@ -445,7 +445,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {
             throw new Error('Cannot join DHT before calling start() on DhtNode')
         }
-        await Promise.all(entryPointDescriptors.map((entryPoint) => 
+        await Promise.all(entryPointDescriptors.map((entryPoint) =>
             this.peerDiscovery!.joinDht(entryPoint, doAdditionalRandomPeerDiscovery, retry)
         ))
     }
@@ -476,7 +476,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             return this.findDataViaPeer(idToFind, sample(this.config.entryPoints)!)
         }
         const result = await this.finder!.startFind(idToFind, true)
-        return result.dataEntries ?? []  // TODO is this fallback needed? 
+        return result.dataEntries ?? []  // TODO is this fallback needed?
     }
 
     public async deleteDataFromDht(idToDelete: Uint8Array): Promise<void> {
@@ -552,7 +552,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.finder!.stop()
         this.peerDiscovery!.stop()
         if (this.config.transport === undefined) {
-            // if the transport was not given in config, the instance was created in start() and 
+            // if the transport was not given in config, the instance was created in start() and
             // this component is responsible for stopping it
             await this.transport!.stop()
         }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -249,7 +249,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             joinTimeout: this.config.dhtJoinTimeout,
             serviceId: this.config.serviceId,
             parallelism: this.config.joinParallelism,
-            addContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
             connectionManager: this.connectionManager,
             peerManager: this.peerManager!
         })

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -244,7 +244,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.initPeerManager()
 
         this.peerDiscovery = new PeerDiscovery({
-            rpcCommunicator: this.rpcCommunicator,
             localPeerDescriptor: this.localPeerDescriptor!,
             joinNoProgressLimit: this.config.joinNoProgressLimit,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
@@ -253,7 +252,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             parallelism: this.config.joinParallelism,
             addContact: (contact: PeerDescriptor) => this.peerManager!.addNewContact(contact),
             connectionManager: this.connectionManager,
-            rpcRequestTimeout: this.config.rpcRequestTimeout,
             peerManager: this.peerManager!
         })
         this.router = new Router({

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -249,7 +249,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             joinTimeout: this.config.dhtJoinTimeout,
             serviceId: this.config.serviceId,
             parallelism: this.config.joinParallelism,
-            addContact: (contact: PeerDescriptor) => this.peerManager!.addNewContact(contact),
+            addContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
             connectionManager: this.connectionManager,
             peerManager: this.peerManager!
         })
@@ -257,7 +257,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
-            addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addNewContact(contact, setActive),
+            addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.handleNewPeers([contact], setActive),
             serviceId: this.config.serviceId,
             connectionManager: this.connectionManager
         })
@@ -268,7 +268,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
-            addContact: (contact: PeerDescriptor) => this.peerManager!.addNewContact(contact),
+            addContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
             isPeerCloserToIdThanSelf: this.isPeerCloserToIdThanSelf.bind(this),
             localDataStore: this.localDataStore
         })
@@ -349,7 +349,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             bucket: this.peerManager!.bucket!,
             serviceId: this.config.serviceId,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
-            addNewContact: (contact: PeerDescriptor) => this.peerManager!.addNewContact(contact),
+            addNewContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
             removeContact: (contact: PeerDescriptor) => this.removeContact(contact)
         })
         this.rpcCommunicator!.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers',

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -246,8 +246,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.peerDiscovery = new PeerDiscovery({
             rpcCommunicator: this.rpcCommunicator,
             localPeerDescriptor: this.localPeerDescriptor!,
-            bucket: this.peerManager!.bucket!,
-            neighborList: this.peerManager!.neighborList!,
             joinNoProgressLimit: this.config.joinNoProgressLimit,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             joinTimeout: this.config.dhtJoinTimeout,
@@ -255,7 +253,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             parallelism: this.config.joinParallelism,
             addContact: this.addNewContact.bind(this),
             connectionManager: this.connectionManager,
-            rpcRequestTimeout: this.config.rpcRequestTimeout
+            rpcRequestTimeout: this.config.rpcRequestTimeout,
+            peerManager: this.peerManager!
         })
         this.router = new Router({
             rpcCommunicator: this.rpcCommunicator,

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -300,6 +300,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ownPeerId: this.getNodeId(),
             connectionManager: this.connectionManager!,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
+            isLayer0: (this.connectionManager !== undefined),
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor)
         })
         this.peerManager.on('contactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) => {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -33,7 +33,6 @@ import { Any } from '../proto/google/protobuf/any'
 import {
     areEqualPeerDescriptors,
     getNodeIdFromPeerDescriptor,
-    keyFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
 import { Router } from './routing/Router'
@@ -339,17 +338,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.emit('disconnected', peerDescriptor, gracefulLeave)
         })
         this.transport!.getAllConnectionPeerDescriptors().forEach((peer) => {
-            const rpcRemote = new DhtNodeRpcRemote(
-                this.localPeerDescriptor!,
-                peer,
-                toProtoRpcClient(new DhtNodeRpcClient(this.rpcCommunicator!.getRpcClientTransport())),
-                this.config.serviceId,
-                this.config.rpcRequestTimeout
-            )
-            if (areEqualPeerDescriptors(peer, this.localPeerDescriptor!)) {
-                logger.error('own peerdescriptor added to connections in initKBucket')
-            }
-            this.peerManager!.connections.set(keyFromPeerDescriptor(peer), rpcRemote)
+            this.peerManager!.handleConnected(peer)
         })
     }
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -329,11 +329,11 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             }
         })
         this.transport!.on('connected', (peerDescriptor: PeerDescriptor) => {
-            this.peerManager!.onTransportConnected(peerDescriptor)
+            this.peerManager!.handleConnected(peerDescriptor)
             this.emit('connected', peerDescriptor)
         })
         this.transport!.on('disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => {
-            this.peerManager!.onTransportDisconnected(peerDescriptor, gracefulLeave)
+            this.peerManager!.handleDisconnected(peerDescriptor, gracefulLeave)
             this.emit('disconnected', peerDescriptor, gracefulLeave)
         })
         this.transport!.getAllConnectionPeerDescriptors().forEach((peer) => {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -430,7 +430,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started) {  // the stopped state is checked in PeerManager
             return
         }
-        this.peerManager!.removeContact(contact)
+        this.peerManager!.handlePeerLeaving(contact)
     }
 
     public async send(msg: Message): Promise<void> {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -512,7 +512,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getNumberOfConnections(): number {
-        return this.peerManager!.connections.size
+        return this.peerManager!.getNumberOfConnections()
     }
 
     public getNumberOfLocalLockedConnections(): number {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -1,9 +1,7 @@
 import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
-import KBucket from 'k-bucket'
 import { EventEmitter } from 'eventemitter3'
-import { SortedContactList } from './contact/SortedContactList'
 import { RoutingRpcCommunicator } from '../transport/RoutingRpcCommunicator'
-import { PeerID, PeerIDKey } from '../helpers/PeerID'
+import { PeerID } from '../helpers/PeerID'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
@@ -31,7 +29,6 @@ import {
     waitForCondition
 } from '@streamr/utils'
 import { toProtoRpcClient } from '@streamr/proto-rpc'
-import { RandomContactList } from './contact/RandomContactList'
 import { Any } from '../proto/google/protobuf/any'
 import {
     areEqualPeerDescriptors,
@@ -54,6 +51,7 @@ import { MarkRequired } from 'ts-essentials'
 import { DhtNodeRpcLocal } from './DhtNodeRpcLocal'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ExternalApiRpcLocal } from './ExternalApiRpcLocal'
+import { PeerManager } from './PeerManager'
 
 export interface DhtNodeEvents {
     newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
@@ -138,10 +136,6 @@ export const createPeerDescriptor = (msg?: ConnectivityResponse, peerId?: string
 export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     private readonly config: StrictDhtNodeOptions
-    private bucket?: KBucket<DhtNodeRpcRemote>
-    private connections: Map<PeerIDKey, DhtNodeRpcRemote> = new Map()
-    private neighborList?: SortedContactList<DhtNodeRpcRemote>
-    private randomPeers?: RandomContactList<DhtNodeRpcRemote>
     private rpcCommunicator?: RoutingRpcCommunicator
     private transport?: ITransport
     private localPeerDescriptor?: PeerDescriptor
@@ -150,6 +144,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private localDataStore = new LocalDataStore()
     private finder?: Finder
     private peerDiscovery?: PeerDiscovery
+    private peerManager?: PeerManager
 
     public connectionManager?: ConnectionManager
     private started = false
@@ -246,12 +241,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
         this.transport.on('message', (message: Message) => this.handleMessage(message))
 
-        this.initKBuckets(peerIdFromPeerDescriptor(this.localPeerDescriptor!))
+        this.initPeerManager()
+
         this.peerDiscovery = new PeerDiscovery({
             rpcCommunicator: this.rpcCommunicator,
             localPeerDescriptor: this.localPeerDescriptor!,
-            bucket: this.bucket!,
-            neighborList: this.neighborList!,
+            bucket: this.peerManager!.bucket!,
+            neighborList: this.peerManager!.neighborList!,
             joinNoProgressLimit: this.config.joinNoProgressLimit,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             joinTimeout: this.config.dhtJoinTimeout,
@@ -263,7 +259,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         })
         this.router = new Router({
             rpcCommunicator: this.rpcCommunicator,
-            connections: this.connections,
+            connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             addContact: this.addNewContact.bind(this),
             serviceId: this.config.serviceId,
@@ -273,7 +269,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             router: this.router,
             sessionTransport: this,
-            connections: this.connections,
+            connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
             addContact: this.addNewContact.bind(this),
@@ -291,7 +287,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             localDataStore: this.localDataStore,
             dhtNodeEmitter: this,
             getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => {
-                return this.bucket!.closest(id, n)
+                return this.peerManager!.bucket!.closest(id, n)
             },
             rpcRequestTimeout: this.config.rpcRequestTimeout
         })
@@ -302,43 +298,46 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
     }
 
-    private initKBuckets(selfId: PeerID) {
-        this.bucket = new KBucket<DhtNodeRpcRemote>({
-            localNodeId: selfId.value,
+    private initPeerManager() {
+        this.peerManager = new PeerManager({
             numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
-            numberOfNodesToPing: this.config.numberOfNodesPerKBucket
+            maxNeighborListSize: this.config.maxNeighborListSize,
+            ownPeerId: this.getNodeId(),
+            connectionManager: this.connectionManager!,
+            peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
+            createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
+            addNewContact: (contact: PeerDescriptor, setActive?: boolean) => this.addNewContact(contact, setActive),
+            removeContact: (contact: PeerDescriptor) => this.removeContact(contact)
         })
-        this.bucket.on('ping', (oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote) => this.onKBucketPing(oldContacts, newContact))
-        this.bucket.on('removed', (contact: DhtNodeRpcRemote) => this.onKBucketRemoved(contact))
-        this.bucket.on('added', (contact: DhtNodeRpcRemote) => this.onKBucketAdded(contact))
-        this.bucket.on('updated', () => {
-            // TODO: Update contact info to the connection manager and reconnect
+        this.peerManager.on('contactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) => {
+            this.emit('contactRemoved', peerDescriptor, activeContacts)
         })
-        this.neighborList = new SortedContactList(selfId, this.config.maxNeighborListSize)
-        this.neighborList.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
-            if (this.stopped) {
-                return
-            }
-            this.emit('contactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
-            this.randomPeers!.addContact(
-                new DhtNodeRpcRemote(
-                    this.localPeerDescriptor!,
-                    removedContact.getPeerDescriptor(),
-                    toProtoRpcClient(new DhtNodeRpcClient(this.rpcCommunicator!.getRpcClientTransport())),
-                    this.config.serviceId,
-                    this.config.rpcRequestTimeout
-                )
-            )
-        })
-        this.neighborList.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.peerManager.on('newContact', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
+            this.emit('newContact', peerDescriptor, activeContacts)
         )
+        this.peerManager.on('randomContactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
+            this.emit('randomContactRemoved', peerDescriptor, activeContacts)
+        )
+        this.peerManager.on('newRandomContact', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
+            this.emit('newRandomContact', peerDescriptor, activeContacts)
+        )
+        this.peerManager.on('kBucketEmpty', () => {
+            if (!this.peerDiscovery!.isJoinOngoing()
+                && this.config.entryPoints
+                && this.config.entryPoints.length > 0
+            ) {
+                setImmediate(async () => {
+                    // TODO should we catch possible promise rejection?
+                    await Promise.all(this.config.entryPoints!.map((entryPoint) => 
+                        this.peerDiscovery!.rejoinDht(entryPoint)
+                    )) 
+                })
+            }
+        })
         this.transport!.on('connected', (peerDescriptor: PeerDescriptor) => this.onTransportConnected(peerDescriptor))
-
         this.transport!.on('disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => {
             this.onTransportDisconnected(peerDescriptor, gracefulLeave)
         })
-
         this.transport!.getAllConnectionPeerDescriptors().forEach((peer) => {
             const rpcRemote = new DhtNodeRpcRemote(
                 this.localPeerDescriptor!,
@@ -350,15 +349,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             if (areEqualPeerDescriptors(peer, this.localPeerDescriptor!)) {
                 logger.error('own peerdescriptor added to connections in initKBucket')
             }
-            this.connections.set(keyFromPeerDescriptor(peer), rpcRemote)
+            this.peerManager!.connections.set(keyFromPeerDescriptor(peer), rpcRemote)
         })
-        this.randomPeers = new RandomContactList(selfId, this.config.maxNeighborListSize)
-        this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
-        )
-        this.randomPeers.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newRandomContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
-        )
     }
 
     private onTransportConnected(peerDescriptor: PeerDescriptor): void {
@@ -374,22 +366,22 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.config.serviceId,
             this.config.rpcRequestTimeout
         )
-        if (!this.connections.has(PeerID.fromValue(rpcRemote.id).toKey())) {
-            this.connections.set(PeerID.fromValue(rpcRemote.id).toKey(), rpcRemote)
-            logger.trace('connectionschange add ' + this.connections.size)
+        if (!this.peerManager!.connections.has(PeerID.fromValue(rpcRemote.id).toKey())) {
+            this.peerManager!.connections.set(PeerID.fromValue(rpcRemote.id).toKey(), rpcRemote)
+            logger.trace('connectionschange add ' + this.peerManager!.connections.size)
         } else {
             logger.trace('new connection not set to connections, there is already a connection with the peer ID')
         }
-        logger.trace('connected: ' + getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + this.connections.size)
+        logger.trace('connected: ' + getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + this.peerManager!.connections.size)
         this.emit('connected', peerDescriptor)
     }
 
     private onTransportDisconnected(peerDescriptor: PeerDescriptor, gracefulLeave: boolean): void {
         logger.trace('disconnected: ' + getNodeIdFromPeerDescriptor(peerDescriptor))
-        this.connections.delete(keyFromPeerDescriptor(peerDescriptor))
+        this.peerManager!.connections.delete(keyFromPeerDescriptor(peerDescriptor))
         // only remove from bucket if we are on layer 0
         if (this.connectionManager) {
-            this.bucket!.remove(peerDescriptor.kademliaId)
+            this.peerManager!.bucket!.remove(peerDescriptor.kademliaId)
 
             if (gracefulLeave === true) {
                 logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
@@ -407,7 +399,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             return
         }
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
-            bucket: this.bucket!,
+            bucket: this.peerManager!.bucket!,
             serviceId: this.config.serviceId,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             addNewContact: (contact: PeerDescriptor) => this.addNewContact(contact),
@@ -442,8 +434,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     private isPeerCloserToIdThanSelf(peer1: PeerDescriptor, compareToId: PeerID): boolean {
-        const distance1 = this.bucket!.distance(peer1.kademliaId, compareToId.value)
-        const distance2 = this.bucket!.distance(this.localPeerDescriptor!.kademliaId, compareToId.value)
+        const distance1 = this.peerManager!.bucket!.distance(peer1.kademliaId, compareToId.value)
+        const distance2 = this.peerManager!.bucket!.distance(this.localPeerDescriptor!.kademliaId, compareToId.value)
         return distance1 < distance2
     }
 
@@ -468,89 +460,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.localPeerDescriptor
     }
 
-    private onKBucketPing(oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote): void {
-        if (this.stopped) {
-            return
-        }
-        const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList(this.getNodeId(), 100)
-        sortingList.addContacts(oldContacts)
-        const sortedContacts = sortingList.getAllContacts()
-        this.connectionManager?.weakUnlockConnection(sortedContacts[sortedContacts.length - 1].getPeerDescriptor())
-        this.bucket?.remove(sortedContacts[sortedContacts.length - 1].getPeerId().value)
-        this.bucket!.add(newContact)
-    }
-
-    private onKBucketRemoved(contact: DhtNodeRpcRemote): void {
-        if (this.stopped) {
-            return
-        }
-        this.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
-        logger.trace(`Removed contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
-        if (this.bucket!.count() === 0
-            && !this.peerDiscovery!.isJoinOngoing()
-            && this.config.entryPoints
-            && this.config.entryPoints.length > 0
-        ) {
-            setImmediate(async () => {
-                // TODO should we catch possible promise rejection?
-                await Promise.all(this.config.entryPoints!.map((entryPoint) => 
-                    this.peerDiscovery!.rejoinDht(entryPoint)
-                )) 
-            })
-        }
-    }
-
-    private onKBucketAdded(contact: DhtNodeRpcRemote): void {
-        if (this.stopped) {
-            return
-        }
-        if (!contact.getPeerId().equals(this.getNodeId())) {
-            // Important to lock here, before the ping result is known
-            this.connectionManager?.weakLockConnection(contact.getPeerDescriptor())
-            if (this.connections.has(contact.getPeerId().toKey())) {
-                logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
-            } else {    // open connection by pinging
-                logger.trace('starting ping ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
-                contact.ping().then((result) => {
-                    if (result) {
-                        logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
-                    } else {
-                        logger.trace('ping failed ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
-                        this.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
-                        this.removeContact(contact.getPeerDescriptor())
-                        this.addClosestContactToBucket()
-                    }
-                    return
-                }).catch((_e) => {
-                    this.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
-                    this.removeContact(contact.getPeerDescriptor())
-                    this.addClosestContactToBucket()
-                })
-            }
-        }
-    }
-
-    private addClosestContactToBucket(): void {
-        if (!this.started || this.stopped) {
-            return
-        }
-        const closest = this.getClosestActiveContactNotInBucket()
-        if (closest) {
-            this.addNewContact(closest.getPeerDescriptor())
-        }
-    }
-
-    private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
-        for (const contactId of this.neighborList!.getContactIds()) {
-            if (!this.bucket!.get(contactId.value) && this.neighborList!.isActive(contactId)) {
-                return this.neighborList!.getContact(contactId)!.contact
-            }
-        }
-        return undefined
-    }
-
     public getClosestContacts(maxCount?: number): PeerDescriptor[] {
-        return this.neighborList!.getClosestContacts(maxCount).map((c) => c.getPeerDescriptor())
+        return this.peerManager!.neighborList!.getClosestContacts(maxCount).map((c) => c.getPeerDescriptor())
     }
 
     public getNodeId(): PeerID {
@@ -558,7 +469,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getBucketSize(): number {
-        return this.bucket!.count()
+        return this.peerManager!.bucket!.count()
     }
 
     private addNewContact(contact: PeerDescriptor, setActive = false): void {
@@ -574,15 +485,17 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 this.config.serviceId,
                 this.config.rpcRequestTimeout
             )
-            if ((this.bucket!.get(contact.kademliaId) === null) && (this.neighborList!.getContact(peerIdFromPeerDescriptor(contact)) === undefined)) {
-                this.neighborList!.addContact(rpcRemote)
+            if ((this.peerManager!.bucket!.get(contact.kademliaId) === null) 
+                && (this.peerManager!.neighborList!.getContact(peerIdFromPeerDescriptor(contact)) === undefined)
+            ) {
+                this.peerManager!.neighborList!.addContact(rpcRemote)
                 if (setActive) {
                     const peerId = peerIdFromPeerDescriptor(contact)
-                    this.neighborList!.setActive(peerId)
+                    this.peerManager!.neighborList!.setActive(peerId)
                 }
-                this.bucket!.add(rpcRemote)
+                this.peerManager!.bucket!.add(rpcRemote)
             } else {
-                this.randomPeers!.addContact(rpcRemote)
+                this.peerManager!.randomPeers!.addContact(rpcRemote)
             }
         }
     }
@@ -600,9 +513,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
         logger.trace(`Removing contact ${getNodeIdFromPeerDescriptor(contact)}`)
         const peerId = peerIdFromPeerDescriptor(contact)
-        this.bucket!.remove(peerId.value)
-        this.neighborList!.removeContact(peerId)
-        this.randomPeers!.removeContact(peerId)
+        this.peerManager!.bucket!.remove(peerId.value)
+        this.peerManager!.neighborList!.removeContact(peerId)
+        this.peerManager!.randomPeers!.removeContact(peerId)
     }
 
     public async send(msg: Message): Promise<void> {
@@ -676,15 +589,15 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getAllConnectionPeerDescriptors(): PeerDescriptor[] {
-        return Array.from(this.connections.values()).map((peer) => peer.getPeerDescriptor())
+        return Array.from(this.peerManager!.connections.values()).map((peer) => peer.getPeerDescriptor())
     }
 
     public getKBucketPeers(): PeerDescriptor[] {
-        return this.bucket!.toArray().map((rpcRemote: DhtNodeRpcRemote) => rpcRemote.getPeerDescriptor())
+        return this.peerManager!.bucket!.toArray().map((rpcRemote: DhtNodeRpcRemote) => rpcRemote.getPeerDescriptor())
     }
 
     public getNumberOfConnections(): number {
-        return this.connections.size
+        return this.peerManager!.connections.size
     }
 
     public getNumberOfLocalLockedConnections(): number {
@@ -700,7 +613,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public async waitForNetworkConnectivity(): Promise<void> {
-        await waitForCondition(() => this.connections.size > 0, this.config.networkConnectivityTimeout)
+        await waitForCondition(() => this.peerManager!.connections.size > 0, this.config.networkConnectivityTimeout)
     }
 
     public hasJoined(): boolean {
@@ -717,14 +630,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.entryPointDisconnectTimeout) {
             clearTimeout(this.entryPointDisconnectTimeout)
         }
-        this.bucket!.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => { 
-            rpcRemote.leaveNotice()
-            this.bucket!.remove(rpcRemote.id)
-        })
-        this.bucket!.removeAllListeners()
         this.localDataStore.clear()
-        this.neighborList!.stop()
-        this.randomPeers!.stop()
+        this.peerManager?.stop()
         this.rpcCommunicator!.stop()
         this.router!.stop()
         this.finder!.stop()
@@ -736,7 +643,16 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
         this.transport = undefined
         this.connectionManager = undefined
-        this.connections.clear()
         this.removeAllListeners()
+    }
+
+    private createDhtNodeRpcRemote(peerDescriptor: PeerDescriptor) {
+        return new DhtNodeRpcRemote(
+            this.localPeerDescriptor!,
+            peerDescriptor,
+            toProtoRpcClient(new DhtNodeRpcClient(this.rpcCommunicator!.getRpcClientTransport())),
+            this.config.serviceId,
+            this.config.rpcRequestTimeout
+        )
     }
 }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -45,8 +45,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     public readonly connections: Map<PeerIDKey, DhtNodeRpcRemote> = new Map()
     // TODO make private
     public neighborList?: SortedContactList<DhtNodeRpcRemote>
-    // TODO make private
-    public randomPeers?: RandomContactList<DhtNodeRpcRemote>
+    private randomPeers?: RandomContactList<DhtNodeRpcRemote>
     private readonly config: PeerManagerConfig
     private stopped: boolean = false
 

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -205,7 +205,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
 
     stop(): void {
         this.stopped = true
-        this.bucket!.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => { 
+        this.bucket!.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => {
             rpcRemote.leaveNotice()
             this.bucket!.remove(rpcRemote.id)
         })
@@ -236,7 +236,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             if (!PeerID.fromValue(contact.kademliaId).equals(this.config.ownPeerId)) {
                 logger.trace(`Adding new contact ${getNodeIdFromPeerDescriptor(contact)}`)
                 const rpcRemote = this.config.createDhtNodeRpcRemote(contact)
-                if ((this.bucket!.get(contact.kademliaId) === null) 
+                if ((this.bucket!.get(contact.kademliaId) === null)
                     && (this.neighborList!.getContact(peerIdFromPeerDescriptor(contact)) === undefined)
                 ) {
                     this.neighborList!.addContact(rpcRemote)

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -189,6 +189,14 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
     }
 
+    handleConnected(peer: PeerDescriptor): void {
+        const rpcRemote = this.config.createDhtNodeRpcRemote(peer)
+        if (PeerID.fromValue(peer.kademliaId).equals(this.config.ownPeerId)) {
+            logger.error('own peerdescriptor added to connections in initKBucket')
+        }
+        this.connections.set(keyFromPeerDescriptor(peer), rpcRemote)
+    }
+
     stop(): void {
         this.stopped = true
         this.bucket!.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => { 

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -215,6 +215,10 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.connections.clear()
     }
 
+    public getNumberOfConnections(): number {
+        return this.connections.size
+    }
+
     handlePeerActive(peerId: PeerID): void {
         this.neighborList!.setActive(peerId)
     }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -188,7 +188,11 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
     }
 
-    public removeContact(contact: PeerDescriptor): void {
+    public handlePeerLeaving(peerDescriptor: PeerDescriptor): void {
+        this.removeContact(peerDescriptor)
+    }
+
+    private removeContact(contact: PeerDescriptor): void {
         if (this.stopped) {
             return
         }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -25,6 +25,7 @@ interface PeerManagerConfig {
     peerDiscoveryQueryBatchSize: number
     ownPeerId: PeerID
     connectionManager: ConnectionManager
+    isLayer0: boolean
     createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => DhtNodeRpcRemote
 }
 
@@ -176,8 +177,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     handleDisconnected(peerDescriptor: PeerDescriptor, gracefulLeave: boolean): void {
         logger.trace('disconnected: ' + getNodeIdFromPeerDescriptor(peerDescriptor))
         this.connections.delete(keyFromPeerDescriptor(peerDescriptor))
-        // only remove from bucket if we are on layer 0
-        if (this.config.connectionManager) {
+        if (this.config.isLayer0) {
             this.bucket!.remove(peerDescriptor.kademliaId)
             if (gracefulLeave === true) {
                 logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -215,6 +215,15 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.connections.clear()
     }
 
+    handlePeerActive(peerId: PeerID): void {
+        this.neighborList!.setActive(peerId)
+    }
+
+    handlePeerUnresponsive(peerId: PeerID): void {
+        this.bucket!.remove(peerId.value)
+        this.neighborList!.removeContact(peerId)
+    }
+
     handleNewPeers(contacts: PeerDescriptor[]): void {
         contacts.forEach((contact) => {
             if (!PeerID.fromValue(contact.kademliaId).equals(this.config.ownPeerId)) {

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -159,9 +159,9 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         return undefined
     }
 
-    onTransportConnected(peerDescriptor: PeerDescriptor): void {
+    handleConnected(peerDescriptor: PeerDescriptor): void {
         if (PeerID.fromValue(peerDescriptor.kademliaId).equals(this.config.ownPeerId)) {
-            logger.error('onTransportConnected() to self')
+            logger.error('handleConnected() to self')
         }
         const rpcRemote = this.config.createDhtNodeRpcRemote(peerDescriptor)
         if (!this.connections.has(PeerID.fromValue(rpcRemote.id).toKey())) {
@@ -173,7 +173,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         logger.trace('connected: ' + getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + this.connections.size)
     }
 
-    onTransportDisconnected(peerDescriptor: PeerDescriptor, gracefulLeave: boolean): void {
+    handleDisconnected(peerDescriptor: PeerDescriptor, gracefulLeave: boolean): void {
         logger.trace('disconnected: ' + getNodeIdFromPeerDescriptor(peerDescriptor))
         this.connections.delete(keyFromPeerDescriptor(peerDescriptor))
         // only remove from bucket if we are on layer 0
@@ -186,14 +186,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
                 logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
             }
         }
-    }
-
-    handleConnected(peer: PeerDescriptor): void {
-        const rpcRemote = this.config.createDhtNodeRpcRemote(peer)
-        if (PeerID.fromValue(peer.kademliaId).equals(this.config.ownPeerId)) {
-            logger.error('own peerdescriptor added to connections in initKBucket')
-        }
-        this.connections.set(keyFromPeerDescriptor(peer), rpcRemote)
     }
 
     public removeContact(contact: PeerDescriptor): void {

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -1,0 +1,174 @@
+import {
+    Logger
+} from '@streamr/utils'
+import KBucket from 'k-bucket'
+import { PeerID, PeerIDKey } from '../helpers/PeerID'
+import {
+    getNodeIdFromPeerDescriptor,
+    peerIdFromPeerDescriptor
+} from '../helpers/peerIdFromPeerDescriptor'
+import {
+    PeerDescriptor
+} from '../proto/packages/dht/protos/DhtRpc'
+import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
+import { RandomContactList } from './contact/RandomContactList'
+import { SortedContactList } from './contact/SortedContactList'
+import { ConnectionManager } from '../connection/ConnectionManager'
+import EventEmitter from 'eventemitter3'
+
+const logger = new Logger(module)
+
+interface PeerManagerConfig {
+    numberOfNodesPerKBucket: number
+    maxNeighborListSize: number
+    peerDiscoveryQueryBatchSize: number
+    ownPeerId: PeerID
+    connectionManager: ConnectionManager
+    createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => DhtNodeRpcRemote
+    addNewContact: (contact: PeerDescriptor, setActive?: boolean) => void
+    removeContact: (contact: PeerDescriptor) => void
+}
+
+export interface PeerManagerEvents {
+    newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    newRandomContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    kBucketEmpty: () => void
+}
+
+export class PeerManager extends EventEmitter<PeerManagerEvents> {
+
+    // TODO make private
+    public bucket?: KBucket<DhtNodeRpcRemote>
+    // TODO make private
+    public readonly connections: Map<PeerIDKey, DhtNodeRpcRemote> = new Map()
+    // TODO make private
+    public neighborList?: SortedContactList<DhtNodeRpcRemote>
+    // TODO make private
+    public randomPeers?: RandomContactList<DhtNodeRpcRemote>
+    private readonly config: PeerManagerConfig
+    private stopped: boolean = false
+
+    constructor(config: PeerManagerConfig) {
+        super()
+        this.config = config
+        this.initKBuckets()
+    }
+
+    private initKBuckets() {
+        this.bucket = new KBucket<DhtNodeRpcRemote>({
+            localNodeId: this.config.ownPeerId.value,
+            numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
+            numberOfNodesToPing: this.config.numberOfNodesPerKBucket
+        })
+        this.bucket.on('ping', (oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote) => this.onKBucketPing(oldContacts, newContact))
+        this.bucket.on('removed', (contact: DhtNodeRpcRemote) => this.onKBucketRemoved(contact))
+        this.bucket.on('added', (contact: DhtNodeRpcRemote) => this.onKBucketAdded(contact))
+        this.bucket.on('updated', () => {
+            // TODO: Update contact info to the connection manager and reconnect
+        })
+        this.neighborList = new SortedContactList(this.config.ownPeerId, this.config.maxNeighborListSize)
+        this.neighborList.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
+            if (this.stopped) {
+                return
+            }
+            this.emit('contactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+            this.randomPeers!.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
+        })
+        this.neighborList.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+            this.emit('newContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        )
+        this.randomPeers = new RandomContactList(this.config.ownPeerId, this.config.maxNeighborListSize)
+        this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+            this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        )
+        this.randomPeers.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+            this.emit('newRandomContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        )
+    }
+
+    private onKBucketPing(oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote): void {
+        if (this.stopped) {
+            return
+        }
+        const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList(this.config.ownPeerId, 100)
+        sortingList.addContacts(oldContacts)
+        const sortedContacts = sortingList.getAllContacts()
+        this.config.connectionManager?.weakUnlockConnection(sortedContacts[sortedContacts.length - 1].getPeerDescriptor())
+        this.bucket?.remove(sortedContacts[sortedContacts.length - 1].getPeerId().value)
+        this.bucket!.add(newContact)
+    }
+
+    private onKBucketRemoved(contact: DhtNodeRpcRemote): void {
+        if (this.stopped) {
+            return
+        }
+        this.config.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
+        logger.trace(`Removed contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+        if (this.bucket!.count() === 0) {
+            this.emit('kBucketEmpty')
+        }
+    }
+
+    private onKBucketAdded(contact: DhtNodeRpcRemote): void {
+        if (this.stopped) {
+            return
+        }
+        if (!contact.getPeerId().equals(this.config.ownPeerId)) {
+            // Important to lock here, before the ping result is known
+            this.config.connectionManager?.weakLockConnection(contact.getPeerDescriptor())
+            if (this.connections.has(contact.getPeerId().toKey())) {
+                logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+            } else {    // open connection by pinging
+                logger.trace('starting ping ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
+                contact.ping().then((result) => {
+                    if (result) {
+                        logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+                    } else {
+                        logger.trace('ping failed ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
+                        this.config.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
+                        this.config.removeContact(contact.getPeerDescriptor())
+                        this.addClosestContactToBucket()
+                    }
+                    return
+                }).catch((_e) => {
+                    this.config.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
+                    this.config.removeContact(contact.getPeerDescriptor())
+                    this.addClosestContactToBucket()
+                })
+            }
+        }
+    }
+
+    private addClosestContactToBucket(): void {
+        if (this.stopped) {
+            return
+        }
+        const closest = this.getClosestActiveContactNotInBucket()
+        if (closest) {
+            this.config.addNewContact(closest.getPeerDescriptor())
+        }
+    }
+
+    private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
+        for (const contactId of this.neighborList!.getContactIds()) {
+            if (!this.bucket!.get(contactId.value) && this.neighborList!.isActive(contactId)) {
+                return this.neighborList!.getContact(contactId)!.contact
+            }
+        }
+        return undefined
+    }
+
+    stop(): void {
+        this.stopped = true
+        this.bucket!.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => { 
+            rpcRemote.leaveNotice()
+            this.bucket!.remove(rpcRemote.id)
+        })
+        this.bucket!.removeAllListeners()
+        this.neighborList!.stop()
+        this.randomPeers!.stop()
+        this.connections.clear()
+    }
+}

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -187,7 +187,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
     }
 
-    public handlePeerLeaving(peerDescriptor: PeerDescriptor): void {
+    handlePeerLeaving(peerDescriptor: PeerDescriptor): void {
         this.removeContact(peerDescriptor)
     }
 
@@ -214,7 +214,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.connections.clear()
     }
 
-    public getNumberOfConnections(): number {
+    getNumberOfConnections(): number {
         return this.connections.size
     }
 

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -171,6 +171,18 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.connections.clear()
     }
 
+    handleNewPeers(contacts: PeerDescriptor[]): void {
+        contacts.forEach((contact) => {
+            if (!PeerID.fromValue(contact.kademliaId).equals(this.config.ownPeerId)) {
+                const rpcRemote = this.config.createDhtNodeRpcRemote(contact)
+                this.addNewContact(contact)
+                if (this.neighborList!.getContact(rpcRemote.getPeerId()) !== undefined) {
+                    this.neighborList!.addContact(rpcRemote)
+                }
+            }
+        })
+    }
+
     addNewContact(contact: PeerDescriptor, setActive = false): void {
         if (this.stopped) {
             return

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -106,7 +106,7 @@ export class DiscoverySession {
 
     public async findClosestNodes(timeout: number): Promise<SortedContactList<DhtNodeRpcRemote>> {
         if (this.config.peerManager.neighborList!.getUncontactedContacts(this.config.parallelism).length === 0) {
-            logger.trace('getUncontactedContacts length was 0 in beginning of discovery, this.neighborList.size: '
+            logger.trace('getUncontactedContacts length was 0 in beginning of discovery, neighborList.size: '
                 + this.config.peerManager.neighborList!.getSize())
             return this.config.peerManager.neighborList!
         }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -1,7 +1,6 @@
 import { RpcCommunicator, toProtoRpcClient } from '@streamr/proto-rpc'
 import { Logger, runAndWaitForEvents3 } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
-import KBucket from 'k-bucket'
 import { v4 } from 'uuid'
 import { PeerID } from '../../helpers/PeerID'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
@@ -10,6 +9,7 @@ import { SortedContactList } from '../contact/SortedContactList'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { ServiceID } from '../../types/ServiceID'
+import { PeerManager } from '../PeerManager'
 
 const logger = new Logger(module)
 
@@ -18,8 +18,6 @@ interface DiscoverySessionEvents {
 }
 
 interface DiscoverySessionConfig {
-    bucket: KBucket<DhtNodeRpcRemote>
-    neighborList: SortedContactList<DhtNodeRpcRemote>
     targetId: Uint8Array
     localPeerDescriptor: PeerDescriptor
     serviceId: ServiceID
@@ -28,6 +26,7 @@ interface DiscoverySessionConfig {
     noProgressLimit: number
     newContactListener?: (rpcRemote: DhtNodeRpcRemote) => void
     rpcRequestTimeout?: number
+    peerManager: PeerManager
 }
 
 export class DiscoverySession {
@@ -60,8 +59,8 @@ export class DiscoverySession {
                 if (this.config.newContactListener) {
                     this.config.newContactListener(rpcRemote)
                 }
-                if (this.config.neighborList.getContact(rpcRemote.getPeerId()) !== undefined) {
-                    this.config.neighborList.addContact(rpcRemote)
+                if (this.config.peerManager.neighborList!.getContact(rpcRemote.getPeerId()) !== undefined) {
+                    this.config.peerManager.neighborList!.addContact(rpcRemote)
                 }
             }
         })
@@ -73,9 +72,9 @@ export class DiscoverySession {
         }
         logger.trace(`Getting closest peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
         this.outgoingClosestPeersRequestsCounter++
-        this.config.neighborList.setContacted(contact.getPeerId())
+        this.config.peerManager.neighborList!.setContacted(contact.getPeerId())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
-        this.config.neighborList.setActive(contact.getPeerId())
+        this.config.peerManager.neighborList!.setActive(contact.getPeerId())
         return returnedContacts
     }
 
@@ -84,9 +83,9 @@ export class DiscoverySession {
             return
         }
         this.ongoingClosestPeersRequests.delete(peerId.toKey())
-        const oldClosestContact = this.config.neighborList.getClosestContactId()
+        const oldClosestContact = this.config.peerManager.neighborList!.getClosestContactId()
         this.addNewContacts(contacts)
-        if (this.config.neighborList.getClosestContactId().equals(oldClosestContact)) {
+        if (this.config.peerManager.neighborList!.getClosestContactId().equals(oldClosestContact)) {
             this.noProgressCounter++
         } else {
             this.noProgressCounter = 0
@@ -98,15 +97,15 @@ export class DiscoverySession {
             return
         }
         this.ongoingClosestPeersRequests.delete(peer.getPeerId().toKey())
-        this.config.bucket.remove(peer.getPeerId().value)
-        this.config.neighborList.removeContact(peer.getPeerId())
+        this.config.peerManager.bucket!.remove(peer.getPeerId().value)
+        this.config.peerManager.neighborList!.removeContact(peer.getPeerId())
     }
 
     private findMoreContacts(): void {
         if (this.stopped) {
             return
         }
-        const uncontacted = this.config.neighborList.getUncontactedContacts(this.config.parallelism)
+        const uncontacted = this.config.peerManager.neighborList!.getUncontactedContacts(this.config.parallelism)
         if (uncontacted.length === 0 || this.noProgressCounter >= this.config.noProgressLimit) {
             this.emitter.emit('discoveryCompleted')
             this.stopped = true
@@ -129,17 +128,17 @@ export class DiscoverySession {
     }
 
     public async findClosestNodes(timeout: number): Promise<SortedContactList<DhtNodeRpcRemote>> {
-        if (this.config.neighborList.getUncontactedContacts(this.config.parallelism).length === 0) {
+        if (this.config.peerManager.neighborList!.getUncontactedContacts(this.config.parallelism).length === 0) {
             logger.trace('getUncontactedContacts length was 0 in beginning of discovery, this.neighborList.size: '
-                + this.config.neighborList.getSize())
-            return this.config.neighborList
+                + this.config.peerManager.neighborList!.getSize())
+            return this.config.peerManager.neighborList!
         }
         await runAndWaitForEvents3<DiscoverySessionEvents>(
             [this.findMoreContacts.bind(this)],
             [[this.emitter, 'discoveryCompleted']],
             timeout
         )
-        return this.config.neighborList
+        return this.config.peerManager.neighborList!
     }
 
     public stop(): void {

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -51,7 +51,7 @@ export class DiscoverySession {
         this.outgoingClosestPeersRequestsCounter++
         this.config.peerManager.neighborList!.setContacted(contact.getPeerId())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
-        this.config.peerManager.neighborList!.setActive(contact.getPeerId())
+        this.config.peerManager.handlePeerActive(contact.getPeerId())
         return returnedContacts
     }
 
@@ -74,8 +74,7 @@ export class DiscoverySession {
             return
         }
         this.ongoingClosestPeersRequests.delete(peer.getPeerId().toKey())
-        this.config.peerManager.bucket!.remove(peer.getPeerId().value)
-        this.config.peerManager.neighborList!.removeContact(peer.getPeerId())
+        this.config.peerManager.handlePeerUnresponsive(peer.getPeerId())
     }
 
     private findMoreContacts(): void {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -15,7 +15,6 @@ interface PeerDiscoveryConfig {
     serviceId: ServiceID
     parallelism: number
     joinTimeout: number
-    addContact: (contact: PeerDescriptor) => void
     connectionManager?: ConnectionManager
     peerManager: PeerManager
 }
@@ -50,7 +49,7 @@ export class PeerDiscovery {
             return
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
-        this.config.addContact(entryPointDescriptor)
+        this.config.peerManager.handleNewPeers([entryPointDescriptor])
         const targetId = peerIdFromPeerDescriptor(this.config.localPeerDescriptor).value
         const closest = this.config.peerManager.bucket!.closest(targetId, this.config.peerDiscoveryQueryBatchSize)
         this.config.peerManager.neighborList!.addContacts(closest)
@@ -136,7 +135,7 @@ export class PeerDiscovery {
         await Promise.allSettled(nodes.map(async (peer: DhtNodeRpcRemote) => {
             const contacts = await peer.getClosestPeers(this.config.localPeerDescriptor.kademliaId)
             contacts.forEach((contact) => {
-                this.config.addContact(contact)
+                this.config.peerManager.handleNewPeers([contact])
             })
         }))
     }

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -4,13 +4,11 @@ import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor, peerIdFromPeerDes
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { Logger, scheduleAtInterval, setAbortableTimeout } from '@streamr/utils'
 import { ConnectionManager } from '../../connection/ConnectionManager'
-import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { createRandomKademliaId } from '../../helpers/kademliaId'
 import { ServiceID } from '../../types/ServiceID'
 import { PeerManager } from '../PeerManager'
 
 interface PeerDiscoveryConfig {
-    rpcCommunicator: RoutingRpcCommunicator
     localPeerDescriptor: PeerDescriptor
     joinNoProgressLimit: number
     peerDiscoveryQueryBatchSize: number
@@ -19,7 +17,6 @@ interface PeerDiscoveryConfig {
     joinTimeout: number
     addContact: (contact: PeerDescriptor) => void
     connectionManager?: ConnectionManager
-    rpcRequestTimeout?: number
     peerManager: PeerManager
 }
 
@@ -70,12 +67,9 @@ export class PeerDiscovery {
         const sessionOptions = {
             targetId,
             localPeerDescriptor: this.config.localPeerDescriptor,
-            serviceId: this.config.serviceId,
-            rpcCommunicator: this.config.rpcCommunicator,
             parallelism: this.config.parallelism,
             noProgressLimit: this.config.joinNoProgressLimit,
-            peerManager: this.config.peerManager,
-            newContactListener: (newPeer: DhtNodeRpcRemote) => this.config.addContact(newPeer.getPeerDescriptor()),
+            peerManager: this.config.peerManager
         }
         return new DiscoverySession(sessionOptions)
     }


### PR DESCRIPTION
Extract `PeerManager` class by moving/extracting peer management methods from `DhtNode`, `PeerDiscovery` and `DiscoverySession` classes. 

This is a cherry-pick from https://github.com/streamr-dev/network/pull/1803, i.e. the original author is @ptesavol. We'll pick functionality changes of that PR to separate PRs so that we can debug and possibly deploy each improvement separately. 

## Future improvements

- Most of the fields of `PeerManager` can be private. The visibility will be corrected when we merge https://github.com/streamr-dev/network/pull/1803
- Rename `ownPeerId` -> `localPeerId`