### PR TITLE
refactor(dht, trackerless-network): Remove obsolete events

### DIFF
--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -17,12 +17,7 @@ export interface ManagedConnectionEvents {
     closing: () => void
 }
 
-interface OutpuBufferEvents {
-    bufferSent: () => void
-    bufferSendingFailed: () => void
-}
-
-interface OutpuBufferEvents {
+interface OutputBufferEvents {
     bufferSent: () => void
     bufferSendingFailed: () => void
 }
@@ -35,7 +30,7 @@ export class ManagedConnection extends EventEmitter<Events> {
 
     private implementation?: IConnection
 
-    private outputBufferEmitter = new EventEmitter<OutpuBufferEvents>()
+    private outputBufferEmitter = new EventEmitter<OutputBufferEvents>()
     private outputBuffer: Uint8Array[] = []
 
     private inputBuffer: Uint8Array[] = []
@@ -249,10 +244,10 @@ export class ManagedConnection extends EventEmitter<Events> {
         } else {
             logger.trace('adding data to outputBuffer')
 
-            let result: RunAndRaceEventsReturnType<OutpuBufferEvents>
+            let result: RunAndRaceEventsReturnType<OutputBufferEvents>
 
             try {
-                result = await runAndRaceEvents3<OutpuBufferEvents>([() => { this.outputBuffer.push(data) }],
+                result = await runAndRaceEvents3<OutputBufferEvents>([() => { this.outputBuffer.push(data) }],
                     this.outputBufferEmitter, ['bufferSent', 'bufferSendingFailed'], 15000)  // TODO use config option or named constant?
             } catch (e) {
                 logger.debug(`Connection to ${getNodeIdOrUnknownFromPeerDescriptor(this.remotePeerDescriptor)} timed out`, {

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -13,8 +13,6 @@ export interface ManagedConnectionEvents {
     handshakeRequest: (source: PeerDescriptor, target?: PeerDescriptor) => void
     handshakeCompleted: (peerDescriptor: PeerDescriptor) => void
     handshakeFailed: () => void
-    bufferSentByOtherConnection: () => void
-    closing: () => void
 }
 
 interface OutputBufferEvents {
@@ -284,7 +282,6 @@ export class ManagedConnection extends EventEmitter<Events> {
         logger.trace('bufferSentByOtherConnection reported')
         this.bufferSentbyOtherConnection = true
         this.outputBufferEmitter.emit('bufferSent')
-        this.emit('bufferSentByOtherConnection')
     }
 
     public acceptHandshake(): void {
@@ -319,7 +316,6 @@ export class ManagedConnection extends EventEmitter<Events> {
         this.closing = true
         
         this.outputBufferEmitter.emit('bufferSendingFailed')
-        this.emit('closing')
        
         if (this.implementation) {
             await this.implementation?.close(gracefulLeave)
@@ -334,8 +330,6 @@ export class ManagedConnection extends EventEmitter<Events> {
 
     public destroy(): void {
         this.closing = true
-        
-        this.emit('closing')
         if (!this.stopped) {
             this.stopped = true
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -58,7 +58,6 @@ import { StoreRpcRemote } from './store/StoreRpcRemote'
 export interface DhtNodeEvents {
     newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    joinCompleted: () => void
     newRandomContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
 }

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -54,13 +54,12 @@ class RemoteContact extends Contact {
 export interface RoutingSessionEvents {
     // This event is emitted when a peer responds with a success ack
     // to routeMessage call
-    routingSucceeded: (sessionId: string) => void
-    partialSuccess: (sessionId: string) => void
-
+    routingSucceeded: () => void
+    partialSuccess: () => void
     // This event is emitted when all the candidates have been gone
     // through, and none of them responds with a success ack
-    routingFailed: (sessionId: string) => void
-    stopped: (sessionId: string) => void
+    routingFailed: () => void
+    stopped: () => void
 }
 
 export enum RoutingMode { ROUTE, FORWARD, RECURSIVE }
@@ -131,9 +130,9 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
 
     private emitFailure() {
         if (this.successfulHopCounter >= 1) {
-            this.emit('partialSuccess', this.sessionId)
+            this.emit('partialSuccess')
         } else {
-            this.emit('routingFailed', this.sessionId)
+            this.emit('routingFailed')
         }
     }
 
@@ -147,7 +146,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         if (this.successfulHopCounter >= this.parallelism || contacts.length === 0) {
             // TODO should call this.stop() so that we do cleanup? (after the routingSucceeded call)
             this.stopped = true
-            this.emit('routingSucceeded', this.sessionId)
+            this.emit('routingSucceeded')
         } else if (contacts.length > 0 && this.ongoingRequests.size === 0) {
             this.sendMoreRequests(contacts)
         }
@@ -224,7 +223,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
     public stop(): void {
         this.stopped = true
         this.contactList.stop()
-        this.emit('stopped', this.sessionId)
+        this.emit('stopped')
         this.removeAllListeners()
     }
 }

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -1,7 +1,6 @@
 import { ConnectionManager, DhtNode, DhtNodeOptions, areEqualPeerDescriptors } from '@streamr/dht'
 import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
 import { MetricsContext, waitForCondition } from '@streamr/utils'
-import { EventEmitter } from 'eventemitter3'
 import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
 import { ProxyDirection, StreamMessage, StreamMessageType } from './proto/packages/trackerless-network/protos/NetworkRpc'
 import { Layer0Node } from './logic/Layer0Node'
@@ -11,10 +10,6 @@ export interface NetworkOptions {
     layer0?: DhtNodeOptions
     networkNode?: StreamrNodeConfig
     metricsContext?: MetricsContext
-}
-
-export interface NetworkStackEvents {
-    stopped: () => void
 }
 
 const instances: NetworkStack[] = []
@@ -38,7 +33,7 @@ if (typeof window === 'object') {
     })
 }
 
-export class NetworkStack extends EventEmitter<NetworkStackEvents> {
+export class NetworkStack {
 
     private layer0Node?: Layer0Node
     private streamrNode?: StreamrNode
@@ -47,7 +42,6 @@ export class NetworkStack extends EventEmitter<NetworkStackEvents> {
     private readonly options: NetworkOptions
 
     constructor(options: NetworkOptions) {
-        super()
         this.options = options
         this.metricsContext = options.metricsContext ?? new MetricsContext()
         this.layer0Node = new DhtNode({

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -58,11 +58,15 @@ interface ProxyDefinition {
     userId: EthereumAddress
 }
 
+interface Events {
+    message: (message: StreamMessage) => void
+}
+
 const logger = new Logger(module)
 
 const SERVICE_ID = 'system/proxy-client'
 
-export class ProxyClient extends EventEmitter {
+export class ProxyClient extends EventEmitter<Events> {
 
     private readonly rpcCommunicator: ListeningRpcCommunicator
     private readonly deliveryRpcLocal: DeliveryRpcLocal


### PR DESCRIPTION
Removed:
- `DhtNodeEvents#joinComplete`
- `ManagedConnectionEvent#bufferSentByOtherConnection` and `ManagedConnectionEvent#closing`
- `NetworkStackEvents`
- the payload `RoutingSessionEvent` events
- duplicate definition of `OutputBufferEvents`

Added event interface for `ProxyClient`.

## Future improvements

- Unify naming of event names and event interfaces
  - use some naming pattern for the event names, maybe something like this:
    - prefer object + verb (e.g. `fooChanged`)
    - if the event is about the data received, then just an object (e.g. `message`)
    - if the event is about the whole object, then just a verb in past tense (e.g. `stopped`)
  - e.g. `SortedContactList#newContact` -> `contactAdded` (there is also `contactRemoved`?)
  - e.g. `StreamrNode#newMessage` -> `message`
- all interfaces in plural
