### PR TITLE
fix(DHT): joinDht end condition

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -155,7 +155,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             joinParallelism: 3,
             maxNeighborListSize: 200,
             numberOfNodesPerKBucket: 8,
-            joinNoProgressLimit: 4,
+            joinNoProgressLimit: 5,
             dhtJoinTimeout: 60000,
             peerDiscoveryQueryBatchSize: 5,
             maxConnections: 80,

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -64,8 +64,6 @@ export class DiscoverySession {
         const newClosestDistance = getDistance(getNodeIdFromBinary(this.config.targetId), newClosestNeighbor.getNodeId())
         if (newClosestDistance >= oldClosestDistance) {
             this.noProgressCounter++
-        } else {
-            this.noProgressCounter = 0
         }
     }
 


### PR DESCRIPTION
## Summary

The joinDht operation was doing too many requests after #2175. The operation could make requests to all nodes in the network in the worst case, in which it would discover closer peers that had their own joins on going. The goal of joinDht is for the node to find its place in the network with a relatively low number of requests. This change sets the number of requests to be relatively low again.

Removed setting noProgressCounter to 0 incases where closer peers were found during join. This fixes a bug that caused the join operations to not end after finding its place in the network fast enough. The removed else block in DiscoverySession is no longer needed as the end condition for uncontacted peers no longer happens as aggressively as before. The end condition for the uncontacted peers list being 0 used to always occur after the closest 10 peers were contacted. Since, the PeerManager's `getClosestContactsTo` now excludes the contacted peers before setting the limit the end condition can only happen if all known contacts have been contacted.

Fixed joinDht end condition to reduce the number of requests performed during joins. This significantly reduces the cpu load in tests with larger networks.

Also, increased the `joinNoProgressLimit` to allow one more requests to be done to discover a larger part of the network. The value was increased since the DiscoverySessions end more aggressively than before. This should balance out the reduced number of requests.
