### PR TITLE
fix(Autocertifier-server): Autocertifier server close handshaked connections after requests

### DIFF
--- a/packages/autocertifier-server/src/StreamrChallenger.ts
+++ b/packages/autocertifier-server/src/StreamrChallenger.ts
@@ -63,6 +63,9 @@ export const runStreamrChallenge = (
                 reject(e)
             }).finally(() => {
                 communicator.stop()
+                // close with leave flag true just in case 
+                // any info of the autocertifer is in the network
+                managedConnection.close(true)
             })
         })
 

--- a/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
+++ b/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
@@ -11,7 +11,7 @@ import {
     SimulatorTransport
 } from '@streamr/dht'
 import path from 'path'
-import { MetricsContext } from '@streamr/utils'
+import { MetricsContext, waitForCondition } from '@streamr/utils'
 
 describe('StreamrChallenger', () => {
 
@@ -66,6 +66,7 @@ describe('StreamrChallenger', () => {
 
     it('Happy path', async () => {
         await runStreamrChallenge('127.0.0.1', '12323', sessionId)
+        await waitForCondition(() => challengedClientTransport.getAllConnectionPeerDescriptors().length === 0)
     })
 
 })


### PR DESCRIPTION
## Summary

Fixed a bug where the autocertifier-server was not closing connections after running challenges
