### PR TITLE
NET-1201: fetch first 1k operators in get operator addresses

### DIFF
--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -321,11 +321,12 @@ export class ContractFacade {
     }
 
     private async getOperatorAddresses(requiredBlockNumber: number): Promise<EthereumAddress[]> {
+        // TODO: use pagination or find a clever efficient way of selecting a random operator (NET-1113)
         const createQuery = () => {
             return {
                 query: `
                     {
-                        operators {
+                        operators(first: 1000) {
                             id
                         }
                     }


### PR DESCRIPTION
## Summary

- Fetch max 1k operators when choosing random operator to check for value breach. 
- Tested the query by hand to ensure over 100 entries are received.
