### PR TITLE
Add try-catch around websocket accept

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketServer.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServer.ts
@@ -102,11 +102,17 @@ export class WebsocketServer extends EventEmitter<ConnectionSourceEvents> {
                     return
                 }
                 
-                const connection = request.accept(undefined, request.origin)
-                
-                logger.trace('IConnection accepted.')
+                let connection
+                try {
+                    connection = request.accept(undefined, request.origin)
+                    logger.trace('Connection accepted.', { remoteAddress: request.remoteAddress })
+                } catch (err) {
+                    logger.debug(`Accepting websocket connection from ${request.remoteAddress} failed`, { err })
+                }
 
-                this.emit('connected', new ServerWebsocket(connection, request.resourceURL))
+                if (connection) {
+                    this.emit('connected', new ServerWebsocket(connection, request.resourceURL))
+                }
             })
             this.httpServer.once('error', (err: Error) => {
                 reject(new WebsocketServerStartError('Starting Websocket server failed', err))

--- a/packages/dht/src/connection/websocket/WebsocketServer.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServer.ts
@@ -107,7 +107,7 @@ export class WebsocketServer extends EventEmitter<ConnectionSourceEvents> {
                     connection = request.accept(undefined, request.origin)
                     logger.trace('Connection accepted.', { remoteAddress: request.remoteAddress })
                 } catch (err) {
-                    logger.debug(`Accepting websocket connection from ${request.remoteAddress} failed`, { err })
+                    logger.debug('Accepting websocket connection failed', { remoteAddress: request.remoteAddress, err })
                 }
 
                 if (connection) {


### PR DESCRIPTION
This kind of uncaught exceptions happen occasionally, which crashes the node. Googling for the EPIPE error reveals that this is apparently due to trying to write to a socket which is already closed. However, this stack trace reveals it happens on accepting an incoming connection to the websocket server, so something's wrong with the connection immediately upon establishment.

```
Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:94:16)
    at handleWriteReq (node:internal/stream_base_commons:63:21)
    at writeGeneric (node:internal/stream_base_commons:149:15)
    at TLSSocket.Socket._writeGeneric (node:net:931:11)
    at TLSSocket.Socket._write (node:net:943:8)
    at writeOrBuffer (node:internal/streams/writable:392:12)
    at _write (node:internal/streams/writable:333:10)
    at TLSSocket.Writable.write (node:internal/streams/writable:337:10)
    at WebSocketRequest.accept (/opt/network/node_modules/websocket/lib/WebSocketRequest.js:458:21)
    at WebSocketServer.<anonymous> (/opt/network/packages/dht/src/connection/websocket/WebsocketServer.ts:108:48) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
```