### PR TITLE
streamr-1.0 fix-start-and-stop-of-autocertifier-client

### DIFF
--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -99,7 +99,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
         this.setLocalPeerDescriptor(localPeerDescriptor)
         if (localPeerDescriptor.websocket && !this.config.tlsCertificate && this.config.websocketServerEnableTls) {
             try {
-                await this.websocketConnector.autoCertify()
+                await this.websocketConnector.startAutocertifierClient()
                 const connectivityResponse = await this.websocketConnector.checkConnectivity(false)
                 const autocertifiedLocalPeerDescriptor = this.config.createLocalPeerDescriptor(connectivityResponse)
                 if (autocertifiedLocalPeerDescriptor.websocket !== undefined) {

--- a/packages/dht/test/end-to-end/RecoveryFromFailedAutoCertification.test.ts
+++ b/packages/dht/test/end-to-end/RecoveryFromFailedAutoCertification.test.ts
@@ -37,8 +37,8 @@ describe('Failed autocertification', () => {
 
     afterEach(async () => {
         await failedAutocertificationNode.stop()
-        await entryPoint.stop()
         await node.stop()
+        await entryPoint.stop()
     })
 
     it('failed auto certification should default to no tls', async () => {


### PR DESCRIPTION
This is the fix-start-and-stop-of-autocertifier-client pull request moved to base upon streamr-1.0 instead of testnet-one

* make test/end-to-end/RecoveryFromFailedAutoCertification.test.ts to stop the entrypoint last to prevent nodes from starting to reconnect through the stopped entrypoint at the end of the test
* rename WebsocketConnector's autoCertify() method to  startAutoCertifierClient() as this is what the method does
* stop AutoCertifierClientFacade in WebsocketConnector if it was started
* start AutoCertifierClient in AutoCertifierClientFacade using an abortable withTimeout() instead of waitForEvent3 (using a async function as waitForEvent3 predicate caused the timeout to keep running in case the predicate threw an exception, which was the reason for test/end-to-end/RecoveryFromFailedAutoCertification.test.ts to hang) 
* because of the above changes test/end-to-end/RecoveryFromFailedAutoCertification.test.ts does not hang anymore