### PR TITLE
refactor(dht): `DhtNodeOptions#peerId` type

### DIFF
--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { DhtNode, NodeType } from '@streamr/dht'
-import { hexToBinary } from '@streamr/utils'
+import { DhtAddress, DhtNode, NodeType, getRawFromDhtAddress } from '@streamr/dht'
 
 const main = async () => {
     const entryPoint = CHAIN_CONFIG.dev2.entryPoints![0]
     const peerDescriptor = {
         ...entryPoint,
-        nodeId: hexToBinary(entryPoint.nodeId),
+        nodeId: getRawFromDhtAddress(entryPoint.nodeId as DhtAddress),
         type: NodeType.NODEJS  // TODO remove this when NET-1070 done
     }
     const dhtNode = new DhtNode({
-        peerId: entryPoint.nodeId,
+        peerId: entryPoint.nodeId as DhtAddress,
         websocketHost: entryPoint.websocket!.host,
         websocketPortRange: {
             min: entryPoint.websocket!.port,

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode } from '../../src/dht/DhtNode'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('Layer 1 on Layer 0 with mocked connections', () => {
@@ -26,22 +26,22 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         layer0EntryPoint = new DhtNode({ peerDescriptor: entrypointDescriptor, websocketServerEnableTls: false })
 
-        const layer0Node1Id = '11'
+        const layer0Node1Id = '11' as DhtAddress
         layer0Node1 = new DhtNode({
             peerId: layer0Node1Id
         })
 
-        const layer0Node2Id = '22'
+        const layer0Node2Id = '22' as DhtAddress
         layer0Node2 = new DhtNode({
             peerId: layer0Node2Id
         })
 
-        const layer0Node3Id = '33'
+        const layer0Node3Id = '33' as DhtAddress
         layer0Node3 = new DhtNode({
             peerId: layer0Node3Id
         })
 
-        const layer0Node4Id = '44'
+        const layer0Node4Id = '44' as DhtAddress
         layer0Node4 = new DhtNode({
             peerId: layer0Node4Id
         })


### PR DESCRIPTION
Changed the type from `string` to `DhtAddress`.

## Future improvements

Do we need both `DhtNode#peerId` and `DhtNode#peerDescriptor` config options?