### PR TITLE
test(dht): Simplify `RouteMessage` test

### DIFF
--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -27,7 +27,6 @@ describe('Route Message With Mock Connections', () => {
     let routerNodes: DhtNode[]
     let simulator: Simulator
     let entryPointDescriptor: PeerDescriptor
-    const receiveMatrix: Array<Array<number>> = []
 
     beforeEach(async () => {
         routerNodes = []
@@ -126,33 +125,13 @@ describe('Route Message With Mock Connections', () => {
     })
 
     it('From all to all', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const i in routerNodes) {
-            const arr: Array<number> = []
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            for (const j in routerNodes) {
-                arr.push(0)
-            }
-            receiveMatrix.push(arr)
-        }
-
         const numsOfReceivedMessages: Record<PeerIDKey, number> = {}
         routerNodes.forEach((node) => {
             numsOfReceivedMessages[getPeerId(node).toKey()] = 0
-            node.on('message', (msg: Message) => {
+            node.on('message', () => {
                 numsOfReceivedMessages[getPeerId(node).toKey()] = numsOfReceivedMessages[getPeerId(node).toKey()] + 1
-                try {
-                    const target = receiveMatrix[parseInt(getPeerId(node).toString()) - 1]
-                    target[parseInt(PeerID.fromValue(msg.sourceDescriptor!.nodeId).toString()) - 1]++
-                } catch (e) {
-                    console.error(e)
-                }
-                if (parseInt(getPeerId(node).toString()) > routerNodes.length || parseInt(getPeerId(node).toString()) === 0) {
-                    console.error(getPeerId(node).toString())
-                }
             })
-        }
-        )
+        })
         await Promise.all(
             routerNodes.map(async (node) =>
                 Promise.all(routerNodes.map(async (receiver) => {


### PR DESCRIPTION
Removed `receiveMatrix` which wasn't written by not read. 

Also removed `getPeerId(node)` checks used `console.error` instead of `jest` assertions. (At least the first part of the check tested the just node id generation which we do at line `45`).

## Open questions

- Should we keep `receiveMatrix` and assert something about it?
- Was the intention of `(parseInt(getPeerId(node).toString()) === 0)` check to assert that the message was not emitted by the entry point node? If that is the case, should we have a `jest` assertion which checks that fact?
  - the id of the entry point was `0` before PR #2187