### PR TITLE
refactor(dht): Simplify `SendOptions`

### DIFF
--- a/packages/dht/src/connection/ConnectionLockRpcRemote.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcRemote.ts
@@ -52,8 +52,8 @@ export class ConnectionLockRpcRemote extends RpcRemote<IConnectionLockRpcClient>
             disconnectMode
         }
         const options = this.formDhtRpcOptions({
-            doNotConnect: true,
-            doNotMindStopped: true,
+            connect: false,
+            sendIfStopped: true,
             timeout: 2000  // TODO use config option or named constant?
         })
         await this.getClient().gracefulDisconnect(request, options)

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -23,7 +23,7 @@ import {
     UnlockRequest
 } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionLockRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
-import { ITransport, SendOptions, TransportEvents } from '../transport/ITransport'
+import { DEFAULT_SEND_OPTIONS, ITransport, SendOptions, TransportEvents } from '../transport/ITransport'
 import { RoutingRpcCommunicator } from '../transport/RoutingRpcCommunicator'
 import { ConnectionLockHandler, LockID } from './ConnectionLockHandler'
 import { ConnectorFacade } from './ConnectorFacade'
@@ -250,9 +250,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         return this.locks.getNumberOfWeakLockedConnections()
     }
 
-    public async send(message: Message, opts?: SendOptions): Promise<void> {
-        const doNotMindStopped = opts?.doNotMindStopped ?? false
-        if (this.state === ConnectionManagerState.STOPPED && !doNotMindStopped) {
+    public async send(message: Message, opts: SendOptions = DEFAULT_SEND_OPTIONS): Promise<void> {
+        if (this.state === ConnectionManagerState.STOPPED && !opts.sendIfStopped) {
             return
         }
         const peerDescriptor = message.targetDescriptor!
@@ -266,17 +265,16 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
         let connection = this.connections.get(nodeId)
-        const doNotConnect = opts?.doNotConnect ?? false
-        if (!connection && !doNotConnect) {
+        if (!connection && opts.connect) {
             connection = this.connectorFacade.createConnection(peerDescriptor)
             this.onNewConnection(connection)
         } else if (!connection) {
-            throw new Err.SendFailed('No connection to target, doNotConnect flag is true')
+            throw new Err.SendFailed('No connection to target, connect flag is false')
         }
         const binary = Message.toBinary(message)
         this.metrics.sendBytesPerSecond.record(binary.byteLength)
         this.metrics.sendMessagesPerSecond.record(1)
-        return connection.send(binary, doNotConnect)
+        return connection.send(binary, opts.connect)
     }
 
     private isConnectionToSelf(peerDescriptor: PeerDescriptor): boolean {

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -233,7 +233,7 @@ export class ManagedConnection extends EventEmitter<Events> {
         this.emit('disconnected', gracefulLeave)
     }
 
-    async send(data: Uint8Array, doNotConnect = false): Promise<void> {
+    async send(data: Uint8Array, connect: boolean): Promise<void> {
         if (this.stopped) {
             throw new Err.SendFailed('ManagedConnection is stopped')
         }
@@ -242,8 +242,8 @@ export class ManagedConnection extends EventEmitter<Events> {
         }
         this.lastUsed = Date.now()
 
-        if (doNotConnect && !this.implementation) {
-            throw new Err.ConnectionNotOpen('Connection not open when calling send() with doNotConnect flag')
+        if (!connect && !this.implementation) {
+            throw new Err.ConnectionNotOpen('Connection not open when calling send() with connect flag as false')
         } else if (this.implementation) {
             this.implementation.send(data)
         } else {

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
@@ -20,7 +20,7 @@ export class RecursiveOperationRpcRemote extends RpcRemote<IRecursiveOperationRp
             routingPath: params.routingPath
         }
         const options = this.formDhtRpcOptions({
-            doNotConnect: true
+            connect: false
         })
         try {
             const ack = await this.getClient().routeRequest(message, options)

--- a/packages/dht/src/dht/routing/RouterRpcRemote.ts
+++ b/packages/dht/src/dht/routing/RouterRpcRemote.ts
@@ -23,7 +23,7 @@ export class RouterRpcRemote extends RpcRemote<IRouterRpcClient> {
             routingPath: params.routingPath
         }
         const options = this.formDhtRpcOptions({
-            doNotConnect: true
+            connect: false
         })
         try {
             const ack = await this.getClient().routeMessage(message, options)
@@ -56,7 +56,7 @@ export class RouterRpcRemote extends RpcRemote<IRouterRpcClient> {
             routingPath: params.routingPath
         }
         const options = this.formDhtRpcOptions({
-            doNotConnect: true
+            connect: false
         })
         try {
             const ack = await this.getClient().forwardMessage(message, options)

--- a/packages/dht/src/dht/store/StoreRpcRemote.ts
+++ b/packages/dht/src/dht/store/StoreRpcRemote.ts
@@ -22,8 +22,7 @@ export class StoreRpcRemote extends RpcRemote<IStoreRpcClient> {
 
     async replicateData(request: ReplicateDataRequest): Promise<void> {
         const options = this.formDhtRpcOptions({
-            timeout: EXISTING_CONNECTION_TIMEOUT,
-            doNotConnect: false
+            timeout: EXISTING_CONNECTION_TIMEOUT
         })
         return this.getClient().replicateData(request, options)
     }

--- a/packages/dht/src/rpc-protocol/DhtCallContext.ts
+++ b/packages/dht/src/rpc-protocol/DhtCallContext.ts
@@ -8,7 +8,8 @@ export class DhtCallContext extends ProtoCallContext implements DhtRpcOptions {
     sourceDescriptor?: PeerDescriptor
     notification?: boolean
     clientId?: number
-    doNotConnect?: boolean 
+    connect?: boolean
+    sendIfStopped?: boolean
     //used in incoming calls
     incomingSourceDescriptor?: PeerDescriptor
 }

--- a/packages/dht/src/rpc-protocol/DhtRpcOptions.ts
+++ b/packages/dht/src/rpc-protocol/DhtRpcOptions.ts
@@ -5,5 +5,6 @@ export interface DhtRpcOptions extends ProtoRpcOptions {
     targetDescriptor?: PeerDescriptor
     sourceDescriptor?: PeerDescriptor
     clientId?: number
-    doNotConnect?: boolean
+    connect?: boolean
+    sendIfStopped?: boolean
 }

--- a/packages/dht/src/transport/ITransport.ts
+++ b/packages/dht/src/transport/ITransport.ts
@@ -7,8 +7,13 @@ export interface TransportEvents {
 }
 
 export interface SendOptions {
-    doNotConnect?: boolean
-    doNotMindStopped?: boolean
+    connect: boolean
+    sendIfStopped: boolean
+}
+
+export const DEFAULT_SEND_OPTIONS = {
+    connect: true,
+    sendIfStopped: false
 }
 
 export interface ITransport {

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -42,7 +42,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
             // TODO maybe sendOptions could be a separate block inside callContext
             const sendOpts = (msg.header.response !== undefined)
                 ? {
-                    // typically we already have a connection, but if it has disconnected for some reasonm
+                    // typically we already have a connection, but if it has disconnected for some reason
                     // maybe the receiver has gone offline (or it is no longer a neighbord) and therefore there
                     // is no point for trying form a new connection
                     connect: false,

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -44,7 +44,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
                 ? {
                     // typically we already have a connection, but if it has disconnected for some reason
                     // the receiver could have gone offline (or it is no longer a neighbor) and therefore there
-                    // is no point for trying form a new connection
+                    // is no point in trying form a new connection
                     connect: false,
                     // TODO maybe this options could be removed?
                     sendIfStopped: true

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -4,15 +4,15 @@ import { RpcCommunicator, RpcCommunicatorConfig } from '@streamr/proto-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 import { RpcMessage } from '../proto/packages/proto-rpc/protos/ProtoRpc'
 import { ServiceID } from '../types/ServiceID'
-import { SendOptions } from './ITransport'
+import { DEFAULT_SEND_OPTIONS, SendOptions } from './ITransport'
 
 export class RoutingRpcCommunicator extends RpcCommunicator {
     private ownServiceId: ServiceID
-    private sendFn: (msg: Message, opts?: SendOptions) => Promise<void>
+    private sendFn: (msg: Message, opts: SendOptions) => Promise<void>
 
     constructor(
         ownServiceId: ServiceID,
-        sendFn: (msg: Message, opts?: SendOptions) => Promise<void>,
+        sendFn: (msg: Message, opts: SendOptions) => Promise<void>,
         config?: RpcCommunicatorConfig
     ) {
         super(config)
@@ -39,15 +39,20 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
                 targetDescriptor
             }
 
-            // TODO is it possible to have explicit default values for "doNotConnect" and "doNotMindStopped"?
-            if (msg.header.response || callContext && callContext.doNotConnect && callContext.doNotMindStopped ) {
-                return this.sendFn(message, { doNotConnect: true, doNotMindStopped: true })
-            } else if (msg.header.response || callContext && callContext.doNotConnect) {
-                return this.sendFn(message, { doNotConnect: true })
-            } else {
-                return this.sendFn(message)
-            }
-
+            // TODO maybe sendOptions could be a separate block inside callContext
+            const sendOpts = (msg.header.response !== undefined)
+                ? {
+                    // typically we already have a connection, but if it has disconnected for some reasonm
+                    // maybe the receiver has gone offline (or it is no longer a neighbord) and therefore there
+                    // is no point for trying form a new connection
+                    connect: false,
+                    // TODO maybe this options could be removed?
+                    sendIfStopped: true
+                } : {
+                    connect: callContext?.connect ?? DEFAULT_SEND_OPTIONS.connect,
+                    sendIfStopped: callContext?.sendIfStopped ?? DEFAULT_SEND_OPTIONS.sendIfStopped
+                }
+            return this.sendFn(message, sendOpts)
         })
     }
 

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -43,7 +43,7 @@ export class RoutingRpcCommunicator extends RpcCommunicator {
             const sendOpts = (msg.header.response !== undefined)
                 ? {
                     // typically we already have a connection, but if it has disconnected for some reason
-                    // maybe the receiver has gone offline (or it is no longer a neighbord) and therefore there
+                    // the receiver could have gone offline (or it is no longer a neighbor) and therefore there
                     // is no point for trying form a new connection
                     connect: false,
                     // TODO maybe this options could be removed?

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -24,7 +24,7 @@ describe('StoreManager', () => {
         const createStoreManager = (
             localNodeId: Uint8Array,
             closestNeighbors: Uint8Array[],
-            replicateData: (request: ReplicateDataRequest, doNotConnect: boolean) => unknown,
+            replicateData: (request: ReplicateDataRequest) => unknown,
             setStale: (key: Key, creator: NodeID, stale: boolean) => unknown
         ): StoreManager => {
             const getClosestNeighborsTo = () => {
@@ -49,7 +49,7 @@ describe('StoreManager', () => {
         describe('this node is primary storer', () => {
 
             it('new node is within redundancy factor', async () => {
-                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setStale = jest.fn<undefined, [Key, NodeID]>()
                 const manager = createStoreManager(
                     NODES_CLOSEST_TO_DATA[0],
@@ -66,7 +66,7 @@ describe('StoreManager', () => {
             })
     
             it('new node is not within redundancy factor', async () => {
-                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setStale = jest.fn<undefined, [Key, NodeID]>()
                 const manager = createStoreManager(
                     NODES_CLOSEST_TO_DATA[0],
@@ -84,7 +84,7 @@ describe('StoreManager', () => {
         describe('this node is not primary storer', () => {
 
             it('this node is within redundancy factor', async () => {
-                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setStale = jest.fn<undefined, [Key, NodeID]>()
                 const manager = createStoreManager(
                     NODES_CLOSEST_TO_DATA[1],
@@ -99,7 +99,7 @@ describe('StoreManager', () => {
             })
 
             it('this node is not within redundancy factor', async () => {
-                const replicateData = jest.fn<undefined, [ReplicateDataRequest, boolean]>()
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setStale = jest.fn<undefined, [Key, NodeID]>()
                 const manager = createStoreManager(
                     NODES_CLOSEST_TO_DATA[3],

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcRemote.ts
@@ -47,7 +47,7 @@ export class HandshakeRpcRemote extends RpcRemote<IHandshakeRpcClient> {
             interleaveTargetDescriptor: originatorDescriptor
         }
         const options = this.formDhtRpcOptions({
-            doNotConnect: true,
+            connect: false,
             timeout: INTERLEAVE_REQUEST_TIMEOUT
         })
         try {


### PR DESCRIPTION
Negate `doNoConnect` -> `connect`, rename `doNotMindStopped` -> `sendIfStopped`. The parameters are required. Also rename related parameter of `DhtCallContect` and `DhtRpcOptions`.

## Future improvements

- Maybe `sendOptions` could be a separate block inside `callContext`
- Maybe `sendIfStopped` is no longer needed?