### PR TITLE
refactor(dht): Rename `DhtNodeOptions#peerId`

### DIFF
--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { DhtNode, NodeType } from '@streamr/dht'
-import { hexToBinary } from '@streamr/utils'
+import { DhtAddress, DhtNode, NodeType, getRawFromDhtAddress } from '@streamr/dht'
 
 const main = async () => {
     const entryPoint = CHAIN_CONFIG.dev2.entryPoints![0]
     const peerDescriptor = {
         ...entryPoint,
-        nodeId: hexToBinary(entryPoint.nodeId),
+        nodeId: getRawFromDhtAddress(entryPoint.nodeId as DhtAddress),
         type: NodeType.NODEJS  // TODO remove this when NET-1070 done
     }
     const dhtNode = new DhtNode({
-        peerId: entryPoint.nodeId,
+        peerId: entryPoint.nodeId as DhtAddress,
         websocketHost: entryPoint.websocket!.host,
         websocketPortRange: {
             min: entryPoint.websocket!.port,

--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -10,7 +10,7 @@ const main = async () => {
         type: NodeType.NODEJS  // TODO remove this when NET-1070 done
     }
     const dhtNode = new DhtNode({
-        peerId: entryPoint.nodeId as DhtAddress,
+        id: entryPoint.nodeId as DhtAddress,
         websocketHost: entryPoint.websocket!.host,
         websocketPortRange: {
             min: entryPoint.websocket!.port,

--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -10,7 +10,7 @@ const main = async () => {
         type: NodeType.NODEJS  // TODO remove this when NET-1070 done
     }
     const dhtNode = new DhtNode({
-        id: entryPoint.nodeId as DhtAddress,
+        nodeId: entryPoint.nodeId as DhtAddress,
         websocketHost: entryPoint.websocket!.host,
         websocketPortRange: {
             min: entryPoint.websocket!.port,

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -75,7 +75,7 @@ export interface DhtNodeOptions {
     websocketHost?: string
     websocketPortRange?: PortRange
     websocketServerEnableTls?: boolean
-    id?: DhtAddress
+    nodeId?: DhtAddress
 
     rpcRequestTimeout?: number
     iceServers?: IceServer[]
@@ -106,7 +106,7 @@ type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
     'networkConnectivityTimeout' |
     'storageRedundancyFactor' |
     'metricsContext' |
-    'id'>
+    'nodeId'>
 
 const logger = new Logger(module)
 
@@ -165,7 +165,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             networkConnectivityTimeout: 10000,
             storageRedundancyFactor: 5,
             metricsContext: new MetricsContext(),
-            id: createRandomDhtAddress()
+            nodeId: createRandomDhtAddress()
         }, conf)
         this.localDataStore = new LocalDataStore(this.config.storeMaxTtl) 
         this.send = this.send.bind(this)
@@ -400,7 +400,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.config.peerDescriptor) {
             this.localPeerDescriptor = this.config.peerDescriptor
         } else {
-            this.localPeerDescriptor = createPeerDescriptor(connectivityResponse, this.config.id)
+            this.localPeerDescriptor = createPeerDescriptor(connectivityResponse, this.config.nodeId)
         }
         return this.localPeerDescriptor
     }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -113,20 +113,20 @@ const logger = new Logger(module)
 export type Events = TransportEvents & DhtNodeEvents
 
 export const createPeerDescriptor = (msg?: ConnectivityResponse, nodeId?: DhtAddress): PeerDescriptor => {
-    let nodeIdRAw: DhtAddressRaw
+    let nodeIdRaw: DhtAddressRaw
     if ((nodeId === undefined) && (msg !== undefined)) {
-        nodeIdRAw = new Uint8Array(20)
+        nodeIdRaw = new Uint8Array(20)
         const ipNum = msg.host.split('.').map((octet, index, array) => {
             return parseInt(octet) * Math.pow(256, (array.length - index - 1))
         }).reduce((prev, curr) => prev + curr)
-        const view = new DataView(nodeIdRAw.buffer)
+        const view = new DataView(nodeIdRaw.buffer)
         view.setInt32(0, ipNum)
-        nodeIdRAw.set((new UUID()).value, 4)
+        nodeIdRaw.set((new UUID()).value, 4)
     } else {
-        nodeIdRAw = getRawFromDhtAddress(nodeId!)
+        nodeIdRaw = getRawFromDhtAddress(nodeId!)
     }
     const nodeType = isBrowserEnvironment() ? NodeType.BROWSER : NodeType.NODEJS
-    const ret: PeerDescriptor = { nodeId: nodeIdRAw, type: nodeType }
+    const ret: PeerDescriptor = { nodeId: nodeIdRaw, type: nodeType }
     if (msg && msg.websocket) {
         ret.websocket = { host: msg.websocket.host, port: msg.websocket.port, tls: msg.websocket.tls }
     }

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -32,7 +32,7 @@ function shuffleArray<T>(array: T[]): T[] {
 
 describe('SortedContactListBenchmark', () => {
 
-    it('adds ' + NUM_ADDS + ' random peerIDs', async () => {
+    it('adds ' + NUM_ADDS + ' random nodeIds', async () => {
         const randomIds = []
         for (let i = 0; i < NUM_ADDS; i++) {
             randomIds.push(createRandomItem(i))

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -2,8 +2,7 @@
 
 import KBucket from 'k-bucket'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
-import crypto from 'crypto'
-import { DhtAddress, DhtAddressRaw, getDhtAddressFromRaw } from '../../src/identifiers'
+import { DhtAddress, DhtAddressRaw, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
 
 const NUM_ADDS = 1000
 
@@ -14,10 +13,11 @@ interface Item {
 }
 
 const createRandomItem = (index: number): Item => {
-    const rand = new Uint8Array(crypto.randomBytes(20))
+    const nodeId = createRandomDhtAddress()
+    const nodeIdRaw = getRawFromDhtAddress(nodeId)
     return {
-        getNodeId: () => getDhtAddressFromRaw(rand),
-        id: rand,
+        getNodeId: () => nodeId,
+        id: nodeIdRaw,
         vectorClock: index
     }
 }
@@ -38,7 +38,7 @@ describe('SortedContactListBenchmark', () => {
             randomIds.push(createRandomItem(i))
         }
         const list = new SortedContactList({
-            referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+            referenceId: createRandomDhtAddress(),
             allowToContainReferenceId: true,
             emitEvents: true
         })
@@ -50,7 +50,7 @@ describe('SortedContactListBenchmark', () => {
         console.timeEnd('SortedContactList.addContact() with emitEvents=true')
 
         const list2 = new SortedContactList({
-            referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+            referenceId: createRandomDhtAddress(),
             allowToContainReferenceId: true,
             emitEvents: false
         })
@@ -61,7 +61,7 @@ describe('SortedContactListBenchmark', () => {
         }
         console.timeEnd('SortedContactList.addContact() with emitEvents=false')
 
-        const kBucket = new KBucket<Item>({ localNodeId: crypto.randomBytes(20) })
+        const kBucket = new KBucket<Item>({ localNodeId: getRawFromDhtAddress(createRandomDhtAddress()) })
         console.time('KBucket.add()')
         for (let i = 0; i < NUM_ADDS; i++) {
             kBucket.add(randomIds[i])
@@ -77,14 +77,14 @@ describe('SortedContactListBenchmark', () => {
 
         console.time('kBucket closest()')
         for (let i = 0; i < NUM_ADDS; i++) {
-            kBucket.closest(crypto.randomBytes(20), 20)
+            kBucket.closest(getRawFromDhtAddress(createRandomDhtAddress()), 20)
         }
         console.timeEnd('kBucket closest()')
 
         console.time('SortedContactList.getClosestContacts() with emitEvents=true')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+                referenceId: createRandomDhtAddress(),
                 allowToContainReferenceId: true,
                 emitEvents: true
             })
@@ -98,7 +98,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+                referenceId: createRandomDhtAddress(),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })
@@ -112,7 +112,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false and lodash')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+                referenceId: createRandomDhtAddress(),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })
@@ -126,7 +126,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() with emitEvents=false and addContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: getDhtAddressFromRaw(crypto.randomBytes(20)),
+                referenceId: createRandomDhtAddress(),
                 allowToContainReferenceId: true,
                 emitEvents: false
             })
@@ -140,10 +140,10 @@ describe('SortedContactListBenchmark', () => {
         const shuffled = shuffleArray(kBucket.toArray())
         console.time('kbucket add and closest')
         for (let i = 0; i < NUM_ADDS; i++) {
-            const bucket2 = new KBucket<Item>({ localNodeId: crypto.randomBytes(20) })
+            const bucket2 = new KBucket<Item>({ localNodeId: getRawFromDhtAddress(createRandomDhtAddress()) })
 
             shuffled.forEach((contact) => bucket2.add(contact))
-            bucket2.closest(crypto.randomBytes(20), 20)
+            bucket2.closest(getRawFromDhtAddress(createRandomDhtAddress()), 20)
         }
         console.timeEnd('kbucket add and closest')
 

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -28,50 +28,50 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         const layer0Node1Id = '11' as DhtAddress
         layer0Node1 = new DhtNode({
-            id: layer0Node1Id
+            nodeId: layer0Node1Id
         })
 
         const layer0Node2Id = '22' as DhtAddress
         layer0Node2 = new DhtNode({
-            id: layer0Node2Id
+            nodeId: layer0Node2Id
         })
 
         const layer0Node3Id = '33' as DhtAddress
         layer0Node3 = new DhtNode({
-            id: layer0Node3Id
+            nodeId: layer0Node3Id
         })
 
         const layer0Node4Id = '44' as DhtAddress
         layer0Node4 = new DhtNode({
-            id: layer0Node4Id
+            nodeId: layer0Node4Id
         })
 
         layer1EntryPoint = new DhtNode({
-            id: getNodeIdFromPeerDescriptor(entrypointDescriptor),
+            nodeId: getNodeIdFromPeerDescriptor(entrypointDescriptor),
             transport: layer0EntryPoint,
             serviceId: 'layer1'
         })
 
         layer1Node1 = new DhtNode({
-            id: layer0Node1Id,
+            nodeId: layer0Node1Id,
             transport: layer0Node1,
             serviceId: 'layer1'
         })
 
         layer1Node2 = new DhtNode({
-            id: layer0Node2Id,
+            nodeId: layer0Node2Id,
             transport: layer0Node2,
             serviceId: 'layer1'
         })
 
         layer1Node3 = new DhtNode({
-            id: layer0Node3Id,
+            nodeId: layer0Node3Id,
             transport: layer0Node3,
             serviceId: 'layer1'
         })
 
         layer1Node4 = new DhtNode({
-            id: layer0Node4Id,
+            nodeId: layer0Node4Id,
             transport: layer0Node4,
             serviceId: 'layer1'
         })

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -28,50 +28,50 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         const layer0Node1Id = '11' as DhtAddress
         layer0Node1 = new DhtNode({
-            peerId: layer0Node1Id
+            id: layer0Node1Id
         })
 
         const layer0Node2Id = '22' as DhtAddress
         layer0Node2 = new DhtNode({
-            peerId: layer0Node2Id
+            id: layer0Node2Id
         })
 
         const layer0Node3Id = '33' as DhtAddress
         layer0Node3 = new DhtNode({
-            peerId: layer0Node3Id
+            id: layer0Node3Id
         })
 
         const layer0Node4Id = '44' as DhtAddress
         layer0Node4 = new DhtNode({
-            peerId: layer0Node4Id
+            id: layer0Node4Id
         })
 
         layer1EntryPoint = new DhtNode({
-            peerId: getNodeIdFromPeerDescriptor(entrypointDescriptor),
+            id: getNodeIdFromPeerDescriptor(entrypointDescriptor),
             transport: layer0EntryPoint,
             serviceId: 'layer1'
         })
 
         layer1Node1 = new DhtNode({
-            peerId: layer0Node1Id,
+            id: layer0Node1Id,
             transport: layer0Node1,
             serviceId: 'layer1'
         })
 
         layer1Node2 = new DhtNode({
-            peerId: layer0Node2Id,
+            id: layer0Node2Id,
             transport: layer0Node2,
             serviceId: 'layer1'
         })
 
         layer1Node3 = new DhtNode({
-            peerId: layer0Node3Id,
+            id: layer0Node3Id,
             transport: layer0Node3,
             serviceId: 'layer1'
         })
 
         layer1Node4 = new DhtNode({
-            peerId: layer0Node4Id,
+            id: layer0Node4Id,
             transport: layer0Node4,
             serviceId: 'layer1'
         })

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode } from '../../src/dht/DhtNode'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('Layer 1 on Layer 0 with mocked connections', () => {
@@ -26,22 +26,22 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         layer0EntryPoint = new DhtNode({ peerDescriptor: entrypointDescriptor, websocketServerEnableTls: false })
 
-        const layer0Node1Id = '11'
+        const layer0Node1Id = '11' as DhtAddress
         layer0Node1 = new DhtNode({
             peerId: layer0Node1Id
         })
 
-        const layer0Node2Id = '22'
+        const layer0Node2Id = '22' as DhtAddress
         layer0Node2 = new DhtNode({
             peerId: layer0Node2Id
         })
 
-        const layer0Node3Id = '33'
+        const layer0Node3Id = '33' as DhtAddress
         layer0Node3 = new DhtNode({
             peerId: layer0Node3Id
         })
 
-        const layer0Node4Id = '44'
+        const layer0Node4Id = '44' as DhtAddress
         layer0Node4 = new DhtNode({
             peerId: layer0Node4Id
         })

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -19,7 +19,7 @@ describe('memory leak', () => {
             }
         })
         let entryPoint: DhtNode | undefined = new DhtNode({
-            peerId: getNodeIdFromPeerDescriptor(entryPointDescriptor),
+            id: getNodeIdFromPeerDescriptor(entryPointDescriptor),
             websocketHost: entryPointDescriptor.websocket!.host,
             websocketPortRange: {
                 min: entryPointDescriptor.websocket!.port,

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -19,7 +19,7 @@ describe('memory leak', () => {
             }
         })
         let entryPoint: DhtNode | undefined = new DhtNode({
-            id: getNodeIdFromPeerDescriptor(entryPointDescriptor),
+            nodeId: getNodeIdFromPeerDescriptor(entryPointDescriptor),
             websocketHost: entryPointDescriptor.websocket!.host,
             websocketPortRange: {
                 min: entryPointDescriptor.websocket!.port,

--- a/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
+++ b/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
@@ -31,7 +31,7 @@ describe('DhtClientRpcTransport', () => {
         const client = toProtoRpcClient(new DhtRpcServiceClient(rpcCommunicator.getRpcClientTransport()))
 
         const peerDescriptor: PeerDescriptor = {
-            peerId: new Uint8Array([56, 59, 77]),
+            nodeId: new Uint8Array([56, 59, 77]),
             type: NodeType.NODEJS
         }
         const res = await client.getClosestPeers({ peerDescriptor, requestId: '1' })

--- a/packages/proto-rpc/test/proto/TestProtos.ts
+++ b/packages/proto-rpc/test/proto/TestProtos.ts
@@ -98,9 +98,9 @@ export interface ClosestPeersResponse {
  */
 export interface PeerDescriptor {
     /**
-     * @generated from protobuf field: bytes peerId = 1;
+     * @generated from protobuf field: bytes nodeId = 1;
      */
-    peerId: Uint8Array;
+    nodeId: Uint8Array;
     /**
      * @generated from protobuf field: NodeType type = 2;
      */
@@ -233,7 +233,7 @@ export const ClosestPeersResponse = new ClosestPeersResponse$Type();
 class PeerDescriptor$Type extends MessageType<PeerDescriptor> {
     constructor() {
         super("PeerDescriptor", [
-            { no: 1, name: "peerId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 1, name: "nodeId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "type", kind: "enum", T: () => ["NodeType", NodeType] },
             { no: 3, name: "udp", kind: "message", T: () => ConnectivityMethod },
             { no: 4, name: "tcp", kind: "message", T: () => ConnectivityMethod },

--- a/packages/proto-rpc/test/protos/TestProtos.proto
+++ b/packages/proto-rpc/test/protos/TestProtos.proto
@@ -42,7 +42,7 @@ message ClosestPeersResponse {
   }
 
 message PeerDescriptor {
-    bytes peerId = 1;
+    bytes nodeId = 1;
     NodeType type = 2;
     ConnectivityMethod udp = 3;
     ConnectivityMethod tcp = 4;

--- a/packages/proto-rpc/test/utils.ts
+++ b/packages/proto-rpc/test/utils.ts
@@ -73,19 +73,19 @@ export const generateId = (stringId: string): Uint8Array => {
 
 export const getMockPeers = (): PeerDescriptor[] => {
     const n1: PeerDescriptor = {
-        peerId: generateId('Neighbor1'),
+        nodeId: generateId('Neighbor1'),
         type: NodeType.NODEJS,
     }
     const n2: PeerDescriptor = {
-        peerId: generateId('Neighbor2'),
+        nodeId: generateId('Neighbor2'),
         type: NodeType.NODEJS,
     }
     const n3: PeerDescriptor = {
-        peerId: generateId('Neighbor3'),
+        nodeId: generateId('Neighbor3'),
         type: NodeType.NODEJS,
     }
     const n4: PeerDescriptor = {
-        peerId: generateId('Neighbor4'),
+        nodeId: generateId('Neighbor4'),
         type: NodeType.NODEJS,
     }
     return [


### PR DESCRIPTION
Renamed `DhtNodeOptions#peerId` to `nodeId` as that config option controls the id of the node (could be just `id` if there we had only few config options in `DhtNodeOptions`).

Also renamed `PeerDescritor#peerId` -> `nodeId` in `TestProtos` so that it is consistent with the `dht` package.