### PR TITLE
refactor(dht): Refactor `StoreManager`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -283,7 +283,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             redundancyFactor: this.config.storageRedundancyFactor,
             localDataStore: this.localDataStore,
             getClosestNeighborsTo: (id: Uint8Array, n?: number) => {
-                return this.peerManager!.getClosestNeighborsTo(getNodeIdFromBinary(id), n)
+                return this.peerManager!.getClosestNeighborsTo(getNodeIdFromBinary(id), n).map((n) => n.getPeerDescriptor())
             },
             createRpcRemote: (contact: PeerDescriptor) => {
                 return new StoreRpcRemote(

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -1,6 +1,6 @@
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { SortedContactList } from '../contact/SortedContactList'
-import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 import { v4 } from 'uuid'
@@ -173,10 +173,9 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
     updateAndGetRoutablePeers(): RemoteContact[] {
         logger.trace('getRoutablePeers() sessionId: ' + this.sessionId)
         // Remove stale contacts that may have been removed from connections
-        this.contactList.getAllContacts().forEach((contact) => {
-            const peerId = peerIdFromPeerDescriptor(contact.getPeerDescriptor())
-            if (this.connections.has(peerId.toNodeId()) === false) {
-                this.contactList.removeContact(peerId.toNodeId())
+        this.contactList.getContactIds().forEach((nodeId) => {
+            if (!this.connections.has(nodeId)) {
+                this.contactList.removeContact(nodeId)
             }
         })
         const contacts = Array.from(this.connections.values())

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -78,14 +78,14 @@ export class StoreManager {
             }
         })
         const selfIsPrimaryStorer = areEqualNodeIds(
-            sortedList.getAllContacts()[0].getNodeId(),
+            sortedList.getClosestContactId(),
             getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         )
         if (selfIsPrimaryStorer) {
             sortedList.addContact(new Contact(newNode))
-            const sorted = sortedList.getAllContacts()
+            const sorted = sortedList.getContactIds()
             // findIndex should never return -1 here because we just added the new node to the list
-            const index = findIndex(sorted, (contact) => areEqualNodeIds(contact.getNodeId(), newNodeId))
+            const index = findIndex(sorted, (nodeId) => areEqualNodeIds(nodeId, newNodeId))
             // if new node is within the storageRedundancyFactor closest nodes to the data
             // do replicate data to it
             if (index < this.config.redundancyFactor) {
@@ -195,7 +195,7 @@ export class StoreManager {
         closestToData.forEach((neighbor) => {
             sortedList.addContact(new Contact(neighbor))
         })
-        const selfIsPrimaryStorer = areEqualNodeIds(sortedList.getAllContacts()[0].getNodeId(), localNodeId)
+        const selfIsPrimaryStorer = areEqualNodeIds(sortedList.getClosestContactId(), localNodeId)
         const targets = selfIsPrimaryStorer
             // if we are the closest to the data, replicate to all storageRedundancyFactor nearest
             ? sortedList.getAllContacts()

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -97,10 +97,10 @@ export class StoreManager {
         }
     }
 
-    private async replicateDataToContact(dataEntry: DataEntry, contact: PeerDescriptor, doNotConnect: boolean = false): Promise<void> {
+    private async replicateDataToContact(dataEntry: DataEntry, contact: PeerDescriptor): Promise<void> {
         const rpcRemote = this.config.createRpcRemote(contact)
         try {
-            await rpcRemote.replicateData({ entry: dataEntry }, doNotConnect)
+            await rpcRemote.replicateData({ entry: dataEntry })
         } catch (e) {
             logger.trace('replicateData() threw an exception ' + e)
         }

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -35,43 +35,27 @@ const logger = new Logger(module)
 
 export class StoreManager {
 
-    private readonly rpcCommunicator: RoutingRpcCommunicator
-    private readonly recursiveOperationManager: IRecursiveOperationManager
-    private readonly localPeerDescriptor: PeerDescriptor
-    private readonly localDataStore: LocalDataStore
-    private readonly serviceId: ServiceID
-    private readonly highestTtl: number
-    private readonly redundancyFactor: number
-    private readonly getClosestNeighborsTo: (id: Uint8Array, n?: number) => DhtNodeRpcRemote[]
     private readonly config: StoreManagerConfig
 
     constructor(config: StoreManagerConfig) {
-        this.rpcCommunicator = config.rpcCommunicator
-        this.recursiveOperationManager = config.recursiveOperationManager
-        this.localPeerDescriptor = config.localPeerDescriptor
-        this.localDataStore = config.localDataStore
-        this.serviceId = config.serviceId
-        this.highestTtl = config.highestTtl
-        this.redundancyFactor = config.redundancyFactor
-        this.getClosestNeighborsTo = config.getClosestNeighborsTo
         this.config = config
-        this.registerLocalRpcMethods(config)
+        this.registerLocalRpcMethods()
     }
 
-    private registerLocalRpcMethods(config: StoreManagerConfig) {
+    private registerLocalRpcMethods() {
         const rpcLocal = new StoreRpcLocal({
-            localDataStore: config.localDataStore,
+            localDataStore: this.config.localDataStore,
             replicateDataToNeighbors: (incomingPeer: PeerDescriptor, dataEntry: DataEntry) => this.replicateDataToNeighbors(incomingPeer, dataEntry),
             selfIsOneOfClosestPeers: (key: Uint8Array): boolean => this.selfIsOneOfClosestPeers(key)
         })
-        this.rpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData',
+        this.config.rpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData',
             (request: StoreDataRequest) => rpcLocal.storeData(request))
-        this.rpcCommunicator.registerRpcNotification(ReplicateDataRequest, 'replicateData',
+        this.config.rpcCommunicator.registerRpcNotification(ReplicateDataRequest, 'replicateData',
             (request: ReplicateDataRequest, context: ServerCallContext) => rpcLocal.replicateData(request, context))
     }
 
     onNewContact(peerDescriptor: PeerDescriptor): void {
-        for (const dataEntry of this.localDataStore.values()) {
+        for (const dataEntry of this.config.localDataStore.values()) {
             this.replicateAndUpdateStaleState(dataEntry, peerDescriptor)
         }
     }
@@ -79,20 +63,23 @@ export class StoreManager {
     private replicateAndUpdateStaleState(dataEntry: DataEntry, newNode: PeerDescriptor): void {
         const newNodeId = getNodeIdFromPeerDescriptor(newNode)
         // TODO use config option or named constant?
-        const closestToData = this.getClosestNeighborsTo(dataEntry.key, 10)
+        const closestToData = this.config.getClosestNeighborsTo(dataEntry.key, 10)
         const sortedList = new SortedContactList<Contact>({
             referenceId: getNodeIdFromDataKey(dataEntry.key), 
             maxSize: 20,  // TODO use config option or named constant?
             allowToContainReferenceId: true,
             emitEvents: false
         })
-        sortedList.addContact(new Contact(this.localPeerDescriptor))
+        sortedList.addContact(new Contact(this.config.localPeerDescriptor))
         closestToData.forEach((con) => {
             if (!areEqualNodeIds(newNodeId, getNodeIdFromPeerDescriptor(con.getPeerDescriptor()))) {
                 sortedList.addContact(new Contact(con.getPeerDescriptor()))
             }
         })
-        const selfIsPrimaryStorer = areEqualNodeIds(sortedList.getAllContacts()[0].getNodeId(), getNodeIdFromPeerDescriptor(this.localPeerDescriptor))
+        const selfIsPrimaryStorer = areEqualNodeIds(
+            sortedList.getAllContacts()[0].getNodeId(),
+            getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
+        )
         if (selfIsPrimaryStorer) {
             sortedList.addContact(new Contact(newNode))
             const sorted = sortedList.getAllContacts()
@@ -100,13 +87,13 @@ export class StoreManager {
             const index = findIndex(sorted, (contact) => areEqualNodeIds(contact.getNodeId(), newNodeId))
             // if new node is within the storageRedundancyFactor closest nodes to the data
             // do replicate data to it
-            if (index < this.redundancyFactor) {
+            if (index < this.config.redundancyFactor) {
                 setImmediate(async () => {
                     await this.replicateDataToContact(dataEntry, newNode)
                 })
             }
         } else if (!this.selfIsOneOfClosestPeers(dataEntry.key)) {
-            this.localDataStore.setStale(dataEntry.key, getNodeIdFromPeerDescriptor(dataEntry.creator!), true)
+            this.config.localDataStore.setStale(dataEntry.key, getNodeIdFromPeerDescriptor(dataEntry.creator!), true)
         }
     }
 
@@ -120,15 +107,15 @@ export class StoreManager {
     }
 
     public async storeDataToDht(key: Uint8Array, data: Any, creator: PeerDescriptor): Promise<PeerDescriptor[]> {
-        logger.debug(`Storing data to DHT ${this.serviceId}`)
-        const result = await this.recursiveOperationManager.execute(key, RecursiveOperation.FIND_NODE)
+        logger.debug(`Storing data to DHT ${this.config.serviceId}`)
+        const result = await this.config.recursiveOperationManager.execute(key, RecursiveOperation.FIND_NODE)
         const closestNodes = result.closestNodes
         const successfulNodes: PeerDescriptor[] = []
-        const ttl = this.highestTtl // ToDo: make TTL decrease according to some nice curve
+        const ttl = this.config.highestTtl // ToDo: make TTL decrease according to some nice curve
         const createdAt = Timestamp.now()
-        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.redundancyFactor; i++) {
-            if (areEqualPeerDescriptors(this.localPeerDescriptor, closestNodes[i])) {
-                this.localDataStore.storeEntry({
+        for (let i = 0; i < closestNodes.length && successfulNodes.length < this.config.redundancyFactor; i++) {
+            if (areEqualPeerDescriptors(this.config.localPeerDescriptor, closestNodes[i])) {
+                this.config.localDataStore.storeEntry({
                     key, 
                     data,
                     creator,
@@ -164,23 +151,23 @@ export class StoreManager {
     }
 
     private selfIsOneOfClosestPeers(dataId: Uint8Array): boolean {
-        const closestPeers = this.getClosestNeighborsTo(dataId, this.redundancyFactor)
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+        const closestPeers = this.config.getClosestNeighborsTo(dataId, this.config.redundancyFactor)
+        const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const sortedList = new SortedContactList<Contact>({
             referenceId: localNodeId, 
-            maxSize: this.redundancyFactor, 
+            maxSize: this.config.redundancyFactor, 
             allowToContainReferenceId: true, 
             emitEvents: false
         })
-        sortedList.addContact(new Contact(this.localPeerDescriptor))
+        sortedList.addContact(new Contact(this.config.localPeerDescriptor))
         closestPeers.forEach((con) => sortedList.addContact(new Contact(con.getPeerDescriptor())))
         return sortedList.getClosestContacts().some((node) => areEqualNodeIds(node.getNodeId(), localNodeId))
     }
 
     private async replicateDataToClosestNodes(): Promise<void> {
-        const dataEntries = Array.from(this.localDataStore.values())
+        const dataEntries = Array.from(this.config.localDataStore.values())
         await Promise.all(dataEntries.map(async (dataEntry) => {
-            const dhtNodeRemotes = this.getClosestNeighborsTo(dataEntry.key, this.redundancyFactor)
+            const dhtNodeRemotes = this.config.getClosestNeighborsTo(dataEntry.key, this.config.redundancyFactor)
             await Promise.all(dhtNodeRemotes.map(async (remoteDhtNode) => {
                 const rpcRemote = this.config.createRpcRemote(remoteDhtNode.getPeerDescriptor())
                 try {
@@ -194,17 +181,17 @@ export class StoreManager {
 
     private replicateDataToNeighbors(incomingPeer: PeerDescriptor, dataEntry: DataEntry): void {
         // sort own contact list according to data id
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+        const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const incomingNodeId = getNodeIdFromPeerDescriptor(incomingPeer)
         // TODO use config option or named constant?
-        const closestToData = this.getClosestNeighborsTo(dataEntry.key, 10)
+        const closestToData = this.config.getClosestNeighborsTo(dataEntry.key, 10)
         const sortedList = new SortedContactList<Contact>({
             referenceId: getNodeIdFromDataKey(dataEntry.key), 
-            maxSize: this.redundancyFactor, 
+            maxSize: this.config.redundancyFactor, 
             allowToContainReferenceId: true, 
             emitEvents: false
         })
-        sortedList.addContact(new Contact(this.localPeerDescriptor))
+        sortedList.addContact(new Contact(this.config.localPeerDescriptor))
         closestToData.forEach((con) => {
             sortedList.addContact(new Contact(con.getPeerDescriptor()))
         })

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -210,12 +210,12 @@ export class StoreManager {
         closestToData.forEach((con) => {
             sortedList.addContact(new Contact(con.getPeerDescriptor()))
         })
-        const selfIsPrimaryStorer = (!areEqualNodeIds(sortedList.getAllContacts()[0].getNodeId(), localNodeId))
+        const selfIsPrimaryStorer = areEqualNodeIds(sortedList.getAllContacts()[0].getNodeId(), localNodeId)
         const targets = selfIsPrimaryStorer
-            // If we are not the closest node to the data, replicate only to the closest one to the data
-            ? [sortedList.getAllContacts()[0]]
             // if we are the closest to the data, replicate to all storageRedundancyFactor nearest
-            : sortedList.getAllContacts()
+            ? sortedList.getAllContacts()
+            // if we are not the closest node to the data, replicate only to the closest one to the data
+            : [sortedList.getAllContacts()[0]]
         targets.forEach((contact) => {
             const contactNodeId = getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())
             if (!areEqualNodeIds(incomingNodeId, contactNodeId) && !areEqualNodeIds(localNodeId, contactNodeId)) {
@@ -224,7 +224,7 @@ export class StoreManager {
                         await this.replicateDataToContact(dataEntry, contact.getPeerDescriptor())
                         logger.trace('replicateDataToContact() returned', { 
                             node: getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()),
-                            replicateOnlyToClosest: selfIsPrimaryStorer
+                            replicateOnlyToClosest: !selfIsPrimaryStorer
                         })
                     })
                 })

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -13,7 +13,6 @@ import { StoreRpcRemote } from './StoreRpcRemote'
 import { Timestamp } from '../../proto/google/protobuf/timestamp'
 import { SortedContactList } from '../contact/SortedContactList'
 import { Contact } from '../contact/Contact'
-import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { ServiceID } from '../../types/ServiceID'
 import { findIndex } from 'lodash'
 import { areEqualNodeIds, getNodeIdFromDataKey } from '../../helpers/nodeId'
@@ -28,7 +27,7 @@ interface StoreManagerConfig {
     serviceId: ServiceID
     highestTtl: number
     redundancyFactor: number
-    getClosestNeighborsTo: (id: Uint8Array, n?: number) => PeerDescriptor[],
+    getClosestNeighborsTo: (id: Uint8Array, n?: number) => PeerDescriptor[]
     createRpcRemote: (contact: PeerDescriptor) => StoreRpcRemote
 }
 

--- a/packages/dht/src/dht/store/StoreRpcRemote.ts
+++ b/packages/dht/src/dht/store/StoreRpcRemote.ts
@@ -20,10 +20,10 @@ export class StoreRpcRemote extends RpcRemote<IStoreRpcClient> {
         }
     }
 
-    async replicateData(request: ReplicateDataRequest, doNotConnect: boolean = false): Promise<void> {
+    async replicateData(request: ReplicateDataRequest): Promise<void> {
         const options = this.formDhtRpcOptions({
             timeout: EXISTING_CONNECTION_TIMEOUT,
-            doNotConnect
+            doNotConnect: false
         })
         return this.getClient().replicateData(request, options)
     }

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -61,6 +61,8 @@ describe('SortedContactList', () => {
         list.addContact(item3)
         list.addContact(item2)
         expect(list.getSize()).toEqual(3)
+        expect(list.getAllContacts()).toEqual([item1, item2, item3])
+        expect(list.getContactIds()).toEqual([item1.getNodeId(), item2.getNodeId(), item3.getNodeId()])
         expect(onContactRemoved).toBeCalledWith(item4, [item1, item2, item3])
         expect(list.getContact(item4.getNodeId())).toBeFalsy()
     })

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -1,0 +1,118 @@
+import { wait, waitForCondition } from '@streamr/utils'
+import { range, sortBy } from 'lodash'
+import { Key } from 'readline'
+import { getDistance } from '../../src/dht/PeerManager'
+import { StoreManager } from '../../src/dht/store/StoreManager'
+import { NodeID, createRandomNodeId, getNodeIdFromBinary } from '../../src/helpers/nodeId'
+import { getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { NodeType, ReplicateDataRequest } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { createMockPeerDescriptor } from '../utils/utils'
+
+const DATA_ENTRY = {
+    key: createRandomNodeId(),
+    creator: createMockPeerDescriptor()
+}
+const NODES_CLOSEST_TO_DATA = sortBy(
+    range(5).map(() => createRandomNodeId()),
+    (id: Uint8Array) => getDistance(getNodeIdFromBinary(id), getNodeIdFromBinary(DATA_ENTRY.key))
+)
+
+describe('StoreManager', () => {
+
+    describe('new contact', () => {
+
+        const createStoreManager = (
+            localNodeId: Uint8Array,
+            closestNeighbors: Uint8Array[],
+            replicateData: (request: ReplicateDataRequest, doNotConnect: boolean) => unknown,
+            setStale: (key: Key, creator: NodeID, stale: boolean) => unknown
+        ): StoreManager => {
+            const getClosestNeighborsTo = () => {
+                return closestNeighbors.map((nodeId) => ({ nodeId, type: NodeType.NODEJS }))
+            }
+            return new StoreManager({
+                rpcCommunicator: {
+                    registerRpcMethod: () => {},
+                    registerRpcNotification: () => {}
+                } as any,
+                recursiveOperationManager: undefined as any,
+                localPeerDescriptor: { nodeId: localNodeId, type: NodeType.NODEJS },
+                localDataStore: { values: () => [DATA_ENTRY], setStale } as any,
+                serviceId: undefined as any,
+                highestTtl: undefined as any,
+                redundancyFactor: 3,
+                getClosestNeighborsTo,
+                createRpcRemote: () => ({ replicateData } as any)
+            })
+        }
+
+        describe('this node is primary storer', () => {
+
+            it('new node is within redundancy factor', async () => {
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const setStale = jest.fn<undefined, [Key, NodeID]>()
+                const manager = createStoreManager(
+                    NODES_CLOSEST_TO_DATA[0],
+                    [NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[3], NODES_CLOSEST_TO_DATA[4]],
+                    replicateData,
+                    setStale
+                )
+                manager.onNewContact({ nodeId: NODES_CLOSEST_TO_DATA[2], type: NodeType.NODEJS })
+                await waitForCondition(() => replicateData.mock.calls.length === 1)
+                expect(replicateData).toHaveBeenCalledWith({
+                    entry: DATA_ENTRY
+                })
+                expect(setStale).not.toHaveBeenCalled()
+            })
+    
+            it('new node is not within redundancy factor', async () => {
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const setStale = jest.fn<undefined, [Key, NodeID]>()
+                const manager = createStoreManager(
+                    NODES_CLOSEST_TO_DATA[0],
+                    [NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[2], NODES_CLOSEST_TO_DATA[3]],
+                    replicateData,
+                    setStale
+                )
+                manager.onNewContact({ nodeId: NODES_CLOSEST_TO_DATA[4], type: NodeType.NODEJS })
+                await wait(50)
+                expect(replicateData).not.toHaveBeenCalled()
+                expect(setStale).not.toHaveBeenCalled()
+            })
+        })
+
+        describe('this node is not primary storer', () => {
+
+            it('this node is within redundancy factor', async () => {
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const setStale = jest.fn<undefined, [Key, NodeID]>()
+                const manager = createStoreManager(
+                    NODES_CLOSEST_TO_DATA[1],
+                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[2], NODES_CLOSEST_TO_DATA[3]],
+                    replicateData,
+                    setStale
+                )
+                manager.onNewContact({ nodeId: NODES_CLOSEST_TO_DATA[4], type: NodeType.NODEJS })
+                await wait(50)
+                expect(replicateData).not.toHaveBeenCalled()
+                expect(setStale).not.toHaveBeenCalled()
+            })
+
+            it('this node is not within redundancy factor', async () => {
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const setStale = jest.fn<undefined, [Key, NodeID]>()
+                const manager = createStoreManager(
+                    NODES_CLOSEST_TO_DATA[3],
+                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[2]],
+                    replicateData,
+                    setStale
+                )
+                manager.onNewContact({ nodeId: NODES_CLOSEST_TO_DATA[4], type: NodeType.NODEJS })
+                await wait(50)
+                expect(replicateData).not.toHaveBeenCalled()
+                expect(setStale).toHaveBeenCalledTimes(1)
+                expect(setStale).toHaveBeenCalledWith(DATA_ENTRY.key, getNodeIdFromPeerDescriptor(DATA_ENTRY.creator), true)
+            })
+        })
+    })
+})


### PR DESCRIPTION
Changes to `StoreManager`:
- Fixed boolean usage of `selfIsPrimaryStorer` in `replicateDataToNeighbors`. The name and the content of the variable didn't match. **Check: it was maybe already used correctly at line 211?**
- Simplified `StoreManagerConfig#getClosestNeighborsTo` return type
- Simplified and optimized the logic of `selfIsOneOfClosestPeers` method
- Removed `doNotConnect` parameter which was always `false` (using explicit `false` in `StoreRpcRemote#replicateData` instead)

Added unit test. Added `StoreManagerConfig#createRpcRemote` dependency field so that we can mock that in the tests.

## Other changes

- Replaced some usages of `SortedContactList#getAllContacts` with `getClosestContactId`/`getContactIds` (we didn't need the `Contact` objects in those cases, just `NodeID`s)
