### PR TITLE
fix(dht): Recursive router can exclude peer

### DIFF
--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -130,13 +130,13 @@ export class Router implements IRouter {
         }
     }
 
-    public doRouteMessage(routedMessage: RouteMessageWrapper, mode = RoutingMode.ROUTE): RouteMessageAck {
+    public doRouteMessage(routedMessage: RouteMessageWrapper, mode = RoutingMode.ROUTE, excludedPeer?: PeerDescriptor): RouteMessageAck {
         if (this.stopped) {
             return createRouteMessageAck(routedMessage, RouteMessageError.STOPPED)
         }
         logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
             + `to ${getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)}`)
-        const session = this.createRoutingSession(routedMessage, mode)
+        const session = this.createRoutingSession(routedMessage, mode, excludedPeer)
         const contacts = session.updateAndGetRoutablePeers()
         if (contacts.length > 0) {
             this.addRoutingSession(session)
@@ -169,7 +169,11 @@ export class Router implements IRouter {
         }
     }
 
-    private createRoutingSession(routedMessage: RouteMessageWrapper, mode: RoutingMode): RoutingSession {
+    private createRoutingSession(routedMessage: RouteMessageWrapper, mode: RoutingMode, excludedPeer?: PeerDescriptor): RoutingSession {
+        const excludedPeers = routedMessage.routingPath.map((descriptor) => peerIdFromPeerDescriptor(descriptor))
+        if (excludedPeer) {
+            excludedPeers.push(peerIdFromPeerDescriptor(excludedPeer))
+        }
         logger.trace('routing session created with connections: ' + this.connections.size)
         return new RoutingSession(
             this.rpcCommunicator,
@@ -178,7 +182,7 @@ export class Router implements IRouter {
             this.connections,
             areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.sourcePeer!) ? 2 : 1,
             mode,
-            routedMessage.routingPath.map((descriptor) => peerIdFromPeerDescriptor(descriptor))
+            excludedPeers
         )
     }
 


### PR DESCRIPTION
Re-added `excludedPeer` parameter to `Router#doRouteMessage`. It was incorrectly removed in https://github.com/streamr-dev/network/pull/2033.

The parameter is used at least in `RecursiveOperationManager#doRouteRequest`. That method is called e.g. from `ExternalApiRpcLocal#externalFindData` which sets `senderPeerDescriptor` as the excluded peer.