### PR TITLE
Fix(DHT): Critical WebSocket connection request bug

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -184,6 +184,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         logger.trace(`Starting ConnectionManager...`)
         await this.connectorFacade.start(
             (connection: ManagedConnection) => this.onNewConnection(connection),
+            (peerDescriptor: PeerDescriptor) => this.hasConnection(peerDescriptor),
             this
         )
         // Garbage collection of connections

--- a/packages/dht/src/connection/ConnectorFacade.ts
+++ b/packages/dht/src/connection/ConnectorFacade.ts
@@ -16,6 +16,7 @@ export interface ConnectorFacade {
     getLocalPeerDescriptor: () => PeerDescriptor | undefined
     start: (
         onNewConnection: (connection: ManagedConnection) => boolean,
+        hasConnection: (peerDescriptor: PeerDescriptor) => boolean,
         autoCertifierTransport: ITransport
     ) => Promise<void>
     stop: () => Promise<void>
@@ -58,6 +59,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
 
     async start(
         onNewConnection: (connection: ManagedConnection) => boolean,
+        hasConnection: (peerDescriptor: PeerDescriptor) => boolean,
         autoCertifierTransport: ITransport
     ): Promise<void> {
         logger.trace(`Creating WebsocketConnectorRpcLocal`)
@@ -65,6 +67,7 @@ export class DefaultConnectorFacade implements ConnectorFacade {
             transport: this.config.transport,
             // TODO should we use canConnect also for WebrtcConnector? (NET-1142)
             onNewConnection,
+            hasConnection,
             portRange: this.config.websocketPortRange,
             host: this.config.websocketHost,
             entrypoints: this.config.entryPoints,

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -45,6 +45,7 @@ const ENTRY_POINT_CONNECTION_ATTEMPTS = 5
 export interface WebsocketConnectorConfig {
     transport: ITransport
     onNewConnection: (connection: ManagedConnection) => boolean
+    hasConnection: (peerDescriptor: PeerDescriptor) => boolean
     portRange?: PortRange
     maxMessageSize?: number
     host?: string
@@ -105,6 +106,7 @@ export class WebsocketConnector {
                 if (this.connectingConnections.has(nodeId)
                     || this.connectingConnections.has(nodeId)
                     || this.ongoingConnectRequests.has(nodeId)
+                    || config.hasConnection(targetPeerDescriptor)
                 ) {
                     return true
                 } else {

--- a/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnectorRpcLocal.ts
@@ -24,16 +24,14 @@ export class WebsocketConnectorRpcLocal implements IWebsocketConnectorRpc {
     }
 
     public async requestConnection(_request: WebsocketConnectionRequest, context: ServerCallContext): Promise<Empty> {
+        if (this.config.abortSignal.aborted) {
+            return {}
+        }
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        setImmediate(() => {
-            if (this.config.abortSignal.aborted) {
-                return
-            }
-            if (!this.config.hasConnection(senderPeerDescriptor)) {
-                const connection = this.config.connect(senderPeerDescriptor)
-                this.config.onNewConnection(connection)
-            }
-        })
+        if (!this.config.hasConnection(senderPeerDescriptor)) {
+            const connection = this.config.connect(senderPeerDescriptor)
+            this.config.onNewConnection(connection)
+        }
         return {}
     }
 }


### PR DESCRIPTION
## Summary

No longer attempt to open a connection to Websocket server when receiving ConnectionRequests if a connection already exists. Opening duplicate client connections caused significant problems as duplicate connection handling is not meant to handle duplicates originating from the same side.

In the worst case, there appeared to be an infinite loop of duplicate connection replacement.

Fixes many flakyness issues on the client and broker tests.

Seems to fix client `end-to-end/publish-subscribe.test.ts` in a full CI setup with an entry point and 3 brokers. However, the test can still fail when running an entry-point only. Investigating this further currently.

## Future improvements
- Why does the simultaneous connections test not catch this issue?
- Add testing to ensure this does not happen again
