### PR TITLE
Fixed memory leak in ServerWebSocket

### DIFF
--- a/packages/dht/src/connection/websocket/ServerWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ServerWebsocket.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3'
 import { IConnection, ConnectionID, ConnectionEvents, ConnectionType } from '../IConnection'
-import { connection as WsConnection } from 'websocket'
+import { Message, connection as WsConnection } from 'websocket'
 import { Logger } from '@streamr/utils'
 import { Url } from 'url'
 import { CUSTOM_GOING_AWAY, GOING_AWAY } from './ClientWebsocket'
@@ -29,35 +29,50 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
     constructor(socket: WsConnection, resourceURL: Url) {
         super()
 
+        this.onMessage = this.onMessage.bind(this)
+        this.onClose = this.onClose.bind(this)
+        this.onError = this.onError.bind(this)
+
         this.resourceURL = resourceURL
         this.connectionId = new ConnectionID()
 
-        socket.on('message', (message) => {
-            logger.trace('ServerWebsocket::onMessage')
-            if (message.type === MessageType.UTF8) {
-                logger.debug('Received string Message: ' + message.utf8Data)
-            } else if (message.type === MessageType.BINARY) {
-                logger.trace('Received Binary Message of ' + message.binaryData.length + ' bytes')
-                this.emit('data',
-                    new Uint8Array(message.binaryData.buffer, message.binaryData.byteOffset,
-                        message.binaryData.byteLength / Uint8Array.BYTES_PER_ELEMENT))
-            }
-        })
-        socket.on('close', (reasonCode, description) => {
-            logger.trace('Peer ' + socket.remoteAddress + ' disconnected.')            
-            this.doDisconnect(reasonCode, description)
-        })
-
-        socket.on('error', (error) => {
-            this.emit('error', error.name)
-        })
+        socket.on('message', this.onMessage)
+        socket.on('close', this.onClose)
+        socket.on('error', this.onError)
 
         this.socket = socket
     }
 
+    private onMessage(message: Message): void {
+        logger.trace('ServerWebsocket::onMessage')
+        if (message.type === MessageType.UTF8) {
+            logger.debug('Received string Message: ' + message.utf8Data)
+        } else if (message.type === MessageType.BINARY) {
+            logger.trace('Received Binary Message of ' + message.binaryData.length + ' bytes')
+            this.emit('data',
+                new Uint8Array(message.binaryData.buffer, message.binaryData.byteOffset,
+                    message.binaryData.byteLength / Uint8Array.BYTES_PER_ELEMENT))
+        }
+    }
+
+    private onClose(reasonCode: number, description: string): void {
+        logger.trace('Peer ' + this.socket?.remoteAddress + ' disconnected.')
+        this.doDisconnect(reasonCode, description)
+    }
+
+    private onError(error: Error): void {
+        this.emit('error', error.name)
+    }
+
+    private stopListening(): void {
+        this.socket?.off('message', this.onMessage)
+        this.socket?.off('close', this.onClose)
+        this.socket?.off('error', this.onError)
+    }
+
     private doDisconnect(reasonCode: number, description: string): void {
         this.stopped = true
-        this.socket?.removeAllListeners()
+        this.stopListening()
         this.socket = undefined
         const gracefulLeave = (reasonCode === GOING_AWAY) || (reasonCode === CUSTOM_GOING_AWAY)
         this.emit('disconnected', gracefulLeave, reasonCode, description)
@@ -93,7 +108,7 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
         if (!this.stopped) {
             this.removeAllListeners()
             if (this.socket) {
-                this.socket.removeAllListeners()
+                this.stopListening()
                 this.socket.close()
                 this.socket = undefined
             }

--- a/packages/dht/test/benchmark/WebsocketServerMemoryLeak.test.ts
+++ b/packages/dht/test/benchmark/WebsocketServerMemoryLeak.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+
+import { wait } from '@streamr/utils'
+import { WebsocketServer } from '../../src/connection/websocket/WebsocketServer'
+import { ClientWebsocket } from '../../src/exports'
+
+// This 'test' is meant to be run manually using the following command:
+// node --inspect ../../../../node_modules/.bin/jest WebsocketServerMemoryLeak.test.ts
+// while wathing for memory leaks in Chrome DevTools
+
+describe('WebsocketServermemoryLeak', () => {
+
+    it('Accepts and detroys connections', async () => {
+        const server = new WebsocketServer({
+            portRange: { min: 19792, max: 19792 },
+            enableTls: false
+        })
+
+        server.on('connected', (connection) => {
+            console.log('ServerWebsocket connected')
+            connection.destroy()
+            console.log('ServerWebsocket destroyed')
+        })
+
+        const port = await server.start()
+        expect(port).toEqual(19792)
+        
+        for (let i = 0; i < 10000; i++) {
+            const clientWebsocket: ClientWebsocket = new ClientWebsocket()
+            clientWebsocket.on('connected', () => {
+                console.log('clientWebsocket connected ' + i)
+            })
+            
+            clientWebsocket.connect(`ws://127.0.0.1:${port}`)
+            i++
+            await wait(3000)
+        }
+
+        await server.stop()
+    }, 120000000)
+})


### PR DESCRIPTION
* Fixed memory leak in ServerWebSocket by switching off listeners of socket properly instead of calling removeAllListeners, which messed up internal event handling of websocket library
* Added a benchmark 'test' which made the memory leak visible in Chrome dev tools before applying the fix 