### PR TITLE
refactor(dht): Optimize peer id utils

### DIFF
--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -5,7 +5,7 @@ import crypto from 'crypto'
 
 export type PeerIDKey = BrandedString<'PeerIDKey'>
 
-export const createPeerIDKey = (nodeId: Uint8Array) => {
+export const createPeerIDKey = (nodeId: Uint8Array): PeerIDKey => {
     return binaryToHex(nodeId) as PeerIDKey
 }
 

--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -1,4 +1,4 @@
-import { BrandedString } from '@streamr/utils'
+import { BrandedString, binaryToHex } from '@streamr/utils'
 import { UUID } from './UUID'
 import { IllegalArguments } from './errors'
 import crypto from 'crypto'
@@ -6,7 +6,7 @@ import crypto from 'crypto'
 export type PeerIDKey = BrandedString<'PeerIDKey'>
 
 export const createPeerIDKey = (nodeId: Uint8Array) => {
-    return Buffer.from(nodeId).toString('hex') as PeerIDKey
+    return binaryToHex(nodeId) as PeerIDKey
 }
 
 export class PeerID {

--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -5,6 +5,10 @@ import crypto from 'crypto'
 
 export type PeerIDKey = BrandedString<'PeerIDKey'>
 
+export const createPeerIDKey = (nodeId: Uint8Array) => {
+    return Buffer.from(nodeId).toString('hex') as PeerIDKey
+}
+
 export class PeerID {
     // avoid creating a new instance for every operation
     private static readonly textEncoder = new TextEncoder() 
@@ -30,7 +34,7 @@ export class PeerID {
             throw new IllegalArguments('Constructor of PeerID must be given either ip, value or stringValue')
         }
 
-        this.key = Buffer.from(this.data).toString('hex') as PeerIDKey
+        this.key = createPeerIDKey(this.data)
     }
 
     static fromIp(ip: string): PeerID {

--- a/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
+++ b/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
@@ -1,4 +1,4 @@
-import { binaryToHex } from '@streamr/utils'
+import { areEqualBinaries, binaryToHex } from '@streamr/utils'
 import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { PeerID, PeerIDKey } from './PeerID'
 
@@ -16,5 +16,5 @@ export const keyFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerIDKey
 }
 
 export const areEqualPeerDescriptors = (peerDescriptor1: PeerDescriptor, peerDescriptor2: PeerDescriptor): boolean => {
-    return peerIdFromPeerDescriptor(peerDescriptor1).equals(peerIdFromPeerDescriptor(peerDescriptor2))
+    return areEqualBinaries(peerDescriptor1.nodeId, peerDescriptor2.nodeId)
 }

--- a/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
+++ b/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
@@ -1,6 +1,6 @@
 import { areEqualBinaries, binaryToHex } from '@streamr/utils'
 import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
-import { PeerID, PeerIDKey } from './PeerID'
+import { PeerID, PeerIDKey, createPeerIDKey } from './PeerID'
 
 export const peerIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerID => {
     return PeerID.fromValue(peerDescriptor.nodeId)
@@ -12,7 +12,7 @@ export const getNodeIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): str
 }
 
 export const keyFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerIDKey => {
-    return PeerID.fromValue(peerDescriptor.nodeId).toKey()
+    return createPeerIDKey(peerDescriptor.nodeId)
 }
 
 export const areEqualPeerDescriptors = (peerDescriptor1: PeerDescriptor, peerDescriptor2: PeerDescriptor): boolean => {


### PR DESCRIPTION
Optimize `areEqualPeerDescriptors` and `keyFromPeerDescriptor` utils. Now the utility functions don't need to create temporary `PeerID` instances.

## Future improvements

We could avoid most of the `UInt8Array`<->`string` conversion by using hex-strings as the internal representation. We'd convert the strings to/from binaries only when the data is transferred via the protocol. 
- There are significantly more internal comparisons and key extractions (for maps etc.) than protocol sends/receives. If we need the binary representation in some loop, we can of course store that locally e.g. in a local variable.
- The internal string representation would also simplify and optimize use cases where the peer id is a key in a map. Currently we need to convert id to `PeerIDKey` each time we access the map.
- The `PeerIDKey` is actually exactly that internal hex-string representation what we'd want to use. Therefore this refactoring is very straighforward: "Let's store  `PeerIDKey` strings instead of `PeerID` object instances".
- We could call that internal representation e.g. `PeerID` or `NodeID` (maybe not `PeerIDKey`  as it is not just a map key, but the peer id itself).
- This simplifies and optimizes also logging as the string can be printed to console directly (no `getNodeIdFromPeerDescriptor` wrapper is needed).