### PR TITLE
fix(trackerless-network): Uniqueness check in `RandomGraphNode#getNeighborCandidatesFromLayer1`

### DIFF
--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -32,6 +32,7 @@ import { markAndCheckDuplicate } from './utils'
 import { NodeID, getNodeIdFromPeerDescriptor } from '../identifiers'
 import { Layer1Node } from './Layer1Node'
 import { StreamPartID } from '@streamr/protocol'
+import { uniqBy } from 'lodash'
 
 export interface Events {
     message: (message: StreamMessage) => void
@@ -256,14 +257,14 @@ export class RandomGraphNode extends EventEmitter<Events> {
     }
 
     private getNeighborCandidatesFromLayer1(): PeerDescriptor[] {
-        const uniqueNodes = new Set<PeerDescriptor>()
+        const nodes: PeerDescriptor[] = []
         this.config.layer1Node.getClosestContacts(this.config.nodeViewSize).forEach((peer: PeerDescriptor) => {
-            uniqueNodes.add(peer)
+            nodes.push(peer)
         })
         this.config.layer1Node.getAllNeighborPeerDescriptors().forEach((peer: PeerDescriptor) => {
-            uniqueNodes.add(peer)
+            nodes.push(peer)
         })
-        return Array.from(uniqueNodes)
+        return uniqBy(nodes, (p) => getNodeIdFromPeerDescriptor(p))
     }
 
     hasProxyConnection(nodeId: NodeID): boolean {


### PR DESCRIPTION
If we get two `PeerDescriptor` objects from `PeerManager`, can we assume that if the descriptors have the same `nodeId`, they are also the same object? Maybe we can't? If that is the case, this PR fixes the uniqueness check in `RandomGraphNode#getNeighborCandidatesFromLayer1`.

This solution is most likely slower than the previous solution.