### PR TITLE
fix(dht): Update of data `stale` state in `StoreRpcLocal#onNewContact`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -281,7 +281,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             highestTtl: this.config.storeHighestTtl,
             redundancyFactor: this.config.storageRedundancyFactor,
             localDataStore: this.localDataStore,
-            getNodesClosestToIdFromBucket: (id: Uint8Array, n?: number) => {
+            getClosestNeighborsTo: (id: Uint8Array, n?: number) => {
                 return this.peerManager!.getClosestNeighborsTo(id, n)
             },
             rpcRequestTimeout: this.config.rpcRequestTimeout

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -101,10 +101,9 @@ export class StoreRpcLocal implements IStoreRpc {
         if (!isClosest) {
             return false
         }
-        const newPeerId = PeerID.fromValue(newNode.nodeId)
         sortedList.addContact(new Contact(newNode))
         const sorted = sortedList.getAllContacts()
-        const index = findIndex(sorted, (contact) => contact.getPeerId().equals(newPeerId))
+        const index = findIndex(sorted, (contact) => contact.getPeerId().equals(newNodeId))
         // if new node is within the storageRedundancyFactor closest nodes to the data
         // do replicate data to it
         return (index < this.redundancyFactor)

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -96,15 +96,16 @@ export class StoreRpcLocal implements IStoreRpc {
             const index = findIndex(sorted, (contact) => contact.getPeerId().equals(newNodeId))
             // if new node is within the storageRedundancyFactor closest nodes to the data
             // do replicate data to it
-            const shouldReplicate = (index < this.redundancyFactor)
-            this.localDataStore.setStale(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!), !shouldReplicate)
-            if (shouldReplicate) {
+            this.localDataStore.setStale(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!), false)
+            if (index < this.redundancyFactor) {
                 try {
                     await this.replicateDataToContact(dataEntry, newNode)
                 } catch (e) {
                     logger.trace('replicateDataToContact() failed', { error: e })
                 }
             }
+        } else {
+            this.localDataStore.setStale(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!), !this.selfIsOneOfClosestPeers(dataEntry.key))
         }
     }
 

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -83,7 +83,6 @@ export class StoreRpcLocal implements IStoreRpc {
 
     private shouldReplicateDataToNewNode(dataEntry: DataEntry, newNode: PeerDescriptor): boolean {
         const newNodeId = PeerID.fromValue(newNode.nodeId)
-        const localPeerId = PeerID.fromValue(this.localPeerDescriptor.nodeId)
         // TODO use config option or named constant?
         const closestToData = this.getNodesClosestToIdFromBucket(dataEntry.key, 10)
         const sortedList = new SortedContactList<Contact>({
@@ -98,7 +97,7 @@ export class StoreRpcLocal implements IStoreRpc {
                 sortedList.addContact(new Contact(con.getPeerDescriptor()))
             }
         })
-        const isClosest = sortedList.getAllContacts()[0].getPeerId().equals(localPeerId)
+        const isClosest = sortedList.getAllContacts()[0].getPeerId().equals(PeerID.fromValue(this.localPeerDescriptor.nodeId))
         if (!isClosest) {
             return false
         }

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -104,7 +104,7 @@ export class StoreRpcLocal implements IStoreRpc {
                     logger.trace('replicateDataToContact() failed', { error: e })
                 }
             }
-        } else if (!this.selfIsOneOfClosestPeers(dataEntry.key)){
+        } else if (!this.selfIsOneOfClosestPeers(dataEntry.key)) {
             this.localDataStore.setStale(dataEntry.key, peerIdFromPeerDescriptor(dataEntry.creator!), true)
         }
     }


### PR DESCRIPTION
Before this PR we incorrectly updated the data entry state to true when `StoreRpcLocal#onNewContact` was called for the closest node. 

This bug was introduced in https://github.com/streamr-dev/network/pull/2137. In `StoreRpcLocal#shouldReplicateDataToNewNode` there is a guard at line `102`. After the refactoring we didn't have any special handling for the guard case, and therefore we incorrectly called `this.localDataStore.setStale(..., true)` if we returned from `StoreRpcLocal#shouldReplicateDataToNewNode` because of the guard.

Now we have a method `replicateAndUpdateStaleStateIfClosest`. If the local node is the closest node for the data:
- it always updates the stale state
- if the new node is quite close to the data (within `redundancyFactor`), it replicates the data to that new node

## TODO

Does this change do the same thing, or something better than https://github.com/streamr-dev/network/pull/2159? If something is missing, we should include that into this PR or cherry-pick that PR 2159 to `streamr-1.0`.

## Open questions

Why we update our `stale` state only if we are the closest node for the data? 

## Other changes

Also renamed the `getNodesClosestToIdFromBucket` to `getClosestNeighborsTo` in `StoreRpcLocal` as that is the name of `PeerManager` method it calls.
