### PR TITLE
NET-1231: Move `environment` into `client`

### DIFF
--- a/packages/broker/src/config/ConfigWizard.ts
+++ b/packages/broker/src/config/ConfigWizard.ts
@@ -72,11 +72,11 @@ export async function start(): Promise<void> {
 
         const config: ConfigFile = {
             $schema: formSchemaUrl(CURRENT_CONFIGURATION_VERSION),
-            environment: environmentId,
             client: {
                 auth: {
                     privateKey,
                 },
+                environment: environmentId,
             },
             plugins: {
                 ...operatorPlugins,

--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -134,7 +134,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -197,7 +197,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -276,7 +276,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -364,7 +364,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -422,7 +422,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -484,7 +484,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -546,7 +546,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -609,7 +609,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -743,7 +743,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -924,7 +924,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -1001,7 +1001,7 @@ describe('Config wizard', () => {
 
         expect(config).not.toContainAnyKeys(['httpServer'])
 
-        expect(config.environment).toEqual('polygon')
+        expect(config.client.environment).toEqual('polygon')
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
@@ -1213,7 +1213,7 @@ describe('Config wizard', () => {
 
         expect(config.client).not.toContainAnyKeys(['contracts', 'network'])
 
-        expect(config.environment).toEqual('mumbai')
+        expect(config.client.environment).toEqual('mumbai')
 
         const summary = logs.join('\n')
 


### PR DESCRIPTION
## Summary

This PR nests config's `environment` within the `client`,  beside `auth`.