### PR TITLE
fix(dht): `DisconnectNoticeResponse` as notification

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -46,7 +46,7 @@ service WebrtcConnectorRpc {
 service ConnectionLockRpc {
   rpc lockRequest (LockRequest) returns (LockResponse);
   rpc unlockRequest (UnlockRequest) returns (google.protobuf.Empty);
-  rpc gracefulDisconnect (DisconnectNotice) returns (DisconnectNoticeResponse);
+  rpc gracefulDisconnect (DisconnectNotice) returns (google.protobuf.Empty);
 }
 
 service ExternalApiRpc {
@@ -285,9 +285,6 @@ enum DisconnectMode {
 
 message DisconnectNotice {
   DisconnectMode disconnectMode = 1;
-}
-
-message DisconnectNoticeResponse {
 }
 
 message ExternalFindDataRequest {

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -10,7 +10,6 @@ import {
 import {
     DisconnectMode,
     DisconnectNotice,
-    DisconnectNoticeResponse,
     LockRequest,
     LockResponse,
     Message,
@@ -144,7 +143,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             (req: LockRequest, context: ServerCallContext) => lockRpcLocal.lockRequest(req, context))
         this.rpcCommunicator.registerRpcNotification(UnlockRequest, 'unlockRequest',
             (req: UnlockRequest, context: ServerCallContext) => lockRpcLocal.unlockRequest(req, context))
-        this.rpcCommunicator.registerRpcMethod(DisconnectNotice, DisconnectNoticeResponse, 'gracefulDisconnect',
+        this.rpcCommunicator.registerRpcNotification(DisconnectNotice, 'gracefulDisconnect',
             (req: DisconnectNotice, context: ServerCallContext) => lockRpcLocal.gracefulDisconnect(req, context))
     }
 

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -7,7 +7,6 @@ import type { ExternalStoreDataRequest } from "./DhtRpc";
 import type { ExternalFindDataResponse } from "./DhtRpc";
 import type { ExternalFindDataRequest } from "./DhtRpc";
 import { ConnectionLockRpc } from "./DhtRpc";
-import type { DisconnectNoticeResponse } from "./DhtRpc";
 import type { DisconnectNotice } from "./DhtRpc";
 import type { UnlockRequest } from "./DhtRpc";
 import type { LockResponse } from "./DhtRpc";
@@ -313,9 +312,9 @@ export interface IConnectionLockRpcClient {
      */
     unlockRequest(input: UnlockRequest, options?: RpcOptions): UnaryCall<UnlockRequest, Empty>;
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, DisconnectNoticeResponse>;
+    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty>;
 }
 /**
  * @generated from protobuf service dht.ConnectionLockRpc
@@ -341,11 +340,11 @@ export class ConnectionLockRpcClient implements IConnectionLockRpcClient, Servic
         return stackIntercept<UnlockRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, DisconnectNoticeResponse> {
+    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty> {
         const method = this.methods[2], opt = this._transport.mergeOptions(options);
-        return stackIntercept<DisconnectNotice, DisconnectNoticeResponse>("unary", this._transport, method, opt, input);
+        return stackIntercept<DisconnectNotice, Empty>("unary", this._transport, method, opt, input);
     }
 }
 /**

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -5,7 +5,6 @@ import { ExternalStoreDataResponse } from "./DhtRpc";
 import { ExternalStoreDataRequest } from "./DhtRpc";
 import { ExternalFindDataResponse } from "./DhtRpc";
 import { ExternalFindDataRequest } from "./DhtRpc";
-import { DisconnectNoticeResponse } from "./DhtRpc";
 import { DisconnectNotice } from "./DhtRpc";
 import { UnlockRequest } from "./DhtRpc";
 import { LockResponse } from "./DhtRpc";
@@ -132,9 +131,9 @@ export interface IConnectionLockRpc<T = ServerCallContext> {
      */
     unlockRequest(request: UnlockRequest, context: T): Promise<Empty>;
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(request: DisconnectNotice, context: T): Promise<DisconnectNoticeResponse>;
+    gracefulDisconnect(request: DisconnectNotice, context: T): Promise<Empty>;
 }
 /**
  * @generated from protobuf service dht.ExternalApiRpc

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -519,11 +519,6 @@ export interface DisconnectNotice {
     disconnectMode: DisconnectMode;
 }
 /**
- * @generated from protobuf message dht.DisconnectNoticeResponse
- */
-export interface DisconnectNoticeResponse {
-}
-/**
  * @generated from protobuf message dht.ExternalFindDataRequest
  */
 export interface ExternalFindDataRequest {
@@ -1093,16 +1088,6 @@ class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
  */
 export const DisconnectNotice = new DisconnectNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DisconnectNoticeResponse$Type extends MessageType$<DisconnectNoticeResponse> {
-    constructor() {
-        super("dht.DisconnectNoticeResponse", []);
-    }
-}
-/**
- * @generated MessageType for protobuf message dht.DisconnectNoticeResponse
- */
-export const DisconnectNoticeResponse = new DisconnectNoticeResponse$Type();
-// @generated message type with reflection information, may provide speed optimized methods
 class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
     constructor() {
         super("dht.ExternalFindDataRequest", [
@@ -1181,7 +1166,7 @@ export const WebrtcConnectorRpc = new ServiceType("dht.WebrtcConnectorRpc", [
 export const ConnectionLockRpc = new ServiceType("dht.ConnectionLockRpc", [
     { name: "lockRequest", options: {}, I: LockRequest, O: LockResponse },
     { name: "unlockRequest", options: {}, I: UnlockRequest, O: Empty },
-    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: DisconnectNoticeResponse }
+    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: Empty }
 ]);
 /**
  * @generated ServiceType for protobuf service dht.ExternalApiRpc

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -7,7 +7,6 @@ import type { ExternalStoreDataRequest } from "./DhtRpc";
 import type { ExternalFindDataResponse } from "./DhtRpc";
 import type { ExternalFindDataRequest } from "./DhtRpc";
 import { ConnectionLockRpc } from "./DhtRpc";
-import type { DisconnectNoticeResponse } from "./DhtRpc";
 import type { DisconnectNotice } from "./DhtRpc";
 import type { UnlockRequest } from "./DhtRpc";
 import type { LockResponse } from "./DhtRpc";
@@ -313,9 +312,9 @@ export interface IConnectionLockRpcClient {
      */
     unlockRequest(input: UnlockRequest, options?: RpcOptions): UnaryCall<UnlockRequest, Empty>;
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, DisconnectNoticeResponse>;
+    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty>;
 }
 /**
  * @generated from protobuf service dht.ConnectionLockRpc
@@ -341,11 +340,11 @@ export class ConnectionLockRpcClient implements IConnectionLockRpcClient, Servic
         return stackIntercept<UnlockRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, DisconnectNoticeResponse> {
+    gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty> {
         const method = this.methods[2], opt = this._transport.mergeOptions(options);
-        return stackIntercept<DisconnectNotice, DisconnectNoticeResponse>("unary", this._transport, method, opt, input);
+        return stackIntercept<DisconnectNotice, Empty>("unary", this._transport, method, opt, input);
     }
 }
 /**

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -5,7 +5,6 @@ import { ExternalStoreDataResponse } from "./DhtRpc";
 import { ExternalStoreDataRequest } from "./DhtRpc";
 import { ExternalFindDataResponse } from "./DhtRpc";
 import { ExternalFindDataRequest } from "./DhtRpc";
-import { DisconnectNoticeResponse } from "./DhtRpc";
 import { DisconnectNotice } from "./DhtRpc";
 import { UnlockRequest } from "./DhtRpc";
 import { LockResponse } from "./DhtRpc";
@@ -132,9 +131,9 @@ export interface IConnectionLockRpc<T = ServerCallContext> {
      */
     unlockRequest(request: UnlockRequest, context: T): Promise<Empty>;
     /**
-     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (dht.DisconnectNoticeResponse);
+     * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
-    gracefulDisconnect(request: DisconnectNotice, context: T): Promise<DisconnectNoticeResponse>;
+    gracefulDisconnect(request: DisconnectNotice, context: T): Promise<Empty>;
 }
 /**
  * @generated from protobuf service dht.ExternalApiRpc

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -519,11 +519,6 @@ export interface DisconnectNotice {
     disconnectMode: DisconnectMode;
 }
 /**
- * @generated from protobuf message dht.DisconnectNoticeResponse
- */
-export interface DisconnectNoticeResponse {
-}
-/**
  * @generated from protobuf message dht.ExternalFindDataRequest
  */
 export interface ExternalFindDataRequest {
@@ -1093,16 +1088,6 @@ class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
  */
 export const DisconnectNotice = new DisconnectNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DisconnectNoticeResponse$Type extends MessageType$<DisconnectNoticeResponse> {
-    constructor() {
-        super("dht.DisconnectNoticeResponse", []);
-    }
-}
-/**
- * @generated MessageType for protobuf message dht.DisconnectNoticeResponse
- */
-export const DisconnectNoticeResponse = new DisconnectNoticeResponse$Type();
-// @generated message type with reflection information, may provide speed optimized methods
 class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
     constructor() {
         super("dht.ExternalFindDataRequest", [
@@ -1181,7 +1166,7 @@ export const WebrtcConnectorRpc = new ServiceType("dht.WebrtcConnectorRpc", [
 export const ConnectionLockRpc = new ServiceType("dht.ConnectionLockRpc", [
     { name: "lockRequest", options: {}, I: LockRequest, O: LockResponse },
     { name: "unlockRequest", options: {}, I: UnlockRequest, O: Empty },
-    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: DisconnectNoticeResponse }
+    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: Empty }
 ]);
 /**
  * @generated ServiceType for protobuf service dht.ExternalApiRpc


### PR DESCRIPTION
Change the response of `gracefulDiconnect` to a notification (it was previously partly treated as a notification).

This is a cherry-pick from https://github.com/streamr-dev/network/pull/2186, i.e. the original author is @ptesavol.