### PR TITLE
fix(network): Do not use virtual time

### DIFF
--- a/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
@@ -34,7 +34,6 @@ describe('HandshakeRpcRemote', () => {
     let mockConnectionManager2: SimulatorTransport
 
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         simulator = new Simulator()
         mockConnectionManager1 = new SimulatorTransport(serverNode, simulator)
         await mockConnectionManager1.start()
@@ -71,7 +70,6 @@ describe('HandshakeRpcRemote', () => {
         await mockConnectionManager1.stop()
         await mockConnectionManager2.stop()
         simulator.stop()
-        Simulator.useFakeTimers(false)
     })
 
     it('handshake', async () => {

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -70,7 +70,6 @@ describe('Handshakes', () => {
     let simulatorTransport3: SimulatorTransport
 
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         simulator = new Simulator()
         simulatorTransport1 = new SimulatorTransport(peerDescriptor1, simulator)
         await simulatorTransport1.start()
@@ -107,7 +106,6 @@ describe('Handshakes', () => {
         await simulatorTransport2.stop()
         await simulatorTransport3.stop()
         simulator.stop()
-        Simulator.useFakeTimers(false)
     })
 
     it('Two nodes can handshake', async () => {

--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -38,7 +38,6 @@ describe('inspect', () => {
     }
 
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         simulator = new Simulator(LatencyType.REAL)
 
         publisherNode = await initiateNode(publisherDescriptor, simulator)
@@ -65,7 +64,6 @@ describe('inspect', () => {
             inspectorNode.stop(),
             ...inspectedNodes.map((node) => node.stop())
         ])
-        Simulator.useFakeTimers(false)
     })
 
     it('gets successful inspections from all suspects', async () => {

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -30,7 +30,6 @@ describe('NetworkNode', () => {
     }
 
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         const simulator = new Simulator()
         transport1 = new SimulatorTransport(pd1, simulator)
         await transport1.start()
@@ -63,7 +62,6 @@ describe('NetworkNode', () => {
             node1.stop(),
             node2.stop()
         ])
-        Simulator.useFakeTimers(false)
     })
 
     it('wait for join + broadcast and subscribe', async () => {

--- a/packages/trackerless-network/test/integration/NetworkRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkRpc.test.ts
@@ -20,7 +20,6 @@ describe('Network RPC', () => {
     let recvCounter = 0
 
     beforeEach(() => {
-        Simulator.useFakeTimers()
         rpcCommunicator1 = new RpcCommunicator()
         rpcCommunicator2 = new RpcCommunicator()
         rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
@@ -40,7 +39,6 @@ describe('Network RPC', () => {
     afterEach(() => {
         rpcCommunicator1.stop()
         rpcCommunicator2.stop()
-        Simulator.useFakeTimers(false)
     })
 
     it('sends Data', async () => {

--- a/packages/trackerless-network/test/integration/NetworkRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkRpc.test.ts
@@ -9,7 +9,6 @@ import { waitForCondition } from '@streamr/utils'
 import { Empty } from '../../src/proto/google/protobuf/empty'
 import { createStreamMessage } from '../utils/utils'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
-import { Simulator } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -19,7 +19,6 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
 
     const peerDescriptors: PeerDescriptor[] = range(numOfNodes).map(() => createMockPeerDescriptor())
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         const simulator = new Simulator(LatencyType.FIXED, 50)
         const entrypointCm = new SimulatorTransport(entrypointDescriptor, simulator)
         const cms: SimulatorTransport[] = range(numOfNodes).map((i) =>
@@ -63,7 +62,6 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         entryPointRandomGraphNode.stop()
         await Promise.all(layer1Nodes.map((node) => node.stop()))
         await Promise.all(graphNodes.map((node) => node.stop()))
-        Simulator.useFakeTimers(false)
     })
 
     it('happy path single node', async () => {

--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node.test.ts
@@ -27,8 +27,6 @@ describe('RandomGraphNode-DhtNode', () => {
         })
     })
     beforeEach(async () => {
-
-        Simulator.useFakeTimers()
         const simulator = new Simulator()
         const entrypointCm = new SimulatorTransport(
             entrypointDescriptor,
@@ -84,7 +82,6 @@ describe('RandomGraphNode-DhtNode', () => {
         entryPointRandomGraphNode.stop()
         await Promise.all(layer1Nodes.map((node) => node.stop()))
         await Promise.all(graphNodes.map((node) => node.stop()))
-        Simulator.useFakeTimers(false)
     })
 
     it('happy path single node ', async () => {

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -43,7 +43,6 @@ describe('stream without default entrypoints', () => {
     })
 
     beforeEach(async () => {
-        Simulator.useFakeTimers()
         const simulator = new Simulator(LatencyType.REAL)
         nodes = []
         numOfReceivedMessages = 0
@@ -76,7 +75,6 @@ describe('stream without default entrypoints', () => {
     afterEach(async () => {
         await entrypoint.stop()
         await Promise.all(nodes.map((node) => node.stop()))
-        Simulator.useFakeTimers(false)
     })
 
     it('can join stream without configured entrypoints one by one', async () => {


### PR DESCRIPTION
## Summary

Stop using virtual time in trackerless-network, virtual time causes significantly increased CPU use and causes increased test flakyness
