### PR TITLE
fix(trackerless-network): Fix publishing

### DIFF
--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -107,8 +107,8 @@ export class NetworkStack {
                     await this.layer0Node?.joinDht(this.options.layer0.entryPoints)
                 }
             })
+            await this.layer0Node!.waitForNetworkConnectivity()
         }
-        await this.layer0Node!.waitForNetworkConnectivity()
     }
 
     getStreamrNode(): StreamrNode {

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -109,6 +109,7 @@ export class StreamrNode extends EventEmitter<Events> {
 
     broadcast(msg: StreamMessage): void {
         const streamPartId = toStreamPartID(msg.messageId!.streamId as StreamID, msg.messageId!.streamPartition)
+        logger.debug(`Broadcasting to stream part ${streamPartId}`)
         this.joinStreamPart(streamPartId)
         this.streamParts.get(streamPartId)!.broadcast(msg)
         this.metrics.broadcastMessagesPerSecond.record(1)
@@ -124,11 +125,11 @@ export class StreamrNode extends EventEmitter<Events> {
     }
 
     joinStreamPart(streamPartId: StreamPartID): void {
-        logger.debug(`Join stream part ${streamPartId}`)
         let streamPart = this.streamParts.get(streamPartId)
         if (streamPart !== undefined) {
             return
         }
+        logger.debug(`Join stream part ${streamPartId}`)
         const layer1Node = this.createLayer1Node(streamPartId, this.knownStreamPartEntryPoints.get(streamPartId) ?? [])
         const entryPointDiscovery = new EntryPointDiscovery({
             streamPartId,


### PR DESCRIPTION
## Summary

No longer call DhtNode#waitForNetworkConnectivity on each publish call. Opening hundreds or thousands of waitForConditions at once caused broadcasting to take seconds during bursts.

This change reduces the CPU load during broadcast bursts by A LOT

## Other changes

- No longer debug log `Join stream part ${streamPartId}` if node has already joined
- Debug log `Broadcasting to stream part ${streamPartId}` on each broadcast 

## Future improvements

- calling `await this.ensureConnectedToControlLayer()` in the NetworkStack is a bit problematic under high cpu since it can take a while to actually execute the promise. In these simply resplving the promise after the first if check can take 100ms. Might make sense to guard the execution of the promise outside the call
