### PR TITLE
fix(dht): Close connections after timeout

### DIFF
--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -56,8 +56,10 @@ export class ManagedConnection extends EventEmitter<Events> {
     private localPeerDescriptor: PeerDescriptor
     protected outgoingConnection?: IConnection
     protected incomingConnection?: IConnection
+
+    // TODO: Temporary debug variable, should be removed in the future.
     private created = Date.now()
-    
+
     constructor(
         localPeerDescriptor: PeerDescriptor,
         connectionType: ConnectionType,

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -42,7 +42,7 @@ describe('Storing data in DHT', () => {
 
     afterEach(async () => {
         await Promise.all(nodes.map((node) => node.stop()))
-    })
+    }, 15000)
 
     it('Storing data works', async () => {
         const storingNodeIndex = 34

--- a/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
@@ -209,4 +209,33 @@ describe('WebRTC Connection Management', () => {
         await disconnectedPromise1
 
     }, 20000)
+
+    it('failed connections are cleaned up', async () => {
+        const msg: Message = {
+            serviceId,
+            messageType: MessageType.RPC,
+            messageId: '1',
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            },
+        }
+
+        const disconnectedPromise1 = new Promise<void>((resolve, _reject) => {
+            manager1.on('disconnected', () => {
+                resolve()
+            })
+        })
+
+        msg.targetDescriptor = {
+            nodeId: new Uint8Array([0, 0, 0, 0, 0]),
+            type: NodeType.NODEJS,
+        }
+        
+        await Promise.allSettled([
+            manager1.send(msg),
+            disconnectedPromise1
+        ])
+        expect(manager1.getConnection(msg.targetDescriptor!)).toBeUndefined()
+    }, 20000)
 })

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable promise/no-nesting */
 
-import { MetricsContext, waitForCondition } from '@streamr/utils'
+import { MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../../src/connection/ConnectorFacade'
 import { ConnectionType } from '../../src/connection/IConnection'
@@ -10,6 +10,7 @@ import { PeerID } from '../../src/helpers/PeerID'
 import * as Err from '../../src/helpers/errors'
 import { Message, MessageType, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
+import { TransportEvents } from '../../src/transport/ITransport'
 
 const createConfig = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultConnectorFacadeConfig, 'createLocalPeerDescriptor'>) => {
     return {
@@ -137,6 +138,28 @@ describe('Websocket Connection Management', () => {
         wsServerManager.send(dummyMessage)
     })
 
+    it('Failed connection requests are cleaned up', async () => {
+        const dummyMessage: Message = {
+            serviceId,
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            },
+            messageType: MessageType.RPC,
+            messageId: 'mockerer',
+            targetDescriptor: {
+                nodeId: new Uint8Array([1, 2, 4]),
+                type: NodeType.NODEJS
+            }
+        }
+
+        await Promise.allSettled([
+            waitForEvent3<TransportEvents>(wsServerManager, 'disconnected', 15000),
+            wsServerManager.send(dummyMessage)
+        ])
+        expect(wsServerManager.getConnection(dummyMessage.targetDescriptor!)).toBeUndefined()
+    }, 20000)
+    
     it('Can open connections to peer with server', async () => {
         const dummyMessage: Message = {
             serviceId,


### PR DESCRIPTION
## Summary

Fixed a critical issue where in cases where the `ManagedConnection's` send time outs we do not close the connections in many cases. This was a major issue in all cases that required signalling to form the connection ie. requested ws connections and webrtc connections. In some cases the websocket client connect would also be stuck in connecting state forever. The clears up that issue as well.

## Future improvements

- Investigate why the `integration/store.test.ts` required an increased afterEach timeout after the fix.
- Are both the closing and stopped fields needed in `ManagedConnection`
