### PR TITLE
fix(dht): Use `CUSTOM_GOING_AWAY` code in websocket close

### DIFF
--- a/packages/dht/src/connection/websocket/ClientWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ClientWebsocket.ts
@@ -8,6 +8,9 @@ const logger = new Logger(module)
 // https://kapeli.com/cheat_sheets/WebSocket_Status_Codes.docset/Contents/Resources/Documents/index
 // Browsers send this automatically when closing a tab
 export const GOING_AWAY = 1001
+// The GOING_AWAY is a reserved code and we shouldn't send that from the application. Therefore
+// we have a custom counterpart
+export const CUSTOM_GOING_AWAY = 3001
 
 const BINARY_TYPE = 'arraybuffer'
 
@@ -69,7 +72,7 @@ export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.destroyed = true
         this.stopListening()
         this.socket = undefined
-        const gracefulLeave = code === GOING_AWAY
+        const gracefulLeave = (code === GOING_AWAY) || (code === CUSTOM_GOING_AWAY)
         this.emit('disconnected', gracefulLeave, code, reason)
         this.removeAllListeners()
     }
@@ -92,7 +95,7 @@ export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.removeAllListeners()
         if (!this.destroyed) {
             logger.trace(`Closing socket for connection ${this.connectionId.toString()}`)
-            this.socket?.close(gracefulLeave === true ? GOING_AWAY : undefined)
+            this.socket?.close(gracefulLeave ? CUSTOM_GOING_AWAY : undefined)
         } else {
             logger.debug('Tried to close() a stopped connection')
         }

--- a/packages/dht/src/connection/websocket/ServerWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ServerWebsocket.ts
@@ -3,7 +3,7 @@ import { IConnection, ConnectionID, ConnectionEvents, ConnectionType } from '../
 import { connection as WsConnection } from 'websocket'
 import { Logger } from '@streamr/utils'
 import { Url } from 'url'
-import { GOING_AWAY } from './ClientWebsocket'
+import { CUSTOM_GOING_AWAY, GOING_AWAY } from './ClientWebsocket'
 
 const logger = new Logger(module)
 
@@ -59,7 +59,7 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.stopped = true
         this.socket?.removeAllListeners()
         this.socket = undefined
-        const gracefulLeave = reasonCode === GOING_AWAY
+        const gracefulLeave = (reasonCode === GOING_AWAY) || (reasonCode === CUSTOM_GOING_AWAY)
         this.emit('disconnected', gracefulLeave, reasonCode, description)
     }
 
@@ -83,7 +83,7 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.emit('disconnected', gracefulLeave, undefined, 'close() called')
         this.removeAllListeners()
         if (!this.stopped) {
-            this.socket?.close(gracefulLeave === true ? GOING_AWAY : undefined)
+            this.socket?.close(gracefulLeave ? GOING_AWAY : undefined)
         } else {
             logger.debug('Tried to close a stopped connection')
         }


### PR DESCRIPTION
Added new `CUSTOM_GOING_AWAY` code.

In browser we can't send `GOING_AWAY`, because it is a reserved code. If we try to close a WebSocket with that code in a browser we get an error:
```
Uncaught (in promise) DOMException: Failed to execute ‘close’ on ‘WebSocket’: The code must be either 1000, or between 3000 and 4999. 1001 is neither.
```

We have two separate codes because browsers send `GOING_AWAY` code automatically when a tab is closed.