### PR TITLE
refactor(dht): Options for `ITransport#send`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -23,7 +23,7 @@ import {
     UnlockRequest
 } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionLockRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
-import { ITransport, TransportEvents } from '../transport/ITransport'
+import { ITransport, SendOptions, TransportEvents } from '../transport/ITransport'
 import { RoutingRpcCommunicator } from '../transport/RoutingRpcCommunicator'
 import { ConnectionLockHandler, LockID } from './ConnectionLockHandler'
 import { ConnectorFacade } from './ConnectorFacade'
@@ -250,7 +250,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         return this.locks.getNumberOfWeakLockedConnections()
     }
 
-    public async send(message: Message, doNotConnect = false, doNotMindStopped = false): Promise<void> {
+    public async send(message: Message, opts?: SendOptions): Promise<void> {
+        const doNotMindStopped = opts?.doNotMindStopped ?? false
         if (this.state === ConnectionManagerState.STOPPED && !doNotMindStopped) {
             return
         }
@@ -265,6 +266,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
         let connection = this.connections.get(nodeId)
+        const doNotConnect = opts?.doNotConnect ?? false
         if (!connection && !doNotConnect) {
             connection = this.connectorFacade.createConnection(peerDescriptor)
             this.onNewConnection(connection)

--- a/packages/dht/src/transport/ITransport.ts
+++ b/packages/dht/src/transport/ITransport.ts
@@ -6,6 +6,11 @@ export interface TransportEvents {
     connected: (peerDescriptor: PeerDescriptor) => void
 }
 
+export interface SendOptions {
+    doNotConnect?: boolean
+    doNotMindStopped?: boolean
+}
+
 export interface ITransport {
     on<T extends keyof TransportEvents>(eventName: T, listener: (message: Message) => void): void
     on<T extends keyof TransportEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
@@ -20,7 +25,7 @@ export interface ITransport {
     off<T extends keyof TransportEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
     off<T extends keyof TransportEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => void): void
 
-    send(msg: Message, doNotConnect?: boolean): Promise<void>
+    send(msg: Message, opts?: SendOptions): Promise<void>
     getLocalPeerDescriptor(): PeerDescriptor
     getAllConnectionPeerDescriptors(): PeerDescriptor[]
     stop(): void | Promise<void>

--- a/packages/dht/src/transport/ListeningRpcCommunicator.ts
+++ b/packages/dht/src/transport/ListeningRpcCommunicator.ts
@@ -9,7 +9,7 @@ export class ListeningRpcCommunicator extends RoutingRpcCommunicator {
     private readonly listener: (msg: Message) => void
 
     constructor(ownServiceId: ServiceID, transport: ITransport, config?: RpcCommunicatorConfig) {
-        super(ownServiceId, (msg, doNotConnect) => transport.send(msg, doNotConnect), config)
+        super(ownServiceId, (msg, opts) => transport.send(msg, opts), config)
         this.listener = (msg: Message) => {
             this.handleMessageFromPeer(msg)
         }

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -4,14 +4,15 @@ import { RpcCommunicator, RpcCommunicatorConfig } from '@streamr/proto-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 import { RpcMessage } from '../proto/packages/proto-rpc/protos/ProtoRpc'
 import { ServiceID } from '../types/ServiceID'
+import { SendOptions } from './ITransport'
 
 export class RoutingRpcCommunicator extends RpcCommunicator {
     private ownServiceId: ServiceID
-    private sendFn: (msg: Message, doNotConnect?: boolean, doNotMindStopped?: boolean) => Promise<void>
+    private sendFn: (msg: Message, opts?: SendOptions) => Promise<void>
 
     constructor(
         ownServiceId: ServiceID,
-        sendFn: (msg: Message, doNotConnect?: boolean) => Promise<void>,
+        sendFn: (msg: Message, opts?: SendOptions) => Promise<void>,
         config?: RpcCommunicatorConfig
     ) {
         super(config)
@@ -40,9 +41,9 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
 
             // TODO is it possible to have explicit default values for "doNotConnect" and "doNotMindStopped"?
             if (msg.header.response || callContext && callContext.doNotConnect && callContext.doNotMindStopped ) {
-                return this.sendFn(message, true, true)
+                return this.sendFn(message, { doNotConnect: true, doNotMindStopped: true })
             } else if (msg.header.response || callContext && callContext.doNotConnect) {
-                return this.sendFn(message, true)
+                return this.sendFn(message, { doNotConnect: true })
             } else {
                 return this.sendFn(message)
             }


### PR DESCRIPTION
Change `ITransport#send` to use options object instead of positional parameters.

## Open questions

- Would it make sense to rename the booleans to be non-negated:
  - `doNotMindStopped` -> `ignoreIfStopped`
  - `doNotConnect` -> `ignoreIfNotConnected` (or just `connect`, and the default would be `true`)