### PR TITLE
fix(DHT): Fix staleness corner case in small networks

### DIFF
--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -112,6 +112,21 @@ describe('StoreManager', () => {
                 expect(setStale).toHaveBeenCalledTimes(1)
                 expect(setStale).toHaveBeenCalledWith(DATA_ENTRY.key, getNodeIdFromBinary(DATA_ENTRY.creator), true)
             })
+
+            it('this node has less than redundancyFactor neighbors', async () => {
+                const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
+                const setStale = jest.fn<undefined, [Key, NodeID]>()
+                const manager = createStoreManager(
+                    NODES_CLOSEST_TO_DATA[3],
+                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[1]],
+                    replicateData,
+                    setStale
+                )
+                manager.onNewContact({ nodeId: NODES_CLOSEST_TO_DATA[4], type: NodeType.NODEJS })
+                await wait(50)
+                expect(replicateData).not.toHaveBeenCalled()
+                expect(setStale).toHaveBeenCalledTimes(0)
+            })
         })
     })
 })


### PR DESCRIPTION
## Summary

Fixed a corner case where staleness of data was set incorrectly in smaller networks. Stale is no longer set true if the number of neighbors a node has in total is less than `redundancyFactor`