### PR TITLE
fix(DHT): fix comparator in RoutingRpcComunicator

### DIFF
--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -51,7 +51,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
     }
 
     public handleMessageFromPeer(message: Message): void {
-        if (message.serviceId == this.ownServiceId && message.body.oneofKind === 'rpcMessage') {
+        if (message.serviceId === this.ownServiceId && message.body.oneofKind === 'rpcMessage') {
             const context = new DhtCallContext()
             context.incomingSourceDescriptor = message.sourceDescriptor
             // TODO should we have some handling for this floating promise?


### PR DESCRIPTION
## Summary

Changed comparator in handleMessageFromPeer to use `===` instead of `==`