### PR TITLE
refactor(dht): Use nodeId in offering hash

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -29,7 +29,7 @@ import { WEBRTC_CLEANUP } from './webrtc/NodeWebrtcConnection'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ConnectionLockRpcLocal } from './ConnectionLockRpcLocal'
 import { DhtAddress } from '../identifiers'
-import { hasSmallerOfferingHashThan } from '../helpers/offering'
+import { getOfferer } from '../helpers/offering'
 
 export interface ConnectionManagerConfig {
     maxConnections?: number
@@ -407,7 +407,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         const nodeId = getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
         logger.trace(nodeId + ' acceptIncomingConnection()')
         if (this.connections.has(nodeId)) {
-            if (!hasSmallerOfferingHashThan(getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()), nodeId)) {
+            if (getOfferer(getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()), nodeId) === 'remote') {
                 logger.trace(nodeId + ' acceptIncomingConnection() replace current connection')
                 // replace the current connection
                 const oldConnection = this.connections.get(nodeId)!

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -5,8 +5,7 @@ import { DuplicateDetector } from '../dht/routing/DuplicateDetector'
 import * as Err from '../helpers/errors'
 import {
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor,
-    peerIdFromPeerDescriptor
+    getNodeIdFromPeerDescriptor
 } from '../helpers/peerIdFromPeerDescriptor'
 import {
     DisconnectMode,
@@ -30,6 +29,7 @@ import { WEBRTC_CLEANUP } from './webrtc/NodeWebrtcConnection'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ConnectionLockRpcLocal } from './ConnectionLockRpcLocal'
 import { DhtAddress } from '../identifiers'
+import { hasSmallerOfferingHashThan } from '../helpers/offering'
 
 export interface ConnectionManagerConfig {
     maxConnections?: number
@@ -407,8 +407,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         const nodeId = getNodeIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
         logger.trace(nodeId + ' acceptIncomingConnection()')
         if (this.connections.has(nodeId)) {
-            const newPeerID = peerIdFromPeerDescriptor(newConnection.getPeerDescriptor()!)
-            if (newPeerID.hasSmallerHashThan(peerIdFromPeerDescriptor(this.getLocalPeerDescriptor()))) {
+            if (!hasSmallerOfferingHashThan(getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()), nodeId)) {
                 logger.trace(nodeId + ' acceptIncomingConnection() replace current connection')
                 // replace the current connection
                 const oldConnection = this.connections.get(nodeId)!

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -15,13 +15,13 @@ import * as Err from '../../helpers/errors'
 import { ManagedConnection } from '../ManagedConnection'
 import {
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor,
-    peerIdFromPeerDescriptor
+    getNodeIdFromPeerDescriptor
 } from '../../helpers/peerIdFromPeerDescriptor'
 import { PortRange } from '../ConnectionManager'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { WebrtcConnectorRpcLocal } from './WebrtcConnectorRpcLocal'
 import { DhtAddress } from '../../identifiers'
+import { hasSmallerOfferingHashThan } from '../../helpers/offering'
 
 const logger = new Logger(module)
 
@@ -216,8 +216,8 @@ export class WebrtcConnector {
     }
 
     public isOffering(targetPeerDescriptor: PeerDescriptor): boolean {
-        const myId = peerIdFromPeerDescriptor(this.localPeerDescriptor!)
-        const theirId = peerIdFromPeerDescriptor(targetPeerDescriptor)
-        return myId.hasSmallerHashThan(theirId)
+        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor!)
+        const remoteNodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        return hasSmallerOfferingHashThan(localNodeId, remoteNodeId)
     }
 }

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -159,7 +159,7 @@ export class WebrtcConnector {
 
         managedConnection.setRemotePeerDescriptor(targetPeerDescriptor)
 
-        this.ongoingConnectAttempts.set(getNodeIdFromPeerDescriptor(targetPeerDescriptor), managedConnection)
+        this.ongoingConnectAttempts.set(targetNodeId, managedConnection)
 
         const delFunc = () => {
             this.ongoingConnectAttempts.delete(nodeId)

--- a/packages/dht/src/helpers/PeerID.ts
+++ b/packages/dht/src/helpers/PeerID.ts
@@ -1,7 +1,6 @@
 import { BrandedString, binaryToHex } from '@streamr/utils'
 import { UUID } from './UUID'
 import { IllegalArguments } from './errors'
-import crypto from 'crypto'
 import { DhtAddress, getDhtAddressFromRaw } from '../identifiers'
 
 export type PeerIDKey = BrandedString<'PeerIDKey'>
@@ -82,16 +81,5 @@ export class PeerID {
 
     get value(): Uint8Array {
         return this.data
-    }
-
-    hasSmallerHashThan(other: PeerID): boolean {
-        const myId = this.toKey()
-        const theirId = other.toKey()
-        return PeerID.offeringHash(myId + ',' + theirId) < PeerID.offeringHash(theirId + ',' + myId)
-    }
-
-    private static offeringHash(idPair: string): number {
-        const buffer = crypto.createHash('md5').update(idPair).digest()
-        return buffer.readInt32LE(0)
     }
 }

--- a/packages/dht/src/helpers/offering.ts
+++ b/packages/dht/src/helpers/offering.ts
@@ -1,8 +1,12 @@
 import crypto from 'crypto'
 import { DhtAddress } from '../identifiers'
 
-export const hasSmallerOfferingHashThan = (localNodeId: DhtAddress, remoteNodeId: DhtAddress): boolean => {
+type Offerer = 'local' | 'remote'
+
+export const getOfferer = (localNodeId: DhtAddress, remoteNodeId: DhtAddress): Offerer => {
     return getOfferingHash(localNodeId + ',' + remoteNodeId) < getOfferingHash(remoteNodeId + ',' + localNodeId)
+        ? 'local'
+        : 'remote'
 }
 
 const getOfferingHash = (idPair: string): number => {

--- a/packages/dht/src/helpers/offering.ts
+++ b/packages/dht/src/helpers/offering.ts
@@ -1,0 +1,11 @@
+import crypto from 'crypto'
+import { DhtAddress } from '../identifiers'
+
+export const hasSmallerOfferingHashThan = (localNodeId: DhtAddress, remoteNodeId: DhtAddress): boolean => {
+    return getOfferingHash(localNodeId + ',' + remoteNodeId) < getOfferingHash(remoteNodeId + ',' + localNodeId)
+}
+
+const getOfferingHash = (idPair: string): number => {
+    const buffer = crypto.createHash('md5').update(idPair).digest()
+    return buffer.readInt32LE(0)
+}

--- a/packages/dht/src/identifiers.ts
+++ b/packages/dht/src/identifiers.ts
@@ -18,3 +18,4 @@ export const getRawFromDhtAddress = (address: DhtAddress): DhtAddressRaw => {
 export const createRandomDhtAddress = (): DhtAddress => {
     return getDhtAddressFromRaw(crypto.randomBytes(KADEMLIA_ID_LENGTH_IN_BYTES))
 }
+


### PR DESCRIPTION
Refactor offerer analysis to use `DhtAddress` instead of `PeerIDKey`. The functionality doesn't change as both of these are the same hex representation of nodeId. This refactoring has been done so that we can remove `PeerID` class in the future.

## Future improvements

Improve test coverage related to the offerer analysis: e.g. `ConnectionManager` tests and `WebrctConnector` tests.