### PR TITLE
deps: `@streamr/config` 5.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6999,9 +6999,9 @@
             "link": true
         },
         "node_modules/@streamr/config": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.0.3.tgz",
-            "integrity": "sha512-x/lfsrMq1aCT/Q8+JoSiPLR03IGcIIGh4iHbzGKt49GGM/X2lDvM3NuxYKpyHbdQCJKyZB0eG+/laBmrZhpKxg=="
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@streamr/config/-/config-5.0.4.tgz",
+            "integrity": "sha512-E8CHzlmE990EIuUw3NOfZw54MovCalLsdbvLjh4hOmo0BhN4MQRMVYoZoHriN1KEiqSmeS7pI5BqSr36+c7hmw=="
         },
         "node_modules/@streamr/dht": {
             "resolved": "packages/dht",
@@ -29130,7 +29130,7 @@
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
-                "@streamr/config": "^5.0.3",
+                "@streamr/config": "^5.0.4",
                 "@streamr/network-contracts": "^7.0.5",
                 "@streamr/protocol": "100.0.0-pretestnet.4",
                 "@streamr/utils": "100.0.0-pretestnet.4",
@@ -29359,7 +29359,7 @@
                 "@ethersproject/web": "^5.5.0",
                 "@lit-protocol/core": "^2.2.5",
                 "@lit-protocol/uint8arrays": "^2.2.61",
-                "@streamr/config": "^5.0.3",
+                "@streamr/config": "^5.0.4",
                 "@streamr/dht": "100.0.0-pretestnet.4",
                 "@streamr/protocol": "100.0.0-pretestnet.4",
                 "@streamr/trackerless-network": "100.0.0-pretestnet.4",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -29,7 +29,7 @@
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "dependencies": {
     "@ethersproject/hdnode": "^5.4.0",
-    "@streamr/config": "^5.0.3",
+    "@streamr/config": "^5.0.4",
     "@streamr/network-contracts": "^7.0.5",
     "@streamr/protocol": "100.0.0-pretestnet.4",
     "@streamr/utils": "100.0.0-pretestnet.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -101,7 +101,7 @@
     "@ethersproject/web": "^5.5.0",
     "@lit-protocol/core": "^2.2.5",
     "@lit-protocol/uint8arrays": "^2.2.61",
-    "@streamr/config": "^5.0.3",
+    "@streamr/config": "^5.0.4",
     "@streamr/dht": "100.0.0-pretestnet.4",
     "@streamr/protocol": "100.0.0-pretestnet.4",
     "@streamr/trackerless-network": "100.0.0-pretestnet.4",

--- a/packages/client/src/Config.ts
+++ b/packages/client/src/Config.ts
@@ -230,6 +230,8 @@ export interface EthereumNetworkConfig {
 //   in Ethereum network
 export type EnvironmentId = 'polygon' | 'mumbai' | 'dev2'
 
+export const DEFAULT_ENVIRONMENT: EnvironmentId = 'polygon'
+
 /**
  * @category Important
  */
@@ -435,7 +437,7 @@ export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc3
 export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStreamrClientConfig => {
     // TODO is it good to cloneDeep the input object as it may have object references (e.g. auth.ethereum)?
     let config = cloneDeep(input)
-    const environment = config.environment ?? 'polygon'
+    const environment = config.environment ?? DEFAULT_ENVIRONMENT
     config = applyEnvironmentDefaults(environment, config)
     const strictConfig = validateConfig(config)
     strictConfig.id ??= generateClientId()

--- a/packages/client/test/unit/Config.test.ts
+++ b/packages/client/test/unit/Config.test.ts
@@ -1,5 +1,5 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { NetworkNodeType, NetworkPeerDescriptor, createStrictConfig, redactConfig } from '../../src/Config'
+import { NetworkNodeType, NetworkPeerDescriptor, createStrictConfig, redactConfig, DEFAULT_ENVIRONMENT } from '../../src/Config'
 import { CONFIG_TEST } from '../../src/ConfigTest'
 import { generateEthereumAccount } from '../../src/Ethereum'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -105,7 +105,7 @@ describe('Config', () => {
                 network: {}
             })
             expect(clientOverrides.network).toEqual(clientDefaults.network)
-            expect(clientOverrides.network.controlLayer.entryPoints![0].nodeId).toEqual('eee1')
+            expect(clientOverrides.network.controlLayer.entryPoints![0].nodeId).toEqual(CHAIN_CONFIG[DEFAULT_ENVIRONMENT].entryPoints[0].nodeId)
         })
 
         it('can override entryPoints', () => {


### PR DESCRIPTION
Update `@streamr/config` dependency. It contains updated entry points for `polygon` environment.

Also added `DEFAULT_ENVIRONMENT` const which we use in config unit test (there we check that the client contains the entry point of the default entrypoint if we don't explicitly set any).