### PR TITLE
fix(DHT): Remove heavy trace log line 

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -8,7 +8,6 @@ import {
     getNodeIdFromPeerDescriptor,
     peerIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
-import { protoToString } from '../helpers/protoToString'
 import {
     DisconnectMode,
     DisconnectNotice,
@@ -344,7 +343,6 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         let message: Message | undefined
         try {
             message = Message.fromBinary(data)
-            logger.trace(`received protojson: ${protoToString(message, Message)}`)
         } catch (e) {
             logger.debug(`Parsing incoming data into Message failed: ${e}`)
             return


### PR DESCRIPTION
## Summary

Remove this trace level log line as it is running a heavy operation used for dev debugging on each received message on the ConnectionManager.
