### PR TITLE
refactor(dht): Remove obsolete fields

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -395,7 +395,6 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             return false
         }
         logger.trace('onNewConnection()')
-        connection.offeredAsIncoming = true
         if (!this.acceptNewConnection(connection)) {
             return false
         }

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -27,19 +27,14 @@ export type Events = ManagedConnectionEvents & ConnectionEvents
 export class ManagedConnection extends EventEmitter<Events> {
 
     private implementation?: IConnection
-
     private outputBufferEmitter = new EventEmitter<OutputBufferEvents>()
     private outputBuffer: Uint8Array[] = []
-
     private inputBuffer: Uint8Array[] = []
-
     public connectionId: ConnectionID
     private remotePeerDescriptor?: PeerDescriptor
     public connectionType: ConnectionType
-
     private handshaker?: Handshaker
     private handshakeCompleted = false
-
     private lastUsed: number = Date.now()
     private stopped = false
     private bufferSentbyOtherConnection = false
@@ -48,7 +43,6 @@ export class ManagedConnection extends EventEmitter<Events> {
     private localPeerDescriptor: PeerDescriptor
     protected outgoingConnection?: IConnection
     protected incomingConnection?: IConnection
-
     // TODO: Temporary debug variable, should be removed in the future.
     private created = Date.now()
 

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -42,7 +42,6 @@ export class ManagedConnection extends EventEmitter<Events> {
 
     private lastUsed: number = Date.now()
     private stopped = false
-    public offeredAsIncoming = false
     private bufferSentbyOtherConnection = false
     private closing = false
     public replacedByOtherConnection = false

--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -22,12 +22,9 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
     public connectionId: ConnectionID
     public readonly connectionType: ConnectionType = ConnectionType.WEBRTC
-
     // We need to keep track of connection state ourselves because
     // RTCPeerConnection.connectionState is not supported on Firefox
-
     private lastState: RTCPeerConnectionState = 'connecting'
-
     private readonly iceServers: IceServer[]
     private peerConnection?: RTCPeerConnection
     private dataChannel?: RTCDataChannel

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -55,7 +55,6 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     private lastState: RtcPeerConnectionState = 'connecting'
     private remoteDescriptionSet = false
     private connectingTimeoutRef?: NodeJS.Timeout
-
     public readonly connectionType: ConnectionType = ConnectionType.WEBRTC
     private readonly iceServers: IceServer[]
     private readonly _bufferThresholdHigh: number // TODO: buffer handling must be implemented before production use (NET-938)

--- a/packages/dht/src/connection/websocket/ClientWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ClientWebsocket.ts
@@ -15,6 +15,7 @@ export const CUSTOM_GOING_AWAY = 3001
 const BINARY_TYPE = 'arraybuffer'
 
 export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements IConnection {
+
     public readonly connectionId: ConnectionID
     private socket?: Websocket
     public connectionType = ConnectionType.WEBSOCKET_CLIENT

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -145,7 +145,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private recursiveOperationManager?: RecursiveOperationManager
     private peerDiscovery?: PeerDiscovery
     private peerManager?: PeerManager
-
     public connectionManager?: ConnectionManager
     private started = false
     private abortController = new AbortController()

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -149,7 +149,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     public connectionManager?: ConnectionManager
     private started = false
     private abortController = new AbortController()
-    private entryPointDisconnectTimeout?: NodeJS.Timeout
 
     constructor(conf: DhtNodeOptions) {
         super()
@@ -552,9 +551,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         logger.trace('stop()')
         this.abortController.abort()
         await this.storeManager!.destroy()
-        if (this.entryPointDisconnectTimeout) {
-            clearTimeout(this.entryPointDisconnectTimeout)
-        }
         this.localDataStore.clear()
         this.peerManager?.stop()
         this.rpcCommunicator!.stop()

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -25,7 +25,6 @@ export class DiscoverySession {
     public readonly sessionId = v4()
     private stopped = false
     private emitter = new EventEmitter<DiscoverySessionEvents>()
-    private outgoingClosestPeersRequestsCounter = 0
     private noProgressCounter = 0
     private ongoingClosestPeersRequests: Set<NodeID> = new Set()
     private contactedPeers: Set<NodeID> = new Set()
@@ -47,7 +46,6 @@ export class DiscoverySession {
             return []
         }
         logger.trace(`Getting closest peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
-        this.outgoingClosestPeersRequestsCounter++
         this.contactedPeers.add(contact.getNodeId())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
         this.config.peerManager.handlePeerActive(contact.getNodeId())
@@ -103,7 +101,6 @@ export class DiscoverySession {
                 .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer.getNodeId(), contacts))
                 .catch(() => this.onClosestPeersRequestFailed(nextPeer))
                 .finally(() => {
-                    this.outgoingClosestPeersRequestsCounter--
                     this.findMoreContacts()
                 })
         }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -22,7 +22,7 @@ interface DiscoverySessionConfig {
 
 export class DiscoverySession {
     
-    public readonly sessionId = v4()
+    public readonly id = v4()
     private stopped = false
     private emitter = new EventEmitter<DiscoverySessionEvents>()
     private noProgressCounter = 0

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -72,7 +72,7 @@ export class PeerDiscovery {
     private async runSessions(sessions: DiscoverySession[], entryPointDescriptor: PeerDescriptor, retry: boolean): Promise<void> {
         try {
             for (const session of sessions) {
-                this.ongoingDiscoverySessions.set(session.sessionId, session)
+                this.ongoingDiscoverySessions.set(session.id, session)
                 await session.findClosestNodes(this.config.joinTimeout)
             }
         } catch (_e) {
@@ -89,7 +89,7 @@ export class PeerDiscovery {
                     await this.ensureRecoveryIntervalIsRunning()
                 }
             }
-            sessions.forEach((session) => this.ongoingDiscoverySessions.delete(session.sessionId))
+            sessions.forEach((session) => this.ongoingDiscoverySessions.delete(session.id))
         }
     }
 

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -26,7 +26,6 @@ export class PeerDiscovery {
     private ongoingDiscoverySessions: Map<string, DiscoverySession> = new Map()
     private rejoinOngoing = false
     private joinCalled = false
-    private rejoinTimeoutRef?: NodeJS.Timeout
     private readonly abortController: AbortController
     private recoveryIntervalStarted = false
     private readonly config: PeerDiscoveryConfig
@@ -153,10 +152,6 @@ export class PeerDiscovery {
 
     public stop(): void {
         this.abortController.abort()
-        if (this.rejoinTimeoutRef) {
-            clearTimeout(this.rejoinTimeoutRef)
-            this.rejoinTimeoutRef = undefined
-        }
         this.ongoingDiscoverySessions.forEach((session) => {
             session.stop()
         })


### PR DESCRIPTION
Do we need any of these:
- `ManagedConnection#offeredAsIncoming`
- `DiscoverySession#outgoingClosestPeersRequestsCounter`
- `PeerDiscovery#rejoinTimeoutRef`
- `DhtNode#entryPointDisconnectTimeout`