### PR TITLE
test(dht): Fix `Find` test assertions

### DIFF
--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -5,8 +5,7 @@ import { RecursiveOperation } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { execSync } from 'child_process'
 import fs from 'fs'
-import { PeerID } from '../../src/helpers/PeerID'
-import { getNodeIdFromPeerDescriptor, peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { Logger, wait } from '@streamr/utils'
 import { debugVars } from '../../src/helpers/debugHelpers'
 import { getDhtAddressFromRaw } from '../../src/identifiers'
@@ -69,7 +68,7 @@ describe('Find correctness', () => {
         const results = await nodes[159].executeRecursiveOperation(getDhtAddressFromRaw(targetId), RecursiveOperation.FIND_NODE)
         logger.info('find over')
         expect(results.closestNodes).toBeGreaterThanOrEqual(5)
-        expect(PeerID.fromValue(targetId).equals(peerIdFromPeerDescriptor(results.closestNodes[0])))
+        expect(getDhtAddressFromRaw(targetId)).toEqual(getNodeIdFromPeerDescriptor(results.closestNodes[0]))
 
     }, 180000)
 })

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -2,8 +2,7 @@ import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor, RecursiveOperation } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } from '../utils/utils'
-import { PeerID } from '../../src/helpers/PeerID'
-import { peerIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
+import { getNodeIdFromPeerDescriptor } from '../../src/helpers/peerIdFromPeerDescriptor'
 import { getDhtAddressFromRaw, getRawFromDhtAddress } from '../../src/identifiers'
 
 const NUM_NODES = 100
@@ -41,7 +40,7 @@ describe('Find correctness', () => {
         const targetId = getRawFromDhtAddress(nodes[45].getNodeId())
         const results = await entryPoint.executeRecursiveOperation(getDhtAddressFromRaw(targetId), RecursiveOperation.FIND_NODE)
         expect(results.closestNodes.length).toBeGreaterThanOrEqual(5)
-        expect(PeerID.fromValue(targetId).equals(peerIdFromPeerDescriptor(results.closestNodes[0])))
+        expect(getDhtAddressFromRaw(targetId)).toEqual(getNodeIdFromPeerDescriptor(results.closestNodes[0]))
     }, 30000)
 
 })


### PR DESCRIPTION
The node ids weren't asserted (the expressions were just `expect(true)`). Also refactored the check to use `DhtAddress` instead of `PeerID`.