### PR TITLE
refactor(dht, trackerless-network): Remove redundant `DhtAddress` conversions

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -65,8 +65,8 @@ enum ConnectionManagerState {
 export interface ConnectionLocker {
     lockConnection(targetDescriptor: PeerDescriptor, lockId: LockID): void
     unlockConnection(targetDescriptor: PeerDescriptor, lockId: LockID): void
-    weakLockConnection(targetDescriptor: PeerDescriptor): void
-    weakUnlockConnection(targetDescriptor: PeerDescriptor): void
+    weakLockConnection(nodeId: DhtAddress): void
+    weakUnlockConnection(nodeId: DhtAddress): void
 }
 
 export interface PortRange {
@@ -483,19 +483,17 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }
     }
 
-    public weakLockConnection(targetDescriptor: PeerDescriptor): void {
-        if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
+    public weakLockConnection(nodeId: DhtAddress): void {
+        if (this.state === ConnectionManagerState.STOPPED || (nodeId === getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()))) {
             return
         }
-        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
         this.locks.addWeakLocked(nodeId)
     }
 
-    public weakUnlockConnection(targetDescriptor: PeerDescriptor): void {
-        if (this.state === ConnectionManagerState.STOPPED || areEqualPeerDescriptors(targetDescriptor, this.getLocalPeerDescriptor())) {
+    public weakUnlockConnection(nodeId: DhtAddress): void {
+        if (this.state === ConnectionManagerState.STOPPED || (nodeId === getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()))) {
             return
         }
-        const nodeId = getNodeIdFromPeerDescriptor(targetDescriptor)
         this.locks.removeWeakLocked(nodeId)
     }
 

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -169,9 +169,9 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         const sortedCandidates = disconnectionCandidates.getAllContacts()
         const targetNum = this.connections.size - maxConnections
         for (let i = 0; i < sortedCandidates.length && i < targetNum; i++) {
-            logger.trace('garbageCollecting ' + getNodeIdFromPeerDescriptor(sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor()))
-            this.gracefullyDisconnectAsync(sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor(),
-                DisconnectMode.NORMAL).catch((_e) => { })
+            const peerDescriptor = sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor()
+            logger.trace('garbageCollecting ' + getNodeIdFromPeerDescriptor(peerDescriptor))
+            this.gracefullyDisconnectAsync(peerDescriptor, DisconnectMode.NORMAL).catch((_e) => { })
         }
     }
 

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -366,26 +366,22 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     }
 
     private onDisconnected(connection: ManagedConnection, gracefulLeave: boolean) {
-        logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()) + ' onDisconnected() gracefulLeave: ' + gracefulLeave)
-
         const nodeId = getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!)
+        logger.trace(nodeId + ' onDisconnected() gracefulLeave: ' + gracefulLeave)
         const storedConnection = this.connections.get(nodeId)
         if (storedConnection && storedConnection.connectionId.equals(connection.connectionId)) {
             this.locks.clearAllLocks(nodeId)
             this.connections.delete(nodeId)
-            logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor())
-                + ' deleted connection in onDisconnected() gracefulLeave: ' + gracefulLeave)
+            logger.trace(nodeId + ' deleted connection in onDisconnected() gracefulLeave: ' + gracefulLeave)
             this.emit('disconnected', connection.getPeerDescriptor()!, gracefulLeave)
             this.onConnectionCountChange()
         } else {
-            logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor())
-                + ' onDisconnected() did nothing, no such connection in connectionManager')
+            logger.trace(nodeId + ' onDisconnected() did nothing, no such connection in connectionManager')
             if (storedConnection) {
-                logger.trace(getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor())
-                    + ' connectionIds do not match ' + storedConnection.connectionId.toString() + ' ' + connection.connectionId.toString())
+                const connectionId = storedConnection.connectionId.toString()
+                logger.trace(nodeId + ' connectionIds do not match ' + connectionId + ' ' + connection.connectionId.toString())
             }
         }
-
     }
 
     private onNewConnection(connection: ManagedConnection): boolean {
@@ -416,8 +412,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         if (this.connections.has(nodeId)) {
             const newPeerID = peerIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
             if (newPeerID.hasSmallerHashThan(peerIdFromPeerDescriptor(this.getLocalPeerDescriptor()))) {
-                logger.trace(getNodeIdOrUnknownFromPeerDescriptor(newConnection.getPeerDescriptor())
-                    + ' acceptIncomingConnection() replace current connection')
+                logger.trace(nodeId + ' acceptIncomingConnection() replace current connection')
                 // replace the current connection
                 const oldConnection = this.connections.get(nodeId)!
                 logger.trace('replaced: ' + nodeId)

--- a/packages/dht/src/connection/simulator/SimulatorConnection.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnection.ts
@@ -45,38 +45,34 @@ export class SimulatorConnection extends Connection implements IConnection {
             this.simulator.send(this, data)
 
         } else {
-            logger.error(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                'tried to send() on a stopped connection')
+            const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+            const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
+            logger.error(localNodeId + ', ' + targetNodeId + 'tried to send() on a stopped connection')
         }
     }
 
     public async close(gracefulLeave: boolean): Promise<void> {
-        logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
-            + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) + ' close()')
+        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+        const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
 
+        logger.trace(localNodeId + ', ' + targetNodeId + ' close()')
         if (!this.stopped) {
-            logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', '
-                + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) + ' close() not stopped')
+            logger.trace(localNodeId + ', ' + targetNodeId + ' close() not stopped')
             this.stopped = true
 
             try {
-                logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                    ' close() calling simulator.disconnect()')
+                logger.trace(localNodeId + ', ' + targetNodeId + ' close() calling simulator.disconnect()')
                 this.simulator.close(this)
-                logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                    ' close() simulator.disconnect returned')
+                logger.trace(localNodeId + ', ' + targetNodeId + ' close() simulator.disconnect returned')
             } catch (e) {
-                logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                    'close aborted' + e)
+                logger.trace(localNodeId + ', ' + targetNodeId + 'close aborted' + e)
             } finally {
-                logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                    ' calling this.doDisconnect')
+                logger.trace(localNodeId + ', ' + targetNodeId + ' calling this.doDisconnect')
                 this.doDisconnect(gracefulLeave)
             }
 
         } else {
-            logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', ' + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) +
-                ' close() tried to close a stopped connection')
+            logger.trace(localNodeId + ', ' + targetNodeId + ' close() tried to close a stopped connection')
         }
     }
 
@@ -109,7 +105,8 @@ export class SimulatorConnection extends Connection implements IConnection {
 
     public handleIncomingDisconnection(): void {
         if (!this.stopped) {
-            logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ' handleIncomingDisconnection()')
+            const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+            logger.trace(localNodeId + ' handleIncomingDisconnection()')
             this.stopped = true
             this.doDisconnect(false)
         } else {
@@ -118,21 +115,23 @@ export class SimulatorConnection extends Connection implements IConnection {
     }
 
     public destroy(): void {
+        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
         if (!this.stopped) {
-            logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ' destroy()')
+            logger.trace(localNodeId + ' destroy()')
             this.removeAllListeners()
             this.close(false).catch((_e) => { })
         } else {
-            logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ' tried to call destroy() a stopped connection')
+            logger.trace(localNodeId + ' tried to call destroy() a stopped connection')
         }
     }
 
     private doDisconnect(gracefulLeave: boolean) {
-        logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ' doDisconnect()')
+        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+        const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
+        logger.trace(localNodeId + ' doDisconnect()')
         this.stopped = true
 
-        logger.trace(getNodeIdFromPeerDescriptor(this.localPeerDescriptor) + ', '
-            + getNodeIdFromPeerDescriptor(this.targetPeerDescriptor) + ' doDisconnect emitting')
+        logger.trace(localNodeId + ', ' + targetNodeId + ' doDisconnect emitting')
 
         this.emit('disconnected', gracefulLeave)
 

--- a/packages/dht/src/connection/simulator/SimulatorConnection.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnection.ts
@@ -134,6 +134,5 @@ export class SimulatorConnection extends Connection implements IConnection {
         logger.trace(localNodeId + ', ' + targetNodeId + ' doDisconnect emitting')
 
         this.emit('disconnected', gracefulLeave)
-
     }
 }

--- a/packages/dht/src/connection/simulator/SimulatorConnector.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnector.ts
@@ -62,7 +62,8 @@ export class SimulatorConnector {
     }
 
     public handleIncomingConnection(sourceConnection: SimulatorConnection): void {
-        logger.trace(getNodeIdFromPeerDescriptor(sourceConnection.localPeerDescriptor) + ' incoming connection, stopped: ' + this.stopped)
+        const localNodeId = getNodeIdFromPeerDescriptor(sourceConnection.localPeerDescriptor)
+        logger.trace(localNodeId + ' incoming connection, stopped: ' + this.stopped)
         if (this.stopped) {
             return
         }
@@ -74,10 +75,10 @@ export class SimulatorConnector {
         logger.trace('connected')
 
         managedConnection.once('handshakeRequest', () => {
-            logger.trace(getNodeIdFromPeerDescriptor(sourceConnection.localPeerDescriptor) + ' incoming handshake request')
+            logger.trace(localNodeId + ' incoming handshake request')
 
             if (this.onNewConnection(managedConnection)) {
-                logger.trace(getNodeIdFromPeerDescriptor(sourceConnection.localPeerDescriptor) + ' calling acceptHandshake')
+                logger.trace(localNodeId + ' calling acceptHandshake')
                 managedConnection.acceptHandshake()
             } else {
                 managedConnection.rejectHandshake(HandshakeError.DUPLICATE_CONNECTION)

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -80,7 +80,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     public start(isOffering: boolean): void {
         const nodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
-        logger.trace(`Starting new connection for peer ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`, { isOffering })
+        logger.trace(`Starting new connection for peer ${nodeId}`, { isOffering })
         this.connection = new PeerConnection(nodeId, {
             iceServers: this.iceServers.map(iceServerAsString),
             maxMessageSize: this.maxMessageSize,
@@ -112,12 +112,13 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     public async setRemoteDescription(description: string, type: string): Promise<void> {
         if (this.connection) {
+            const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
             try {
-                logger.trace(`Setting remote descriptor for peer: ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`)
+                logger.trace(`Setting remote descriptor for peer: ${remoteNodeId}`)
                 this.connection.setRemoteDescription(description, type as DescriptionType)
                 this.remoteDescriptionSet = true
             } catch (err) {
-                logger.debug(`Failed to set remote descriptor for peer ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`)
+                logger.debug(`Failed to set remote descriptor for peer ${remoteNodeId}`)
             }
         } else {
             this.doClose(false, `Tried to set description for non-existent connection`)
@@ -127,11 +128,12 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     public addRemoteCandidate(candidate: string, mid: string): void {
         if (this.connection) {
             if (this.remoteDescriptionSet) {
+                const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
                 try {
-                    logger.trace(`Setting remote candidate for peer: ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`)
+                    logger.trace(`Setting remote candidate for peer: ${remoteNodeId}`)
                     this.connection.addRemoteCandidate(candidate, mid)
                 } catch (err) {
-                    logger.debug(`Failed to set remote candidate for peer ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`)
+                    logger.debug(`Failed to set remote candidate for peer ${remoteNodeId}`)
                 }
             } else {
                 // TODO: should queue candidates until remote description is set?
@@ -147,7 +149,8 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
             try {
                 this.dataChannel!.sendMessageBinary(data as Buffer)
             } catch (err) {
-                logger.debug('Failed to send binary message to ' + getNodeIdFromPeerDescriptor(this.remotePeerDescriptor) + err)
+                const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+                logger.debug('Failed to send binary message to ' + remoteNodeId + err)
             }
         }
     }
@@ -158,10 +161,8 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     private doClose(gracefulLeave: boolean, reason?: string): void {
         if (!this.closed) {
-            logger.trace(
-                `Closing Node WebRTC Connection to ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`
-                + `${(reason !== undefined) ? `, reason: ${reason}` : ''}`
-            )
+            const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+            logger.trace(`Closing Node WebRTC Connection to ${remoteNodeId}` + `${(reason !== undefined) ? `, reason: ${reason}` : ''}`)
 
             this.closed = true
             

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -241,7 +241,7 @@ export class WebsocketConnector {
             )
             managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
 
-            this.connectingConnections.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+            this.connectingConnections.set(nodeId, managedConnection)
 
             const delFunc = () => {
                 if (this.connectingConnections.has(nodeId)) {
@@ -283,9 +283,10 @@ export class WebsocketConnector {
             undefined,
             targetPeerDescriptor
         )
-        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(getNodeIdFromPeerDescriptor(targetPeerDescriptor)))
+        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        managedConnection.on('disconnected', () => this.ongoingConnectRequests.delete(nodeId))
         managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
-        this.ongoingConnectRequests.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+        this.ongoingConnectRequests.set(nodeId, managedConnection)
         return managedConnection
     }
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -386,7 +386,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private handleMessage(message: Message): void {
         const nodeId = getNodeIdFromPeerDescriptor(message.sourceDescriptor!)
         if (message.serviceId === this.config.serviceId) {
-            logger.trace('callig this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
+            logger.trace('calling this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else {
             logger.trace('emit "message" ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -384,13 +384,12 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     private handleMessage(message: Message): void {
+        const nodeId = getNodeIdFromPeerDescriptor(message.sourceDescriptor!)
         if (message.serviceId === this.config.serviceId) {
-            logger.trace('callig this.handleMessageFromPeer ' + getNodeIdFromPeerDescriptor(message.sourceDescriptor!)
-                + ' ' + message.serviceId + ' ' + message.messageId)
+            logger.trace('callig this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else {
-            logger.trace('emit "message" ' + getNodeIdFromPeerDescriptor(message.sourceDescriptor!)
-                + ' ' + message.serviceId + ' ' + message.messageId)
+            logger.trace('emit "message" ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)
         }
     }
@@ -406,7 +405,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     public getClosestContacts(limit?: number): PeerDescriptor[] {
         return this.peerManager!.getClosestContactsTo(
-            getNodeIdFromPeerDescriptor(this.localPeerDescriptor!),
+            this.getNodeId(),
             limit).map((peer) => peer.getPeerDescriptor()
         )
     }
@@ -462,7 +461,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.peerDiscovery!.isJoinOngoing() && connectedEntryPoints.length > 0) {
             return this.storeDataViaPeer(key, data, sample(connectedEntryPoints)!)
         }
-        return this.storeManager!.storeDataToDht(key, data, creator ?? getNodeIdFromPeerDescriptor(this.localPeerDescriptor!))
+        return this.storeManager!.storeDataToDht(key, data, creator ?? this.getNodeId())
     }
 
     public async storeDataViaPeer(key: DhtAddress, data: Any, peer: PeerDescriptor): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/DhtNodeRpcRemote.ts
+++ b/packages/dht/src/dht/DhtNodeRpcRemote.ts
@@ -41,7 +41,7 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
     }
 
     async getClosestPeers(nodeId: DhtAddress): Promise<PeerDescriptor[]> {
-        logger.trace(`Requesting getClosestPeers on ${this.serviceId} from ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Requesting getClosestPeers on ${this.serviceId} from ${this.getNodeId()}`)
         const request: ClosestPeersRequest = {
             nodeId: getRawFromDhtAddress(nodeId),
             requestId: v4()
@@ -56,7 +56,7 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
     }
 
     async ping(): Promise<boolean> {
-        logger.trace(`Requesting ping on ${this.serviceId} from ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Requesting ping on ${this.serviceId} from ${this.getNodeId()}`)
         const request: PingRequest = {
             requestId: v4()
         }
@@ -67,13 +67,13 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
                 return true
             }
         } catch (err) {
-            logger.trace(`ping failed on ${this.serviceId} to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}: ${err}`)
+            logger.trace(`ping failed on ${this.serviceId} to ${this.getNodeId()}: ${err}`)
         }
         return false
     }
 
     leaveNotice(): void {
-        logger.trace(`Sending leaveNotice on ${this.serviceId} from ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Sending leaveNotice on ${this.serviceId} from ${this.getNodeId()}`)
         const options = this.formDhtRpcOptions({
             notification: true
         })

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -129,25 +129,27 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         if (contact.getNodeId() !== this.config.localNodeId) {
+            const peerDescriptor = contact.getPeerDescriptor()
+            const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
             // Important to lock here, before the ping result is known
-            this.config.connectionManager?.weakLockConnection(contact.getPeerDescriptor())
+            this.config.connectionManager?.weakLockConnection(peerDescriptor)
             if (this.connections.has(contact.getNodeId())) {
-                logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+                logger.trace(`Added new contact ${nodeId}`)
             } else {    // open connection by pinging
-                logger.trace('starting ping ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
+                logger.trace('starting ping ' + nodeId)
                 contact.ping().then((result) => {
                     if (result) {
-                        logger.trace(`Added new contact ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+                        logger.trace(`Added new contact ${nodeId}`)
                     } else {
-                        logger.trace('ping failed ' + getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
-                        this.config.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
-                        this.removeContact(contact.getPeerDescriptor())
+                        logger.trace('ping failed ' + nodeId)
+                        this.config.connectionManager?.weakUnlockConnection(peerDescriptor)
+                        this.removeContact(peerDescriptor)
                         this.addClosestContactToBucket()
                     }
                     return
                 }).catch((_e) => {
-                    this.config.connectionManager?.weakUnlockConnection(contact.getPeerDescriptor())
-                    this.removeContact(contact.getPeerDescriptor())
+                    this.config.connectionManager?.weakUnlockConnection(peerDescriptor)
+                    this.removeContact(peerDescriptor)
                     this.addClosestContactToBucket()
                 })
             }
@@ -185,19 +187,20 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         } else {
             logger.trace('new connection not set to connections, there is already a connection with the peer ID')
         }
-        logger.trace('connected: ' + getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + this.connections.size)
+        logger.trace('connected: ' + nodeId + ' ' + this.connections.size)
     }
 
     handleDisconnected(peerDescriptor: PeerDescriptor, gracefulLeave: boolean): void {
-        logger.trace('disconnected: ' + getNodeIdFromPeerDescriptor(peerDescriptor))
-        this.connections.delete(getNodeIdFromPeerDescriptor(peerDescriptor))
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        logger.trace('disconnected: ' + nodeId)
+        this.connections.delete(nodeId)
         if (this.config.isLayer0) {
             this.bucket.remove(peerDescriptor.nodeId)
             if (gracefulLeave === true) {
-                logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
+                logger.trace(nodeId + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
                 this.removeContact(peerDescriptor)
             } else {
-                logger.trace(getNodeIdFromPeerDescriptor(peerDescriptor) + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
+                logger.trace(nodeId + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
             }
         }
     }
@@ -210,8 +213,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         if (this.stopped) {
             return
         }
-        logger.trace(`Removing contact ${getNodeIdFromPeerDescriptor(contact)}`)
         const nodeId = getNodeIdFromPeerDescriptor(contact)
+        logger.trace(`Removing contact ${nodeId}`)
         this.bucket.remove(getRawFromDhtAddress(nodeId))
         this.contacts.removeContact(nodeId)
         this.randomPeers.removeContact(nodeId)

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -147,13 +147,14 @@ export class PeerDiscovery {
         if (this.isStopped()) {
             return
         }
+        const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const nodes = this.config.peerManager.getClosestNeighborsTo(
-            getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor),
+            localNodeId,
             this.config.parallelism
         )
         await Promise.allSettled(
             nodes.map(async (peer: DhtNodeRpcRemote) => {
-                const contacts = await peer.getClosestPeers(getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor))
+                const contacts = await peer.getClosestPeers(localNodeId)
                 this.config.peerManager.handleNewPeers(contacts)
             })
         )

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
@@ -33,8 +33,8 @@ export class RecursiveOperationRpcRemote extends RpcRemote<RecursiveOperationRpc
             const fromNode = previousPeer
                 ? getNodeIdFromPeerDescriptor(previousPeer)
                 : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            // eslint-disable-next-line max-len
-            logger.debug(`Failed to send routeRequest message from ${fromNode} to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} with: ${err}`)
+            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+            logger.debug(`Failed to send routeRequest message from ${fromNode} to ${toNode} with: ${err}`)
             return false
         }
         return true

--- a/packages/dht/src/dht/routing/RouterRpcRemote.ts
+++ b/packages/dht/src/dht/routing/RouterRpcRemote.ts
@@ -39,7 +39,8 @@ export class RouterRpcRemote extends RpcRemote<RouterRpcClient> {
             const fromNode = previousPeer
                 ? getNodeIdFromPeerDescriptor(previousPeer)
                 : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            logger.trace(`Failed to send routeMessage from ${fromNode} to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} with: ${err}`)
+            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+            logger.trace(`Failed to send routeMessage from ${fromNode} to ${toNode} with: ${err}`)
             return false
         }
         return true
@@ -67,9 +68,8 @@ export class RouterRpcRemote extends RpcRemote<RouterRpcClient> {
             const fromNode = previousPeer
                 ? getNodeIdFromPeerDescriptor(previousPeer)
                 : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            logger.trace(
-                `Failed to send forwardMessage from ${fromNode} to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} with: ${err}`
-            )
+            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+            logger.trace(`Failed to send forwardMessage from ${fromNode} to ${toNode} with: ${err}`)
             return false
         }
         return true

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -112,11 +112,13 @@ export class StoreManager {
         const ttl = this.config.highestTtl // ToDo: make TTL decrease according to some nice curve
         const createdAt = Timestamp.now()
         for (let i = 0; i < closestNodes.length && successfulNodes.length < this.config.redundancyFactor; i++) {
+            const keyRaw = getRawFromDhtAddress(key)
+            const creatorRaw = getRawFromDhtAddress(creator)
             if (areEqualPeerDescriptors(this.config.localPeerDescriptor, closestNodes[i])) {
                 this.config.localDataStore.storeEntry({
-                    key: getRawFromDhtAddress(key),
+                    key: keyRaw,
                     data,
-                    creator: getRawFromDhtAddress(creator),
+                    creator: creatorRaw,
                     createdAt,
                     storedAt: Timestamp.now(), 
                     ttl, 
@@ -129,9 +131,9 @@ export class StoreManager {
             const rpcRemote = this.config.createRpcRemote(closestNodes[i])
             try {
                 await rpcRemote.storeData({
-                    key: getRawFromDhtAddress(key),
+                    key: keyRaw,
                     data,
-                    creator: getRawFromDhtAddress(creator),
+                    creator: creatorRaw,
                     createdAt,
                     ttl
                 })

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -62,10 +62,11 @@ export class StoreManager {
 
     private replicateAndUpdateStaleState(dataEntry: DataEntry, newNode: PeerDescriptor): void {
         const newNodeId = getNodeIdFromPeerDescriptor(newNode)
+        const key = getDhtAddressFromRaw(dataEntry.key)
         // TODO use config option or named constant?
-        const closestToData = this.config.getClosestNeighborsTo(getDhtAddressFromRaw(dataEntry.key), 10)
+        const closestToData = this.config.getClosestNeighborsTo(key, 10)
         const sortedList = new SortedContactList<Contact>({
-            referenceId: getDhtAddressFromRaw(dataEntry.key), 
+            referenceId: key, 
             maxSize: 20,  // TODO use config option or named constant?
             allowToContainReferenceId: true,
             emitEvents: false
@@ -89,8 +90,8 @@ export class StoreManager {
                     await this.replicateDataToContact(dataEntry, newNode)
                 })
             }
-        } else if (!this.selfIsWithinRedundancyFactor(getDhtAddressFromRaw(dataEntry.key))) {
-            this.config.localDataStore.setStale(getDhtAddressFromRaw(dataEntry.key), getDhtAddressFromRaw(dataEntry.creator), true)
+        } else if (!this.selfIsWithinRedundancyFactor(key)) {
+            this.config.localDataStore.setStale(key, getDhtAddressFromRaw(dataEntry.creator), true)
         }
     }
 
@@ -173,10 +174,11 @@ export class StoreManager {
         // sort own contact list according to data id
         const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const incomingNodeId = getNodeIdFromPeerDescriptor(incomingPeer)
+        const key = getDhtAddressFromRaw(dataEntry.key)
         // TODO use config option or named constant?
-        const closestToData = this.config.getClosestNeighborsTo(getDhtAddressFromRaw(dataEntry.key), 10)
+        const closestToData = this.config.getClosestNeighborsTo(key, 10)
         const sortedList = new SortedContactList<Contact>({
-            referenceId: getDhtAddressFromRaw(dataEntry.key), 
+            referenceId: key, 
             maxSize: this.config.redundancyFactor, 
             allowToContainReferenceId: true, 
             emitEvents: false

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -192,13 +192,13 @@ export class StoreManager {
             // if we are not the closest node to the data, replicate only to the closest one to the data
             : [sortedList.getAllContacts()[0]]
         targets.forEach((contact) => {
-            const contactNodeId = getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())
+            const contactNodeId = contact.getNodeId()
             if ((incomingNodeId !== contactNodeId) && (localNodeId !== contactNodeId)) {
                 setImmediate(() => {
                     executeSafePromise(async () => {
                         await this.replicateDataToContact(dataEntry, contact.getPeerDescriptor())
                         logger.trace('replicateDataToContact() returned', { 
-                            node: getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()),
+                            node: contactNodeId,
                             replicateOnlyToClosest: !selfIsPrimaryStorer
                         })
                     })

--- a/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
+++ b/packages/dht/src/helpers/peerIdFromPeerDescriptor.ts
@@ -7,8 +7,6 @@ export const peerIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): PeerID
     return PeerID.fromValue(peerDescriptor.nodeId)
 }
 
-// TODO could use this in trackerless-network (instead of copy-pasted same implementation)
-// and move this to nodeId.ts
 export const getNodeIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): DhtAddress => {
     return getDhtAddressFromRaw(peerDescriptor.nodeId)
 }

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import { Logger } from '@streamr/utils'
 import { PeerID } from '../../src/helpers/PeerID'
-import { getNodeIdFromPeerDescriptor, keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { keyFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { Contact } from '../../src/dht/contact/Contact'
 import { DhtAddress, getDhtAddressFromRaw, getRawFromDhtAddress } from '../../src/identifiers'
@@ -95,7 +95,7 @@ describe('Replicate data from node to node in DHT', () => {
 
         logger.info('Nodes sorted according to distance to data are: ')
         closest.forEach((contact) => {
-            logger.info(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))
+            logger.info(contact.getNodeId())
         })
 
         logger.info('node 0 joining to the DHT')
@@ -110,7 +110,7 @@ describe('Replicate data from node to node in DHT', () => {
         logger.info('Nodes sorted according to distance to data with storing nodes marked are: ')
 
         closest.forEach((contact) => {
-            const node = nodesById.get(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))!
+            const node = nodesById.get(contact.getNodeId())!
             let hasDataMarker = ''
             
             // @ts-expect-error private field
@@ -120,7 +120,7 @@ describe('Replicate data from node to node in DHT', () => {
             }
 
             // eslint-disable-next-line max-len
-            logger.info(peerIdFromPeerDescriptor(contact.getPeerDescriptor()) + ' ' + getNodeIdFromPeerDescriptor(node.getLocalPeerDescriptor()) + hasDataMarker)
+            logger.info(peerIdFromPeerDescriptor(contact.getPeerDescriptor()) + ' ' + node.getNodeId() + hasDataMarker)
         })
 
         logger.info(NUM_NODES + ' nodes joining layer0 DHT')
@@ -139,7 +139,7 @@ describe('Replicate data from node to node in DHT', () => {
         logger.info('After join of 99 nodes: nodes sorted according to distance to data with storing nodes marked are: ')
 
         closest.forEach((contact) => {
-            const node = nodesById.get(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))!
+            const node = nodesById.get(contact.getNodeId())!
             let hasDataMarker = ''
 
             // @ts-expect-error private field
@@ -148,10 +148,10 @@ describe('Replicate data from node to node in DHT', () => {
                 hasDataMarker = '<-'
             }
 
-            logger.info(getNodeIdFromPeerDescriptor(node.getLocalPeerDescriptor()) + hasDataMarker)
+            logger.info(node.getNodeId() + hasDataMarker)
         })
 
-        const closestNode = nodesById.get(getNodeIdFromPeerDescriptor(closest[0].getPeerDescriptor()))!
+        const closestNode = nodesById.get(closest[0].getNodeId())!
 
         // @ts-expect-error private field
         const store = closestNode.localDataStore

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -50,10 +50,11 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
     private handleRequest(request: StreamPartHandshakeRequest, context: ServerCallContext): StreamPartHandshakeResponse {
         const senderDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const getInterleaveSourceIds = () => (request.interleaveSourceId !== undefined) ? [getDhtAddressFromRaw(request.interleaveSourceId)] : []
-        if (this.config.ongoingInterleaves.has(getNodeIdFromPeerDescriptor(senderDescriptor))) {
+        const senderNodeId = getNodeIdFromPeerDescriptor(senderDescriptor)
+        if (this.config.ongoingInterleaves.has(senderNodeId)) {
             return this.rejectHandshake(request)
         } else if (this.config.targetNeighbors.hasNode(senderDescriptor)
-            || this.config.ongoingHandshakes.has(getNodeIdFromPeerDescriptor(senderDescriptor))
+            || this.config.ongoingHandshakes.has(senderNodeId)
         ) {
             return this.acceptHandshake(request, senderDescriptor)
         } else if (this.config.targetNeighbors.size() + this.config.ongoingHandshakes.size < this.config.maxNeighborCount) {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -30,12 +30,11 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
         if (this.config.targetNeighbors.hasNodeById(senderId)) {
-            const newPeerDescriptors = message.neighborDescriptors
-                .filter((peerDescriptor) => {
-                    const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
-                    const ownNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
-                    return nodeId !== ownNodeId && !this.config.targetNeighbors.getIds().includes(nodeId)
-                })
+            const ownNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
+            const newPeerDescriptors = message.neighborDescriptors.filter((peerDescriptor) => {
+                const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+                return nodeId !== ownNodeId && !this.config.targetNeighbors.getIds().includes(nodeId)
+            })
             newPeerDescriptors.forEach((peerDescriptor) => this.config.nearbyNodeView.add(
                 new DeliveryRpcRemote(
                     this.config.localPeerDescriptor,


### PR DESCRIPTION
Remove some redundant `DhtAddress` conversions. E.g. avoiding some extra getNodeIdFromPeerDescriptor by introducing local variables and changing parameter types.

Also removed unnecessary `Contact` wrapping in `ConnectionManager#garbageCollectConnections`.
