### PR TITLE
fix(dht): Private loopback addresses

### DIFF
--- a/packages/dht/src/helpers/AddressTools.ts
+++ b/packages/dht/src/helpers/AddressTools.ts
@@ -1,10 +1,12 @@
 import ipaddr from 'ipaddr.js'
 
 // IPv4 private address ranges as specified by RFC 1918
+// and private loopback addresses
 const IPv4PrivateRanges = [
     '10.0.0.0/8',
     '172.16.0.0/12',
     '192.168.0.0/16',
+    '127.0.0.0/8'
 ].map((a) => ipaddr.parseCIDR(a))
 
 export function isPrivateIPv4(address: string): boolean {

--- a/packages/dht/test/unit/AddressTools.test.ts
+++ b/packages/dht/test/unit/AddressTools.test.ts
@@ -37,4 +37,8 @@ describe('isPrivateIPv4', () => {
     it('return false for a public address', () => {
         expect(isPrivateIPv4('203.0.113.181')).toBe(false)
     })
+
+    it('return true for localhost IP address', () => {
+        expect(isPrivateIPv4('127.0.0.1')).toBe(true)
+    })
 })


### PR DESCRIPTION
Added private loopback addresses for `isPrivateIPv4` function. This way the it returns `true` e.g. for `127.0.0.1` .

## Open questions

Maybe the `isPrivateIPv4` function name is ok after this change? Or should we rename it?