### PR TITLE
test(dht): Remove `Simulator#useFakeTimers`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6372,29 +6372,6 @@
                 "@sinonjs/commons": "^3.0.0"
             }
         },
-        "node_modules/@sinonjs/samsam": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
-            "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
-            "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "lodash.get": "^4.4.2",
-                "type-detect": "^4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/text-encoding": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-            "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
-        },
         "node_modules/@smithy/abort-controller": {
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.14.tgz",
@@ -17515,11 +17492,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/just-extend": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
-        },
         "node_modules/k-bucket": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
@@ -18698,11 +18670,6 @@
             "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
             "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
             "dev": true
-        },
-        "node_modules/lodash.get": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
         },
         "node_modules/lodash.isarguments": {
             "version": "3.1.0",
@@ -20195,39 +20162,6 @@
             "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/nise": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-            "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
-            "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@sinonjs/text-encoding": "^0.7.1",
-                "just-extend": "^4.0.2",
-                "path-to-regexp": "^1.7.0"
-            }
-        },
-        "node_modules/nise/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/nise/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "node_modules/nise/node_modules/path-to-regexp": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-            "dependencies": {
-                "isarray": "0.0.1"
             }
         },
         "node_modules/node-abi": {
@@ -25260,51 +25194,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/sinon": {
-            "version": "15.1.2",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.2.tgz",
-            "integrity": "sha512-uG1pU54Fis4EfYOPoEi13fmRHgZNg/u+3aReSEzHsN52Bpf+bMVfsBQS5MjouI+rTuG6UBIINlpuuO2Epr7SiA==",
-            "deprecated": "16.1.1",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0",
-                "@sinonjs/fake-timers": "^10.1.0",
-                "@sinonjs/samsam": "^8.0.0",
-                "diff": "^5.1.0",
-                "nise": "^5.1.4",
-                "supports-color": "^7.2.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/sinon"
-            }
-        },
-        "node_modules/sinon/node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/sinon/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/sinon/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/sirv": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
@@ -29468,7 +29357,6 @@
                 "k-bucket": "^5.1.0",
                 "lodash": "^4.17.21",
                 "node-datachannel": "^0.4.3",
-                "sinon": "15.1.2",
                 "uuid": "^9.0.1",
                 "websocket": "^1.0.34"
             },

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -40,7 +40,6 @@
     "k-bucket": "^5.1.0",
     "lodash": "^4.17.21",
     "node-datachannel": "^0.4.3",
-    "sinon": "15.1.2",
     "uuid": "^9.0.1",
     "websocket": "^1.0.34"
   },

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -10,17 +10,7 @@ import { getRegionDelayMatrix } from './pings'
 import { getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import Heap from 'heap'
 import { debugVars } from '../../helpers/debugHelpers'
-import * as sinon from 'sinon'
 import { NodeID } from '../../helpers/nodeId'
-
-// TODO take this from @streamr/test-utils (we can't access devDependencies as Simulator
-// is currently in "src" directory instead of "test" directory)
-// eslint-disable-next-line no-underscore-dangle
-declare let _streamr_electron_test: any
-export function isRunningInElectron(): boolean {
-    // eslint-disable-next-line no-underscore-dangle
-    return typeof _streamr_electron_test !== 'undefined'
-}
 
 const logger = new Logger(module)
 
@@ -121,22 +111,6 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
     })
 
     private simulatorTimeout?: NodeJS.Timeout
-    private static clock: sinon.SinonFakeTimers | undefined
-
-    static useFakeTimers(on = true): void {
-        if (!isRunningInElectron()) {  // never use fake timers in browser environment
-            if (on) {
-                if (!Simulator.clock) {
-                    Simulator.clock = sinon.useFakeTimers()
-                }
-            } else {
-                if (Simulator.clock) {
-                    Simulator.clock.restore()
-                    Simulator.clock = undefined
-                }
-            }
-        }
-    }
 
     constructor(latencyType: LatencyType = LatencyType.NONE, fixedLatency?: number) {
         super()
@@ -311,11 +285,6 @@ export class Simulator extends EventEmitter<ConnectionSourceEvents> {
         const timeDifference = firstOperationTime - currentTime
 
         this.simulatorTimeout = setTimeout(this.executeQueuedOperations, timeDifference)
-       
-        if (Simulator.clock) {
-            // TODO should we have some handling for this floating promise?
-            Simulator.clock.runAllAsync()
-        }
     }
 
     private scheduleOperation(operation: SimulatorOperation) {


### PR DESCRIPTION
Virtual time is no longer used (https://github.com/streamr-dev/network/pull/2181). Removed the virtual time functionality from the simulator.

As `sinon` is no longer used as prod dependency after this change, this PR resolves the packaging issue mentioned in NET-1137:

> Older version of sinonjs/fake-timers library causes issues with typescript when es6 modules are expected. This issue has already been fixed for the sinon/js library since version https://github.com/sinonjs/fake-timers/commits/v11.2.0 , but jest libraries are still using an older version of sinon.