### PR TITLE
chore: temporary logging increase (testnet-one only)

### DIFF
--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -416,6 +416,13 @@ export class ContractFacade {
                 voteEndTimestampInSecs: number,
                 metadataAsString?: string
             ) => {
+                logger.info('Receive raw review request', {
+                    sponsorship,
+                    targetOperator,
+                    voteStartTimestampInSecs,
+                    voteEndTimestampInSecs,
+                    metadataAsString
+                }) // TODO: remove when missing votes issue is solved
                 let partition: number
                 try {
                     partition = parsePartitionFromReviewRequestMetadata(metadataAsString)

--- a/packages/broker/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/broker/src/plugins/operator/OperatorPlugin.ts
@@ -209,6 +209,13 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
             ) => {
                 try {
                     if (isLeader()) {
+                        logger.info('Process review request', {
+                            sponsorshipAddress,
+                            targetOperator,
+                            partition,
+                            votingPeriodStartTimestamp,
+                            votingPeriodEndTimestamp
+                        }) // TODO: remove when missing votes issue is solved
                         await reviewSuspectNode({
                             sponsorshipAddress,
                             targetOperator,


### PR DESCRIPTION
## Summary

Add some temporary `info` level logging to debug missing votes issue. Basically want to understand whether we are not getting `ReviewRequest` events from JSON RPC or whether we have bug in our code. 

This PR doesn't need to be ported to mainline dev branch 1.0 since it is a temporary thing.