### PR TITLE
refactor(dht): Remove `RouterConfig#rpcRequestTimeout`

### DIFF
--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -19,8 +19,6 @@ export interface RouterConfig {
     connections: Map<NodeID, DhtNodeRpcRemote>
     addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     connectionManager?: ConnectionManager
-    // TODO use this or remove the config option?
-    rpcRequestTimeout?: number
 }
 
 interface ForwardingTableEntry {


### PR DESCRIPTION
The field was not used.

## Future improvements

In most cases the rpcRequestTimeout is either evaluated from `RpcRemote#getTimeout` or given explicitly. Maybe we could remove `DhtNode#rpcRequestTimeout` parameter if we'd refactor `Transport` to provide the timeout? Currently `DhtNode#rpcRequestTimeout` is used for Simulator and layer1 nodes.
- e.g. we'd add `getTimeout: (localPeerDescriptor: PeerDescriptor, remotePeerDescriptor: PeerDescriptor) => number` to `ITransport`
- and `RoutingRpcCommunicator` would get `ITransport` instead of `send()` as a constructor parameter