### PR TITLE
NET-1133: Update config wizard to create v1.0 configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15425,15 +15425,6 @@
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
             "dev": true
         },
-        "node_modules/immer": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
-            "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/immer"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -29865,7 +29856,6 @@
                 "ethers": "^5.4.7",
                 "express": "^4.17.1",
                 "heap": "^0.2.6",
-                "immer": "^10.0.3",
                 "lodash": "^4.17.21",
                 "merge2": "^1.4.1",
                 "nat-type-identifier": "^2.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3847,6 +3847,798 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@inquirer/checkbox": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.0.tgz",
+            "integrity": "sha512-3cKJkW1vIZAs4NaS0reFsnpAjP0azffYII4I2R7PTI7ZTMg5Y1at4vzXccOH3762b2c2L4drBhpJpf9uiaGNxA==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "figures": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/checkbox/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/checkbox/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.15.tgz",
+            "integrity": "sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/confirm/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/confirm/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/confirm/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/confirm/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/confirm/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/confirm/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-5.1.1.tgz",
+            "integrity": "sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==",
+            "dependencies": {
+                "@inquirer/type": "^1.1.5",
+                "@types/mute-stream": "^0.0.4",
+                "@types/node": "^20.9.0",
+                "@types/wrap-ansi": "^3.0.0",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "cli-spinners": "^2.9.1",
+                "cli-width": "^4.1.0",
+                "figures": "^3.2.0",
+                "mute-stream": "^1.0.0",
+                "run-async": "^3.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^6.2.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/@types/node": {
+            "version": "20.10.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+            "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/cli-width": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/core/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/mute-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/run-async": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+            "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/editor": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.13.tgz",
+            "integrity": "sha512-gBxjqt0B9GLN0j6M/tkEcmcIvB2fo9Cw0f5NRqDTkYyB9AaCzj7qvgG0onQ3GVPbMyMbbP4tWYxrBOaOdKpzNA==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "chalk": "^4.1.2",
+                "external-editor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/editor/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/editor/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/editor/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/editor/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/editor/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/editor/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/expand": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.14.tgz",
+            "integrity": "sha512-yS6fJ8jZYAsxdxuw2c8XTFMTvMR1NxZAw3LxDaFnqh7BZ++wTQ6rSp/2gGJhMacdZ85osb+tHxjVgx7F+ilv5g==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "chalk": "^4.1.2",
+                "figures": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/expand/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/expand/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/expand/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/expand/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/expand/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/expand/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-1.2.14.tgz",
+            "integrity": "sha512-tISLGpUKXixIQue7jypNEShrdzJoLvEvZOJ4QRsw5XTfrIYfoWFqAjMQLerGs9CzR86yAI89JR6snHmKwnNddw==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/input/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/input/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/input/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/input/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/input/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/input/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/password": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-1.1.14.tgz",
+            "integrity": "sha512-vL2BFxfMo8EvuGuZYlryiyAB3XsgtbxOcFs4H9WI9szAS/VZCAwdVqs8rqEeaAf/GV/eZOghIOYxvD91IsRWSg==",
+            "dependencies": {
+                "@inquirer/input": "^1.2.14",
+                "@inquirer/type": "^1.1.5",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/password/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/password/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/prompts": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.0.tgz",
+            "integrity": "sha512-BBCqdSnhNs+WziSIo4f/RNDu6HAj4R/Q5nMgJb5MNPFX8sJGCvj9BoALdmR0HTWXyDS7TO8euKj6W6vtqCQG7A==",
+            "dependencies": {
+                "@inquirer/checkbox": "^1.5.0",
+                "@inquirer/confirm": "^2.0.15",
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/editor": "^1.2.13",
+                "@inquirer/expand": "^1.1.14",
+                "@inquirer/input": "^1.2.14",
+                "@inquirer/password": "^1.1.14",
+                "@inquirer/rawlist": "^1.2.14",
+                "@inquirer/select": "^1.3.1"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/rawlist": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.14.tgz",
+            "integrity": "sha512-xIYmDpYgfz2XGCKubSDLKEvadkIZAKbehHdWF082AyC2I4eHK44RUfXaoOAqnbqItZq4KHXS6jDJ78F2BmQvxg==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/rawlist/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/rawlist/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/rawlist/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/rawlist/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/rawlist/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/rawlist/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.3.1.tgz",
+            "integrity": "sha512-EgOPHv7XOHEqiBwBJTyiMg9r57ySyW4oyYCumGp+pGyOaXQaLb2kTnccWI6NFd9HSi5kDJhF7YjA+3RfMQJ2JQ==",
+            "dependencies": {
+                "@inquirer/core": "^5.1.1",
+                "@inquirer/type": "^1.1.5",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "figures": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/@inquirer/select/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/select/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
+            "integrity": "sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==",
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -7310,16 +8102,6 @@
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
-        "node_modules/@types/inquirer": {
-            "version": "8.2.10",
-            "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.2.10.tgz",
-            "integrity": "sha512-IdD5NmHyVjWM8SHWo/kPBgtzXatwPkfwzyP3fN1jF2g9BWt5WO+8hL2F4o2GKIYsU40PpqeevuUWvkS/roXJkA==",
-            "dev": true,
-            "dependencies": {
-                "@types/through": "*",
-                "rxjs": "^7.2.0"
-            }
-        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -7426,6 +8208,14 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
+        },
+        "node_modules/@types/mute-stream": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+            "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/node": {
             "version": "18.18.13",
@@ -7612,15 +8402,6 @@
                 "@types/superagent": "*"
             }
         },
-        "node_modules/@types/through": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
-            "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -7646,6 +8427,11 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.2.tgz",
             "integrity": "sha512-UqCG7NjNyume6e+BHcFkOQOS8of/E18V2z/jTRkiD98YiiryYOFBVvPxqA/8PQCwkn7icKqz/hFflMIRN2HGhQ=="
+        },
+        "node_modules/@types/wrap-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+            "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
         },
         "node_modules/@types/ws": {
             "version": "8.5.10",
@@ -29019,6 +29805,7 @@
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
                 "@ethersproject/hdnode": "^5.4.0",
+                "@inquirer/prompts": "^3.3.0",
                 "@streamr/config": "^5.0.5",
                 "@streamr/network-contracts": "^7.0.5",
                 "@streamr/protocol": "100.0.0-pretestnet.4",
@@ -29034,7 +29821,6 @@
                 "ethers": "^5.4.7",
                 "express": "^4.17.1",
                 "heap": "^0.2.6",
-                "inquirer": "^8.2.6",
                 "lodash": "^4.17.21",
                 "merge2": "^1.4.1",
                 "nat-type-identifier": "^2.0.9",
@@ -29044,7 +29830,7 @@
                 "streamr-client": "100.0.0-pretestnet.4",
                 "uuid": "^9.0.1",
                 "ws": "^8.14.2",
-                "zod": "^3.22.2"
+                "zod": "^3.22.4"
             },
             "bin": {
                 "delete-expired-data": "dist/bin/delete-expired-data.js",
@@ -29058,7 +29844,6 @@
                 "@types/cors": "^2.8.17",
                 "@types/express": "^4.17.21",
                 "@types/heap": "^0.2.34",
-                "@types/inquirer": "^8.1.3",
                 "@types/lodash": "^4.14.202",
                 "@types/merge2": "^1.4.4",
                 "@types/node-fetch": "^2.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4631,6 +4631,41 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@inquirer/testing": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/testing/-/testing-2.1.9.tgz",
+            "integrity": "sha512-WOE84gVft9p8C7i5HVFybHYdtocRWTXYe+95/D60Z+DS3TcZpD0ph33BC3Y8tv8m9YHcmQaLAVA3PusMp0j+9g==",
+            "dev": true,
+            "dependencies": {
+                "@inquirer/type": "^1.1.5",
+                "@types/mute-stream": "^0.0.4",
+                "@types/node": "^20.9.0",
+                "ansi-escapes": "^4.3.2",
+                "mute-stream": "^1.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/@inquirer/testing/node_modules/@types/node": {
+            "version": "20.10.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+            "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@inquirer/testing/node_modules/mute-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@inquirer/type": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.5.tgz",
@@ -29849,6 +29884,7 @@
                 "streamr-broker-init": "dist/bin/config-wizard.js"
             },
             "devDependencies": {
+                "@inquirer/testing": "^2.1.9",
                 "@streamr/dht": "100.0.0-pretestnet.4",
                 "@streamr/test-utils": "100.0.0-pretestnet.4",
                 "@types/cors": "^2.8.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15390,6 +15390,15 @@
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
             "dev": true
         },
+        "node_modules/immer": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+            "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -29821,6 +29830,7 @@
                 "ethers": "^5.4.7",
                 "express": "^4.17.1",
                 "heap": "^0.2.6",
+                "immer": "^10.0.3",
                 "lodash": "^4.17.21",
                 "merge2": "^1.4.1",
                 "nat-type-identifier": "^2.0.9",

--- a/packages/broker/bin/config-wizard.ts
+++ b/packages/broker/bin/config-wizard.ts
@@ -8,7 +8,7 @@ program
     .name('broker-config-wizard')
     .description('Run the configuration wizard for the broker')
 
-void (async () => {
+;(async () => {
     try {
         await start()
     } catch (e) {

--- a/packages/broker/bin/config-wizard.ts
+++ b/packages/broker/bin/config-wizard.ts
@@ -8,4 +8,10 @@ program
     .name('broker-config-wizard')
     .description('Run the configuration wizard for the broker')
 
-start()
+void (async () => {
+    try {
+        await start()
+    } catch (e) {
+        console.error('Streamr Node Config Wizard encountered an error:\n', e)
+    }
+})()

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -45,7 +45,6 @@
     "ethers": "^5.4.7",
     "express": "^4.17.1",
     "heap": "^0.2.6",
-    "immer": "^10.0.3",
     "lodash": "^4.17.21",
     "merge2": "^1.4.1",
     "nat-type-identifier": "^2.0.9",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -45,6 +45,7 @@
     "ethers": "^5.4.7",
     "express": "^4.17.1",
     "heap": "^0.2.6",
+    "immer": "^10.0.3",
     "lodash": "^4.17.21",
     "merge2": "^1.4.1",
     "nat-type-identifier": "^2.0.9",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -29,6 +29,7 @@
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "dependencies": {
     "@ethersproject/hdnode": "^5.4.0",
+    "@inquirer/prompts": "^3.3.0",
     "@streamr/config": "^5.0.5",
     "@streamr/network-contracts": "^7.0.5",
     "@streamr/protocol": "100.0.0-pretestnet.4",
@@ -44,7 +45,6 @@
     "ethers": "^5.4.7",
     "express": "^4.17.1",
     "heap": "^0.2.6",
-    "inquirer": "^8.2.6",
     "lodash": "^4.17.21",
     "merge2": "^1.4.1",
     "nat-type-identifier": "^2.0.9",
@@ -54,7 +54,7 @@
     "streamr-client": "100.0.0-pretestnet.4",
     "uuid": "^9.0.1",
     "ws": "^8.14.2",
-    "zod": "^3.22.2"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@streamr/dht": "100.0.0-pretestnet.4",
@@ -62,7 +62,6 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/heap": "^0.2.34",
-    "@types/inquirer": "^8.1.3",
     "@types/lodash": "^4.14.202",
     "@types/merge2": "^1.4.4",
     "@types/node-fetch": "^2.6.4",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -58,6 +58,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@inquirer/testing": "^2.1.9",
     "@streamr/dht": "100.0.0-pretestnet.4",
     "@streamr/test-utils": "100.0.0-pretestnet.4",
     "@types/cors": "^2.8.17",

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -36,13 +36,11 @@ export const start = async (): Promise<void> => {
 
         const operator = await getOperatorAddress()
 
-        const operatorPlugins = operator
-            ? {
-                  operator: {
-                      operatorContractAddress: operator,
-                  },
-              }
-            : {}
+        const operatorPlugins = operator ? {
+            operator: {
+                operatorContractAddress: operator,
+            },
+        } : {}
 
         const { http, ...pubsubPlugins } = await getPubsubPlugins()
 
@@ -78,16 +76,12 @@ export const start = async (): Promise<void> => {
             >
             > ~ *Congratulations, you've setup your Streamr node!*
             > Your node address is ${chalk.greenBright(nodeAddress)}
-            > Your node's generated name is ${chalk.greenBright(
-                getNodeMnemonic(privateKey)
-            )}
+            > Your node's generated name is ${chalk.greenBright(getNodeMnemonic(privateKey))}
         `)
 
         if (operator) {
             const resume = progress((f) =>
-                style(
-                    `> Your node address has *${f} MATIC* _– checking balance…_`
-                )
+                style(`> Your node address has *${f} MATIC* _– checking balance…_`)
             )
 
             try {
@@ -142,10 +136,7 @@ export const start = async (): Promise<void> => {
                     }
                 } else {
                     log(`
-                    > x Your Operator could not be found on the **${network.replace(
-                        /\w/,
-                        (l) => l.toUpperCase()
-                    )}** network, see
+                        > x Your Operator could not be found on the **${network.replace(/\w/, (l) => l.toUpperCase())}** network, see
                     `)
                 }
 
@@ -486,8 +477,6 @@ function progress(fn: (frame: string) => string): () => void {
 
     let frameNo = 0
 
-    let intervalId: NodeJS.Timeout | undefined
-
     function tick() {
         process.stdout.clearLine(0)
 
@@ -496,13 +485,11 @@ function progress(fn: (frame: string) => string): () => void {
         process.stdout.write(fn(frames[frameNo]))
 
         frameNo = (frameNo + 1) % frames.length
-
-        setTimeout
     }
 
     tick()
 
-    intervalId = setInterval(tick, 400)
+    const intervalId = setInterval(tick, 400)
 
     return () => {
         clearInterval(intervalId)
@@ -517,8 +504,8 @@ function style(message: string) {
     let result = message
 
     const filters: [RegExp, chalk.Chalk][] = [
-        [/\*\*([^\*]+)\*\*/g, chalk.bold],
-        [/\*([^\*]+)\*/g, chalk.whiteBright],
+        [/\*\*([^*]+)\*\*/g, chalk.bold],
+        [/\*([^*]+)\*/g, chalk.whiteBright],
         [/_([^_]+)_/g, chalk.gray],
     ]
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -475,9 +475,9 @@ async function getNativeBalance(
     network: 'polygon' | 'mumbai',
     address: string
 ): Promise<BigNumber> {
-    const url = config[network].rpcEndpoints[0]?.url || ''
+    const url = config[network].rpcEndpoints[0]?.url
 
-    if (!/^https?:/i.test(url)) {
+    if (!url || !/^https?:/i.test(url)) {
         throw new Error('Invalid RPC')
     }
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -152,7 +152,7 @@ export async function start(): Promise<void> {
                         ? 'https://streamr.network/hub'
                         : 'https://mumbai.streamr.network/hub'
 
-                if (nodes) {
+                if (nodes !== undefined) {
                     if (!nodes.includes(nodeAddress.toLowerCase())) {
                         log(
                             '> ! You will need to pair your node with your Operator:'
@@ -448,7 +448,7 @@ async function getNativeBalance(
 async function getOperatorNodeAddresses(
     environmentId: EnvironmentId,
     operatorAddress: string
-): Promise<null | string[]> {
+): Promise<string[] | undefined> {
     const url = streamrConfig[environmentId].theGraphUrl
 
     const resp = await fetch(url, {
@@ -469,7 +469,7 @@ async function getOperatorNodeAddresses(
         })
         .parse(await resp.json())
 
-    return data.operator?.nodes || null
+    return data.operator ? data.operator.nodes : undefined
 }
 
 /**

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -68,7 +68,7 @@ export const start = async () => {
 
         persistConfig(
             storagePath,
-            network === 'polygon' ? config : decorateMumbaiConfig(config)
+            network === 'polygon' ? config : getMumbaiConfig(config)
         )
 
         const lines = [
@@ -307,7 +307,7 @@ function persistConfig(storagePath: string, config: ConfigFile) {
 /**
  * Adjusts the given config for the Mumbai test environment.
  */
-function decorateMumbaiConfig(config: ConfigFile): ConfigFile {
+function getMumbaiConfig(config: ConfigFile): ConfigFile {
     return produce(config, (draft) => {
         draft.client || (draft.client = {})
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -10,7 +10,7 @@ import path from 'path'
 import { z } from 'zod'
 import {
     CURRENT_CONFIGURATION_VERSION,
-    formSchemaUrl
+    formSchemaUrl,
 } from '../config/migration'
 import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
 import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
@@ -28,7 +28,7 @@ export const start = async () => {
         },
         success: (tick: boolean, ...args: unknown[]) => {
             console.info(tick ? chalk.greenBright('✓') : ' ', ...args)
-        }
+        },
     }
 
     try {
@@ -42,7 +42,7 @@ export const start = async () => {
 
         if (httpServer) {
             Object.assign(pubsubPlugins, {
-                http: {}
+                http: {},
             })
         }
 
@@ -52,18 +52,18 @@ export const start = async () => {
             $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
             client: {
                 auth: {
-                    privateKey
-                }
+                    privateKey,
+                },
             },
             plugins: {
                 ...operatorPlugins,
-                ...pubsubPlugins
+                ...pubsubPlugins,
             },
             httpServer: httpServer?.port
                 ? {
-                      port: httpServer.port
+                      port: httpServer.port,
                   }
-                : void 0
+                : void 0,
         }
 
         persistConfig(
@@ -86,20 +86,18 @@ export const start = async () => {
             chalk.whiteBright(`streamr-broker ${storagePath}`),
             ``,
             `For environment specific run instructions, see`,
-            `https://docs.streamr.network/guides/how-to-run-streamr-node`
+            `https://docs.streamr.network/guides/how-to-run-streamr-node`,
         ]
 
         logger.success(false)
 
         lines.forEach((line, index) => logger.success(!index, line))
     } catch (e: any) {
-        if (/force closed/i.test(e.message)) {
+        if (typeof e.message === 'string' && /force closed/i.test(e.message)) {
             return
         }
 
-        logger.error(
-            `Streamr Node Config Wizard encountered an error:\n${e.message}`
-        )
+        throw e
     }
 }
 
@@ -119,7 +117,7 @@ async function getPrivateKey() {
     const privateKeySource = await select<'Generate' | 'Import'>({
         message:
             'Do you want to generate a new Ethereum private key or import an existing one?',
-        choices: [{ value: 'Generate' }, { value: 'Import' }]
+        choices: [{ value: 'Generate' }, { value: 'Import' }],
     })
 
     const privateKey = await (async () => {
@@ -135,7 +133,7 @@ async function getPrivateKey() {
                 } catch (_) {}
 
                 return 'Invalid private key provided.'
-            }
+            },
         })
     })()
 
@@ -146,7 +144,7 @@ async function getPrivateKey() {
             default: false,
             transformer(value) {
                 return value ? `Your node's private key: ${privateKey}` : 'no'
-            }
+            },
         })
     }
 
@@ -164,10 +162,10 @@ async function getNetwork() {
             { value: 'polygon', name: 'Streamr 1.0 testnet + Polygon' },
             {
                 value: 'mumbai',
-                name: 'Streamr 1.0 testing environment + Mumbai'
-            }
+                name: 'Streamr 1.0 testing environment + Mumbai',
+            },
         ],
-        default: 'polygon'
+        default: 'polygon',
     })
 }
 
@@ -178,7 +176,7 @@ async function getOperatorPlugins() {
     const setupOperator = await confirm({
         message:
             'Do you wish to participate in earning rewards by staking on stream Sponsorships?',
-        default: true
+        default: true,
     })
 
     if (!setupOperator) {
@@ -191,9 +189,9 @@ async function getOperatorPlugins() {
                 message: 'Enter your Operator address:',
                 validate(value) {
                     return isAddress(value) ? true : 'Invalid ethereum address'
-                }
-            })
-        }
+                },
+            }),
+        },
     }
 }
 
@@ -204,7 +202,7 @@ type PubsubPluginKey = 'websocket' | 'mqtt' | 'http'
 const DefaultPort: Record<PubsubPluginKey, number> = {
     websocket: WebsocketConfigSchema.properties.port.default,
     mqtt: MqttConfigSchema.properties.port.default,
-    http: BrokerConfigSchema.properties.httpServer.properties.port.default
+    http: BrokerConfigSchema.properties.httpServer.properties.port.default,
 }
 
 /**
@@ -214,7 +212,7 @@ async function getPubsubPlugins() {
     const setupPubsub = await confirm({
         message:
             'Do you wish to use your node for data publishing/subscribing?',
-        default: true
+        default: true,
     })
 
     if (!setupPubsub) {
@@ -226,8 +224,8 @@ async function getPubsubPlugins() {
         choices: [
             { value: 'websocket', name: 'WebSocket' },
             { value: 'mqtt', name: 'MQTT' },
-            { value: 'http', name: 'HTTP' }
-        ]
+            { value: 'http', name: 'HTTP' },
+        ],
     })
 
     const pubsubPlugins: Partial<Record<PubsubPluginKey, PubsubPlugin>> = {}
@@ -243,7 +241,8 @@ async function getPubsubPlugins() {
                     try {
                         return !!z.coerce
                             .number({
-                                invalid_type_error: 'Non-numeric value provided'
+                                invalid_type_error:
+                                    'Non-numeric value provided',
                             })
                             .int('Non-integer value provided')
                             .min(1024)
@@ -254,7 +253,7 @@ async function getPubsubPlugins() {
                             .map(({ message }) => message)
                             .join(', ')
                     }
-                }
+                },
             })
         )
 
@@ -271,14 +270,14 @@ async function getStoragePath() {
     while (true) {
         const path = await input({
             message: 'Select a path to store the generated config in',
-            default: getDefaultFile()
+            default: getDefaultFile(),
         })
 
         const proceed =
             !existsSync(path) ||
             (await confirm({
                 message: `The selected destination ${path} already exists. Do you want to overwrite it?`,
-                default: false
+                default: false,
             }))
 
         if (proceed) {
@@ -295,7 +294,7 @@ function persistConfig(storagePath: string, config: ConfigFile) {
 
     if (!existsSync(dirPath)) {
         mkdirSync(dirPath, {
-            recursive: true
+            recursive: true,
         })
     }
 
@@ -317,19 +316,19 @@ function getMumbaiConfig(config: ConfigFile): ConfigFile {
             id: chainId,
             entryPoints,
             theGraphUrl,
-            rpcEndpoints: rpcs
+            rpcEndpoints: rpcs,
         } = cfg.mumbai
 
         draft.client.network = {
             controlLayer: {
-                entryPoints
-            }
+                entryPoints,
+            },
         }
 
         const {
             StreamRegistry: streamRegistryChainAddress,
             StreamStorageRegistry: streamStorageRegistryChainAddress,
-            StorageNodeRegistry: storageNodeRegistryChainAddress
+            StorageNodeRegistry: storageNodeRegistryChainAddress,
         } = cfg.mumbai.contracts
 
         draft.client.contracts = {
@@ -339,9 +338,9 @@ function getMumbaiConfig(config: ConfigFile): ConfigFile {
             streamRegistryChainRPCs: {
                 name: 'mumbai',
                 chainId,
-                rpcs
+                rpcs,
             },
-            theGraphUrl
+            theGraphUrl,
         }
     })
 }

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -8,10 +8,6 @@ import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { produce } from 'immer'
 import path from 'path'
 import { z } from 'zod'
-import {
-    CURRENT_CONFIGURATION_VERSION,
-    formSchemaUrl,
-} from '../config/migration'
 import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
 import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
 import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
@@ -67,7 +63,6 @@ export const start = async (): Promise<void> => {
         const httpServer = http?.port ? { port: http.port } : void 0
 
         const config: ConfigFile = {
-            $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
             client: {
                 auth: {
                     privateKey,

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -1,36 +1,33 @@
-import inquirer, { Answers } from 'inquirer'
-import { Wallet } from 'ethers'
-import path from 'path'
-import { writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs'
-import chalk from 'chalk'
-import { v4 as uuid } from 'uuid'
-
-import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
-import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
-import * as BrokerConfigSchema from './config.schema.json'
-import { getDefaultFile } from './config'
-import { CURRENT_CONFIGURATION_VERSION, formSchemaUrl } from '../config/migration'
-import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
+import { checkbox, confirm, input, password, select } from '@inquirer/prompts'
 import { toEthereumAddress } from '@streamr/utils'
+import chalk from 'chalk'
+import { Wallet } from 'ethers'
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
+import path from 'path'
+import { v4 as uuid } from 'uuid'
+import { z } from 'zod'
+import {
+    CURRENT_CONFIGURATION_VERSION,
+    formSchemaUrl
+} from '../config/migration'
+import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
+import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
+import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
+import { ConfigFile, getDefaultFile } from './config'
+import * as BrokerConfigSchema from './config.schema.json'
 
-export interface PrivateKeyAnswers extends Answers {
-    generateOrImportPrivateKey: 'Import' | 'Generate'
-    importPrivateKey?: string
+type Plugin = { port: number }
+
+type PluginKey = 'websocket' | 'mqtt' | 'http'
+
+const DefaultPort: Record<PluginKey, number> = {
+    websocket: WebsocketConfigSchema.properties.port.default,
+    mqtt: MqttConfigSchema.properties.port.default,
+    http: BrokerConfigSchema.properties.httpServer.properties.port.default
 }
 
-export interface PluginAnswers extends Answers {
-    enabledApiPlugins: string[]
-    websocketPort?: string
-    mqttPort?: string
-    httpPort?: string
-}
-
-export interface StorageAnswers extends Answers {
-    storagePath: string
-}
-
-const createLogger = () => {
-    return {
+export const start = async () => {
+    const logger = {
         info: (...args: any[]) => {
             console.info(chalk.bgWhite.black(':'), ...args)
         },
@@ -38,217 +35,167 @@ const createLogger = () => {
             console.error(chalk.bgRed.black('!'), ...args)
         }
     }
-}
 
-const generateApiKey = (): string => {
-    const hex = uuid().split('-').join('')
-    return Buffer.from(hex).toString('base64').replace(/[^0-9a-z]/gi, '')
-}
-
-export const DEFAULT_CONFIG_PORTS: Record<string, number> = {
-    WS: WebsocketConfigSchema.properties.port.default,
-    MQTT: MqttConfigSchema.properties.port.default,
-    HTTP: BrokerConfigSchema.properties.httpServer.properties.port.default
-}
-
-const PLUGIN_NAMES: Record<string, string> = {
-    WS: 'websocket',
-    MQTT: 'mqtt',
-    HTTP: 'http'
-}
-
-const PRIVATE_KEY_SOURCE_GENERATE = 'Generate'
-const PRIVATE_KEY_SOURCE_IMPORT = 'Import'
-
-export const CONFIG_TEMPLATE: any = {
-    $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
-    client: {
-        auth: {}
-    },
-    plugins: {},
-    apiAuthentication: {
-        keys: [generateApiKey()]
-    }
-}
-
-const PRIVATE_KEY_PROMPTS: Array<inquirer.Question | inquirer.ListQuestion | inquirer.CheckboxQuestion> = [
-    {
-        type: 'list',
-        name:'generateOrImportPrivateKey',
-        message: 'Do you want to generate a new Ethereum private key or import an existing one?',
-        choices: [PRIVATE_KEY_SOURCE_GENERATE, PRIVATE_KEY_SOURCE_IMPORT]
-    },
-    {
-        type: 'password',
-        name:'importPrivateKey',
-        message: 'Please provide the private key to import',
-        when: (answers: inquirer.Answers): boolean => {
-            return answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT
-        },
-        validate: (input: string): string | boolean => {
-            try {
-                new Wallet(input)
-                return true
-            } catch (e: any) {
-                return 'Invalid private key provided.'
-            }
-        }
-    },
-    {
-        type: 'confirm',
-        name: 'revealGeneratedPrivateKey',
-        // eslint-disable-next-line max-len
-        message: 'We strongly recommend backing up your private key. It will be written into the config file, but would you also like to see this sensitive information on screen now?',
-        default: false,
-        when: (answers: inquirer.Answers): boolean => {
-            return answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_GENERATE
-        }
-    }
-]
-
-const createPluginPrompts = (): Array<inquirer.Question | inquirer.ListQuestion | inquirer.CheckboxQuestion> => {
-    const selectApiPluginsPrompt: inquirer.CheckboxQuestion = {
-        type: 'checkbox',
-        name: 'enabledApiPlugins',
-        message: 'Select the plugins to enable',
-        choices: Object.values(PLUGIN_NAMES)
-    }
-
-    const portPrompts: Array<inquirer.Question> = Object.keys(DEFAULT_CONFIG_PORTS).map((key) => {
-        const name = PLUGIN_NAMES[key]
-        const defaultPort = DEFAULT_CONFIG_PORTS[key]
-        return {
-            type: 'input',
-            name: `${name}Port`,
-            message: `Provide a port for the ${name} Plugin [Enter for default: ${defaultPort}]`,
-            when: (answers: inquirer.Answers) => {
-                return answers.enabledApiPlugins.includes(name)
-            },
-            validate: (input: string | number): string | boolean => {
-                const MIN_PORT_VALUE = 1024
-                const MAX_PORT_VALUE = 49151
-                const portNumber = (typeof input === 'string') ? Number(input) : input
-                if (Number.isNaN(portNumber)) {
-                    return `Non-numeric value provided`
-                }
-
-                if (!Number.isInteger(portNumber)) {
-                    return `Non-integer value provided`
-                }
-
-                if (portNumber < MIN_PORT_VALUE || portNumber > MAX_PORT_VALUE) {
-                    return `Out of range port ${portNumber} provided (valid range ${MIN_PORT_VALUE}-${MAX_PORT_VALUE})`
-                }
-                return true
-            },
-            default: defaultPort
-        }
-    })
-
-    return [
-        selectApiPluginsPrompt,
-        ...portPrompts
-    ]
-}
-
-export const PROMPTS = {
-    privateKey: PRIVATE_KEY_PROMPTS,
-    plugins: createPluginPrompts(),
-}
-
-export const storagePathPrompts = [{
-    type: 'input',
-    name: 'storagePath',
-    message: 'Select a path to store the generated config in',
-    default: getDefaultFile()
-},
-{
-    type: 'confirm',
-    name: 'overwrite',
-    message: (answers: inquirer.Answers): string => `The selected destination ${answers.storagePath} already exists, do you want to overwrite it?`,
-    default: false,
-    when: (answers: inquirer.Answers): boolean => existsSync(answers.storagePath)
-}]
-
-export const getConfig = (privateKey: string, pluginsAnswers: PluginAnswers): any => {
-    const config = { ... CONFIG_TEMPLATE, plugins: { ... CONFIG_TEMPLATE.plugins } }
-    config.client.auth.privateKey = privateKey
-
-    const pluginKeys = Object.keys(PLUGIN_NAMES)
-    pluginKeys.forEach((pluginKey) => {
-        const pluginName = PLUGIN_NAMES[pluginKey]
-        const defaultPort = DEFAULT_CONFIG_PORTS[pluginKey]
-        if (pluginsAnswers.enabledApiPlugins && pluginsAnswers.enabledApiPlugins.includes(pluginName)) {
-            let pluginConfig = {}
-            const portNumber = parseInt(pluginsAnswers[`${pluginName}Port`])
-            if (portNumber !== defaultPort) {
-                const portObject = { port: portNumber }
-                if (pluginName === PLUGIN_NAMES.HTTP) {
-                    // the http plugin is special, it needs to be added to the config after the other plugins
-                    config.httpServer = portObject
-                } else {
-                    // user provided a custom value, fill in
-                    pluginConfig = portObject
-                }
-            }
-            config.plugins![pluginName] = pluginConfig
-        }
-    })
-
-    return config
-}
-
-const selectStoragePath = async (): Promise<StorageAnswers> => {
-    let answers
-    do {
-        answers = await inquirer.prompt(storagePathPrompts)
-    } while (answers.overwrite === false)
-    return answers as any
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const createStorageFile = (config: any, answers: StorageAnswers): string => {
-    const dirPath = path.dirname(answers.storagePath)
-    const dirExists = existsSync(dirPath)
-    if (!dirExists) {
-        mkdirSync(dirPath, {
-            recursive: true
+    try {
+        const privateKeySource = await select<'Generate' | 'Import'>({
+            message:
+                'Do you want to generate a new Ethereum private key or import an existing one?',
+            choices: [{ value: 'Generate' }, { value: 'Import' }]
         })
-    }
-    writeFileSync(answers.storagePath, JSON.stringify(config, null, 4))
-    chmodSync(answers.storagePath, '600')
-    return answers.storagePath
-}
 
-export const getPrivateKey = (answers: PrivateKeyAnswers): string => {
-    return (answers.generateOrImportPrivateKey === PRIVATE_KEY_SOURCE_IMPORT) ? answers.importPrivateKey! : Wallet.createRandom().privateKey
+        const privateKey = await (async () => {
+            if (privateKeySource === 'Generate') {
+                return Wallet.createRandom().privateKey
+            }
+
+            return password({
+                message: 'Please provide the private key to import',
+                validate(value) {
+                    try {
+                        return !!new Wallet(value)
+                    } catch (_) {}
+
+                    return 'Invalid private key provided.'
+                }
+            })
+        })()
+
+        if (privateKeySource === 'Generate') {
+            await confirm({
+                message:
+                    'We strongly recommend backing up your private key.\nIt will be written into the config file, but would you also like to see this sensitive information on screen now?',
+                default: false,
+                transformer(value) {
+                    return value
+                        ? `Your node's private key: ${privateKey}`
+                        : 'No'
+                }
+            })
+        }
+
+        const pluginKeys = await checkbox<PluginKey>({
+            message: 'Select the plugins to enable',
+            choices: [
+                { value: 'websocket', name: 'WebSocket' },
+                { value: 'mqtt', name: 'MQTT' },
+                { value: 'http', name: 'HTTP' }
+            ]
+        })
+
+        const enabledPlugins: Partial<Record<PluginKey, Plugin>> = {}
+
+        for (const pluginKey of pluginKeys) {
+            const defaultPort = DefaultPort[pluginKey]
+
+            const port = Number(
+                await input({
+                    message: `Provide a port for the ${pluginKey} plugin`,
+                    default: defaultPort.toString(),
+                    validate(value) {
+                        try {
+                            return !!z.coerce
+                                .number({
+                                    invalid_type_error:
+                                        'Non-numeric value provided'
+                                })
+                                .int('Non-integer value provided')
+                                .min(1024)
+                                .max(49151)
+                                .parse(value)
+                        } catch (e: unknown) {
+                            return (e as z.ZodError).issues
+                                .map(({ message }) => message)
+                                .join(', ')
+                        }
+                    }
+                })
+            )
+
+            if (port !== defaultPort) {
+                enabledPlugins[pluginKey] = { port }
+            }
+        }
+
+        const { http: httpServer, ...plugins } = enabledPlugins
+
+        if (httpServer) {
+            Object.assign(plugins, {
+                http: {}
+            })
+        }
+
+        const storagePath = await (async () => {
+            while (true) {
+                const path = await input({
+                    message: 'Select a path to store the generated config in',
+                    default: getDefaultFile()
+                })
+
+                const proceed =
+                    !existsSync(path) ||
+                    (await confirm({
+                        message: `The selected destination ${path} already exists. Do you want to overwrite it?`,
+                        default: false
+                    }))
+
+                if (proceed) {
+                    return path
+                }
+            }
+        })()
+
+        const apiKey = Buffer.from(uuid().replace(/-/g, ''))
+            .toString('base64')
+            .replace(/[^\da-z]/gi, '')
+
+        const config: ConfigFile = {
+            $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
+            client: {
+                auth: {
+                    privateKey
+                }
+            },
+            plugins,
+            apiAuthentication: {
+                keys: [apiKey]
+            },
+            httpServer
+        }
+
+        const dirPath = path.dirname(storagePath)
+
+        if (!existsSync(dirPath)) {
+            mkdirSync(dirPath, {
+                recursive: true
+            })
+        }
+
+        writeFileSync(storagePath, JSON.stringify(config, null, 4))
+
+        chmodSync(storagePath, '600')
+
+        logger.info('Welcome to the Streamr Network')
+
+        logger.info(
+            `Your node's generated name is ${getNodeMnemonic(privateKey)}.`
+        )
+
+        logger.info('You can start the broker now with')
+
+        logger.info(`streamr-broker ${storagePath}`)
+    } catch (e: any) {
+        if (/force closed/i.test(e.message)) {
+            return
+        }
+
+        logger.error(
+            `Streamr Node Config Wizard encountered an error:\n${e.message}`
+        )
+    }
 }
 
 export const getNodeMnemonic = (privateKey: string): string => {
-    return generateMnemonicFromAddress(toEthereumAddress(new Wallet(privateKey).address))
-}
-
-export const start = async (
-    getPrivateKeyAnswers = (): Promise<PrivateKeyAnswers> => inquirer.prompt(PRIVATE_KEY_PROMPTS) as any,
-    getPluginAnswers = (): Promise<PluginAnswers> => inquirer.prompt(createPluginPrompts()) as any,
-    getStorageAnswers = selectStoragePath,
-    logger = createLogger()
-): Promise<void> => {
-    try {
-        const privateKeyAnswers = await getPrivateKeyAnswers()
-        const privateKey = getPrivateKey(privateKeyAnswers)
-        if (privateKeyAnswers.revealGeneratedPrivateKey) {
-            logger.info(`This is your node's private key: ${privateKey}`)
-        }
-        const pluginsAnswers = await getPluginAnswers()
-        const config = getConfig(privateKey, pluginsAnswers)
-        const storageAnswers = await getStorageAnswers()
-        const storagePath = createStorageFile(config, storageAnswers)
-        logger.info('Welcome to the Streamr Network')
-        logger.info(`Your node's generated name is ${getNodeMnemonic(privateKey)}.`)
-        logger.info('You can start the broker now with')
-        logger.info(`streamr-broker ${storagePath}`)
-    } catch (e: any) {
-        logger.error(`Broker Config Wizard encountered an error:\n${e.message}`)
-    }
+    return generateMnemonicFromAddress(
+        toEthereumAddress(new Wallet(privateKey).address)
+    )
 }

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -21,15 +21,31 @@ import { ConfigFile, getDefaultFile } from './config'
 export const start = async (): Promise<void> => {
     const logger = {
         info: (...args: any[]) => {
-            console.info(chalk.bgWhite.black(':'), ...args)
+            console.info(chalk.bgGrey(' '), ...args)
         },
         error: (...args: any[]) => {
             console.error(chalk.bgRed.black('!'), ...args)
         },
-        success: (tick: boolean, ...args: unknown[]) => {
-            console.info(tick ? chalk.greenBright('✓') : ' ', ...args)
-        },
     }
+
+    console.info()
+
+    logger.info()
+
+    logger.info(' ', chalk.whiteBright.bold('Welcome to the Streamr Network!'))
+
+    logger.info(' ', 'This Config Wizard will help you setup your node.')
+
+    logger.info(' ', 'The steps are documented here:')
+
+    logger.info(
+        ' ',
+        'https://docs.streamr.network/guides/how-to-run-streamr-node#config-wizard'
+    )
+
+    logger.info()
+
+    console.info()
 
     try {
         const privateKey = await getPrivateKey()
@@ -69,27 +85,45 @@ export const start = async (): Promise<void> => {
             network === 'polygon' ? config : getMumbaiConfig(config)
         )
 
-        const lines = [
+        console.info()
+
+        logger.info(
+            chalk.greenBright('✓'),
             chalk.bold.whiteBright(
                 `Congratulations, you've set up your Streamr Network node!`
-            ),
+            )
+        )
+
+        logger.info(
+            ` `,
             `Your node address is ${chalk.greenBright(
                 new Wallet(privateKey).address
-            )}`,
+            )}`
+        )
+
+        logger.info(
+            ` `,
             `Your node's generated name is ${chalk.greenBright(
                 getNodeMnemonic(privateKey)
-            )}`,
-            ``,
-            `You can start your Streamr node now with`,
-            chalk.whiteBright(`streamr-broker ${storagePath}`),
-            ``,
-            `For environment specific run instructions, see`,
-            `https://docs.streamr.network/guides/how-to-run-streamr-node`,
-        ]
+            )}`
+        )
 
-        logger.success(false)
+        logger.info()
 
-        lines.forEach((line, index) => logger.success(!index, line))
+        logger.info(` `, `You can start your Streamr node now with`)
+
+        logger.info(` `, chalk.whiteBright(`streamr-broker ${storagePath}`))
+
+        logger.info()
+
+        logger.info(` `, `For environment specific run instructions, see`)
+
+        logger.info(
+            ` `,
+            `https://docs.streamr.network/guides/how-to-run-streamr-node`
+        )
+
+        console.info()
     } catch (e: any) {
         if (typeof e.message === 'string' && /force closed/i.test(e.message)) {
             return

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -239,11 +239,13 @@ async function getPrivateKey(): Promise<string> {
     return privateKey
 }
 
+type NetworkKey = 'polygon' | 'mumbai'
+
 /**
  * Lets the user decide the desired network for their node.
  */
-async function getNetwork(): Promise<'polygon' | 'mumbai'> {
-    return select<Awaited<ReturnType<typeof getNetwork>>>({
+async function getNetwork(): Promise<NetworkKey> {
+    return select<NetworkKey>({
         message:
             'Which network do you want to configure your node to connect to?',
         choices: [

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -87,6 +87,9 @@ export const start = async (): Promise<void> => {
 
         console.info()
 
+        logger.info()
+
+
         logger.info(
             chalk.greenBright('✓'),
             chalk.bold.whiteBright(
@@ -122,6 +125,8 @@ export const start = async (): Promise<void> => {
             ` `,
             `https://docs.streamr.network/guides/how-to-run-streamr-node`
         )
+
+        logger.info()
 
         console.info()
     } catch (e: any) {

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -7,6 +7,7 @@ import { isAddress } from 'ethers/lib/utils'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { produce } from 'immer'
 import capitalize from 'lodash/capitalize'
+import omit from 'lodash/omit'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { z } from 'zod'
@@ -50,15 +51,19 @@ export async function start(): Promise<void> {
 
         const { http, ...pubsubPlugins } = await getPubsubPlugins()
 
+        /**
+         * Port number for the `http` plugin has to be defined within
+         * the `httpServer` object in the config's root. See below.
+         */
         if (http) {
             Object.assign(pubsubPlugins, {
-                http: {},
+                http: omit(http, 'port'),
             })
         }
 
-        const storagePath = await getStoragePath()
-
         const httpServer = http?.port ? { port: http.port } : undefined
+
+        const storagePath = await getStoragePath()
 
         const apiKey = Buffer.from(uuid().replace(/-/g, ''))
             .toString('base64')

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -8,6 +8,10 @@ import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { produce } from 'immer'
 import path from 'path'
 import { z } from 'zod'
+import {
+    CURRENT_CONFIGURATION_VERSION,
+    formSchemaUrl,
+} from '../config/migration'
 import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
 import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
 import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
@@ -55,6 +59,7 @@ export const start = async (): Promise<void> => {
         const httpServer = http?.port ? { port: http.port } : void 0
 
         const config: ConfigFile = {
+            $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
             client: {
                 auth: {
                     privateKey,

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -108,9 +108,9 @@ export async function start(): Promise<void> {
             try {
                 const balance = await getNativeBalance(environmentId, nodeAddress)
 
-                const content = `Your node address has *${utils
-                    .formatEther(balance)
-                    .replace(/\.\d+/, (f) => f.substring(0, 3))} MATIC*`
+                const content = `Your node address has *${Number(
+                    utils.formatEther(balance)
+                ).toFixed(2)} MATIC*`
 
                 resume()
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -6,6 +6,7 @@ import { BigNumber, Wallet, providers, utils } from 'ethers'
 import { isAddress } from 'ethers/lib/utils'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { produce } from 'immer'
+import capitalize from 'lodash/capitalize'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
 import { z } from 'zod'
@@ -16,8 +17,8 @@ import {
 import { generateMnemonicFromAddress } from '../helpers/generateMnemonicFromAddress'
 import * as MqttConfigSchema from '../plugins/mqtt/config.schema.json'
 import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
-import * as BrokerConfigSchema from './config.schema.json'
 import { ConfigFile, getDefaultFile } from './config'
+import * as BrokerConfigSchema from './config.schema.json'
 
 const MIN_BALANCE = utils.parseEther('0.1')
 
@@ -153,7 +154,7 @@ export async function start(): Promise<void> {
                     }
                 } else {
                     log(`
-                        > x Your Operator could not be found on the **${network.replace(/\w/, (l) => l.toUpperCase())}** network, see
+                        > x Your Operator could not be found on the **${capitalize(network)}** network, see
                     `)
                 }
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -221,7 +221,9 @@ async function getPrivateKey(): Promise<string> {
             message: 'Please provide the private key to import',
             validate(value) {
                 try {
-                    return !!new Wallet(value)
+                    new Wallet(value)
+
+                    return true
                 } catch (_) {
                     return 'Invalid private key provided.'
                 }
@@ -336,7 +338,7 @@ async function getPubsubPlugins(): Promise<Partial<Record<PubsubPluginKey, Pubsu
                 default: defaultPort.toString(),
                 validate(value) {
                     try {
-                        return !!z.coerce
+                        z.coerce
                             .number({
                                 invalid_type_error:
                                     'Non-numeric value provided',
@@ -363,6 +365,8 @@ async function getPubsubPlugins(): Promise<Partial<Record<PubsubPluginKey, Pubsu
                                 }
                             })
                             .parse(value)
+
+                        return true
                     } catch (e: unknown) {
                         return (e as z.ZodError).issues
                             .map(({ message }) => message)

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -177,6 +177,10 @@ export async function start(): Promise<void> {
         `)
     } catch (e: any) {
         if (typeof e.message === 'string' && /force closed/i.test(e.message)) {
+            /**
+             * Hitting ctrl+c key combination causes the `inquirer` library to throw
+             * the "User force closed the prompt" exception. Let's ignore it.
+             */
             return
         }
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -478,9 +478,11 @@ function progress(fn: (frame: string) => string): () => void {
     let frameNo = 0
 
     function tick() {
-        process.stdout.clearLine(0)
+        if (process.stdout.isTTY) {
+            process.stdout.clearLine(0)
 
-        process.stdout.cursorTo(0)
+            process.stdout.cursorTo(0)
+        }
 
         process.stdout.write(fn(frames[frameNo]))
 
@@ -494,9 +496,11 @@ function progress(fn: (frame: string) => string): () => void {
     return () => {
         clearInterval(intervalId)
 
-        process.stdout.clearLine(0)
+        if (process.stdout.isTTY) {
+            process.stdout.clearLine(0)
 
-        process.stdout.cursorTo(0)
+            process.stdout.cursorTo(0)
+        }
     }
 }
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -1,10 +1,12 @@
 import { checkbox, confirm, input, password, select } from '@inquirer/prompts'
+import { config as cfg } from '@streamr/config'
 import { toEthereumAddress } from '@streamr/utils'
 import chalk from 'chalk'
 import { Wallet } from 'ethers'
+import { isAddress } from 'ethers/lib/utils'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
+import { produce } from 'immer'
 import path from 'path'
-import { v4 as uuid } from 'uuid'
 import { z } from 'zod'
 import {
     CURRENT_CONFIGURATION_VERSION,
@@ -16,16 +18,6 @@ import * as WebsocketConfigSchema from '../plugins/websocket/config.schema.json'
 import { ConfigFile, getDefaultFile } from './config'
 import * as BrokerConfigSchema from './config.schema.json'
 
-type Plugin = { port: number }
-
-type PluginKey = 'websocket' | 'mqtt' | 'http'
-
-const DefaultPort: Record<PluginKey, number> = {
-    websocket: WebsocketConfigSchema.properties.port.default,
-    mqtt: MqttConfigSchema.properties.port.default,
-    http: BrokerConfigSchema.properties.httpServer.properties.port.default
-}
-
 export const start = async () => {
     const logger = {
         info: (...args: any[]) => {
@@ -33,120 +25,28 @@ export const start = async () => {
         },
         error: (...args: any[]) => {
             console.error(chalk.bgRed.black('!'), ...args)
+        },
+        success: (tick: boolean, ...args: unknown[]) => {
+            console.info(tick ? chalk.greenBright('✓') : ' ', ...args)
         }
     }
 
     try {
-        const privateKeySource = await select<'Generate' | 'Import'>({
-            message:
-                'Do you want to generate a new Ethereum private key or import an existing one?',
-            choices: [{ value: 'Generate' }, { value: 'Import' }]
-        })
+        const privateKey = await getPrivateKey()
 
-        const privateKey = await (async () => {
-            if (privateKeySource === 'Generate') {
-                return Wallet.createRandom().privateKey
-            }
+        const network = await getNetwork()
 
-            return password({
-                message: 'Please provide the private key to import',
-                validate(value) {
-                    try {
-                        return !!new Wallet(value)
-                    } catch (_) {}
+        const operatorPlugins = await getOperatorPlugins()
 
-                    return 'Invalid private key provided.'
-                }
-            })
-        })()
-
-        if (privateKeySource === 'Generate') {
-            await confirm({
-                message:
-                    'We strongly recommend backing up your private key.\nIt will be written into the config file, but would you also like to see this sensitive information on screen now?',
-                default: false,
-                transformer(value) {
-                    return value
-                        ? `Your node's private key: ${privateKey}`
-                        : 'No'
-                }
-            })
-        }
-
-        const pluginKeys = await checkbox<PluginKey>({
-            message: 'Select the plugins to enable',
-            choices: [
-                { value: 'websocket', name: 'WebSocket' },
-                { value: 'mqtt', name: 'MQTT' },
-                { value: 'http', name: 'HTTP' }
-            ]
-        })
-
-        const enabledPlugins: Partial<Record<PluginKey, Plugin>> = {}
-
-        for (const pluginKey of pluginKeys) {
-            const defaultPort = DefaultPort[pluginKey]
-
-            const port = Number(
-                await input({
-                    message: `Provide a port for the ${pluginKey} plugin`,
-                    default: defaultPort.toString(),
-                    validate(value) {
-                        try {
-                            return !!z.coerce
-                                .number({
-                                    invalid_type_error:
-                                        'Non-numeric value provided'
-                                })
-                                .int('Non-integer value provided')
-                                .min(1024)
-                                .max(49151)
-                                .parse(value)
-                        } catch (e: unknown) {
-                            return (e as z.ZodError).issues
-                                .map(({ message }) => message)
-                                .join(', ')
-                        }
-                    }
-                })
-            )
-
-            if (port !== defaultPort) {
-                enabledPlugins[pluginKey] = { port }
-            }
-        }
-
-        const { http: httpServer, ...plugins } = enabledPlugins
+        const { http: httpServer, ...pubsubPlugins } = await getPubsubPlugins()
 
         if (httpServer) {
-            Object.assign(plugins, {
+            Object.assign(pubsubPlugins, {
                 http: {}
             })
         }
 
-        const storagePath = await (async () => {
-            while (true) {
-                const path = await input({
-                    message: 'Select a path to store the generated config in',
-                    default: getDefaultFile()
-                })
-
-                const proceed =
-                    !existsSync(path) ||
-                    (await confirm({
-                        message: `The selected destination ${path} already exists. Do you want to overwrite it?`,
-                        default: false
-                    }))
-
-                if (proceed) {
-                    return path
-                }
-            }
-        })()
-
-        const apiKey = Buffer.from(uuid().replace(/-/g, ''))
-            .toString('base64')
-            .replace(/[^\da-z]/gi, '')
+        const storagePath = await getStoragePath()
 
         const config: ConfigFile = {
             $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
@@ -155,34 +55,43 @@ export const start = async () => {
                     privateKey
                 }
             },
-            plugins,
-            apiAuthentication: {
-                keys: [apiKey]
+            plugins: {
+                ...operatorPlugins,
+                ...pubsubPlugins
             },
-            httpServer
+            httpServer: httpServer?.port
+                ? {
+                      port: httpServer.port
+                  }
+                : void 0
         }
 
-        const dirPath = path.dirname(storagePath)
-
-        if (!existsSync(dirPath)) {
-            mkdirSync(dirPath, {
-                recursive: true
-            })
-        }
-
-        writeFileSync(storagePath, JSON.stringify(config, null, 4))
-
-        chmodSync(storagePath, '600')
-
-        logger.info('Welcome to the Streamr Network')
-
-        logger.info(
-            `Your node's generated name is ${getNodeMnemonic(privateKey)}.`
+        persistConfig(
+            storagePath,
+            network === 'polygon' ? config : decorateMumbaiConfig(config)
         )
 
-        logger.info('You can start the broker now with')
+        const lines = [
+            chalk.bold.whiteBright(
+                `Congratulations, you've set up your Streamr Network node!`
+            ),
+            `Your node address is ${chalk.greenBright(
+                new Wallet(privateKey).address
+            )}`,
+            `Your node's generated name is ${chalk.greenBright(
+                getNodeMnemonic(privateKey)
+            )}`,
+            ``,
+            `You can start your Streamr node now with`,
+            chalk.whiteBright(`streamr-broker ${storagePath}`),
+            ``,
+            `For environment specific run instructions, see`,
+            `https://docs.streamr.network/guides/how-to-run-streamr-node`
+        ]
 
-        logger.info(`streamr-broker ${storagePath}`)
+        logger.success(false)
+
+        lines.forEach((line, index) => logger.success(!index, line))
     } catch (e: any) {
         if (/force closed/i.test(e.message)) {
             return
@@ -194,8 +103,245 @@ export const start = async () => {
     }
 }
 
+/**
+ * Generates a mnemonic for a given private key.
+ */
 export const getNodeMnemonic = (privateKey: string): string => {
     return generateMnemonicFromAddress(
         toEthereumAddress(new Wallet(privateKey).address)
     )
+}
+
+/**
+ * Lets the user generate a private key or import an existing private key.
+ */
+async function getPrivateKey() {
+    const privateKeySource = await select<'Generate' | 'Import'>({
+        message:
+            'Do you want to generate a new Ethereum private key or import an existing one?',
+        choices: [{ value: 'Generate' }, { value: 'Import' }]
+    })
+
+    const privateKey = await (async () => {
+        if (privateKeySource === 'Generate') {
+            return Wallet.createRandom().privateKey
+        }
+
+        return password({
+            message: 'Please provide the private key to import',
+            validate(value) {
+                try {
+                    return !!new Wallet(value)
+                } catch (_) {}
+
+                return 'Invalid private key provided.'
+            }
+        })
+    })()
+
+    if (privateKeySource === 'Generate') {
+        await confirm({
+            message:
+                'We strongly recommend backing up your private key. It will be written into the config file, but would you also like to see this sensitive information on screen now?',
+            default: false,
+            transformer(value) {
+                return value ? `Your node's private key: ${privateKey}` : 'no'
+            }
+        })
+    }
+
+    return privateKey
+}
+
+/**
+ * Lets the user decide the desired network for their node.
+ */
+async function getNetwork() {
+    return select<'polygon' | 'mumbai'>({
+        message:
+            'Which network do you want to configure your node to connect to?',
+        choices: [
+            { value: 'polygon', name: 'Streamr 1.0 testnet + Polygon' },
+            {
+                value: 'mumbai',
+                name: 'Streamr 1.0 testing environment + Mumbai'
+            }
+        ],
+        default: 'polygon'
+    })
+}
+
+/**
+ * Lets the user gather and configure desired operator plugins.
+ */
+async function getOperatorPlugins() {
+    const setupOperator = await confirm({
+        message:
+            'Do you wish to participate in earning rewards by staking on stream Sponsorships?',
+        default: true
+    })
+
+    if (!setupOperator) {
+        return {}
+    }
+
+    return {
+        operator: {
+            operatorContractAddress: await input({
+                message: 'Enter your Operator address:',
+                validate(value) {
+                    return isAddress(value) ? true : 'Invalid ethereum address'
+                }
+            })
+        }
+    }
+}
+
+type PubsubPlugin = { port?: number }
+
+type PubsubPluginKey = 'websocket' | 'mqtt' | 'http'
+
+const DefaultPort: Record<PubsubPluginKey, number> = {
+    websocket: WebsocketConfigSchema.properties.port.default,
+    mqtt: MqttConfigSchema.properties.port.default,
+    http: BrokerConfigSchema.properties.httpServer.properties.port.default
+}
+
+/**
+ * Lets the user select and configure desired pub/sub plugins.
+ */
+async function getPubsubPlugins() {
+    const setupPubsub = await confirm({
+        message:
+            'Do you wish to use your node for data publishing/subscribing?',
+        default: true
+    })
+
+    if (!setupPubsub) {
+        return {}
+    }
+
+    const keys = await checkbox<PubsubPluginKey>({
+        message: 'Select the plugins to enable',
+        choices: [
+            { value: 'websocket', name: 'WebSocket' },
+            { value: 'mqtt', name: 'MQTT' },
+            { value: 'http', name: 'HTTP' }
+        ]
+    })
+
+    const pubsubPlugins: Partial<Record<PubsubPluginKey, PubsubPlugin>> = {}
+
+    for (const key of keys) {
+        const defaultPort = DefaultPort[key]
+
+        const port = Number(
+            await input({
+                message: `Provide a port for the ${key} plugin`,
+                default: defaultPort.toString(),
+                validate(value) {
+                    try {
+                        return !!z.coerce
+                            .number({
+                                invalid_type_error: 'Non-numeric value provided'
+                            })
+                            .int('Non-integer value provided')
+                            .min(1024)
+                            .max(49151)
+                            .parse(value)
+                    } catch (e: unknown) {
+                        return (e as z.ZodError).issues
+                            .map(({ message }) => message)
+                            .join(', ')
+                    }
+                }
+            })
+        )
+
+        pubsubPlugins[key] = port !== defaultPort ? { port } : {}
+    }
+
+    return pubsubPlugins
+}
+
+/**
+ * Lets the user decide where to write the config file.
+ */
+async function getStoragePath() {
+    while (true) {
+        const path = await input({
+            message: 'Select a path to store the generated config in',
+            default: getDefaultFile()
+        })
+
+        const proceed =
+            !existsSync(path) ||
+            (await confirm({
+                message: `The selected destination ${path} already exists. Do you want to overwrite it?`,
+                default: false
+            }))
+
+        if (proceed) {
+            return path
+        }
+    }
+}
+
+/**
+ * Writes given config structure into a file.
+ */
+function persistConfig(storagePath: string, config: ConfigFile) {
+    const dirPath = path.dirname(storagePath)
+
+    if (!existsSync(dirPath)) {
+        mkdirSync(dirPath, {
+            recursive: true
+        })
+    }
+
+    writeFileSync(storagePath, JSON.stringify(config, null, 4))
+
+    chmodSync(storagePath, '600')
+}
+
+/**
+ * Adjusts the given config for the Mumbai test environment.
+ */
+function decorateMumbaiConfig(config: ConfigFile): ConfigFile {
+    return produce(config, (draft) => {
+        draft.client || (draft.client = {})
+
+        draft.client.metrics = false
+
+        const {
+            id: chainId,
+            entryPoints,
+            theGraphUrl,
+            rpcEndpoints: rpcs
+        } = cfg.mumbai
+
+        draft.client.network = {
+            controlLayer: {
+                entryPoints
+            }
+        }
+
+        const {
+            StreamRegistry: streamRegistryChainAddress,
+            StreamStorageRegistry: streamStorageRegistryChainAddress,
+            StorageNodeRegistry: storageNodeRegistryChainAddress
+        } = cfg.mumbai.contracts
+
+        draft.client.contracts = {
+            streamRegistryChainAddress,
+            streamStorageRegistryChainAddress,
+            storageNodeRegistryChainAddress,
+            streamRegistryChainRPCs: {
+                name: 'mumbai',
+                chainId,
+                rpcs
+            },
+            theGraphUrl
+        }
+    })
 }

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -112,7 +112,7 @@ export async function start(): Promise<void> {
 
                 const content = `Your node address has *${utils
                     .formatEther(balance)
-                    .replace(/\.(\d+)/, (f) => f.substring(0, 3))} MATIC*`
+                    .replace(/\.\d+/, (f) => f.substring(0, 3))} MATIC*`
 
                 resume()
 

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -70,7 +70,7 @@ export async function start(): Promise<void> {
             .toString('base64')
             .replace(/[^\da-z]/gi, '')
 
-        let config: ConfigFile = {
+        const config: ConfigFile = {
             $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
             environment: environmentId,
             client: {
@@ -84,14 +84,11 @@ export async function start(): Promise<void> {
             },
             httpServer,
             apiAuthentication: {
-                keys: [apiKey]
+                keys: [apiKey],
             },
         }
 
-        persistConfig(
-            storagePath,
-            config,
-        )
+        persistConfig(storagePath, config)
 
         log(`
             >
@@ -101,12 +98,17 @@ export async function start(): Promise<void> {
         `)
 
         if (operator) {
-            const resume = progress((f) =>
-                style(`> Your node address has *${f} MATIC* _– checking balance…_`)
+            const resume = animateLine((spinner) =>
+                style(
+                    `> Your node address has *${spinner} MATIC* _– checking balance…_`
+                )
             )
 
             try {
-                const balance = await getNativeBalance(environmentId, nodeAddress)
+                const balance = await getNativeBalance(
+                    environmentId,
+                    nodeAddress
+                )
 
                 const content = `Your node address has *${Number(
                     utils.formatEther(balance)
@@ -131,14 +133,17 @@ export async function start(): Promise<void> {
         if (operator) {
             log('> ')
 
-            const resume = progress((f) =>
+            const resume = animateLine((spinner) =>
                 style(`
-                    > _Checking if your node has been paired with your Operator… ${f}_
+                    > _Checking if your node has been paired with your Operator… ${spinner}_
                 `)
             )
 
             try {
-                const nodes = await getOperatorNodeAddresses(environmentId, operator)
+                const nodes = await getOperatorNodeAddresses(
+                    environmentId,
+                    operator
+                )
 
                 resume()
 
@@ -473,7 +478,7 @@ async function getOperatorNodeAddresses(
  * @returns A teardown callback that cleans up the line and brings
  * the cursor to BOL.
  */
-function progress(fn: (frame: string) => string): () => void {
+function animateLine(fn: (spinner: string) => string): () => void {
     const frames = '◢◣◤◥'
 
     let frameNo = 0

--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -7,6 +7,7 @@ import { isAddress } from 'ethers/lib/utils'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
 import { produce } from 'immer'
 import path from 'path'
+import { v4 as uuid } from 'uuid'
 import { z } from 'zod'
 import {
     CURRENT_CONFIGURATION_VERSION,
@@ -58,6 +59,10 @@ export async function start(): Promise<void> {
 
         const httpServer = http?.port ? { port: http.port } : undefined
 
+        const apiKey = Buffer.from(uuid().replace(/-/g, ''))
+            .toString('base64')
+            .replace(/[^\da-z]/gi, '')
+
         let config: ConfigFile = {
             $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
             client: {
@@ -70,6 +75,9 @@ export async function start(): Promise<void> {
                 ...pubsubPlugins,
             },
             httpServer,
+            apiAuthentication: {
+                keys: [apiKey]
+            }
         }
 
         if (network === 'mumbai') {

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -30,17 +30,8 @@ export interface ConfigFile extends Config {
     $schema?: string
 }
 
-export interface ConfigFile extends Config {
-    $schema?: string
-}
-
 export const getDefaultFile = (): string => {
     const relativePath = '.streamr/config/default.json'
-    return path.join(os.homedir(), relativePath)
-}
-
-export const getLegacyDefaultFile = (): string => {
-    const relativePath = '/.streamr/broker-config.json'
     return path.join(os.homedir(), relativePath)
 }
 

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -7,7 +7,7 @@ import { ApiAuthentication } from '../apiAuthentication'
 
 export interface Config {
     client?: StreamrClientConfig
-    environment?: 'mumbai'
+    environment?: 'mumbai' | 'polygon'
     httpServer?: {
         port: number
         sslCertificate?: {

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -35,6 +35,11 @@ export const getDefaultFile = (): string => {
     return path.join(os.homedir(), relativePath)
 }
 
+export const getLegacyDefaultFile = (): string => {
+    const relativePath = '/.streamr/broker-config.json'
+    return path.join(os.homedir(), relativePath)
+}
+
 export function overrideConfigToEnvVarsIfGiven(config: Config): void {
 
     const parseValue = (value: string) => {

--- a/packages/broker/src/config/config.ts
+++ b/packages/broker/src/config/config.ts
@@ -7,6 +7,7 @@ import { ApiAuthentication } from '../apiAuthentication'
 
 export interface Config {
     client?: StreamrClientConfig
+    environment?: 'mumbai'
     httpServer?: {
         port: number
         sslCertificate?: {

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -1,7 +1,8 @@
+import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import cloneDeep from 'lodash/cloneDeep'
-import { ConfigFile, getDefaultFile, getLegacyDefaultFile } from './config'
+import { ConfigFile, getDefaultFile } from './config'
 
 export const CURRENT_CONFIGURATION_VERSION = 2
 
@@ -144,7 +145,7 @@ export const readConfigAndMigrateIfNeeded = (fileName: string | undefined): Conf
     let explicitTargetFile = undefined
     if (fileName === undefined) {
         const defaultTargetFile = getDefaultFile()
-        const legacyTargetFile = getLegacyDefaultFile()
+        const legacyTargetFile = path.join(os.homedir(), '.streamr/broker-config.json')
         fileName = [defaultTargetFile, legacyTargetFile].find((file) => fs.existsSync(file))
         if (fileName === undefined) {
             /*

--- a/packages/broker/src/config/migration.ts
+++ b/packages/broker/src/config/migration.ts
@@ -1,8 +1,7 @@
-import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import cloneDeep from 'lodash/cloneDeep'
-import { ConfigFile, getDefaultFile } from './config'
+import { ConfigFile, getDefaultFile, getLegacyDefaultFile } from './config'
 
 export const CURRENT_CONFIGURATION_VERSION = 2
 
@@ -145,7 +144,7 @@ export const readConfigAndMigrateIfNeeded = (fileName: string | undefined): Conf
     let explicitTargetFile = undefined
     if (fileName === undefined) {
         const defaultTargetFile = getDefaultFile()
-        const legacyTargetFile = path.join(os.homedir(), '.streamr/broker-config.json')
+        const legacyTargetFile = getLegacyDefaultFile()
         fileName = [defaultTargetFile, legacyTargetFile].find((file) => fs.existsSync(file))
         if (fileName === undefined) {
             /*

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -132,7 +132,9 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -193,7 +195,9 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -270,7 +274,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -356,7 +362,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -412,7 +420,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -472,7 +482,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -532,7 +544,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -593,7 +607,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -725,7 +741,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -904,7 +922,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -979,7 +999,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
+        expect(config).not.toContainAnyKeys(['httpServer'])
+
+        expect(config.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -1440,7 +1462,9 @@ describe('Config wizard', () => {
 
         const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
 
-        expect(config.apiAuthentication.keys).toEqual(['NWViZWNiY2Y1YWRmNGZjNjllOTk2MzFlOGU2NGNjOWI'])
+        expect(config.apiAuthentication.keys).toEqual([
+            'NWViZWNiY2Y1YWRmNGZjNjllOTk2MzFlOGU2NGNjOWI',
+        ])
     })
 })
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1608,9 +1608,13 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
 
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
-    jest.spyOn(process.stdout, 'cursorTo').mockImplementation(() => true)
+    if (typeof process.stdout.cursorTo === 'function') {
+        jest.spyOn(process.stdout, 'cursorTo').mockImplementation(() => true)
+    }
 
-    jest.spyOn(process.stdout, 'clearLine').mockImplementation(() => true)
+    if (typeof process.stdout.clearLine === 'function') {
+        jest.spyOn(process.stdout, 'clearLine').mockImplementation(() => true)
+    }
 
     void [checkbox, confirm, input, password, select].forEach((prompt) => {
         prompt.mockImplementation(async (config: any) => {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1608,11 +1608,9 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
 
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
-    if (typeof process.stdout.cursorTo === 'function') {
+    if (process.stdout.isTTY) {
         jest.spyOn(process.stdout, 'cursorTo').mockImplementation(() => true)
-    }
 
-    if (typeof process.stdout.clearLine === 'function') {
         jest.spyOn(process.stdout, 'clearLine').mockImplementation(() => true)
     }
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -116,14 +116,9 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -138,7 +133,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('prints out the generated private key onto the screen', async () => {
+    it('prints out the generated private key onto the screen if told to', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey({ type: 'Y' }, 'enter', {
@@ -178,14 +173,9 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -256,14 +246,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -300,7 +285,7 @@ describe('Config wizard', () => {
         expect(existsSync(storagePath)).toBe(false)
     })
 
-    it('enables WebSocket plugin on the default port', async () => {
+    it('enables websocket plugin on the default port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -337,14 +322,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -359,7 +339,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('enables WebSocket plugin on a custom port', async () => {
+    it('enables websocket plugin on a custom port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -396,14 +376,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -418,7 +393,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('enables MQTT plugin on the default port', async () => {
+    it('enables mqtt plugin on the default port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -459,14 +434,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -481,7 +451,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('enables MQTT plugin on a custom port', async () => {
+    it('enables mqtt plugin on a custom port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -522,14 +492,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -544,7 +509,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('enables HTTP plugin on the default port', async () => {
+    it('enables http plugin on the default port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -586,14 +551,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -608,7 +568,7 @@ describe('Config wizard', () => {
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
 
-    it('enables HTTP plugin on a custom port', async () => {
+    it('enables http plugin on a custom port', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -652,12 +612,7 @@ describe('Config wizard', () => {
 
         expect(config.httpServer.port).toEqual(4000)
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -724,14 +679,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -800,12 +750,7 @@ describe('Config wizard', () => {
 
         expect(config.httpServer.port).toEqual(4000)
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -907,14 +852,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -985,14 +925,9 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config).not.toMatchObject({
-            client: {
-                contracts: expect.anything(),
-                network: expect.anything(),
-            },
-        })
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
         const summary = logs.join('\n')
 
@@ -1131,7 +1066,7 @@ describe('Config wizard', () => {
         })
     })
 
-    it('creates a Mumbai environment config file', async () => {
+    it('creates a Mumbai-flavoured config file', async () => {
         await expect([
             Step.privateKeySource('enter'),
             Step.revealPrivateKey('enter'),
@@ -1167,8 +1102,6 @@ describe('Config wizard', () => {
 
         const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
 
-        console.log(readFileSync(storagePath).toString('utf-8'))
-
         expect(config).toMatchObject({
             client: {
                 auth: {
@@ -1192,7 +1125,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect('httpServer' in config).toBe(false)
+        expect(config).not.toContainAnyKeys(['httpServer'])
 
         expect(config.client.network.controlLayer.entryPoints[0]).toMatchObject({
             nodeId: expect.stringMatching(/\w/),

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -132,7 +132,7 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -193,7 +193,7 @@ describe('Config wizard', () => {
 
         expect(config.plugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -270,7 +270,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -356,7 +356,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -412,7 +412,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -472,7 +472,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -532,7 +532,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -593,7 +593,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -725,7 +725,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -904,7 +904,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -979,7 +979,7 @@ describe('Config wizard', () => {
 
         expect(otherPlugins).toBeEmptyObject()
 
-        expect(config).not.toContainAnyKeys(['httpServer'])
+        expect(config).not.toContainAnyKeys(['httpServer', 'environment'])
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -1189,23 +1189,9 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.client.network.controlLayer.entryPoints[0]).toMatchObject(
-            {
-                nodeId: expect.stringMatching(/\w/),
-            }
-        )
+        expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
-        expect(config.client.contracts).toMatchObject({
-            streamRegistryChainAddress:
-                expect.stringMatching(/^0x[\da-f]{40}$/i),
-            streamStorageRegistryChainAddress:
-                expect.stringMatching(/^0x[\da-f]{40}$/i),
-            storageNodeRegistryChainAddress:
-                expect.stringMatching(/^0x[\da-f]{40}$/i),
-            streamRegistryChainRPCs: expect.objectContaining({
-                name: 'mumbai',
-            }),
-        })
+        expect(config.environment).toEqual('mumbai')
 
         const summary = logs.join('\n')
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1608,6 +1608,10 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
 
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
+    /**
+     * `isTTY` is false in CI which also means `clearLine` and
+     * `cursorTo` are not functions.
+     */
     if (process.stdout.isTTY) {
         jest.spyOn(process.stdout, 'cursorTo').mockImplementation(() => true)
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -56,9 +56,9 @@ describe('Config wizard', () => {
 
     let storagePath = path.join(tempDir, 'config.json')
 
-    let fakeBalance = jest.fn(() => '0.0')
+    const fakeBalance = jest.fn(() => '0.0')
 
-    let fakeFetchResponseBody = jest.fn(
+    const fakeFetchResponseBody = jest.fn(
         () => '{"data":{"operator":{"nodes":[]}}}'
     )
 
@@ -1266,7 +1266,7 @@ describe('Config wizard', () => {
 
         const summary = logs.join('\n')
 
-        expect(summary).toMatch(/failed to fetch node\'s balance/i)
+        expect(summary).toMatch(/failed to fetch node's balance/i)
 
         expect(summary).not.toMatch(/has \d+.\d+ matic/i)
 

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1612,8 +1612,8 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
     jest.spyOn(console, 'info').mockImplementation((...args: unknown[]) => {
         const log = args
             .join('')
-            // eslint-disable-next-line no-control-regex
-            .replace(/\x1B\[\d+m/g, '')
+            // Remove colors.
+            .replace(/\x1B\[\d+m/g, '') // eslint-disable-line no-control-regex
             .trim()
 
         if (log) {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1636,8 +1636,8 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
     jest.spyOn(console, 'info').mockImplementation((...args: unknown[]) => {
         const log = args
             .join('')
-            // Remove colors.
-            .replace(/\x1B\[\d+m/g, '') // eslint-disable-line no-control-regex
+            // eslint-disable-next-line no-control-regex
+            .replace(/\x1B\[\d+m/g, '') // Remove colors.
             .trim()
 
         if (log) {

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, existsSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import { getNodeMnemonic, start } from '../../src/config/ConfigWizard'
@@ -10,6 +10,8 @@ import {
     password as passwordMock,
     select as selectMock,
 } from '@inquirer/prompts'
+import chalk from 'chalk'
+import { Wallet } from 'ethers'
 
 const checkbox = checkboxMock as jest.MockedFunction<any>
 
@@ -37,20 +39,31 @@ jest.mock('@inquirer/prompts', () => {
 type AnswerMock = {
     prompt: jest.MockedFunction<any>
     question: RegExp
-    action: (r: Awaited<ReturnType<typeof render>>) => void
+    action: (r: Awaited<ReturnType<typeof render>>) => Promise<void>
+    validate?: (screen: string) => void
 }
 
-describe('Config wizard', () => {
-    let answers: string[] = []
+const GeneratedPrivateKey =
+    '0x9a2f3b058b9b457f9f954e62ea9fd2cefe2978736ffb3ef2c1782ccfad9c411d'
 
+const ImportedPrivateKey =
+    '0xb269c55ff525eac7633e80c01732d499015d5c22ce952e68272023c1d6c7f92f'
+
+const OperatorAddress = '0x54d68882d5329397928787ec496da3ba8e45c48c'
+
+describe('Config wizard', () => {
     let logs: string[] = []
 
     let tempDir = mkdtempSync(path.join(os.tmpdir(), 'test-config-wizard'))
 
+    let storagePath = path.join(tempDir, 'config.json')
+
     beforeEach(() => {
         jest.clearAllMocks()
 
-        answers = []
+        tempDir = mkdtempSync(path.join(os.tmpdir(), 'test-config-wizard'))
+
+        storagePath = path.join(tempDir, 'config.json')
 
         logs = []
 
@@ -64,139 +77,1148 @@ describe('Config wizard', () => {
                 logs.push(log)
             }
         })
+
+        jest.spyOn(Wallet, 'createRandom').mockImplementation(
+            () => new Wallet(GeneratedPrivateKey)
+        )
     })
 
     afterAll(() => {
         jest.clearAllMocks()
     })
 
-    const inquirer = jest.requireActual('@inquirer/prompts')
-
-    function getActualPrompt(promptMock: jest.MockedFunction<any>) {
-        switch (promptMock) {
-            case checkbox:
-                return inquirer.checkbox
-            case confirm:
-                return inquirer.confirm
-            case input:
-                return inquirer.input
-            case password:
-                return inquirer.password
-            case select:
-                return inquirer.select
-            default:
-                throw 'Unknown prompt mock'
-        }
-    }
-
-    function mockAnswers(mocks: AnswerMock[]) {
-        void [checkbox, confirm, input, password, select].forEach(
-            (prompt, i) => {
-                prompt.mockImplementation(async (config: any) => {
-                    const inc = mocks.find(
-                        (inc) =>
-                            inc.prompt === prompt &&
-                            inc.question.test(config.message)
-                    )
-
-                    if (!inc) {
-                        throw `Invalid mock for ${config.message}`
-                    }
-
-                    const r = await render(getActualPrompt(prompt), config)
-
-                    inc.action(r)
-
-                    const answer = await r.answer
-
-                    answers.push(answer)
-
-                    return answer
-                })
-            }
+    it('creates a config file with a generates private key', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            false,
+            storagePath
         )
-    }
 
-    function act(...actions: ({ type: string } | { keypress: string })[]) {
-        return ({ events, ...r }: Awaited<ReturnType<typeof render>>) => {
-            actions.forEach((action) => {
-                if ('type' in action) {
-                    return void events.type(action.type)
-                }
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
 
-                events.keypress(action.keypress)
-            })
-        }
-    }
-
-    it('creates a config file', async () => {
-        const storagePath = path.join(tempDir, 'config.json')
-
-        mockAnswers([
-            {
-                prompt: select,
-                question: /want to generate/i,
-                action: act({ keypress: 'enter' }),
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
             },
-            {
-                prompt: confirm,
-                question: /sensitive information on screen/i,
-                action: act({ keypress: 'enter' }),
+        })
+
+        expect(config.plugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
             },
-            {
-                prompt: select,
-                question: /which network/i,
-                action: act({ keypress: 'enter' }),
-            },
-            {
-                prompt: confirm,
-                question: /participate in earning rewards/i,
-                action: act({ type: 'n' }, { keypress: 'enter' }),
-            },
-            {
-                prompt: confirm,
-                question: /node for data publishing/i,
-                action: act({ type: 'n' }, { keypress: 'enter' }),
-            },
-            {
-                prompt: input,
-                question: /path to store/i,
-                action: act(
-                    {
-                        type: storagePath,
-                    },
-                    { keypress: 'enter' }
-                ),
-            },
-        ])
-
-        await start()
-
-        expect(answers.length).toEqual(6)
-
-        const [source, reveal, network, rewards, pubsub, filePath] = answers
-
-        expect(source).toEqual('Generate')
-
-        expect(reveal).toEqual(false)
-
-        expect(network).toEqual('polygon')
-
-        expect(rewards).toEqual(false)
-
-        expect(pubsub).toEqual(false)
-
-        expect(filePath).toEqual(storagePath)
-
-        expect(existsSync(storagePath)).toBe(true)
+        })
 
         const summary = logs.join('\n')
 
         expect(summary).toMatch(/congratulations/i)
 
-        expect(summary).toMatch(/your node address is 0x[\da-f]{40}\n/i)
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
 
-        expect(summary).toMatch(/generated name is( \w+){3}\n/i)
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('prints out the generated private key onto the screen', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey({ type: 'Y' }, 'enter', {
+                find: GeneratedPrivateKey,
+            }),
+            Step.network('enter'),
+            Step.rewards('abort'),
+        ]).toMatchAnswers('Generate', true, 'polygon')
+    })
+
+    it('creates a config file with an imported private key', async () => {
+        await expect([
+            Step.privateKeySource({ keypress: 'down' }, 'enter'),
+            Step.providePrivateKey({ type: ImportedPrivateKey }, 'enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Import',
+            ImportedPrivateKey,
+            'polygon',
+            false,
+            false,
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: ImportedPrivateKey,
+                },
+            },
+        })
+
+        expect(config.plugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x58cf5F58A722C544b7c39868c78D571519bB08b0\n`
+        )
+
+        expect(summary).toInclude(`generated name is Flee Kit Stomach\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('validates given private key', async () => {
+        await expect([
+            Step.privateKeySource({ keypress: 'down' }, 'enter'),
+            Step.providePrivateKey(
+                { type: 'zzz' },
+                'enter',
+                { find: /invalid private key/i },
+                { keypress: 'backspace' },
+                { keypress: 'backspace' },
+                { keypress: 'backspace' },
+                { type: ImportedPrivateKey },
+                'enter'
+            ),
+            Step.network('abort'),
+        ]).toMatchAnswers('Import', ImportedPrivateKey)
+
+        expect(existsSync(storagePath)).toBe(false)
+    })
+
+    it('enables rewards (operator plugin)', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards('enter'),
+            Step.operator({ type: OperatorAddress }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            true,
+            OperatorAddress,
+            false,
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { operator, ...otherPlugins } = config.plugins
+
+        expect(operator).toMatchObject({
+            operatorContractAddress: OperatorAddress,
+        })
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('validates the operator address', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards('enter'),
+            Step.operator(
+                { type: 'zzz' },
+                'enter',
+                { find: /invalid ethereum address/i },
+                { keypress: 'backspace' },
+                { keypress: 'backspace' },
+                { keypress: 'backspace' },
+                { type: OperatorAddress },
+                'enter'
+            ),
+            Step.pubsub('abort'),
+        ]).toMatchAnswers('Generate', false, 'polygon', true, OperatorAddress)
+
+        expect(existsSync(storagePath)).toBe(false)
+    })
+
+    it('enables WebSocket plugin on the default port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins({ keypress: 'space' }, 'enter'),
+            Step.pubsubPort('enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket',
+            '7170',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, ...otherPlugins } = config.plugins
+
+        expect(websocket).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables WebSocket plugin on a custom port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins({ keypress: 'space' }, 'enter'),
+            Step.pubsubPort({ type: '2000' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket',
+            '2000',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, ...otherPlugins } = config.plugins
+
+        expect(websocket.port).toEqual(2000)
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables MQTT plugin on the default port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort('enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'mqtt',
+            '1883',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { mqtt, ...otherPlugins } = config.plugins
+
+        expect(mqtt).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables MQTT plugin on a custom port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort({ type: '3000' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'mqtt',
+            '3000',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { mqtt, ...otherPlugins } = config.plugins
+
+        expect(mqtt.port).toEqual(3000)
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables HTTP plugin on the default port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'down' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort('enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'http',
+            '7171',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { http, ...otherPlugins } = config.plugins
+
+        expect(http).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables HTTP plugin on a custom port', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'down' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort({ type: '4000' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'http',
+            '4000',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { http, ...otherPlugins } = config.plugins
+
+        expect(http).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect(config.httpServer.port).toEqual(4000)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables all pubsub plugins on default ports', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort('enter'),
+            Step.pubsubPort('enter'),
+            Step.pubsubPort('enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket,mqtt,http',
+            '7170',
+            '1883',
+            '7171',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, mqtt, http, ...otherPlugins } = config.plugins
+
+        expect(websocket).toBeEmptyObject()
+
+        expect(mqtt).toBeEmptyObject()
+
+        expect(http).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('enables all pubsub plugins on custom ports', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort({ type: '2000' }, 'enter'),
+            Step.pubsubPort({ type: '3000' }, 'enter'),
+            Step.pubsubPort({ type: '4000' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket,mqtt,http',
+            '2000',
+            '3000',
+            '4000',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, mqtt, http, ...otherPlugins } = config.plugins
+
+        expect(websocket.port).toEqual(2000)
+
+        expect(mqtt.port).toEqual(3000)
+
+        expect(http).toBeEmptyObject()
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect(config.httpServer.port).toEqual(4000)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('validates port number values', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins({ keypress: 'space' }, 'enter'),
+            Step.pubsubPort(
+                { type: '12' },
+                'enter',
+                { find: /greater than or equal to 1024/i },
+                { keypress: 'backspace' },
+                { keypress: 'backspace' },
+                { type: '128000' },
+                'enter',
+                { find: /less than or equal to 49151/i },
+                'abort'
+            ),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket'
+        )
+
+        expect(existsSync(storagePath)).toBe(false)
+    })
+
+    it('disallows duplicated ports', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                { keypress: 'down' },
+                'enter'
+            ),
+            Step.pubsubPort({ type: '2000' }, 'enter'),
+            Step.pubsubPort(
+                { type: '2000' },
+                'enter',
+                {
+                    find: /port 2000 is taken by websocket/i,
+                },
+                { keypress: 'backspace' },
+                { type: '1' },
+                'enter'
+            ),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket,mqtt',
+            '2000',
+            '2001',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, mqtt, ...otherPlugins } = config.plugins
+
+        expect(websocket.port).toEqual(2000)
+
+        expect(mqtt.port).toEqual(2001)
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('disallows taking default ports if they are inexplicitly used', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                { keypress: 'down' },
+                'enter'
+            ),
+            Step.pubsubPort('enter'),
+            Step.pubsubPort(
+                { type: '7170' },
+                'enter',
+                {
+                    find: /port 7170 is taken by websocket/i,
+                },
+                { keypress: 'backspace' },
+                { type: '9' },
+                'enter'
+            ),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            true,
+            'websocket,mqtt',
+            '7170',
+            '7179',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, mqtt, ...otherPlugins } = config.plugins
+
+        expect(websocket).toBeEmptyObject()
+
+        expect(mqtt.port).toEqual(7179)
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config).not.toMatchObject({
+            client: {
+                contracts: expect.anything(),
+                network: expect.anything(),
+            },
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
+
+        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+    })
+
+    it('allows to uses a custom file path for the config file', async () => {
+        storagePath = path.join(tempDir, 'CUSTOMDIR', 'foobar.json')
+
+        expect(existsSync(storagePath)).toBe(false)
+
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            false,
+            storagePath
+        )
+
+        expect(existsSync(storagePath)).toBe(true)
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+    })
+
+    it('overwrites the existing config file if told to', async () => {
+        writeFileSync(storagePath, '{"FOOBAR":true}')
+
+        let config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            FOOBAR: true,
+        })
+
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+            Step.overwriteStorage({ type: 'y' }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            false,
+            storagePath,
+            true
+        )
+
+        expect(existsSync(storagePath)).toBe(true)
+
+        config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+    })
+
+    it('allows to change the storage location if the one they initially picked is taken', async () => {
+        writeFileSync(storagePath, '{"FOOBAR":true}')
+
+        let config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            FOOBAR: true,
+        })
+
+        const otherStoragePath = path.join(tempDir, 'foobar.json')
+
+        expect(otherStoragePath).not.toEqual(storagePath)
+
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network('enter'),
+            Step.rewards({ type: 'n' }, 'enter'),
+            Step.pubsub({ type: 'n' }, 'enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+            Step.overwriteStorage('enter'),
+            Step.storage({ type: otherStoragePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'polygon',
+            false,
+            false,
+            storagePath,
+            false,
+            otherStoragePath
+        )
+
+        config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            FOOBAR: true,
+        })
+
+        config = JSON.parse(readFileSync(otherStoragePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+    })
+
+    it('creates a Mumbai environment config file', async () => {
+        await expect([
+            Step.privateKeySource('enter'),
+            Step.revealPrivateKey('enter'),
+            Step.network({ keypress: 'down' }, 'enter'),
+            Step.rewards('enter'),
+            Step.operator({ type: OperatorAddress }, 'enter'),
+            Step.pubsub('enter'),
+            Step.pubsubPlugins(
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                { keypress: 'down' },
+                { keypress: 'space' },
+                'enter'
+            ),
+            Step.pubsubPort('enter'),
+            Step.pubsubPort('enter'),
+            Step.pubsubPort('enter'),
+            Step.storage({ type: storagePath }, 'enter'),
+        ]).toMatchAnswers(
+            'Generate',
+            false,
+            'mumbai',
+            true,
+            OperatorAddress,
+            true,
+            'websocket,mqtt,http',
+            '7170',
+            '1883',
+            '7171',
+            storagePath
+        )
+
+        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+
+        console.log(readFileSync(storagePath).toString('utf-8'))
+
+        expect(config).toMatchObject({
+            client: {
+                auth: {
+                    privateKey: GeneratedPrivateKey,
+                },
+            },
+        })
+
+        const { websocket, mqtt, http, operator, ...otherPlugins } =
+            config.plugins
+
+        expect(websocket).toBeEmptyObject()
+
+        expect(mqtt).toBeEmptyObject()
+
+        expect(http).toBeEmptyObject()
+
+        expect(operator).toMatchObject({
+            operatorContractAddress: OperatorAddress,
+        })
+
+        expect(otherPlugins).toBeEmptyObject()
+
+        expect('httpServer' in config).toBe(false)
+
+        expect(config.client.network.controlLayer.entryPoints[0]).toMatchObject({
+            nodeId: expect.stringMatching(/\w/),
+        })
+
+        expect(config.client.contracts).toMatchObject({
+            streamRegistryChainAddress:
+                expect.stringMatching(/^0x[\da-f]{40}$/i),
+            streamStorageRegistryChainAddress:
+                expect.stringMatching(/^0x[\da-f]{40}$/i),
+            storageNodeRegistryChainAddress:
+                expect.stringMatching(/^0x[\da-f]{40}$/i),
+            streamRegistryChainRPCs: expect.objectContaining({
+                name: 'mumbai',
+            }),
+        })
+
+        const summary = logs.join('\n')
+
+        expect(summary).toMatch(/congratulations/i)
+
+        expect(summary).toInclude(
+            `node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc\n`
+        )
+
+        expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
         expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
     })
@@ -210,4 +1232,227 @@ describe('getNodeMnemonic', () => {
             )
         ).toEqual('Mountain Until Gun')
     })
+})
+
+function act(
+    ...actions: (
+        | 'abort'
+        | 'enter'
+        | { type: string }
+        | { keypress: string }
+        | { find: RegExp | string }
+    )[]
+) {
+    return async ({
+        events,
+        getScreen,
+    }: Awaited<ReturnType<typeof render>>) => {
+        for (const action of actions) {
+            await (async () => {
+                if (action === 'abort') {
+                    throw 'abort'
+                }
+
+                if (action === 'enter') {
+                    return void events.keypress('enter')
+                }
+
+                if ('find' in action) {
+                    await Promise.resolve()
+
+                    const screen = getScreen()
+
+                    const { find } = action
+
+                    const found =
+                        find instanceof RegExp
+                            ? find.test(screen)
+                            : screen.includes(find)
+
+                    if (!found) {
+                        throw `Failed to find ${find} in\n${screen}`
+                    }
+
+                    return
+                }
+
+                if ('type' in action) {
+                    return void events.type(action.type)
+                }
+
+                events.keypress(action.keypress)
+            })()
+        }
+    }
+}
+
+const Step: Record<
+    | 'privateKeySource'
+    | 'revealPrivateKey'
+    | 'providePrivateKey'
+    | 'network'
+    | 'rewards'
+    | 'pubsub'
+    | 'storage'
+    | 'operator'
+    | 'pubsubPlugins'
+    | 'pubsubPort'
+    | 'overwriteStorage',
+    (...actions: Parameters<typeof act>) => AnswerMock
+> = {
+    privateKeySource: (...actions) => ({
+        prompt: select,
+        question: /want to generate/i,
+        action: act(...actions),
+    }),
+    revealPrivateKey: (...actions) => ({
+        prompt: confirm,
+        question: /sensitive information on screen/i,
+        action: act(...actions),
+    }),
+    providePrivateKey: (...actions) => ({
+        prompt: password,
+        question: /provide the private key/i,
+        action: act(...actions),
+    }),
+    network: (...actions) => ({
+        prompt: select,
+        question: /which network/i,
+        action: act(...actions),
+    }),
+    rewards: (...actions) => ({
+        prompt: confirm,
+        question: /participate in earning rewards/i,
+        action: act(...actions),
+    }),
+    pubsub: (...actions) => ({
+        prompt: confirm,
+        question: /node for data publishing/i,
+        action: act(...actions),
+    }),
+    storage: (...actions) => ({
+        prompt: input,
+        question: /path to store/i,
+        action: act(...actions),
+    }),
+    operator: (...actions) => ({
+        prompt: input,
+        question: /operator address/i,
+        action: act(...actions),
+    }),
+    pubsubPlugins: (...actions) => ({
+        prompt: checkbox,
+        question: /plugins to enable/i,
+        action: act(...actions),
+    }),
+    pubsubPort: (...actions) => ({
+        prompt: input,
+        question: /provide a port/i,
+        action: act(...actions),
+    }),
+    overwriteStorage: (...actions) => ({
+        prompt: confirm,
+        question: /do you want to overwrite/i,
+        action: act(...actions),
+    }),
+}
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toMatchAnswers(...answers: (string | boolean)[]): Promise<void>
+        }
+        interface ExpectExtendMap {
+            toMatchAnswers: (
+                this: jest.MatcherContext,
+                actual: AnswerMock[],
+                ...params: (string | boolean)[]
+            ) => Promise<jest.CustomMatcherResult>
+        }
+    }
+}
+
+expect.extend({
+    async toMatchAnswers(mocks, ...expectedAnswers) {
+        let mocksCopy = [...mocks]
+
+        const answers: (string | boolean)[] = []
+
+        function getActualPrompt(promptMock: jest.MockedFunction<any>) {
+            const inquirer = jest.requireActual('@inquirer/prompts')
+
+            switch (promptMock) {
+                case checkbox:
+                    return inquirer.checkbox
+                case confirm:
+                    return inquirer.confirm
+                case input:
+                    return inquirer.input
+                case password:
+                    return inquirer.password
+                case select:
+                    return inquirer.select
+                default:
+                    throw 'Unknown prompt mock'
+            }
+        }
+
+        void [checkbox, confirm, input, password, select].forEach((prompt) => {
+            prompt.mockImplementation(async (config: any) => {
+                const inq = mocksCopy.find(
+                    (inq) =>
+                        inq.prompt === prompt &&
+                        inq.question.test(config.message)
+                )
+
+                if (!inq) {
+                    throw `Missing mock for ${chalk.whiteBright(
+                        `"${config.message}"`
+                    )}`
+                }
+
+                mocksCopy = mocksCopy.filter((i) => i !== inq)
+
+                const r = await render(getActualPrompt(prompt), config)
+
+                await inq.action(r)
+
+                const answer = await r.answer
+
+                answers.push(Array.isArray(answer) ? answer.join() : answer)
+
+                return answer
+            })
+        })
+
+        try {
+            await start()
+        } catch (e) {
+            if (
+                typeof e === 'string' &&
+                (/missing mock/i.test(e) || /failed to find/i.test(e))
+            ) {
+                return {
+                    message: () => e,
+                    pass: false,
+                }
+            }
+
+            if (e !== 'abort') {
+                throw e
+            }
+        }
+
+        return {
+            message: () =>
+                `Expected answers: ${expectedAnswers.join(
+                    ', '
+                )}\nReceived answers: ${answers
+                    .map((a, i) =>
+                        a === expectedAnswers[i] ? a : chalk.redBright(a)
+                    )
+                    .join(', ')}.`,
+            pass: JSON.stringify(expectedAnswers) === JSON.stringify(answers),
+        }
+    },
 })


### PR DESCRIPTION
## Summary

New Streamr config wizard! 🧙🏻

## Changes

The way the wizard is built is different. I still use the `inquirer` library buy flavoured slightly different. It's more about individual prompt methods (`confirm`, `select`, etc.).

I also test it different. `@inquirer/testing` helped me make the tests more "integrational". I pretend to be the user and validate the output of each scenario.

## How to run locally for a quick test?

```
npm run clean
npm run bootstrap
cd packages/broker
npx esbuild
npx esbuild bin/config-wizard.ts --platform=node --target=node18 --bundle --packages=external > dist/wizard.js && node dist/wizard.js
```

## Example output
```
✓ Congratulations, you've set up your Streamr Network node!
  Your node address is 0x394c8d686B6B083b9bd91DB9f6238140D961e922
  Your node's generated name is Deer Good Foam

  You can start your Streamr node now with
  streamr-broker /Users/mariusz/.streamr/config/default.json

  For environment specific run instructions, see
  https://docs.streamr.network/guides/how-to-run-streamr-node
```

![example](https://github.com/streamr-dev/network/assets/320066/91216d59-1682-4b49-ba9d-875bc6373837)

