### PR TITLE
fix(autocertifier-client): Check the certificate.json file can be read and written before requesting certificates

### DIFF
--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -34,9 +34,10 @@ const ensureConfigFileWritable = (directory: string): void => {
 const getBaseDirectory = (directory: string): string => {
     const subDirs = directory.split(path.sep)
     while (subDirs.length > 0) {
-        const current = subDirs.pop()
-        if (fs.existsSync(current!)) {
-           return subDirs.join(path.sep)
+        subDirs.pop()
+        const current = subDirs.join(path.sep)
+        if (fs.existsSync(current)) {
+           return current
         }
     }
     return path.sep

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -33,13 +33,13 @@ const ensureConfigFileWritable = (directory: string): void => {
 
 const getBaseDirectory = (directory: string): string => {
     const subDirs = directory.split(path.sep)
-    while (subDirs.length > 0) {
-        subDirs.pop()
+    do {
         const current = subDirs.join(path.sep)
         if (fs.existsSync(current)) {
            return current
         }
-    }
+        subDirs.pop()
+    } while (subDirs.length > 0)
     return path.sep
 }
 

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -21,7 +21,7 @@ const logger = new Logger(module)
 const ensureConfigFileWritable = (directory: string): void => {
     const baseDirectory = getBaseDirectory(directory)
     fs.accessSync(baseDirectory, fs.constants.W_OK | fs.constants.R_OK)
-    logger.trace(`Directory ${baseDirectory} is writable`)
+    logger.trace(`Directory ${baseDirectory} is readable and writable`)
 }
 
 const getBaseDirectory = (directory: string): string => {

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -20,6 +20,7 @@ const logger = new Logger(module)
 
 const ensureConfigFileWritable = (directory: string): void => {
     const baseDirectory = getBaseDirectory(directory)
+    logger.info(`Found base directory ${baseDirectory}`)
     try {
         fs.accessSync(baseDirectory, fs.constants.W_OK)
         logger.info(`Directory ${baseDirectory} is writable`)

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -19,6 +19,7 @@ export type HasSession = (request: HasSessionRequest, context: ServerCallContext
 const logger = new Logger(module)
 
 const ensureConfigFileWritable = (directory: string): void => {
+    logger.info(`Checking if directory ${directory} is writable`)
     const baseDirectory = getBaseDirectory(directory)
     logger.info(`Found base directory ${baseDirectory}`)
     try {

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -22,6 +22,7 @@ const ensureConfigFileWritable = (directory: string): void => {
     const baseDirectory = getBaseDirectory(directory)
     try {
         fs.accessSync(baseDirectory, fs.constants.W_OK)
+        logger.info(`Directory ${baseDirectory} is writable`)
     } catch (err) {
         logger.error(err)
         throw new Error(`Directory ${baseDirectory} is not writable`)

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -7,7 +7,6 @@ import { RestClient } from './RestClient'
 import { CertifiedSubdomain } from './data/CertifiedSubdomain'
 import fs from 'fs'
 import path from 'path'
-import os from 'os'
 import * as forge from 'node-forge'
 import { Logger } from '@streamr/utils'
 
@@ -21,20 +20,23 @@ const logger = new Logger(module)
 
 const ensureConfigFileWritable = (directory: string): void => {
     const baseDirectory = getBaseDirectory(directory)
-    if (!fs.access(baseDirectory, fs.CONSTANTS.W_OK)) {
+    try {
+        fs.accessSync(baseDirectory, fs.constants.W_OK)
+    } catch (err) {
+        logger.error(err)
         throw new Error(`Directory ${baseDirectory} is not writable`)
     }
 }
 
 const getBaseDirectory = (directory: string): string => {
-    const subDirs = directory.split(os.separator)
+    const subDirs = directory.split(path.sep)
     while (subDirs.length > 0) {
         const current = subDirs.pop()
-        if (fs.existsSync(current)) {
-           return subDirs.join(os.separator)
+        if (fs.existsSync(current!)) {
+           return subDirs.join(path.sep)
         }
     }
-    return os.separator
+    return path.sep
 }
 
 export const SERVICE_ID = 'system/auto-certificer'

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -19,16 +19,9 @@ export type HasSession = (request: HasSessionRequest, context: ServerCallContext
 const logger = new Logger(module)
 
 const ensureConfigFileWritable = (directory: string): void => {
-    logger.info(`Checking if directory ${directory} is writable`)
     const baseDirectory = getBaseDirectory(directory)
-    logger.info(`Found base directory ${baseDirectory}`)
-    try {
-        fs.accessSync(baseDirectory, fs.constants.W_OK)
-        logger.info(`Directory ${baseDirectory} is writable`)
-    } catch (err) {
-        logger.error(err)
-        throw new Error(`Directory ${baseDirectory} is not writable`)
-    }
+    fs.accessSync(baseDirectory, fs.constants.W_OK)
+    logger.trace(`Directory ${baseDirectory} is writable`)
 }
 
 const getBaseDirectory = (directory: string): string => {

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -20,7 +20,7 @@ const logger = new Logger(module)
 
 const ensureConfigFileWritable = (directory: string): void => {
     const baseDirectory = getBaseDirectory(directory)
-    fs.accessSync(baseDirectory, fs.constants.W_OK)
+    fs.accessSync(baseDirectory, fs.constants.W_OK | fs.constants.R_OK)
     logger.trace(`Directory ${baseDirectory} is writable`)
 }
 
@@ -29,7 +29,7 @@ const getBaseDirectory = (directory: string): string => {
     do {
         const current = subDirs.join(path.sep)
         if (fs.existsSync(current)) {
-           return current
+            return current
         }
         subDirs.pop()
     } while (subDirs.length > 0)

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -112,7 +112,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
                     })
                 }
             } catch (err) {
-                logger.warn('Failed to auto-certify, disabling WebSocket server TLS')
+                logger.warn('Failed to auto-certify, disabling WebSocket server TLS', { error: err })
                 await this.restartWebsocketConnector({
                     ...webSocketConnectorConfig,
                     serverEnableTls: false


### PR DESCRIPTION
## Summary

Fixed an issue where nodes could be creating new subdomains on each restart. This caused the autocertifier-server to have thousands of subdomains per IP address.

## Future improvements

- Could ensure that existing `certificate.json` files have correct permissions on restarts.
- Server could ensure that multiple subdomains are not created for individual IP addresses
