### PR TITLE
fix(DHT): More redundant requests per join

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -155,7 +155,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             joinParallelism: 3,
             maxNeighborListSize: 200,
             numberOfNodesPerKBucket: 8,
-            joinNoProgressLimit: 5,
+            joinNoProgressLimit: 10,
             dhtJoinTimeout: 60000,
             peerDiscoveryQueryBatchSize: 5,
             maxConnections: 80,


### PR DESCRIPTION
## Summary

Double the number of redundant `getClosestPeers` requests per DiscoverySession to ensure that smaller Layer0 networks do not split
