### PR TITLE
fix(dht): Do not send message while `ConnectionManager` is stopping

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -249,7 +249,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     }
 
     public async send(message: Message, opts: SendOptions = DEFAULT_SEND_OPTIONS): Promise<void> {
-        if (this.state === ConnectionManagerState.STOPPED && !opts.sendIfStopped) {
+        if ((this.state === ConnectionManagerState.STOPPED || this.state === ConnectionManagerState.STOPPING) && !opts.sendIfStopped) {
             return
         }
         const peerDescriptor = message.targetDescriptor!


### PR DESCRIPTION
Do not send messages when `ConnectionManager` is in `STOPPING` state.

This is a cherry-pick from https://github.com/streamr-dev/network/pull/2186, i.e. the original author is @ptesavol.