### PR TITLE
test(dht): Use mock data entries

### DIFF
--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -1,10 +1,9 @@
 import { DhtNode } from '../../src/dht/DhtNode'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
-import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
-import { Any } from '../../src/proto/google/protobuf/any'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { createMockConnectionDhtNode } from '../utils/utils'
 import { createRandomNodeId } from '../../src/helpers/nodeId'
+import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
+import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
 
 describe('DhtNodeExternalApi', () => {
 
@@ -28,12 +27,10 @@ describe('DhtNodeExternalApi', () => {
     })
 
     it('findData happy path', async () => {
-        const data = Any.pack(dhtNode1.getLocalPeerDescriptor(), PeerDescriptor)
-        const key = createRandomNodeId()
-        await dhtNode1.storeDataToDht(key, data)
-
-        const foundData = await remote.findDataViaPeer(key, dhtNode1.getLocalPeerDescriptor())
-        expect(Any.unpack(foundData[0].data!, PeerDescriptor)).toEqual(dhtNode1.getLocalPeerDescriptor())
+        const entry = createMockDataEntry()
+        await dhtNode1.storeDataToDht(entry.key, entry.data!)
+        const foundData = await remote.findDataViaPeer(entry.key, dhtNode1.getLocalPeerDescriptor())
+        expectEqualData(foundData[0], entry)
     })
     
     it('findData returns empty array if no data found', async () => {
@@ -42,13 +39,10 @@ describe('DhtNodeExternalApi', () => {
     })
 
     it('external store data happy path', async () => {
-        const storedPeerDescriptor = createMockPeerDescriptor()
-        const data = Any.pack(storedPeerDescriptor, PeerDescriptor)
-        const key = createRandomNodeId()
-
-        await remote.storeDataViaPeer(key, data, dhtNode1.getLocalPeerDescriptor())
-        const foundData = await remote.findDataViaPeer(key, dhtNode1.getLocalPeerDescriptor())
-        expect(areEqualPeerDescriptors(Any.unpack(foundData[0].data!, PeerDescriptor), storedPeerDescriptor)).toEqual(true)
+        const entry = createMockDataEntry()
+        await remote.storeDataViaPeer(entry.key, entry.data!, dhtNode1.getLocalPeerDescriptor())
+        const foundData = await remote.findDataViaPeer(entry.key, dhtNode1.getLocalPeerDescriptor())
+        expectEqualData(foundData[0], entry)
         expect(areEqualPeerDescriptors(foundData[0].creator!, remote.getLocalPeerDescriptor())).toEqual(true)
     })
   

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -8,10 +8,10 @@ import fs from 'fs'
 import { Logger, hexToBinary } from '@streamr/utils'
 import { PeerID } from '../../src/helpers/PeerID'
 import { getNodeIdFromPeerDescriptor, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { Any } from '../../src/proto/google/protobuf/any'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { Contact } from '../../src/dht/contact/Contact'
 import { NodeID } from '../../src/helpers/nodeId'
+import { createMockDataEntry } from '../utils/mock/mockDataEntry'
 
 const logger = new Logger(module)
 
@@ -77,7 +77,7 @@ describe('Replicate data from node to node in DHT', () => {
 
     it('Data replicates to the closest node no matter where it is stored', async () => {
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const data = createMockDataEntry({ key: dataKey.value })
 
         // calculate offline which node is closest to the data
 
@@ -105,7 +105,7 @@ describe('Replicate data from node to node in DHT', () => {
         await nodes[0].joinDht([entrypointDescriptor])
 
         logger.info('storing data to node 0')
-        const successfulStorers = await nodes[0].storeDataToDht(dataKey.value, data)
+        const successfulStorers = await nodes[0].storeDataToDht(dataKey.value, data.data!)
         expect(successfulStorers.length).toBe(1)
         logger.info('data successfully stored to node 0')
 
@@ -159,7 +159,7 @@ describe('Replicate data from node to node in DHT', () => {
 
     it('Data replicates to the last remaining node if all other nodes leave gracefully', async () => {
         const dataKey = PeerID.fromString('3232323e12r31r3')
-        const data = Any.pack(entrypointDescriptor, PeerDescriptor)
+        const data = createMockDataEntry({ key: dataKey.value })
 
         logger.info(NUM_NODES + ' nodes joining layer0 DHT')
         await Promise.all(
@@ -175,7 +175,7 @@ describe('Replicate data from node to node in DHT', () => {
         const randomIndex = Math.floor(Math.random() * nodes.length)
         logger.info('storing data to a random node: ' + randomIndex)
 
-        const successfulStorers = await nodes[randomIndex].storeDataToDht(dataKey.value, data)
+        const successfulStorers = await nodes[randomIndex].storeDataToDht(dataKey.value, data.data!)
 
         logger.info('data successfully stored to ' + successfulStorers + ' nodes')
 

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -2,9 +2,8 @@ import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode, createMockPeerDescriptor, waitConnectionManagersReadyForTesting } from '../utils/utils'
+import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { Any } from '../../src/proto/google/protobuf/any'
-import { createRandomNodeId } from '../../src/helpers/nodeId'
 
 describe('Storing data in DHT', () => {
     let entryPoint: DhtNode
@@ -43,44 +42,34 @@ describe('Storing data in DHT', () => {
 
     it('Storing data works', async () => {
         const storingNodeIndex = 34
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
-        const successfulStorers = await nodes[storingNodeIndex].storeDataToDht(dataKey, data)
+        const entry = createMockDataEntry()
+        const successfulStorers = await nodes[storingNodeIndex].storeDataToDht(entry.key, entry.data!)
         expect(successfulStorers.length).toBeGreaterThan(4)
     }, 30000)
 
     it('Storing and getting data works', async () => {
         const storingNode = getRandomNode()
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
-        const successfulStorers = await storingNode.storeDataToDht(dataKey, data)
+        const entry = createMockDataEntry()
+        const successfulStorers = await storingNode.storeDataToDht(entry.key, entry.data!)
         expect(successfulStorers.length).toBeGreaterThan(4)
-
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.getDataFromDht(dataKey)
-        results.forEach((entry) => {
-            const foundData = Any.unpack(entry.data!, PeerDescriptor)
-            expect(areEqualPeerDescriptors(foundData, storedData)).toBeTrue()
+        const results = await fetchingNode.getDataFromDht(entry.key)
+        results.forEach((result) => {
+            expectEqualData(result, entry)
         })
     }, 30000)
 
     it('storing with explicit creator', async () => {
         const storingNode = getRandomNode()
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
+        const entry = createMockDataEntry()
         const requestor = createMockPeerDescriptor()
-        const successfulStorers = await storingNode.storeDataToDht(dataKey, data, requestor)
+        const successfulStorers = await storingNode.storeDataToDht(entry.key, entry.data!, requestor)
         expect(successfulStorers.length).toBeGreaterThan(4)
-
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.getDataFromDht(dataKey)
-        results.forEach((entry) => {
-            const foundData = Any.unpack(entry.data!, PeerDescriptor)
-            expect(areEqualPeerDescriptors(foundData, storedData)).toBeTrue()
-            expect(areEqualPeerDescriptors(entry.creator!, requestor)).toBeTrue()
+        const results = await fetchingNode.getDataFromDht(entry.key)
+        results.forEach((result) => {
+            expectEqualData(result, entry)
+            expect(areEqualPeerDescriptors(result.creator!, requestor)).toBeTrue()
         })
     }, 30000)
 })

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -1,10 +1,8 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
+import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
+import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { createMockConnectionDhtNode, createMockPeerDescriptor, waitConnectionManagersReadyForTesting } from '../utils/utils'
-import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
-import { Any } from '../../src/proto/google/protobuf/any'
-import { createRandomNodeId } from '../../src/helpers/nodeId'
 
 describe('Storing data in DHT', () => {
     let entryPoint: DhtNode
@@ -43,47 +41,36 @@ describe('Storing data in DHT', () => {
 
     it('Data can be deleted', async () => {
         const storingNode = getRandomNode()
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
-        const successfulStorers = await storingNode.storeDataToDht(dataKey, data)
+        const entry = createMockDataEntry()
+        const successfulStorers = await storingNode.storeDataToDht(entry.key, entry.data!)
         expect(successfulStorers.length).toBeGreaterThan(4)
-        await storingNode.deleteDataFromDht(dataKey, true)
-
+        await storingNode.deleteDataFromDht(entry.key, true)
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.getDataFromDht(dataKey)
-        results.forEach((entry) => {
-            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
-            expect(entry.deleted).toBeTrue()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
+        const results = await fetchingNode.getDataFromDht(entry.key)
+        results.forEach((result) => {
+            expect(result.deleted).toBeTrue()
+            expectEqualData(result, entry)
         })
     }, 90000)
 
     it('Data can be deleted and re-stored', async () => {
         const storingNode = getRandomNode()
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
-        const successfulStorers1 = await storingNode.storeDataToDht(dataKey, data)
+        const entry = createMockDataEntry()
+        const successfulStorers1 = await storingNode.storeDataToDht(entry.key, entry.data!)
         expect(successfulStorers1.length).toBeGreaterThan(4)
-        await storingNode.deleteDataFromDht(dataKey, true)
-
+        await storingNode.deleteDataFromDht(entry.key, true)
         const fetchingNode = getRandomNode()
-        const results1 = await fetchingNode.getDataFromDht(dataKey)
-        results1.forEach((entry) => {
-            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
-            expect(entry.deleted).toBeTrue()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
+        const results1 = await fetchingNode.getDataFromDht(entry.key)
+        results1.forEach((result) => {
+            expect(result.deleted).toBeTrue()
+            expectEqualData(result, entry)
         })
-
-        const successfulStorers2 = await storingNode.storeDataToDht(dataKey, data)
+        const successfulStorers2 = await storingNode.storeDataToDht(entry.key, entry.data!)
         expect(successfulStorers2.length).toBeGreaterThan(4)
-
-        const results2 = await fetchingNode.getDataFromDht(dataKey)
-        results2.forEach((entry) => {
-            const fetchedDescriptor = Any.unpack(entry.data!, PeerDescriptor)
-            expect(entry.deleted).toBeFalse()
-            expect(areEqualPeerDescriptors(fetchedDescriptor, storedData)).toBeTrue()
+        const results2 = await fetchingNode.getDataFromDht(entry.key)
+        results2.forEach((result) => {
+            expect(result.deleted).toBeFalse()
+            expectEqualData(result, entry)
         })
     }, 90000)
 })

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -1,11 +1,8 @@
-import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
+import { createMockConnectionDhtNode } from '../utils/utils'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { Simulator } from '../../src/connection/simulator/Simulator'
-import { Any } from '../../src/proto/google/protobuf/any'
-import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { areEqualPeerDescriptors } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { waitForCondition } from '@streamr/utils'
-import { createRandomNodeId } from '../../src/helpers/nodeId'
+import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 
 describe('Storing data in DHT with two peers', () => {
 
@@ -41,31 +38,22 @@ describe('Storing data in DHT with two peers', () => {
     })
 
     it('Node can store on two peer DHT', async () => {
-        const storedData1 = createMockPeerDescriptor()
-        const storedData2 = createMockPeerDescriptor()
-        const dataKey1 = createRandomNodeId()
-        const dataKey2 = createRandomNodeId()
-        const data1 = Any.pack(storedData1, PeerDescriptor)
-        const data2 = Any.pack(storedData2, PeerDescriptor)
-
-        await otherNode.storeDataToDht(dataKey1, data1)
-        await entryPoint.storeDataToDht(dataKey2, data2)
-
-        const foundData1 = await otherNode.getDataFromDht(dataKey1)
-        const foundData2 = await entryPoint.getDataFromDht(dataKey2)
-        expect(areEqualPeerDescriptors(storedData1, Any.unpack(foundData1[0]!.data!, PeerDescriptor))).toBeTrue()
-        expect(areEqualPeerDescriptors(storedData2, Any.unpack(foundData2[0]!.data!, PeerDescriptor))).toBeTrue()
+        const storedData1 = createMockDataEntry()
+        const storedData2 = createMockDataEntry()
+        await otherNode.storeDataToDht(storedData1.key, storedData1.data!)
+        await entryPoint.storeDataToDht(storedData2.key, storedData2.data!)
+        const foundData1 = await otherNode.getDataFromDht(storedData1.key)
+        const foundData2 = await entryPoint.getDataFromDht(storedData2.key)
+        expectEqualData(foundData1[0], storedData1)
+        expectEqualData(foundData2[0], storedData2)
     })
 
     it('Can store on one peer DHT', async () => {
         await otherNode.stop()
         await waitForCondition(() => entryPoint.getNumberOfNeighbors() === 0)
-        const dataKey = createRandomNodeId()
-        const storedData = createMockPeerDescriptor()
-        const data = Any.pack(storedData, PeerDescriptor)
-        await entryPoint.storeDataToDht(dataKey, data)
-
-        const foundData = await entryPoint.getDataFromDht(dataKey)
-        expect(areEqualPeerDescriptors(storedData, Any.unpack(foundData[0]!.data!, PeerDescriptor))).toBeTrue()
+        const storedData = createMockDataEntry()
+        await entryPoint.storeDataToDht(storedData.key, storedData.data!)
+        const foundData = await entryPoint.getDataFromDht(storedData.key)
+        expectEqualData(foundData[0], storedData)
     }, 60000)
 })

--- a/packages/dht/test/integration/StoreRpcRemote.test.ts
+++ b/packages/dht/test/integration/StoreRpcRemote.test.ts
@@ -9,7 +9,7 @@ import { generateId, mockStoreRpc } from '../utils/utils'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { StoreRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { StoreRpcRemote } from '../../src/dht/store/StoreRpcRemote'
-import { Any } from '../../src/proto/google/protobuf/any'
+import { createMockDataEntry } from '../utils/mock/mockDataEntry'
 
 describe('StoreRpcRemote', () => {
 
@@ -25,10 +25,10 @@ describe('StoreRpcRemote', () => {
         nodeId: generateId('server'),
         type: NodeType.NODEJS
     }
-    const data = Any.pack(clientPeerDescriptor, PeerDescriptor)
+    const data = createMockDataEntry()
     const request: StoreDataRequest = {
-        key: clientPeerDescriptor.nodeId,
-        data,
+        key: data.key,
+        data: data.data,
         ttl: 10
     }
 

--- a/packages/dht/test/utils/mock/mockDataEntry.ts
+++ b/packages/dht/test/utils/mock/mockDataEntry.ts
@@ -1,0 +1,36 @@
+import { MessageType as MessageType$, ScalarType } from '@protobuf-ts/runtime'
+import { randomString } from '@streamr/utils'
+import crypto from 'crypto'
+import { Timestamp } from '../../../src/proto/google/protobuf/timestamp'
+import { Any } from '../../../src/proto/google/protobuf/any'
+import { DataEntry } from '../../../src/proto/packages/dht/protos/DhtRpc'
+import { createMockPeerDescriptor } from '../utils'
+
+const MockData = new class extends MessageType$<{ foo: string }> {
+    constructor() {
+        super('MockData', [
+            { no: 1, name: 'foo', kind: 'scalar', opt: false, T: ScalarType.STRING }
+        ])
+    }
+}
+
+export const createMockDataEntry = (entry: Partial<DataEntry> = {}): DataEntry => {
+    return { 
+        key: crypto.randomBytes(10),
+        data: Any.pack({ foo: randomString(5) }, MockData),
+        creator: entry.creator ?? createMockPeerDescriptor(),
+        ttl: 10000,
+        stale: false,
+        deleted: false,
+        createdAt: Timestamp.now(),
+        ...entry
+    }
+}
+
+export const unpackData = (entry: DataEntry): { foo: string } => {
+    return Any.unpack(entry.data!, MockData)
+}
+
+export const expectEqualData = (entry1: DataEntry, entry2: DataEntry): void => {
+    expect(unpackData(entry1).foo).toBe(unpackData(entry2).foo)
+}


### PR DESCRIPTION
Use mock `DataEntry` instances in test which store data. This way we can have a clear separation between the data and the creator/storer/etc.