### PR TITLE
test(dht): Refactor `LocalDataStore` test

### DIFF
--- a/packages/dht/src/dht/find/Finder.ts
+++ b/packages/dht/src/dht/find/Finder.ts
@@ -116,7 +116,7 @@ export class Finder implements IFinder {
             action
         })
         if (this.connections.size === 0) {
-            const data = this.localDataStore.getEntry(PeerID.fromValue(idToFind))
+            const data = this.localDataStore.getEntries(PeerID.fromValue(idToFind))
             session.doSendFindResponse(
                 [this.localPeerDescriptor],
                 [this.localPeerDescriptor],
@@ -188,7 +188,7 @@ export class Finder implements IFinder {
         sourcePeer: PeerDescriptor,
         sessionId: string
     ): void {
-        const data = this.localDataStore.getEntry(PeerID.fromValue(idToFind))
+        const data = this.localDataStore.getEntries(PeerID.fromValue(idToFind))
         if (data.size > 0) {
             this.sendFindResponse(routingPath, sourcePeer, sessionId, [], data, true)
         }
@@ -196,7 +196,7 @@ export class Finder implements IFinder {
 
     private findLocalData(idToFind: Uint8Array, fetchData: boolean): Map<PeerIDKey, DataEntry> | undefined {
         if (fetchData) {
-            return this.localDataStore.getEntry(PeerID.fromValue(idToFind))
+            return this.localDataStore.getEntries(PeerID.fromValue(idToFind))
         }
         return undefined
     }

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -70,7 +70,7 @@ export class LocalDataStore {
         return this.store
     }
 
-    public getEntry(key: PeerID): Map<PeerIDKey, DataEntry> {
+    public getEntries(key: PeerID): Map<PeerIDKey, DataEntry> {
         const dataEntries = new Map<PeerIDKey, DataEntry>
         this.store.get(key.toKey())?.forEach((value, key) => {
             dataEntries.set(key, value.dataEntry)

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -110,7 +110,7 @@ describe('Replicate data from node to node in DHT', () => {
             let hasDataMarker = ''
             
             // @ts-expect-error private field
-            if (node.localDataStore.getEntry(dataKey)) {
+            if (node.localDataStore.getEntries(dataKey)) {
                 hasDataMarker = '<-'
             }
 
@@ -139,7 +139,7 @@ describe('Replicate data from node to node in DHT', () => {
 
             // @ts-expect-error private field
 
-            if (node.localDataStore.getEntry(dataKey)) {
+            if (node.localDataStore.getEntries(dataKey)) {
                 hasDataMarker = '<-'
             }
 
@@ -149,7 +149,7 @@ describe('Replicate data from node to node in DHT', () => {
         const closestNode = nodesById.get(PeerID.fromValue(closest[0].getPeerDescriptor().nodeId).toKey())!
 
         // @ts-expect-error private field
-        expect(closestNode.localDataStore.getEntry(dataKey).size).toBeGreaterThanOrEqual(1)
+        expect(closestNode.localDataStore.getEntries(dataKey).size).toBeGreaterThanOrEqual(1)
     }, 180000)
 
     it('Data replicates to the last remaining node if all other nodes leave gracefully', async () => {
@@ -187,7 +187,7 @@ describe('Replicate data from node to node in DHT', () => {
 
             logger.info('Stopping node ' + nodeIndex + ' ' +
                 // @ts-expect-error private field
-                (nodes[nodeIndex].localDataStore.getEntry(dataKey) ? ', has data' : ' does not have data'))
+                (nodes[nodeIndex].localDataStore.getEntries(dataKey) ? ', has data' : ' does not have data'))
 
             await nodes[nodeIndex].stop()
         }
@@ -195,10 +195,10 @@ describe('Replicate data from node to node in DHT', () => {
         logger.info('after random graceful leaving, node ' + randomIndices[0] + ' is left')
 
         // @ts-expect-error private field
-        logger.info('data of ' + randomIndices[0] + ' was ' + nodes[randomIndices[0]].localDataStore.getEntry(dataKey))
+        logger.info('data of ' + randomIndices[0] + ' was ' + nodes[randomIndices[0]].localDataStore.getEntries(dataKey))
 
         // @ts-expect-error private field
-        expect(nodes[randomIndices[0]].localDataStore.getEntry(dataKey).size).toBeGreaterThanOrEqual(1)
+        expect(nodes[randomIndices[0]].localDataStore.getEntries(dataKey).size).toBeGreaterThanOrEqual(1)
 
     }, 180000)
 })

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -32,8 +32,8 @@ describe('LocalDataStore', () => {
     it('can store', () => {
         const dataKey = peerIdFromPeerDescriptor(creator1)
         storeEntry(dataKey, creator1)
-        const fetchedData = localDataStore.getEntry(dataKey)
-        fetchedData.forEach((entry) => {
+        const fetchedEntries = localDataStore.getEntry(dataKey)
+        fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
         })
@@ -43,8 +43,8 @@ describe('LocalDataStore', () => {
         const dataKey = peerIdFromPeerDescriptor(creator1)
         storeEntry(dataKey, creator1)
         storeEntry(dataKey, creator2, creator1)
-        const fetchedData = localDataStore.getEntry(dataKey)
-        fetchedData.forEach((entry) => {
+        const fetchedEntries = localDataStore.getEntry(dataKey)
+        fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
         })
@@ -55,8 +55,8 @@ describe('LocalDataStore', () => {
         storeEntry(dataKey, creator1)
         storeEntry(dataKey, creator2)
         localDataStore.deleteEntry(dataKey, creator1)
-        const fetchedData = localDataStore.getEntry(dataKey)
-        fetchedData.forEach((entry) => {
+        const fetchedEntries = localDataStore.getEntry(dataKey)
+        fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator2)).toBeTrue()
         })
@@ -68,8 +68,8 @@ describe('LocalDataStore', () => {
         storeEntry(dataKey, creator2)
         localDataStore.deleteEntry(dataKey, creator1)
         localDataStore.deleteEntry(dataKey, creator2)
-        const fetchedData = localDataStore.getEntry(dataKey)
-        expect(fetchedData.size).toBe(0)
+        const fetchedEntries = localDataStore.getEntry(dataKey)
+        expect(fetchedEntries.size).toBe(0)
     })
 
     it('data is deleted after TTL', async () => {
@@ -78,8 +78,8 @@ describe('LocalDataStore', () => {
         const intitialStore = localDataStore.getEntry(dataKey)
         expect(intitialStore.size).toBe(1)
         await wait(1100)
-        const fetchedData = localDataStore.getEntry(dataKey)
-        expect(fetchedData.size).toBe(0)
+        const fetchedEntries = localDataStore.getEntry(dataKey)
+        expect(fetchedEntries.size).toBe(0)
     })
 
     describe('mark data as deleted', () => {

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -13,11 +13,10 @@ import { DataEntry, PeerDescriptor } from '../../src/proto/packages/dht/protos/D
 import { createMockPeerDescriptor } from '../utils/utils'
 
 const createMockEntry = (entry: Partial<DataEntry>): DataEntry => {
-    const creator = entry.creator ?? createMockPeerDescriptor()
     return { 
         key: crypto.randomBytes(10),
-        data: Any.pack(creator, PeerDescriptor),  // TODO use random data, i.e. createMockPeerDescriptor(),
-        creator,
+        data: Any.pack(createMockPeerDescriptor(), PeerDescriptor),
+        creator: entry.creator ?? createMockPeerDescriptor(),
         ttl: 10000,
         stale: false,
         deleted: false,

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -32,7 +32,7 @@ describe('LocalDataStore', () => {
     it('can store', () => {
         const dataKey = peerIdFromPeerDescriptor(creator1)
         storeEntry(dataKey, creator1)
-        const fetchedEntries = localDataStore.getEntry(dataKey)
+        const fetchedEntries = localDataStore.getEntries(dataKey)
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
@@ -43,7 +43,7 @@ describe('LocalDataStore', () => {
         const dataKey = peerIdFromPeerDescriptor(creator1)
         storeEntry(dataKey, creator1)
         storeEntry(dataKey, creator2, creator1)
-        const fetchedEntries = localDataStore.getEntry(dataKey)
+        const fetchedEntries = localDataStore.getEntries(dataKey)
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
@@ -55,7 +55,7 @@ describe('LocalDataStore', () => {
         storeEntry(dataKey, creator1)
         storeEntry(dataKey, creator2)
         localDataStore.deleteEntry(dataKey, creator1)
-        const fetchedEntries = localDataStore.getEntry(dataKey)
+        const fetchedEntries = localDataStore.getEntries(dataKey)
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator2)).toBeTrue()
@@ -68,17 +68,17 @@ describe('LocalDataStore', () => {
         storeEntry(dataKey, creator2)
         localDataStore.deleteEntry(dataKey, creator1)
         localDataStore.deleteEntry(dataKey, creator2)
-        const fetchedEntries = localDataStore.getEntry(dataKey)
+        const fetchedEntries = localDataStore.getEntries(dataKey)
         expect(fetchedEntries.size).toBe(0)
     })
 
     it('data is deleted after TTL', async () => {
         const dataKey = peerIdFromPeerDescriptor(creator1)
         storeEntry(dataKey, creator1, undefined, 1000)
-        const intitialStore = localDataStore.getEntry(dataKey)
+        const intitialStore = localDataStore.getEntries(dataKey)
         expect(intitialStore.size).toBe(1)
         await wait(1100)
-        const fetchedEntries = localDataStore.getEntry(dataKey)
+        const fetchedEntries = localDataStore.getEntries(dataKey)
         expect(fetchedEntries.size).toBe(0)
     })
 
@@ -87,11 +87,11 @@ describe('LocalDataStore', () => {
         it('happy path', () => {
             const dataKey = peerIdFromPeerDescriptor(creator1)
             storeEntry(dataKey, creator1)
-            const notDeletedData = localDataStore.getEntry(dataKey)
+            const notDeletedData = localDataStore.getEntries(dataKey)
             expect(notDeletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeFalse()
             const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(creator1))
             expect(returnValue).toBe(true)
-            const deletedData = localDataStore.getEntry(dataKey)
+            const deletedData = localDataStore.getEntries(dataKey)
             expect(deletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeTrue()
         })
 

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -58,7 +58,7 @@ describe('LocalDataStore', () => {
         const creator2 = createMockPeerDescriptor()
         const key = peerIdFromPeerDescriptor(creator1).value
         const storedEntry1 = createMockEntry({ key, creator: creator1 })
-        const storedEntry2 = createMockEntry({ key, creator: creator2, data: Any.pack(creator1, PeerDescriptor) })
+        const storedEntry2 = createMockEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
         localDataStore.storeEntry(storedEntry2)
         const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(key))

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -29,8 +29,6 @@ const createMockEntry = (entry: Partial<DataEntry>): DataEntry => {
 describe('LocalDataStore', () => {
 
     let localDataStore: LocalDataStore
-    const creator1 = createMockPeerDescriptor()
-    const creator2 = createMockPeerDescriptor()
 
     const getEntryArray = (key: Uint8Array) => {
         return Array.from(localDataStore.getEntries(PeerID.fromValue(key)).values())
@@ -57,6 +55,8 @@ describe('LocalDataStore', () => {
     })
 
     it('multiple storers behind one key', () => {
+        const creator1 = createMockPeerDescriptor()
+        const creator2 = createMockPeerDescriptor()
         const key = peerIdFromPeerDescriptor(creator1).value
         const storedEntry1 = createMockEntry({ key, creator: creator1 })
         const storedEntry2 = createMockEntry({ key, creator: creator2, data: Any.pack(creator1, PeerDescriptor) })
@@ -69,6 +69,8 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove data entries', () => {
+        const creator1 = createMockPeerDescriptor()
+        const creator2 = createMockPeerDescriptor()
         const key = peerIdFromPeerDescriptor(creator1).value
         const storedEntry1 = createMockEntry({ key, creator: creator1 })
         const storedEntry2 = createMockEntry({ key, creator: creator2 })
@@ -81,6 +83,8 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove all data entries', () => {
+        const creator1 = createMockPeerDescriptor()
+        const creator2 = createMockPeerDescriptor()
         const key = peerIdFromPeerDescriptor(creator1).value
         const storedEntry1 = createMockEntry({ key, creator: creator1 })
         const storedEntry2 = createMockEntry({ key, creator: creator2 })
@@ -92,7 +96,7 @@ describe('LocalDataStore', () => {
     })
 
     it('data is deleted after TTL', async () => {
-        const storedEntry = createMockEntry({ creator: creator1, ttl: 1000 })
+        const storedEntry = createMockEntry({ ttl: 1000 })
         localDataStore.storeEntry(storedEntry)
         expect(getEntryArray(storedEntry.key)).toHaveLength(1)
         await wait(1100)
@@ -102,6 +106,7 @@ describe('LocalDataStore', () => {
     describe('mark data as deleted', () => {
 
         it('happy path', () => {
+            const creator1 = createMockPeerDescriptor()
             const storedEntry = createMockEntry({ creator: creator1 })
             localDataStore.storeEntry(storedEntry)
             const notDeletedData = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
@@ -113,15 +118,15 @@ describe('LocalDataStore', () => {
         })
 
         it('data not stored', () => {
-            const dataKey = peerIdFromPeerDescriptor(creator1)
-            const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(creator2))
+            const dataKey = peerIdFromPeerDescriptor(createMockPeerDescriptor())
+            const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(createMockPeerDescriptor()))
             expect(returnValue).toBe(false)
         })
 
         it('data not stored by the given creator', () => {
-            const storedEntry = createMockEntry({ creator: creator1 })
+            const storedEntry = createMockEntry({})
             localDataStore.storeEntry(storedEntry)
-            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(creator2))
+            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(createMockPeerDescriptor()))
             expect(returnValue).toBe(false)
         })
     })

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -9,18 +9,13 @@ import { LocalDataStore } from '../../src/dht/store/LocalDataStore'
 import { wait } from '@streamr/utils'
 import { Timestamp } from '../../src/proto/google/protobuf/timestamp'
 import { PeerID } from '../../src/helpers/PeerID'
+import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('LocalDataStore', () => {
 
     let localDataStore: LocalDataStore
-    const creator1: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS
-    }
-    const creator2: PeerDescriptor = {
-        nodeId: new Uint8Array([3, 2, 1]),
-        type: NodeType.NODEJS
-    }
+    const creator1 = createMockPeerDescriptor()
+    const creator2 = createMockPeerDescriptor()
 
     const storeEntry = (dataKey: PeerID, creator: PeerDescriptor, explicitData?: PeerDescriptor, explicitTtl?: number) => {
         localDataStore.storeEntry({ creator: creator, key: dataKey.value, data: Any.pack(explicitData ?? creator, PeerDescriptor), ttl: explicitTtl ?? 10000, stale: false, deleted: false, createdAt: Timestamp.now() })

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -41,10 +41,10 @@ describe('LocalDataStore', () => {
         return Array.from(localDataStore.getEntries(PeerID.fromValue(key)).values())
     }
 
-    const haveEqualData = (entry1: DataEntry, entry2: DataEntry) => {
+    const expectEqualData = (entry1: DataEntry, entry2: DataEntry) => {
         const entity1 = Any.unpack(entry1.data!, MockData)
         const entity2 = Any.unpack(entry2.data!, MockData)
-        return (entity1.foo === entity2.foo)
+        expect(entity1.foo).toBe(entity2.foo)
     }
 
     beforeEach(() => {
@@ -60,7 +60,7 @@ describe('LocalDataStore', () => {
         localDataStore.storeEntry(storedEntry)
         const fetchedEntries = getEntryArray(storedEntry.key)
         expect(fetchedEntries).toHaveLength(1)
-        expect(haveEqualData(fetchedEntries[0], storedEntry )).toBeTrue()
+        expectEqualData(fetchedEntries[0], storedEntry)
     })
 
     it('multiple storers behind one key', () => {
@@ -73,8 +73,8 @@ describe('LocalDataStore', () => {
         localDataStore.storeEntry(storedEntry2)
         const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(key))
         expect(fetchedEntries.size).toBe(2)
-        expect(haveEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator1))!, storedEntry1))
-        expect(haveEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator2))!, storedEntry2))
+        expectEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator1))!, storedEntry1)
+        expectEqualData(fetchedEntries.get(keyFromPeerDescriptor(creator2))!, storedEntry2)
     })
 
     it('can remove data entries', () => {
@@ -88,7 +88,7 @@ describe('LocalDataStore', () => {
         localDataStore.deleteEntry(PeerID.fromValue(key), creator1)
         const fetchedEntries = getEntryArray(key)
         expect(fetchedEntries).toHaveLength(1)
-        expect(haveEqualData(fetchedEntries[0], storedEntry2 )).toBeTrue()
+        expectEqualData(fetchedEntries[0], storedEntry2)
     })
 
     it('can remove all data entries', () => {

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -1,25 +1,35 @@
-import { Any } from '../../src/proto/google/protobuf/any'
-import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { wait } from '@streamr/utils'
+import crypto from 'crypto'
+import { MarkRequired } from 'ts-essentials'
+import { LocalDataStore } from '../../src/dht/store/LocalDataStore'
+import { PeerID } from '../../src/helpers/PeerID'
 import {
     areEqualPeerDescriptors,
     keyFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { LocalDataStore } from '../../src/dht/store/LocalDataStore'
-import { wait } from '@streamr/utils'
+import { Any } from '../../src/proto/google/protobuf/any'
 import { Timestamp } from '../../src/proto/google/protobuf/timestamp'
-import { PeerID } from '../../src/helpers/PeerID'
+import { DataEntry, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
+
+const createMockEntry = (entry: MarkRequired<Partial<DataEntry>, 'creator'>): DataEntry => {
+    return { 
+        key: crypto.randomBytes(10),
+        data: Any.pack(entry.creator, PeerDescriptor),  // TODO use random data, i.e. createMockPeerDescriptor()
+        ttl: 10000,
+        stale: false,
+        deleted: false,
+        createdAt: Timestamp.now(),
+        ...entry
+    }
+}
 
 describe('LocalDataStore', () => {
 
     let localDataStore: LocalDataStore
     const creator1 = createMockPeerDescriptor()
     const creator2 = createMockPeerDescriptor()
-
-    const storeEntry = (dataKey: PeerID, creator: PeerDescriptor, explicitData?: PeerDescriptor, explicitTtl?: number) => {
-        localDataStore.storeEntry({ creator: creator, key: dataKey.value, data: Any.pack(explicitData ?? creator, PeerDescriptor), ttl: explicitTtl ?? 10000, stale: false, deleted: false, createdAt: Timestamp.now() })
-    }
 
     beforeEach(() => {
         localDataStore = new LocalDataStore()
@@ -30,9 +40,9 @@ describe('LocalDataStore', () => {
     })
 
     it('can store', () => {
-        const dataKey = peerIdFromPeerDescriptor(creator1)
-        storeEntry(dataKey, creator1)
-        const fetchedEntries = localDataStore.getEntries(dataKey)
+        const storedEntry = createMockEntry({ creator: creator1 })
+        localDataStore.storeEntry(storedEntry)
+        const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
@@ -40,10 +50,12 @@ describe('LocalDataStore', () => {
     })
 
     it('multiple storers behind one key', () => {
-        const dataKey = peerIdFromPeerDescriptor(creator1)
-        storeEntry(dataKey, creator1)
-        storeEntry(dataKey, creator2, creator1)
-        const fetchedEntries = localDataStore.getEntries(dataKey)
+        const key = peerIdFromPeerDescriptor(creator1).value
+        const storedEntry1 = createMockEntry({ key, creator: creator1 })
+        const storedEntry2 = createMockEntry({ key, creator: creator2, data: Any.pack(creator1, PeerDescriptor) })
+        localDataStore.storeEntry(storedEntry1)
+        localDataStore.storeEntry(storedEntry2)
+        const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(key))
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator1)).toBeTrue()
@@ -51,11 +63,13 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove data entries', () => {
-        const dataKey = peerIdFromPeerDescriptor(creator1)
-        storeEntry(dataKey, creator1)
-        storeEntry(dataKey, creator2)
-        localDataStore.deleteEntry(dataKey, creator1)
-        const fetchedEntries = localDataStore.getEntries(dataKey)
+        const key = peerIdFromPeerDescriptor(creator1).value
+        const storedEntry1 = createMockEntry({ key, creator: creator1 })
+        const storedEntry2 = createMockEntry({ key, creator: creator2 })
+        localDataStore.storeEntry(storedEntry1)
+        localDataStore.storeEntry(storedEntry2)
+        localDataStore.deleteEntry(PeerID.fromValue(key), creator1)
+        const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(key))
         fetchedEntries.forEach((entry) => {
             const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
             expect(areEqualPeerDescriptors(fetchedDescriptor, creator2)).toBeTrue()
@@ -63,35 +77,37 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove all data entries', () => {
-        const dataKey = peerIdFromPeerDescriptor(creator1)
-        storeEntry(dataKey, creator1)
-        storeEntry(dataKey, creator2)
-        localDataStore.deleteEntry(dataKey, creator1)
-        localDataStore.deleteEntry(dataKey, creator2)
-        const fetchedEntries = localDataStore.getEntries(dataKey)
+        const key = peerIdFromPeerDescriptor(creator1).value
+        const storedEntry1 = createMockEntry({ key, creator: creator1 })
+        const storedEntry2 = createMockEntry({ key, creator: creator2 })
+        localDataStore.storeEntry(storedEntry1)
+        localDataStore.storeEntry(storedEntry2)
+        localDataStore.deleteEntry(PeerID.fromValue(key), creator1)
+        localDataStore.deleteEntry(PeerID.fromValue(key), creator2)
+        const fetchedEntries = localDataStore.getEntries(PeerID.fromValue(key))
         expect(fetchedEntries.size).toBe(0)
     })
 
     it('data is deleted after TTL', async () => {
-        const dataKey = peerIdFromPeerDescriptor(creator1)
-        storeEntry(dataKey, creator1, undefined, 1000)
-        const intitialStore = localDataStore.getEntries(dataKey)
-        expect(intitialStore.size).toBe(1)
+        const storedEntry = createMockEntry({ creator: creator1, ttl: 1000 })
+        localDataStore.storeEntry(storedEntry)
+        const fethedEntriesBeforeExpiration = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
+        expect(fethedEntriesBeforeExpiration.size).toBe(1)
         await wait(1100)
-        const fetchedEntries = localDataStore.getEntries(dataKey)
-        expect(fetchedEntries.size).toBe(0)
+        const fetchedEntriesAfterExpiration = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
+        expect(fetchedEntriesAfterExpiration.size).toBe(0)
     })
 
     describe('mark data as deleted', () => {
 
         it('happy path', () => {
-            const dataKey = peerIdFromPeerDescriptor(creator1)
-            storeEntry(dataKey, creator1)
-            const notDeletedData = localDataStore.getEntries(dataKey)
+            const storedEntry = createMockEntry({ creator: creator1 })
+            localDataStore.storeEntry(storedEntry)
+            const notDeletedData = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
             expect(notDeletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeFalse()
-            const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(creator1))
+            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(creator1))
             expect(returnValue).toBe(true)
-            const deletedData = localDataStore.getEntries(dataKey)
+            const deletedData = localDataStore.getEntries(PeerID.fromValue(storedEntry.key))
             expect(deletedData.get(keyFromPeerDescriptor(creator1))!.deleted).toBeTrue()
         })
 
@@ -102,9 +118,9 @@ describe('LocalDataStore', () => {
         })
 
         it('data not stored by the given creator', () => {
-            const dataKey = peerIdFromPeerDescriptor(creator1)
-            storeEntry(dataKey, creator1)
-            const returnValue = localDataStore.markAsDeleted(dataKey.value, peerIdFromPeerDescriptor(creator2))
+            const storedEntry = createMockEntry({ creator: creator1 })
+            localDataStore.storeEntry(storedEntry)
+            const returnValue = localDataStore.markAsDeleted(storedEntry.key, peerIdFromPeerDescriptor(creator2))
             expect(returnValue).toBe(false)
         })
     })

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -16,7 +16,7 @@ const MockData = new class extends MessageType$<{ foo: string }> {
     constructor() {
         super('MockData', [
             { no: 1, name: 'foo', kind: 'scalar', opt: false, T: ScalarType.STRING }
-        ]);
+        ])
     }
 }
 


### PR DESCRIPTION
Refactored `LocalDataStore` test to use random data instead of data being always the `PeerDescriptor` of the creator.  The data object is of type `MockData` so that we have a clear separation of data and a creator (both were previously of type `PeerDescriptor`). Also other refactoring, e.g. asserting entry array length.

Also renamed `LocalDataStore#getEntry()` to `getEntries()`.
