### PR TITLE
fix(network): Fix stream split recovery filtering logic

### DIFF
--- a/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
@@ -165,7 +165,8 @@ export class EntryPointDiscovery {
             if (this.config.layer1Node.getNumberOfNeighbors() < NETWORK_SPLIT_AVOIDANCE_LIMIT) {
                 // Filter out nodes that are not neighbors as those nodes are assumed to be offline
                 const nodesToAvoid = rediscoveredEntrypoints
-                    .filter((peer) => !this.config.layer1Node.getAllNeighborPeerDescriptors().includes(peer))
+                    .filter((peer) => !this.config.layer1Node.getAllNeighborPeerDescriptors()
+                        .some((neighbor) => areEqualPeerDescriptors(neighbor, peer)))
                     .map((peer) => getNodeIdFromPeerDescriptor(peer))
                 nodesToAvoid.forEach((node) => this.networkSplitAvoidedNodes.add(node))
                 throw new Error(`Network split is still possible`)


### PR DESCRIPTION
## Summary

Check if PeerDescriptor exists in an array with `.some((peerDescriptor) => areEqualPeerDescriptors)` instead of `.includes(peerDescriptor)`

`includes` is not able to compare binaries appropriately