### PR TITLE
test(dht): Do not add duplicate entry point in `StoreAndDelete` test

### DIFF
--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -25,7 +25,6 @@ describe('Storing data in DHT', () => {
         entryPoint = await createMockConnectionDhtNode(simulator,
             createRandomNodeId(), K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
-        nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(simulator, 
                 undefined, K, MAX_CONNECTIONS, 60000)

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -12,7 +12,6 @@ const K = 4
 
 describe('Storing data in DHT', () => {
 
-    let entryPoint: DhtNode
     let nodes: DhtNode[]
     const simulator = new Simulator(LatencyType.REAL)
 
@@ -22,7 +21,7 @@ describe('Storing data in DHT', () => {
 
     beforeEach(async () => {
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator,
+        const entryPoint = await createMockConnectionDhtNode(simulator,
             createRandomNodeId(), K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {


### PR DESCRIPTION
There was no need to call `nodes.push(entryPoint)` twice?