### PR TITLE
fix(dht): Use `storeMaxTtl` config option

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -141,7 +141,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private localPeerDescriptor?: PeerDescriptor
     public router?: Router
     private storeRpcLocal?: StoreRpcLocal
-    private localDataStore = new LocalDataStore()
+    private localDataStore: LocalDataStore
     private finder?: Finder
     private peerDiscovery?: PeerDiscovery
     private peerManager?: PeerManager
@@ -169,6 +169,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             metricsContext: new MetricsContext(),
             peerId: new UUID().toHex()
         }, conf)
+        this.localDataStore = new LocalDataStore(this.config.storeMaxTtl) 
         this.send = this.send.bind(this)
     }
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -279,7 +279,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
             highestTtl: this.config.storeHighestTtl,
-            maxTtl: this.config.storeMaxTtl,
             redundancyFactor: this.config.storageRedundancyFactor,
             localDataStore: this.localDataStore,
             getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => {

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -3,13 +3,12 @@ import { DataEntry } from '../../proto/packages/dht/protos/DhtRpc'
 import { peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 
 const MIN_TTL = 1 * 1000
-const MAX_TTL = 300 * 1000
 
-const createTtlValue = (ttl: number): number => {
+const createTtlValue = (ttl: number, maxTtl: number): number => {
     if (ttl < MIN_TTL) {
         return MIN_TTL
-    } else if (ttl > MAX_TTL) {
-        return MAX_TTL
+    } else if (ttl > maxTtl) {
+        return maxTtl
     } else {
         return ttl
     }
@@ -23,6 +22,13 @@ interface LocalDataEntry {
 type Key = Uint8Array
 
 export class LocalDataStore {
+
+    private readonly maxTtl: number
+
+    constructor(maxTtl: number) {
+        this.maxTtl = maxTtl
+    }
+
     // A map into which each node can store one value per data key
     // The first key is the key of the data, the second key is the
     // PeerID of the creator of the data
@@ -50,7 +56,7 @@ export class LocalDataStore {
             dataEntry,
             ttlTimeout: setTimeout(() => {
                 this.deleteEntry(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!))
-            }, createTtlValue(dataEntry.ttl))
+            }, createTtlValue(dataEntry.ttl, this.maxTtl))
         })
         return true
     }

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -2,18 +2,6 @@ import { PeerID, PeerIDKey } from '../../helpers/PeerID'
 import { DataEntry } from '../../proto/packages/dht/protos/DhtRpc'
 import { peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 
-const MIN_TTL = 1 * 1000
-
-const createTtlValue = (ttl: number, maxTtl: number): number => {
-    if (ttl < MIN_TTL) {
-        return MIN_TTL
-    } else if (ttl > maxTtl) {
-        return maxTtl
-    } else {
-        return ttl
-    }
-}
-
 interface LocalDataEntry {
     dataEntry: DataEntry
     ttlTimeout: NodeJS.Timeout
@@ -56,7 +44,7 @@ export class LocalDataStore {
             dataEntry,
             ttlTimeout: setTimeout(() => {
                 this.deleteEntry(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!))
-            }, createTtlValue(dataEntry.ttl, this.maxTtl))
+            }, Math.min(dataEntry.ttl, this.maxTtl))
         })
         return true
     }

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -29,7 +29,6 @@ interface DataStoreConfig {
     localPeerDescriptor: PeerDescriptor
     localDataStore: LocalDataStore
     serviceId: ServiceID
-    maxTtl: number
     highestTtl: number
     redundancyFactor: number
     getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => DhtNodeRpcRemote[]
@@ -45,7 +44,6 @@ export class StoreRpcLocal implements IStoreRpc {
     private readonly localPeerDescriptor: PeerDescriptor
     private readonly localDataStore: LocalDataStore
     private readonly serviceId: ServiceID
-    private readonly maxTtl: number
     private readonly highestTtl: number
     private readonly redundancyFactor: number
     private readonly getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => DhtNodeRpcRemote[]
@@ -57,7 +55,6 @@ export class StoreRpcLocal implements IStoreRpc {
         this.localPeerDescriptor = config.localPeerDescriptor
         this.localDataStore = config.localDataStore
         this.serviceId = config.serviceId
-        this.maxTtl = config.maxTtl
         this.highestTtl = config.highestTtl
         this.redundancyFactor = config.redundancyFactor
         this.rpcRequestTimeout = config.rpcRequestTimeout
@@ -184,8 +181,7 @@ export class StoreRpcLocal implements IStoreRpc {
 
     // RPC service implementation
     async storeData(request: StoreDataRequest): Promise<StoreDataResponse> {
-        const ttl = Math.min(request.ttl, this.maxTtl)
-        const { key, data, createdAt, creator } = request
+        const { key, data, creator, createdAt, ttl } = request
         this.localDataStore.storeEntry({ 
             key, 
             data,

--- a/packages/dht/test/unit/Finder.test.ts
+++ b/packages/dht/test/unit/Finder.test.ts
@@ -73,7 +73,7 @@ describe('Finder', () => {
             router,
             connections: new Map(),
             serviceId: 'Finder',
-            localDataStore: new LocalDataStore(),
+            localDataStore: new LocalDataStore(30 * 100),
             sessionTransport: transport,
             addContact: () => {},
             isPeerCloserToIdThanSelf: (_peer1, _compareToId) => true,

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -47,7 +47,7 @@ describe('LocalDataStore', () => {
     }
 
     beforeEach(() => {
-        localDataStore = new LocalDataStore()
+        localDataStore = new LocalDataStore(30 * 1000)
     })
 
     afterEach(() => {


### PR DESCRIPTION
Use the `storeMaxTtl` config option instead of hardcode `TTL_MAX`.

Before this PR the data storage TTL handling was done in two places: 
- in `LocalDataStore` using the hardcoded: it scheduled the auto-deletion to happen between `TTL_MIN` and `TTL_MAX`
- in `StoreRpcLocal` using the configured value:  it mutated the entry's `ttl` if it was greater than `storeMaxTtl`.

Now the TTL handling is done only in `LocalDataStore`. The`StoreRpcLocal` no longer mutates the entry. That way the `storeMaxTtl` option just controls how long this node keeps the entry, and the option doesn't affect the entries which are replicated to other nodes via this node.

Removed also hardcoded `TTL_MIN` limit. If we need the limit, we should add a `DhtNode` config option for that.
