### PR TITLE
refactor(trackerless-network): Simplify `NodeList` methods

### DIFF
--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -39,11 +39,11 @@ export class NodeList extends EventEmitter<Events> {
         }
     }
 
-    removeById(nodeId: DhtAddress): void {
+    remove(nodeId: DhtAddress): void {
         this.nodes.delete(nodeId)
     }
 
-    hasNodeById(nodeId: DhtAddress): boolean {
+    has(nodeId: DhtAddress): boolean {
         return this.nodes.has(nodeId)
     }
 

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -39,10 +39,6 @@ export class NodeList extends EventEmitter<Events> {
         }
     }
 
-    remove(peerDescriptor: PeerDescriptor): void {
-        this.nodes.delete(getNodeIdFromPeerDescriptor(peerDescriptor))
-    }
-
     removeById(nodeId: DhtAddress): void {
         this.nodes.delete(nodeId)
     }

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { sample } from 'lodash'
 import { DeliveryRpcRemote } from './DeliveryRpcRemote'
 import { EventEmitter } from 'eventemitter3'
@@ -41,10 +41,6 @@ export class NodeList extends EventEmitter<Events> {
 
     removeById(nodeId: DhtAddress): void {
         this.nodes.delete(nodeId)
-    }
-
-    hasNode(peerDescriptor: PeerDescriptor): boolean {
-        return this.nodes.has(getNodeIdFromPeerDescriptor(peerDescriptor))
     }
 
     hasNodeById(nodeId: DhtAddress): boolean {

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -96,8 +96,8 @@ export class RandomGraphNode extends EventEmitter<Events> {
                 if (contact) {
                     const nodeId = getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())
                     this.config.layer1Node.removeContact(contact.getPeerDescriptor())
-                    this.config.targetNeighbors.removeById(nodeId)
-                    this.config.nearbyNodeView.removeById(nodeId)
+                    this.config.targetNeighbors.remove(nodeId)
+                    this.config.nearbyNodeView.remove(nodeId)
                     this.config.connectionLocker.unlockConnection(contact.getPeerDescriptor(), this.config.streamPartId)
                     this.config.neighborFinder.start([sourceId])
                     this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)
@@ -259,8 +259,8 @@ export class RandomGraphNode extends EventEmitter<Events> {
 
     private onNodeDisconnected(peerDescriptor: PeerDescriptor): void {
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
-        if (this.config.targetNeighbors.hasNodeById(nodeId)) {
-            this.config.targetNeighbors.removeById(nodeId)
+        if (this.config.targetNeighbors.has(nodeId)) {
+            this.config.targetNeighbors.remove(nodeId)
             this.config.connectionLocker.unlockConnection(peerDescriptor, this.config.streamPartId)
             this.config.neighborFinder.start([nodeId])
             this.config.temporaryConnectionRpcLocal.removeNode(nodeId)

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -94,10 +94,9 @@ export class RandomGraphNode extends EventEmitter<Events> {
                 || this.config.proxyConnectionRpcLocal?.getConnection(sourceId )?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {
-                    const nodeId = getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())
                     this.config.layer1Node.removeContact(contact.getPeerDescriptor())
-                    this.config.targetNeighbors.remove(nodeId)
-                    this.config.nearbyNodeView.remove(nodeId)
+                    this.config.targetNeighbors.remove(sourceId)
+                    this.config.nearbyNodeView.remove(sourceId)
                     this.config.connectionLocker.unlockConnection(contact.getPeerDescriptor(), this.config.streamPartId)
                     this.config.neighborFinder.start([sourceId])
                     this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -94,9 +94,10 @@ export class RandomGraphNode extends EventEmitter<Events> {
                 || this.config.proxyConnectionRpcLocal?.getConnection(sourceId )?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {
+                    const nodeId = getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())
                     this.config.layer1Node.removeContact(contact.getPeerDescriptor())
-                    this.config.targetNeighbors.remove(contact.getPeerDescriptor())
-                    this.config.nearbyNodeView.remove(contact.getPeerDescriptor())
+                    this.config.targetNeighbors.removeById(nodeId)
+                    this.config.nearbyNodeView.removeById(nodeId)
                     this.config.connectionLocker.unlockConnection(contact.getPeerDescriptor(), this.config.streamPartId)
                     this.config.neighborFinder.start([sourceId])
                     this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)
@@ -258,10 +259,11 @@ export class RandomGraphNode extends EventEmitter<Events> {
 
     private onNodeDisconnected(peerDescriptor: PeerDescriptor): void {
         if (this.config.targetNeighbors.hasNode(peerDescriptor)) {
-            this.config.targetNeighbors.remove(peerDescriptor)
+            const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+            this.config.targetNeighbors.removeById(nodeId)
             this.config.connectionLocker.unlockConnection(peerDescriptor, this.config.streamPartId)
-            this.config.neighborFinder.start([getNodeIdFromPeerDescriptor(peerDescriptor)])
-            this.config.temporaryConnectionRpcLocal.removeNode(peerDescriptor)
+            this.config.neighborFinder.start([nodeId])
+            this.config.temporaryConnectionRpcLocal.removeNode(nodeId)
         }
     }
 

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -258,8 +258,8 @@ export class RandomGraphNode extends EventEmitter<Events> {
     }
 
     private onNodeDisconnected(peerDescriptor: PeerDescriptor): void {
-        if (this.config.targetNeighbors.hasNode(peerDescriptor)) {
-            const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        if (this.config.targetNeighbors.hasNodeById(nodeId)) {
             this.config.targetNeighbors.removeById(nodeId)
             this.config.connectionLocker.unlockConnection(peerDescriptor, this.config.streamPartId)
             this.config.neighborFinder.start([nodeId])

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -53,7 +53,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
         const senderNodeId = getNodeIdFromPeerDescriptor(senderDescriptor)
         if (this.config.ongoingInterleaves.has(senderNodeId)) {
             return this.rejectHandshake(request)
-        } else if (this.config.targetNeighbors.hasNodeById(senderNodeId)
+        } else if (this.config.targetNeighbors.has(senderNodeId)
             || this.config.ongoingHandshakes.has(senderNodeId)
         ) {
             return this.acceptHandshake(request, senderDescriptor)
@@ -108,7 +108,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
                 // and unlock the connection
                 // If response is not accepted, keep the last node as a neighbor
                 if (response.accepted) {
-                    this.config.targetNeighbors.removeById(getNodeIdFromPeerDescriptor(lastPeerDescriptor!))
+                    this.config.targetNeighbors.remove(getNodeIdFromPeerDescriptor(lastPeerDescriptor!))
                     this.config.connectionLocker.unlockConnection(lastPeerDescriptor!, this.config.streamPartId)
                 }
                 return
@@ -132,9 +132,9 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
         const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
         try {
             await this.config.handshakeWithInterleaving(message.interleaveTargetDescriptor!, senderId)
-            if (this.config.targetNeighbors.hasNodeById(senderId)) {
+            if (this.config.targetNeighbors.has(senderId)) {
                 this.config.connectionLocker.unlockConnection(senderPeerDescriptor, this.config.streamPartId)
-                this.config.targetNeighbors.removeById(senderId)
+                this.config.targetNeighbors.remove(senderId)
             }
             return { accepted: true }
         } catch (err) {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -108,7 +108,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
                 // and unlock the connection
                 // If response is not accepted, keep the last node as a neighbor
                 if (response.accepted) {
-                    this.config.targetNeighbors.remove(last.getPeerDescriptor())
+                    this.config.targetNeighbors.removeById(getNodeIdFromPeerDescriptor(lastPeerDescriptor!))
                     this.config.connectionLocker.unlockConnection(lastPeerDescriptor!, this.config.streamPartId)
                 }
                 return
@@ -134,7 +134,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
             await this.config.handshakeWithInterleaving(message.interleaveTargetDescriptor!, senderId)
             if (this.config.targetNeighbors.hasNodeById(senderId)) {
                 this.config.connectionLocker.unlockConnection(senderPeerDescriptor, this.config.streamPartId)
-                this.config.targetNeighbors.remove(senderPeerDescriptor)
+                this.config.targetNeighbors.removeById(senderId)
             }
             return { accepted: true }
         } catch (err) {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -53,7 +53,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
         const senderNodeId = getNodeIdFromPeerDescriptor(senderDescriptor)
         if (this.config.ongoingInterleaves.has(senderNodeId)) {
             return this.rejectHandshake(request)
-        } else if (this.config.targetNeighbors.hasNode(senderDescriptor)
+        } else if (this.config.targetNeighbors.hasNodeById(senderNodeId)
             || this.config.ongoingHandshakes.has(senderNodeId)
         ) {
             return this.acceptHandshake(request, senderDescriptor)

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -49,7 +49,7 @@ export class NeighborUpdateManager {
             const res = await this.createRemote(neighbor.getPeerDescriptor()).updateNeighbors(this.config.streamPartId, neighborDescriptors)
             if (res.removeMe) {
                 const nodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
-                this.config.targetNeighbors.removeById(nodeId)
+                this.config.targetNeighbors.remove(nodeId)
                 this.config.neighborFinder.start([nodeId])
             }
         }))

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -48,8 +48,9 @@ export class NeighborUpdateManager {
         await Promise.allSettled(this.config.targetNeighbors.getAll().map(async (neighbor) => {
             const res = await this.createRemote(neighbor.getPeerDescriptor()).updateNeighbors(this.config.streamPartId, neighborDescriptors)
             if (res.removeMe) {
-                this.config.targetNeighbors.remove(neighbor.getPeerDescriptor())
-                this.config.neighborFinder.start([getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())])
+                const nodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
+                this.config.targetNeighbors.removeById(nodeId)
+                this.config.neighborFinder.start([nodeId])
             }
         }))
     }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -29,7 +29,7 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
     async neighborUpdate(message: NeighborUpdate, context: ServerCallContext): Promise<NeighborUpdate> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const senderId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
-        if (this.config.targetNeighbors.hasNodeById(senderId)) {
+        if (this.config.targetNeighbors.has(senderId)) {
             const ownNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
             const newPeerDescriptors = message.neighborDescriptors.filter((peerDescriptor) => {
                 const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -222,7 +222,7 @@ export class ProxyClient extends EventEmitter<Events> {
 
     private removeConnection(nodeId: DhtAddress): void {
         this.connections.delete(nodeId)
-        this.targetNeighbors.removeById(nodeId)
+        this.targetNeighbors.remove(nodeId)
     }
 
     broadcast(msg: StreamMessage, previousNode?: DhtAddress): void {

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -28,7 +28,7 @@ export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
     }
 
     removeNode(nodeId: DhtAddress): void {
-        this.temporaryNodes.removeById(nodeId)
+        this.temporaryNodes.remove(nodeId)
     }
 
     async openConnection(

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -1,7 +1,7 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { TemporaryConnectionRequest, TemporaryConnectionResponse } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { ITemporaryConnectionRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
-import { DhtCallContext, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { NodeList } from '../NodeList'
 import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
@@ -27,8 +27,8 @@ export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
         return this.temporaryNodes
     }
 
-    removeNode(peerDescriptor: PeerDescriptor): void {
-        this.temporaryNodes.remove(peerDescriptor)
+    removeNode(nodeId: DhtAddress): void {
+        this.temporaryNodes.removeById(nodeId)
     }
 
     async openConnection(

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -119,7 +119,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(targetNeighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake accepted', async () => {
@@ -134,7 +134,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(targetNeighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake rejected', async () => {
@@ -149,7 +149,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(false)
-        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(false)
+        expect(targetNeighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(false)
     })
 
     it('Handshake with Interleaving', async () => {
@@ -165,7 +165,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
-        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor3))).toEqual(true)
+        expect(targetNeighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(targetNeighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor3))).toEqual(true)
     })
 })

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -119,7 +119,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNode(peerDescriptor1)).toEqual(true)
+        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake accepted', async () => {
@@ -134,7 +134,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNode(peerDescriptor1)).toEqual(true)
+        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake rejected', async () => {
@@ -149,7 +149,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(false)
-        expect(targetNeighbors.hasNode(peerDescriptor1)).toEqual(false)
+        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(false)
     })
 
     it('Handshake with Interleaving', async () => {
@@ -165,7 +165,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(targetNeighbors.hasNode(peerDescriptor1)).toEqual(true)
-        expect(targetNeighbors.hasNode(peerDescriptor3)).toEqual(true)
+        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(targetNeighbors.hasNodeById(getNodeIdFromPeerDescriptor(peerDescriptor3))).toEqual(true)
     })
 })

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -67,12 +67,6 @@ describe('NodeList', () => {
         expect(nodeList.hasNode(newDescriptor2)).toEqual(false)
     })
 
-    it('remove', () => {
-        const toRemove = nodeList.getFirst([])
-        nodeList.remove(toRemove!.getPeerDescriptor())
-        expect(nodeList.hasNode(toRemove!.getPeerDescriptor())).toEqual(false)
-    })
-
     it('removeById', () => {
         const toRemove = nodeList.getFirst([])
         const nodeId = getNodeIdFromPeerDescriptor(toRemove!.getPeerDescriptor())

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -56,7 +56,7 @@ describe('NodeList', () => {
         }
         const newNode = createRemoteGraphNode(newDescriptor)
         nodeList.add(newNode)
-        expect(nodeList.hasNodeById(getNodeIdFromPeerDescriptor(newDescriptor))).toEqual(true)
+        expect(nodeList.has(getNodeIdFromPeerDescriptor(newDescriptor))).toEqual(true)
 
         const newDescriptor2 = {
             nodeId: new Uint8Array([1, 2, 4]),
@@ -64,14 +64,14 @@ describe('NodeList', () => {
         }
         const newNode2 = createRemoteGraphNode(newDescriptor2)
         nodeList.add(newNode2)
-        expect(nodeList.hasNodeById(getNodeIdFromPeerDescriptor(newDescriptor2))).toEqual(false)
+        expect(nodeList.has(getNodeIdFromPeerDescriptor(newDescriptor2))).toEqual(false)
     })
 
     it('removeById', () => {
         const toRemove = nodeList.getFirst([])
         const nodeId = getNodeIdFromPeerDescriptor(toRemove!.getPeerDescriptor())
-        nodeList.removeById(nodeId)
-        expect(nodeList.hasNodeById(nodeId)).toEqual(false)
+        nodeList.remove(nodeId)
+        expect(nodeList.has(nodeId)).toEqual(false)
     })
 
     it('getFirst', () => {

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -56,7 +56,7 @@ describe('NodeList', () => {
         }
         const newNode = createRemoteGraphNode(newDescriptor)
         nodeList.add(newNode)
-        expect(nodeList.hasNode(newDescriptor)).toEqual(true)
+        expect(nodeList.hasNodeById(getNodeIdFromPeerDescriptor(newDescriptor))).toEqual(true)
 
         const newDescriptor2 = {
             nodeId: new Uint8Array([1, 2, 4]),
@@ -64,14 +64,14 @@ describe('NodeList', () => {
         }
         const newNode2 = createRemoteGraphNode(newDescriptor2)
         nodeList.add(newNode2)
-        expect(nodeList.hasNode(newDescriptor2)).toEqual(false)
+        expect(nodeList.hasNodeById(getNodeIdFromPeerDescriptor(newDescriptor2))).toEqual(false)
     })
 
     it('removeById', () => {
         const toRemove = nodeList.getFirst([])
         const nodeId = getNodeIdFromPeerDescriptor(toRemove!.getPeerDescriptor())
         nodeList.removeById(nodeId)
-        expect(nodeList.hasNode(toRemove!.getPeerDescriptor())).toEqual(false)
+        expect(nodeList.hasNodeById(nodeId)).toEqual(false)
     })
 
     it('getFirst', () => {

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -67,7 +67,7 @@ describe('NodeList', () => {
         expect(nodeList.has(getNodeIdFromPeerDescriptor(newDescriptor2))).toEqual(false)
     })
 
-    it('removeById', () => {
+    it('remove', () => {
         const toRemove = nodeList.getFirst([])
         const nodeId = getNodeIdFromPeerDescriptor(toRemove!.getPeerDescriptor())
         nodeList.remove(nodeId)

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -57,7 +57,6 @@ describe('RandomGraphNode', () => {
         targetNeighbors.add(mockRemote)
         const ids = randomGraphNode.getTargetNeighborIds()
         expect(ids[0]).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))
-        targetNeighbors.remove(mockRemote.getPeerDescriptor())
     })
 
     it('getNearbyNodeView', () => {


### PR DESCRIPTION
Simplified `NodeList` methods to operate on nodeId instead of `PeerDescritor`. This way we can simplify the usage and also avoid some redundant `PeerDescriptor` -> `DhtAddress` conversions.

Also removed an obsolete statement from `RandomGraphNode` test.