### PR TITLE
refactor(dht): Refactor `RecursiveOperationSession`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -270,7 +270,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
             addContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
-            isPeerCloserToIdThanSelf: this.isPeerCloserToIdThanSelf.bind(this),
             localDataStore: this.localDataStore
         })
         this.storeManager = new StoreManager({
@@ -383,12 +382,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             (req: ExternalStoreDataRequest, context: ServerCallContext) => externalApiRpcLocal.externalStoreData(req, context),
             { timeout: 10000 }  // TODO use config option or named constant?
         )
-    }
-
-    private isPeerCloserToIdThanSelf(peer: PeerDescriptor, compareToId: NodeID): boolean {
-        const distance1 = getDistance(getNodeIdFromPeerDescriptor(peer), compareToId)
-        const distance2 = getDistance(this.getNodeId(), compareToId)
-        return distance1 < distance2
     }
 
     private handleMessage(message: Message): void {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -50,7 +50,7 @@ import { MarkRequired } from 'ts-essentials'
 import { DhtNodeRpcLocal } from './DhtNodeRpcLocal'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ExternalApiRpcLocal } from './ExternalApiRpcLocal'
-import { PeerManager, getDistance } from './PeerManager'
+import { PeerManager } from './PeerManager'
 import { ServiceID } from '../types/ServiceID'
 import { NodeID, getNodeIdFromBinary } from '../helpers/nodeId'
 

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -118,7 +118,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
         })
         if (this.connections.size === 0) {
             const data = this.localDataStore.getEntries(targetId)
-            session.doSendResponse(
+            session.onResponseReceived(
                 [this.localPeerDescriptor],
                 [this.localPeerDescriptor],
                 Array.from(data.values()),
@@ -168,7 +168,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
         const isOwnNode = areEqualPeerDescriptors(this.localPeerDescriptor, targetPeerDescriptor)
         if (isOwnNode && this.ongoingSessions.has(serviceId)) {
             this.ongoingSessions.get(serviceId)!
-                .doSendResponse(routingPath, closestNodes, dataEntries, noCloserNodesFound)
+                .onResponseReceived(routingPath, closestNodes, dataEntries, noCloserNodesFound)
         } else {
             // TODO use config option or named constant?
             const remoteCommunicator = new ListeningRpcCommunicator(serviceId, this.sessionTransport, { rpcRequestTimeout: 15000 })

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -1,8 +1,5 @@
 import {
     DataEntry,
-    Message,
-    MessageType,
-    NodeType,
     PeerDescriptor,
     RecursiveOperation,
     RecursiveOperationRequest,
@@ -16,7 +13,6 @@ import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../help
 import { Logger, hexToBinary, runAndWaitForEvents3, wait } from '@streamr/utils'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { RecursiveOperationSessionRpcRemote } from './RecursiveOperationSessionRpcRemote'
-import { v4 } from 'uuid'
 import { RecursiveOperationSession, RecursiveOperationSessionEvents } from './RecursiveOperationSession'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { ITransport } from '../../transport/ITransport'

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -193,14 +193,13 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
             return createRouteMessageAck(routedMessage, RouteMessageError.STOPPED)
         }
         const targetId = getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)
-        const msg = routedMessage.message
-        const recursiveOperationRequest = msg?.body.oneofKind === 'recursiveOperationRequest' ? msg.body.recursiveOperationRequest : undefined
+        const request = (routedMessage.message!.body as { recursiveOperationRequest: RecursiveOperationRequest }).recursiveOperationRequest
         // TODO use config option or named constant?
         const closestPeersToDestination = this.getClosestConnections(routedMessage.destinationPeer!.nodeId, 5)
-        const data = (recursiveOperationRequest!.operation === RecursiveOperation.FETCH_DATA) 
+        const data = (request.operation === RecursiveOperation.FETCH_DATA) 
             ? this.localDataStore.getEntries(hexToBinary(targetId))
             : undefined
-        if (recursiveOperationRequest!.operation === RecursiveOperation.DELETE_DATA) {
+        if (request.operation === RecursiveOperation.DELETE_DATA) {
             this.localDataStore.markAsDeleted(hexToBinary(targetId), getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!))
         }
         if (areEqualPeerDescriptors(this.localPeerDescriptor, routedMessage.destinationPeer!)) {
@@ -208,7 +207,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
             this.sendResponse(
                 routedMessage.routingPath,
                 routedMessage.sourcePeer!,
-                recursiveOperationRequest!.sessionId,
+                request.sessionId,
                 closestPeersToDestination,
                 data,
                 true
@@ -226,7 +225,7 @@ export class RecursiveOperationManager implements IRecursiveOperationManager {
                 this.sendResponse(
                     routedMessage.routingPath,
                     routedMessage.sourcePeer!,
-                    recursiveOperationRequest!.sessionId,
+                    request.sessionId,
                     closestPeersToDestination,
                     data,
                     noCloserContactsFound

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -12,7 +12,7 @@ import { RecursiveOperationSessionRpcLocal } from './RecursiveOperationSessionRp
 import { NodeID, areEqualNodeIds, getNodeIdFromBinary } from '../../helpers/nodeId'
 
 export interface RecursiveOperationSessionEvents {
-    completed: (results: PeerDescriptor[]) => void
+    completed: () => void
 }
 
 export interface RecursiveOperationSessionConfig {
@@ -170,7 +170,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
                     clearTimeout(this.timeoutTask)
                     this.timeoutTask = undefined
                 }
-                this.emit('completed', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
+                this.emit('completed')
                 this.completionEventEmitted = true
             }
         }
@@ -190,7 +190,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
     private onNoCloserPeersFound(): void {
         this.noCloserNodesReceivedCounter += 1
         if (this.isCompleted()) {
-            this.emit('completed', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
+            this.emit('completed')
             this.completionEventEmitted = true
             if (this.timeoutTask) {
                 clearTimeout(this.timeoutTask)
@@ -200,7 +200,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
             if (!this.timeoutTask && !this.completionEventEmitted) {
                 this.timeoutTask = setTimeout(() => {
                     if (!this.completionEventEmitted) {
-                        this.emit('completed', this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()))
+                        this.emit('completed')
                         this.completionEventEmitted = true
                     }
                 }, 4000)  // TODO use config option or named constant?
@@ -223,6 +223,6 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
             this.timeoutTask = undefined
         }
         this.rpcCommunicator.destroy()
-        this.emit('completed', [])
+        this.emit('completed')
     }
 }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -64,8 +64,8 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
 
     private registerLocalRpcMethods() {
         const rpcLocal = new RecursiveOperationSessionRpcLocal({
-            doSendResponse: (routingPath: PeerDescriptor[], nodes: PeerDescriptor[], dataEntries: DataEntry[], noCloserNodesFound: boolean) => {
-                this.doSendResponse(routingPath, nodes, dataEntries, noCloserNodesFound)
+            onResponseReceived: (routingPath: PeerDescriptor[], nodes: PeerDescriptor[], dataEntries: DataEntry[], noCloserNodesFound: boolean) => {
+                this.onResponseReceived(routingPath, nodes, dataEntries, noCloserNodesFound)
             }
         })
         this.rpcCommunicator.registerRpcNotification(RecursiveOperationResponse, 'sendResponse',
@@ -129,7 +129,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         return Array.from(this.foundData.values()).some((entry) => entry.stale === false)
     }
 
-    public doSendResponse(
+    public onResponseReceived(
         routingPath: PeerDescriptor[],
         nodes: PeerDescriptor[],
         dataEntries: DataEntry[],

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -219,10 +219,12 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         }
     }
 
-    public getResults = (): RecursiveOperationResult => ({
-        closestNodes: this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()),
-        dataEntries: Array.from(this.foundData.values())
-    })
+    public getResults(): RecursiveOperationResult {
+        return {
+            closestNodes: this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()),
+            dataEntries: Array.from(this.foundData.values())
+        }
+    }
 
     public getId(): string {
         return this.id

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -1,6 +1,17 @@
 import EventEmitter from 'eventemitter3'
 import { v4 } from 'uuid'
-import { DataEntry, PeerDescriptor, RecursiveOperationResponse, RecursiveOperation, RouteMessageWrapper, RouteMessageAck, NodeType, RecursiveOperationRequest, Message, MessageType } from '../../proto/packages/dht/protos/DhtRpc'
+import { 
+    DataEntry,
+    PeerDescriptor,
+    RecursiveOperationResponse,
+    RecursiveOperation,
+    RouteMessageWrapper,
+    RouteMessageAck,
+    NodeType,
+    RecursiveOperationRequest,
+    Message,
+    MessageType
+} from '../../proto/packages/dht/protos/DhtRpc'
 import { ITransport } from '../../transport/ITransport'
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
 import { Contact } from '../contact/Contact'
@@ -213,7 +224,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         dataEntries: Array.from(this.foundData.values())
     })
 
-    public getId() {
+    public getId(): string {
         return this.id
     }
 

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
@@ -6,7 +6,7 @@ import { Logger } from '@streamr/utils'
 const logger = new Logger(module)
 
 interface RecursiveOperationSessionRpcLocalConfig {
-    doSendResponse: (routingPath: PeerDescriptor[], nodes: PeerDescriptor[], dataEntries: DataEntry[], noCloserNodesFound: boolean) => void
+    onResponseReceived: (routingPath: PeerDescriptor[], nodes: PeerDescriptor[], dataEntries: DataEntry[], noCloserNodesFound: boolean) => void
 }
 
 export class RecursiveOperationSessionRpcLocal implements IRecursiveOperationSessionRpc {
@@ -19,7 +19,7 @@ export class RecursiveOperationSessionRpcLocal implements IRecursiveOperationSes
     
     async sendResponse(report: RecursiveOperationResponse): Promise<Empty> {
         logger.trace('RecursiveOperationResponse arrived: ' + JSON.stringify(report))
-        this.config.doSendResponse(report.routingPath, report.closestConnectedPeers, report.dataEntries, report.noCloserNodesFound)
+        this.config.onResponseReceived(report.routingPath, report.closestConnectedPeers, report.dataEntries, report.noCloserNodesFound)
         return {}
     }
 }

--- a/packages/dht/src/transport/ITransport.ts
+++ b/packages/dht/src/transport/ITransport.ts
@@ -4,7 +4,6 @@ export interface TransportEvents {
     disconnected: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => void
     message: (message: Message) => void
     connected: (peerDescriptor: PeerDescriptor) => void
-
 }
 
 export interface ITransport {

--- a/packages/dht/src/transport/ListeningRpcCommunicator.ts
+++ b/packages/dht/src/transport/ListeningRpcCommunicator.ts
@@ -9,7 +9,7 @@ export class ListeningRpcCommunicator extends RoutingRpcCommunicator {
     private readonly listener: (msg: Message) => void
 
     constructor(ownServiceId: ServiceID, transport: ITransport, config?: RpcCommunicatorConfig) {
-        super(ownServiceId, transport.send, config)
+        super(ownServiceId, (msg, doNotConnect) => transport.send(msg, doNotConnect), config)
         this.listener = (msg: Message) => {
             this.handleMessageFromPeer(msg)
         }

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -79,7 +79,6 @@ describe('RecursiveOperationManager', () => {
             localDataStore: new LocalDataStore(30 * 100),
             sessionTransport: transport,
             addContact: () => {},
-            isPeerCloserToIdThanSelf: (_peer1, _compareToId) => true,
             rpcCommunicator: rpcCommunicator as any
         })
     }

--- a/packages/dht/test/unit/RecursiveOperationSession.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationSession.test.ts
@@ -1,0 +1,63 @@
+import { toProtoRpcClient } from '@streamr/proto-rpc'
+import { waitForCondition } from '@streamr/utils'
+import { range } from 'lodash'
+import { RecursiveOperationSession } from '../../src/dht/recursive-operation/RecursiveOperationSession'
+import { RecursiveOperationSessionRpcRemote } from '../../src/dht/recursive-operation/RecursiveOperationSessionRpcRemote'
+import { ServiceID } from '../../src/exports'
+import { createRandomNodeId } from '../../src/helpers/nodeId'
+import { Message, PeerDescriptor, RecursiveOperation } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { RecursiveOperationSessionRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
+import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
+import { FakeEnvironment } from '../utils/FakeTransport'
+import { createMockPeerDescriptor } from '../utils/utils'
+
+describe('RecursiveOperationSession', () => {
+
+    let environment: FakeEnvironment
+    let localPeerDescriptor: PeerDescriptor
+
+    const createRpcRemote = (serviceId: ServiceID) => {
+        const transport = environment.createTransport()
+        const send = (msg: Message) => transport.send(msg)
+        return new RecursiveOperationSessionRpcRemote(
+            createMockPeerDescriptor(),
+            localPeerDescriptor,
+            serviceId,
+            toProtoRpcClient(new RecursiveOperationSessionRpcClient(new RoutingRpcCommunicator(serviceId, send).getRpcClientTransport()))
+        )
+    }
+
+    beforeEach(() => {
+        environment = new FakeEnvironment()
+        localPeerDescriptor = createMockPeerDescriptor()
+    })
+
+    it('happy path', async () => {
+        const doRouteRequest = jest.fn()
+        const session = new RecursiveOperationSession({
+            transport: environment.createTransport(),
+            targetId: createRandomNodeId(),
+            localPeerDescriptor,
+            waitedRoutingPathCompletions: 3,
+            operation: RecursiveOperation.FIND_NODE,
+            doRouteRequest
+        })
+        const onCompleted = jest.fn()
+        session.on('completed', onCompleted)
+
+        session.start('')
+        expect(doRouteRequest).toHaveBeenCalled()
+        range(3).forEach(() => {
+            const remote = createRpcRemote(session.getId())
+            remote.sendResponse([createMockPeerDescriptor(), createMockPeerDescriptor()], [createMockPeerDescriptor(), createMockPeerDescriptor()], [], true)    
+        })
+
+        // TODO now waits for the 4s timeout, could setup test so that it completes by receiving
+        // all data it wants
+        await waitForCondition(() => onCompleted.mock.calls.length > 0)
+        const result = session.getResults()
+        // TODO assert peer descriptors
+        expect(result.closestNodes).toHaveLength(6)
+        expect(result.dataEntries).toEqual([])
+    })
+})

--- a/packages/dht/test/unit/RecursiveOperationSession.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationSession.test.ts
@@ -49,7 +49,12 @@ describe('RecursiveOperationSession', () => {
         expect(doRouteRequest).toHaveBeenCalled()
         range(3).forEach(() => {
             const remote = createRpcRemote(session.getId())
-            remote.sendResponse([createMockPeerDescriptor(), createMockPeerDescriptor()], [createMockPeerDescriptor(), createMockPeerDescriptor()], [], true)    
+            remote.sendResponse(
+                [createMockPeerDescriptor(), createMockPeerDescriptor()],
+                [createMockPeerDescriptor(), createMockPeerDescriptor()],
+                [],
+                true
+            )
         })
 
         // TODO now waits for the 4s timeout, could setup test so that it completes by receiving

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'eventemitter3'
+import { ITransport, TransportEvents } from '../../src/transport/ITransport'
+import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc';
+
+class FakeTransport extends EventEmitter<TransportEvents> implements ITransport {
+
+    private onSend: (msg: Message) => void
+
+    constructor(onSend: (msg: Message) => void) {
+        super()
+        this.onSend = onSend
+    }
+
+    async send(msg: Message): Promise<void> {
+        this.onSend(msg)
+    }
+
+    getLocalPeerDescriptor(): PeerDescriptor {
+        throw new Error('not implemented');
+    }
+
+    getAllConnectionPeerDescriptors(): PeerDescriptor[] {
+        throw new Error('not implemented');
+    }
+
+    stop(): void | Promise<void> {
+    }
+}
+
+export class FakeEnvironment {
+
+    private transports: FakeTransport[] = []
+
+    createTransport(): ITransport {
+        const transport = new FakeTransport((msg) => {
+            this.transports.forEach((t) => t.emit('message', msg))
+        })
+        this.transports.push(transport)
+        return transport
+    }
+}

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'eventemitter3'
 import { ITransport, TransportEvents } from '../../src/transport/ITransport'
-import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc';
+import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 
 class FakeTransport extends EventEmitter<TransportEvents> implements ITransport {
 
@@ -15,14 +15,17 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport 
         this.onSend(msg)
     }
 
+    // eslint-disable-next-line class-methods-use-this
     getLocalPeerDescriptor(): PeerDescriptor {
-        throw new Error('not implemented');
+        throw new Error('not implemented')
     }
 
+    // eslint-disable-next-line class-methods-use-this
     getAllConnectionPeerDescriptors(): PeerDescriptor[] {
-        throw new Error('not implemented');
+        throw new Error('not implemented')
     }
 
+    // eslint-disable-next-line class-methods-use-this
     stop(): void | Promise<void> {
     }
 }


### PR DESCRIPTION
Refactored `RecursiveOperationSession` and added unit test for it.

## Changes

- `RecursiveOperationSession` creates its own id
- Added `RecursiveOperationSession#start()` (previously the sending of the request was done in  `RecursiveOperationManager`)
- Removed type check from `doRouteRequest` as the function implementation assumes non-null (by using `!` assertions for the `recursiveOperationRequest` variable)
- Moved `isPeerCloserToIdThanSelf` from `DhtNode` to `RecursiveOperationManager` as it doesn't any `DhtNode` fields
- Simplify `data` param handling in `RecursiveOperationManager#sendResponse`
  - e.g. removed unnecessary `DataEntry.create.bind(DataEntry)` transformation
- Renamed `doSendResponse` -> `onResponseReceived` as the method doesn't send a response, but is a callback of RPC local's method which receives the method (which is sent by the remote by calling the `sendResponse` RPC call)
- Remove the payload of `completed` event as it was no used by any component
- Convert `RecursiveOperationSessiongetResults` to normal method

## Test utils

- Added `FakeTransport` class. When we create multiple instances of these transports via `FakeEnvironment#createTransport` the instances can automatically communicate with each other.

## Other changes

- Use arrow function in `ListeningRpcCommunicator` constructor so that `transport.send` works without binding

## Future improvements

- The `RecursiveOperationSession` test could assert peer descriptors (instead of the length of the array), and we could modify the test setup so that the test completes by receiving all data it wants (instead of completing after 4s timeout)
- Would it make sense to give `excludedPeer` as one of the fields `RecursiveOperationSession`? 
  - If it  needs to exclude the peer only in `start`, but not for when it receives data, the current setup is maybe ok
- Could simplify the logic in `RecursiveOperationManager#sendResponse`, which doesn't always send but instead calls  `onResponseReceived`. Should we e.g. move the `isOwnNode` check to the caller, or rename the method?