### PR TITLE
fix(network): fix flaky test `integration/RandomGraphNode-Layer1Node-Latencies.test.ts`

### DIFF
--- a/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/RandomGraphNode-Layer1Node-Latencies.test.ts
@@ -84,11 +84,7 @@ describe('RandomGraphNode-DhtNode-Latencies', () => {
         await Promise.all(range(4).map(async (i) => {
             await layer1Nodes[i].joinDht([entrypointDescriptor])
         }))
-        await Promise.all(range(4).map((i) => {
-            return waitForCondition(() => {
-                return graphNodes[i].getTargetNeighborIds().length >= 4
-            }, 15000, 2000)
-        }))
+        await waitForCondition(() => range(4).every((i) => graphNodes[i].getTargetNeighborIds().length >= 4), 15000, 1000)
         range(4).forEach((i) => {
             expect(graphNodes[i].getNearbyNodeView().getIds().length).toBeGreaterThanOrEqual(4)
             expect(graphNodes[i].getTargetNeighborIds().length).toBeGreaterThanOrEqual(4)


### PR DESCRIPTION
## Summary

Fixed flaky test. The test was improperly waiting for all nodes to have at least 4 connections.

## Future improvements

Refactor the test to use `lodash#take` instead of range
