### PR TITLE
refactor(dht): Type of `RouteMessageWrapper#destinationPeer`

### DIFF
--- a/packages/client/src/utils/utils.ts
+++ b/packages/client/src/utils/utils.ts
@@ -149,9 +149,6 @@ export function peerDescriptorTranslator(json: NetworkPeerDescriptor): PeerDescr
 }
 
 export function convertPeerDescriptorToNetworkPeerDescriptor(descriptor: PeerDescriptor): NetworkPeerDescriptor {
-    if (descriptor.type === NodeType.VIRTUAL) {
-        throw new Error('nodeType "virtual" not supported')
-    }
     return {
         ...descriptor,
         nodeId: binaryToHex(descriptor.nodeId),

--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -149,7 +149,6 @@ message ConnectivityMethod {
 enum NodeType {
   NODEJS = 0;
   BROWSER = 1;
-  VIRTUAL = 3;
 }
 
 enum RpcResponseError {

--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -162,7 +162,7 @@ enum RpcResponseError {
 message RouteMessageWrapper {
   PeerDescriptor sourcePeer = 1;
   string requestId = 2;
-  PeerDescriptor destinationPeer = 3;
+  bytes target = 3;
   Message message = 4;
   repeated PeerDescriptor reachableThrough = 5;
   repeated PeerDescriptor routingPath = 6;

--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -160,8 +160,8 @@ enum RpcResponseError {
 }
 
 message RouteMessageWrapper {
-  PeerDescriptor sourcePeer = 1;
-  string requestId = 2;
+  string requestId = 1;
+  PeerDescriptor sourcePeer = 2;
   bytes target = 3;
   Message message = 4;
   repeated PeerDescriptor reachableThrough = 5;

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -10,7 +10,7 @@ import {
 import { Router } from '../routing/Router'
 import { RoutingMode } from '../routing/RoutingSession'
 import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
-import { Logger, hexToBinary, runAndWaitForEvents3, wait } from '@streamr/utils'
+import { Logger, areEqualBinaries, hexToBinary, runAndWaitForEvents3, wait } from '@streamr/utils'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { RecursiveOperationSessionRpcRemote } from './RecursiveOperationSessionRpcRemote'
 import { RecursiveOperationSession, RecursiveOperationSessionEvents } from './RecursiveOperationSession'
@@ -169,17 +169,17 @@ export class RecursiveOperationManager {
         if (this.stopped) {
             return createRouteMessageAck(routedMessage, RouteMessageError.STOPPED)
         }
-        const targetId = getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)
+        const targetId = getNodeIdFromBinary(routedMessage.target)
         const request = (routedMessage.message!.body as { recursiveOperationRequest: RecursiveOperationRequest }).recursiveOperationRequest
         // TODO use config option or named constant?
-        const closestPeersToDestination = this.getClosestConnections(routedMessage.destinationPeer!.nodeId, 5)
+        const closestPeersToDestination = this.getClosestConnections(routedMessage.target, 5)
         const dataEntries = (request.operation === RecursiveOperation.FETCH_DATA) 
             ? Array.from(this.config.localDataStore.getEntries(hexToBinary(targetId)).values())
             : []
         if (request.operation === RecursiveOperation.DELETE_DATA) {
             this.config.localDataStore.markAsDeleted(hexToBinary(targetId), getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!))
         }
-        if (areEqualPeerDescriptors(this.config.localPeerDescriptor, routedMessage.destinationPeer!)) {
+        if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, routedMessage.target)) {
             // TODO this is also very similar case to what we do at line 255, could simplify the code paths?
             this.sendResponse(
                 routedMessage.routingPath,

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
@@ -12,7 +12,7 @@ export class RecursiveOperationRpcRemote extends RpcRemote<IRecursiveOperationRp
 
     async routeRequest(params: RouteMessageWrapper): Promise<boolean> {
         const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
+            target: params.target,
             sourcePeer: params.sourcePeer,
             message: params.message,
             requestId: params.requestId ?? v4(),

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -99,7 +99,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         const routeMessage: RouteMessageWrapper = {
             message: msg,
             requestId: v4(),
-            destinationPeer: targetDescriptor,
+            target: targetDescriptor.nodeId,
             sourcePeer: this.config.localPeerDescriptor,
             reachableThrough: [],
             routingPath: []

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -7,7 +7,6 @@ import {
     RecursiveOperation,
     RouteMessageWrapper,
     RouteMessageAck,
-    NodeType,
     RecursiveOperationRequest,
     Message,
     MessageType
@@ -79,10 +78,6 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
     }
 
     private wrapRequest(serviceId: ServiceID): RouteMessageWrapper {
-        const targetDescriptor: PeerDescriptor = {
-            nodeId: this.config.targetId,
-            type: NodeType.VIRTUAL
-        }
         const request: RecursiveOperationRequest = {
             sessionId: this.getId(),
             operation: this.config.operation
@@ -99,7 +94,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         const routeMessage: RouteMessageWrapper = {
             message: msg,
             requestId: v4(),
-            target: targetDescriptor.nodeId,
+            target: this.config.targetId,
             sourcePeer: this.config.localPeerDescriptor,
             reachableThrough: [],
             routingPath: []

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -11,7 +11,7 @@ import { ConnectionManager } from '../../connection/ConnectionManager'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { v4 } from 'uuid'
 import { RouterRpcLocal, createRouteMessageAck } from './RouterRpcLocal'
-import { NodeID } from '../../helpers/nodeId'
+import { NodeID, getNodeIdFromBinary } from '../../helpers/nodeId'
 
 export interface RouterConfig {
     rpcCommunicator: RoutingRpcCommunicator
@@ -83,11 +83,10 @@ export class Router {
         const targetPeerDescriptor = msg.targetDescriptor!
         const forwardingEntry = this.forwardingTable.get(getNodeIdFromPeerDescriptor(targetPeerDescriptor))
         if (forwardingEntry && forwardingEntry.peerDescriptors.length > 0) {
-            const forwardingPeer = forwardingEntry.peerDescriptors[0]
             const forwardedMessage: RouteMessageWrapper = {
                 message: msg,
                 requestId: v4(),
-                destinationPeer: forwardingPeer,
+                target: forwardingEntry.peerDescriptors[0].nodeId,
                 sourcePeer: this.config.localPeerDescriptor,
                 reachableThrough,
                 routingPath: []
@@ -102,7 +101,7 @@ export class Router {
             const routedMessage: RouteMessageWrapper = {
                 message: msg,
                 requestId: v4(),
-                destinationPeer: targetPeerDescriptor,
+                target: targetPeerDescriptor.nodeId,
                 sourcePeer: this.config.localPeerDescriptor,
                 reachableThrough,
                 routingPath: []
@@ -121,7 +120,7 @@ export class Router {
             return createRouteMessageAck(routedMessage, RouteMessageError.STOPPED)
         }
         logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
-            + `to ${getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)}`)
+            + `to ${getNodeIdFromBinary(routedMessage.target)}`)
         const session = this.createRoutingSession(routedMessage, mode, excludedPeer)
         const contacts = session.updateAndGetRoutablePeers()
         if (contacts.length > 0) {

--- a/packages/dht/src/dht/routing/RouterRpcLocal.ts
+++ b/packages/dht/src/dht/routing/RouterRpcLocal.ts
@@ -1,10 +1,11 @@
-import { Logger } from '@streamr/utils'
+import { Logger, areEqualBinaries } from '@streamr/utils'
 import { ConnectionManager } from '../../connection/ConnectionManager'
 import { areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../helpers/peerIdFromPeerDescriptor'
 import { PeerDescriptor, RouteMessageAck, RouteMessageError, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
 import { IRouterRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
 import { DuplicateDetector } from './DuplicateDetector'
 import { RoutingMode } from './RoutingSession'
+import { getNodeIdFromBinary } from '../../helpers/nodeId'
 
 interface RouterRpcLocalConfig {
     doRouteMessage: (routedMessage: RouteMessageWrapper, mode?: RoutingMode) => RouteMessageAck
@@ -36,13 +37,13 @@ export class RouterRpcLocal implements IRouterRpc {
     async routeMessage(routedMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
         if (this.config.duplicateRequestDetector.isMostLikelyDuplicate(routedMessage.requestId)) {
             logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
-                + `to ${getNodeIdFromPeerDescriptor(routedMessage.destinationPeer!)} is likely a duplicate`)
+                + `to ${getNodeIdFromBinary(routedMessage.target)} is likely a duplicate`)
             return createRouteMessageAck(routedMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received routeMessage ${routedMessage.requestId}`)
         this.config.addContact(routedMessage.sourcePeer!, true)
         this.config.duplicateRequestDetector.add(routedMessage.requestId)
-        if (areEqualPeerDescriptors(this.config.localPeerDescriptor, routedMessage.destinationPeer!)) {
+        if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, routedMessage.target)) {
             logger.trace(`routing message targeted to self ${routedMessage.requestId}`)
             this.config.setForwardingEntries(routedMessage)
             this.config.connectionManager?.handleMessage(routedMessage.message!)
@@ -55,13 +56,13 @@ export class RouterRpcLocal implements IRouterRpc {
     async forwardMessage(forwardMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
         if (this.config.duplicateRequestDetector.isMostLikelyDuplicate(forwardMessage.requestId)) {
             logger.trace(`Forwarding message ${forwardMessage.requestId} from ${getNodeIdFromPeerDescriptor(forwardMessage.sourcePeer!)} `
-                + `to ${getNodeIdFromPeerDescriptor(forwardMessage.destinationPeer!)} is likely a duplicate`)
+                + `to ${getNodeIdFromBinary(forwardMessage.target)} is likely a duplicate`)
             return createRouteMessageAck(forwardMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received forward routeMessage ${forwardMessage.requestId}`)
         this.config.addContact(forwardMessage.sourcePeer!, true)
         this.config.duplicateRequestDetector.add(forwardMessage.requestId)
-        if (areEqualPeerDescriptors(this.config.localPeerDescriptor, forwardMessage.destinationPeer!)) {
+        if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, forwardMessage.target)) {
             return this.forwardToDestination(forwardMessage)
         } else {
             return this.config.doRouteMessage(forwardMessage, RoutingMode.FORWARD)
@@ -75,7 +76,7 @@ export class RouterRpcLocal implements IRouterRpc {
             this.config.connectionManager?.handleMessage(forwardedMessage)
             return createRouteMessageAck(routedMessage)
         }
-        return this.config.doRouteMessage({ ...routedMessage, destinationPeer: forwardedMessage.targetDescriptor })
+        return this.config.doRouteMessage({ ...routedMessage, target: forwardedMessage.targetDescriptor!.nodeId })
     }
 
 }

--- a/packages/dht/src/dht/routing/RouterRpcRemote.ts
+++ b/packages/dht/src/dht/routing/RouterRpcRemote.ts
@@ -1,12 +1,11 @@
 import { RouteMessageError, RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
 import { v4 } from 'uuid'
 import {
-    areEqualPeerDescriptors,
     getNodeIdFromPeerDescriptor
 } from '../../helpers/peerIdFromPeerDescriptor'
 import { IRouterRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
 import { RpcRemote } from '../contact/RpcRemote'
-import { Logger } from '@streamr/utils'
+import { Logger, areEqualBinaries } from '@streamr/utils'
 import { getPreviousPeer } from './getPreviousPeer'
 
 const logger = new Logger(module)
@@ -15,7 +14,7 @@ export class RouterRpcRemote extends RpcRemote<IRouterRpcClient> {
 
     async routeMessage(params: RouteMessageWrapper): Promise<boolean> {
         const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
+            target: params.target,
             sourcePeer: params.sourcePeer,
             message: params.message,
             requestId: params.requestId ?? v4(),
@@ -29,7 +28,7 @@ export class RouterRpcRemote extends RpcRemote<IRouterRpcClient> {
             const ack = await this.getClient().routeMessage(message, options)
             // Success signal if sent to destination and error includes duplicate
             if (ack.error === RouteMessageError.DUPLICATE
-                && areEqualPeerDescriptors(params.destinationPeer!, this.getPeerDescriptor())
+                && areEqualBinaries(params.target, this.getPeerDescriptor().nodeId)
             ) {
                 return true
             } else if (ack.error !== undefined) {
@@ -48,7 +47,7 @@ export class RouterRpcRemote extends RpcRemote<IRouterRpcClient> {
 
     async forwardMessage(params: RouteMessageWrapper): Promise<boolean> {
         const message: RouteMessageWrapper = {
-            destinationPeer: params.destinationPeer,
+            target: params.target,
             sourcePeer: params.sourcePeer,
             message: params.message,
             requestId: params.requestId ?? v4(),

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -13,7 +13,7 @@ import { Contact } from '../contact/Contact'
 import { RecursiveOperationRpcRemote } from '../recursive-operation/RecursiveOperationRpcRemote'
 import { EXISTING_CONNECTION_TIMEOUT } from '../contact/RpcRemote'
 import { getPreviousPeer } from './getPreviousPeer'
-import { NodeID } from '../../helpers/nodeId'
+import { NodeID, getNodeIdFromBinary } from '../../helpers/nodeId'
 
 const logger = new Logger(module)
 
@@ -90,7 +90,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         const previousPeer = getPreviousPeer(config.routedMessage)
         const previousId = previousPeer ? getNodeIdFromPeerDescriptor(previousPeer) : undefined
         this.contactList = new SortedContactList({
-            referenceId: getNodeIdFromPeerDescriptor(config.routedMessage.destinationPeer!),
+            referenceId: getNodeIdFromBinary(config.routedMessage.target),
             maxSize: 10000,  // TODO use config option or named constant?
             allowToContainReferenceId: true,
             nodeIdDistanceLimit: previousId,

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -253,9 +253,9 @@ export interface RouteMessageWrapper {
      */
     requestId: string;
     /**
-     * @generated from protobuf field: dht.PeerDescriptor destinationPeer = 3;
+     * @generated from protobuf field: bytes target = 3;
      */
-    destinationPeer?: PeerDescriptor;
+    target: Uint8Array;
     /**
      * @generated from protobuf field: dht.Message message = 4;
      */
@@ -874,7 +874,7 @@ class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
         super("dht.RouteMessageWrapper", [
             { no: 1, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
             { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "destinationPeer", kind: "message", T: () => PeerDescriptor },
+            { no: 3, name: "target", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "message", kind: "message", T: () => Message },
             { no: 5, name: "reachableThrough", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
             { no: 6, name: "routingPath", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -245,13 +245,13 @@ export interface ConnectivityMethod {
  */
 export interface RouteMessageWrapper {
     /**
-     * @generated from protobuf field: dht.PeerDescriptor sourcePeer = 1;
-     */
-    sourcePeer?: PeerDescriptor;
-    /**
-     * @generated from protobuf field: string requestId = 2;
+     * @generated from protobuf field: string requestId = 1;
      */
     requestId: string;
+    /**
+     * @generated from protobuf field: dht.PeerDescriptor sourcePeer = 2;
+     */
+    sourcePeer?: PeerDescriptor;
     /**
      * @generated from protobuf field: bytes target = 3;
      */
@@ -561,11 +561,7 @@ export enum NodeType {
     /**
      * @generated from protobuf enum value: BROWSER = 1;
      */
-    BROWSER = 1,
-    /**
-     * @generated from protobuf enum value: VIRTUAL = 3;
-     */
-    VIRTUAL = 3
+    BROWSER = 1
 }
 /**
  * @generated from protobuf enum dht.RpcResponseError
@@ -872,8 +868,8 @@ export const ConnectivityMethod = new ConnectivityMethod$Type();
 class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
     constructor() {
         super("dht.RouteMessageWrapper", [
-            { no: 1, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
-            { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
             { no: 3, name: "target", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "message", kind: "message", T: () => Message },
             { no: 5, name: "reachableThrough", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -169,7 +169,7 @@ describe('Layer1', () => {
     //                 }
     //                 await sender.doRouteMessage({
     //                     message,
-    //                     destinationPeer: receiver.getPeerDescriptor(),
+    //                     target: receiver.getPeerDescriptor().nodeId,
     //                     sourcePeer: sender.getPeerDescriptor(),
     //                     requestId: v4(),
     //                     reachableThrough: [],

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -84,7 +84,7 @@ describe('Route Message With Mock Connections', () => {
         await runAndWaitForEvents3<DhtNodeEvents>([() => {
             sourceNode.router!.doRouteMessage({
                 message,
-                destinationPeer: destinationNode.getLocalPeerDescriptor(),
+                target: destinationNode.getLocalPeerDescriptor().nodeId,
                 requestId: v4(),
                 sourcePeer: sourceNode.getLocalPeerDescriptor(),
                 reachableThrough: [],
@@ -116,7 +116,7 @@ describe('Route Message With Mock Connections', () => {
             }
             sourceNode.router!.doRouteMessage({
                 message,
-                destinationPeer: destinationNode.getLocalPeerDescriptor(),
+                target: destinationNode.getLocalPeerDescriptor().nodeId,
                 requestId: v4(),
                 sourcePeer: sourceNode.getLocalPeerDescriptor(),
                 reachableThrough: [],
@@ -172,7 +172,7 @@ describe('Route Message With Mock Connections', () => {
                         }
                         node.router!.doRouteMessage({
                             message,
-                            destinationPeer: receiver.getLocalPeerDescriptor(),
+                            target: receiver.getLocalPeerDescriptor().nodeId,
                             sourcePeer: node.getLocalPeerDescriptor(),
                             requestId: v4(),
                             reachableThrough: [],
@@ -208,7 +208,7 @@ describe('Route Message With Mock Connections', () => {
 
         const routeMessageWrapper: RouteMessageWrapper = {
             message: closestPeersRequestMessage,
-            destinationPeer: destinationNode.getLocalPeerDescriptor(),
+            target: destinationNode.getLocalPeerDescriptor().nodeId,
             requestId: v4(),
             sourcePeer: sourceNode.getLocalPeerDescriptor(),
             reachableThrough: [entryPointDescriptor],
@@ -240,7 +240,7 @@ describe('Route Message With Mock Connections', () => {
             message: requestMessage,
             requestId: v4(),
             sourcePeer: sourceNode.getLocalPeerDescriptor(),
-            destinationPeer: entryPoint.getLocalPeerDescriptor()!,
+            target: entryPoint.getLocalPeerDescriptor()!.nodeId,
             reachableThrough: [],
             routingPath: []
         }

--- a/packages/dht/test/integration/RouterRpcRemote.test.ts
+++ b/packages/dht/test/integration/RouterRpcRemote.test.ts
@@ -44,7 +44,7 @@ describe('RemoteRouter', () => {
             requestId: 'routed',
             message: routed,
             sourcePeer: clientPeerDescriptor,
-            destinationPeer: serverPeerDescriptor,
+            target: serverPeerDescriptor.nodeId,
             reachableThrough: [],
             routingPath: []
         })
@@ -67,7 +67,7 @@ describe('RemoteRouter', () => {
             requestId: 'routed',
             message: routed,
             sourcePeer: clientPeerDescriptor,
-            destinationPeer: serverPeerDescriptor,
+            target: serverPeerDescriptor.nodeId,
             reachableThrough: [],
             routingPath: []
         })

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -56,7 +56,7 @@ describe('RecursiveOperationManager', () => {
         routingPath: [],
         reachableThrough: [],
         sourcePeer: peerDescriptor1,
-        destinationPeer: peerDescriptor2
+        target: peerDescriptor2.nodeId
     }
     const rpcCommunicator = new FakeRpcCommunicator()
 
@@ -109,7 +109,7 @@ describe('RecursiveOperationManager', () => {
             requestId: 'REQ',
             routingPath: [],
             reachableThrough: [],
-            destinationPeer: peerDescriptor1,
+            target: peerDescriptor1.nodeId,
             sourcePeer: peerDescriptor2
         })).rejects.toThrow()
         manager.stop()

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -36,7 +36,7 @@ describe('Router', () => {
         requestId: 'REQ',
         routingPath: [],
         reachableThrough: [],
-        destinationPeer: peerDescriptor1,
+        target: peerDescriptor1.nodeId,
         sourcePeer: peerDescriptor2
     }
     let connections: Map<NodeID, DhtNodeRpcRemote>
@@ -63,7 +63,7 @@ describe('Router', () => {
     it('doRouteMessage without connections', async () => {
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', {
             message,
-            destinationPeer: peerDescriptor2,
+            target: peerDescriptor2.nodeId,
             requestId: v4(),
             sourcePeer: peerDescriptor1,
             reachableThrough: [],
@@ -76,7 +76,7 @@ describe('Router', () => {
         connections.set(PeerID.fromString('test').toNodeId(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', {
             message,
-            destinationPeer: peerDescriptor2,
+            target: peerDescriptor2.nodeId,
             requestId: v4(),
             sourcePeer: peerDescriptor1,
             reachableThrough: [],

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -31,7 +31,7 @@ describe('RoutingSession', () => {
         requestId: 'REQ',
         routingPath: [],
         reachableThrough: [],
-        destinationPeer: mockPeerDescriptor1,
+        target: mockPeerDescriptor1.nodeId,
         sourcePeer: mockPeerDescriptor2
     }
 

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -27,7 +27,7 @@ const toEqualPeerDescriptor = (
         messages.push(formErrorMessage('nodeId', binaryToHex(expected.nodeId), binaryToHex(actual.nodeId)))
     }
     if (!isEqual(expected.type, actual.type)) {
-        const typeNames = { [NodeType.NODEJS]: 'NODEJS', [NodeType.BROWSER]: 'BROWSER', [NodeType.VIRTUAL]: 'VIRTUAL' }
+        const typeNames = { [NodeType.NODEJS]: 'NODEJS', [NodeType.BROWSER]: 'BROWSER' }
         messages.push(formErrorMessage('type', typeNames[expected.type], typeNames[actual.type]))
     }
     expectEqualConnectivityMethod('udp', expected.udp, actual.udp, messages)

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -253,9 +253,9 @@ export interface RouteMessageWrapper {
      */
     requestId: string;
     /**
-     * @generated from protobuf field: dht.PeerDescriptor destinationPeer = 3;
+     * @generated from protobuf field: bytes target = 3;
      */
-    destinationPeer?: PeerDescriptor;
+    target: Uint8Array;
     /**
      * @generated from protobuf field: dht.Message message = 4;
      */
@@ -874,7 +874,7 @@ class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
         super("dht.RouteMessageWrapper", [
             { no: 1, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
             { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "destinationPeer", kind: "message", T: () => PeerDescriptor },
+            { no: 3, name: "target", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "message", kind: "message", T: () => Message },
             { no: 5, name: "reachableThrough", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
             { no: 6, name: "routingPath", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -245,13 +245,13 @@ export interface ConnectivityMethod {
  */
 export interface RouteMessageWrapper {
     /**
-     * @generated from protobuf field: dht.PeerDescriptor sourcePeer = 1;
-     */
-    sourcePeer?: PeerDescriptor;
-    /**
-     * @generated from protobuf field: string requestId = 2;
+     * @generated from protobuf field: string requestId = 1;
      */
     requestId: string;
+    /**
+     * @generated from protobuf field: dht.PeerDescriptor sourcePeer = 2;
+     */
+    sourcePeer?: PeerDescriptor;
     /**
      * @generated from protobuf field: bytes target = 3;
      */
@@ -561,11 +561,7 @@ export enum NodeType {
     /**
      * @generated from protobuf enum value: BROWSER = 1;
      */
-    BROWSER = 1,
-    /**
-     * @generated from protobuf enum value: VIRTUAL = 3;
-     */
-    VIRTUAL = 3
+    BROWSER = 1
 }
 /**
  * @generated from protobuf enum dht.RpcResponseError
@@ -872,8 +868,8 @@ export const ConnectivityMethod = new ConnectivityMethod$Type();
 class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
     constructor() {
         super("dht.RouteMessageWrapper", [
-            { no: 1, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
-            { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "sourcePeer", kind: "message", T: () => PeerDescriptor },
             { no: 3, name: "target", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "message", kind: "message", T: () => Message },
             { no: 5, name: "reachableThrough", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },


### PR DESCRIPTION
Renamed `RouteMessageWrapper#destinationPeer` -> `target` and changed the type `PeerDescriptor` -> `bytes`.

Removed `NodeType.VIRTUAL` as that is no longer needed.

Also reordered `RouteMessageWrapper` fields.

## Future improvements

- The `RouteMessageWrapper#target` can be a node id or data key. Now we handle the target with node id utility functions (e.g. `getNodeIdFromBinary`), but we could maybe introduce a new type (e.g. `NetworkAddress`) and/or helper methods for handling this kind of generic address
- Rename `RouteMessageWrapper#sourcePeer` -> `source` (and maybe `Message#sourceDescriptor` -> `source`, `Message#targetDescriptor` -> `target`)
- Check if it is possible to change the type also for some of these:
  -  `RouteMessageWrapper#sourcePeer`
  - `Message#sourceDescriptor`
  - `Message#targetDescriptor`
