### PR TITLE
refactor(dht): `ConnectionID` as branded string

### DIFF
--- a/packages/dht/src/connection/Connection.ts
+++ b/packages/dht/src/connection/Connection.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'eventemitter3'
 import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionID, ConnectionType, ConnectionEvents } from './IConnection'
+import { v4 as uuid } from 'uuid'
 
 export class Connection extends EventEmitter<ConnectionEvents> {
     public connectionId: ConnectionID
@@ -9,7 +10,7 @@ export class Connection extends EventEmitter<ConnectionEvents> {
     
     constructor(connectionType: ConnectionType) {
         super()
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
         this.connectionType = connectionType
     }
 
@@ -20,4 +21,8 @@ export class Connection extends EventEmitter<ConnectionEvents> {
     getPeerDescriptor(): PeerDescriptor | undefined {
         return this.peerDescriptor
     }
+}
+
+export const createRandomConnectionId = (): ConnectionID => {
+    return uuid() as ConnectionID
 }

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -357,7 +357,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         const nodeId = getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!)
         logger.trace(nodeId + ' onDisconnected() gracefulLeave: ' + gracefulLeave)
         const storedConnection = this.connections.get(nodeId)
-        if (storedConnection && storedConnection.connectionId.equals(connection.connectionId)) {
+        if (storedConnection && (storedConnection.connectionId === connection.connectionId)) {
             this.locks.clearAllLocks(nodeId)
             this.connections.delete(nodeId)
             logger.trace(nodeId + ' deleted connection in onDisconnected() gracefulLeave: ' + gracefulLeave)
@@ -366,8 +366,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         } else {
             logger.trace(nodeId + ' onDisconnected() did nothing, no such connection in connectionManager')
             if (storedConnection) {
-                const connectionId = storedConnection.connectionId.toString()
-                logger.trace(nodeId + ' connectionIds do not match ' + connectionId + ' ' + connection.connectionId.toString())
+                logger.trace(nodeId + ' connectionIds do not match ' + storedConnection.connectionId + ' ' + connection.connectionId.toString())
             }
         }
     }

--- a/packages/dht/src/connection/IConnection.ts
+++ b/packages/dht/src/connection/IConnection.ts
@@ -1,4 +1,4 @@
-import { UUID } from '../helpers/UUID'
+import { BrandedString } from '@streamr/utils'
 
 export interface ConnectionEvents {
     data: (bytes: Uint8Array) => void
@@ -15,13 +15,7 @@ export enum ConnectionType {
     SIMULATOR_CLIENT = 'simulator-client',
 }
 
-export type ConnectionIDKey = string & { readonly __brand: 'connectionIDKey' } // Nominal typing 
-
-export class ConnectionID extends UUID {
-    toMapKey(): ConnectionIDKey {
-        return this.toString() as ConnectionIDKey
-    }
-}
+export type ConnectionID = BrandedString<'ConnectionID'>
 
 export interface IConnection {
     

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -6,6 +6,7 @@ import { Logger, runAndRaceEvents3, RunAndRaceEventsReturnType } from '@streamr/
 import EventEmitter from 'eventemitter3'
 import { getNodeIdOrUnknownFromPeerDescriptor } from './ConnectionManager'
 import { DhtAddress, getNodeIdFromPeerDescriptor } from '../identifiers'
+import { createRandomConnectionId } from './Connection'
 
 export interface ManagedConnectionEvents {
     managedData: (bytes: Uint8Array, remotePeerDescriptor: PeerDescriptor) => void
@@ -58,7 +59,7 @@ export class ManagedConnection extends EventEmitter<Events> {
         this.outgoingConnection = outgoingConnection
         this.incomingConnection = incomingConnection
         this.connectionType = connectionType
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
 
         this.send = this.send.bind(this)
         this.onDisconnected = this.onDisconnected.bind(this)

--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -3,6 +3,7 @@ import { WebrtcConnectionEvents, IWebrtcConnection, RtcDescription } from './IWe
 import { IConnection, ConnectionID, ConnectionEvents, ConnectionType } from '../IConnection'
 import { Logger } from '@streamr/utils'
 import { IceServer } from './WebrtcConnector'
+import { createRandomConnectionId } from '../Connection'
 
 const logger = new Logger(module)
 
@@ -34,7 +35,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
     constructor(params: Params) {
         super()
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
         this.iceServers = params.iceServers ?? []
     }
 
@@ -222,7 +223,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
         this.emit('connected')
     }
 
-    public setConnectionId(connectionID: string): void {
-        this.connectionId = new ConnectionID(connectionID)
+    public setConnectionId(connectionId: ConnectionID): void {
+        this.connectionId = connectionId
     }
 }

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -9,6 +9,7 @@ import { iceServerAsString } from './iceServerAsString'
 import { IceServer } from './WebrtcConnector'
 import { PortRange } from '../ConnectionManager'
 import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { createRandomConnectionId } from '../Connection'
 
 const logger = new Logger(module)
 
@@ -67,7 +68,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     constructor(params: Params) {
         super()
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
         this.iceServers = params.iceServers ?? []
         // eslint-disable-next-line no-underscore-dangle
         this._bufferThresholdHigh = params.bufferThresholdHigh ?? 2 ** 17
@@ -253,7 +254,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
         return !this.closed && this.lastState === 'connected' && !!this.dataChannel
     }
 
-    public setConnectionId(connectionID: string): void {
-        this.connectionId = new ConnectionID(connectionID)
+    public setConnectionId(connectionId: ConnectionID): void {
+        this.connectionId = connectionId
     }
 }

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -177,16 +177,16 @@ export class WebrtcConnector {
                 candidate = replaceInternalIpWithExternalIp(candidate, this.config.externalIp)
                 logger.debug(`onLocalCandidate injected external ip ${candidate} ${mid}`)
             }
-            remoteConnector.sendIceCandidate(candidate, mid, connection.connectionId.toString())
+            remoteConnector.sendIceCandidate(candidate, mid, connection.connectionId)
         })
 
         if (offering) {
             connection.once('localDescription', (description: string) => {
-                remoteConnector.sendRtcOffer(description, connection.connectionId.toString())
+                remoteConnector.sendRtcOffer(description, connection.connectionId)
             })
         } else {
             connection.once('localDescription', (description: string) => {
-                remoteConnector.sendRtcAnswer(description, connection.connectionId.toString())
+                remoteConnector.sendRtcAnswer(description, connection.connectionId)
             })
         }
 

--- a/packages/dht/src/connection/websocket/ClientWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ClientWebsocket.ts
@@ -2,6 +2,7 @@ import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 import { ICloseEvent, IMessageEvent, w3cwebsocket as Websocket } from 'websocket'
 import { ConnectionEvents, ConnectionID, ConnectionType, IConnection } from '../IConnection'
+import { createRandomConnectionId } from '../Connection'
 
 const logger = new Logger(module)
 
@@ -24,7 +25,7 @@ export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements I
 
     constructor() {
         super()
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
     }
 
     // TODO explicit default value for "selfSigned" or make it required
@@ -95,7 +96,7 @@ export class ClientWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.emit('disconnected', gracefulLeave, undefined, 'close() called')
         this.removeAllListeners()
         if (!this.destroyed) {
-            logger.trace(`Closing socket for connection ${this.connectionId.toString()}`)
+            logger.trace(`Closing socket for connection ${this.connectionId}`)
             this.socket?.close(gracefulLeave ? CUSTOM_GOING_AWAY : undefined)
         } else {
             logger.debug('Tried to close() a stopped connection')

--- a/packages/dht/src/connection/websocket/ServerWebsocket.ts
+++ b/packages/dht/src/connection/websocket/ServerWebsocket.ts
@@ -4,6 +4,7 @@ import { Message, connection as WsConnection } from 'websocket'
 import { Logger } from '@streamr/utils'
 import { Url } from 'url'
 import { CUSTOM_GOING_AWAY, GOING_AWAY } from './ClientWebsocket'
+import { createRandomConnectionId } from '../Connection'
 
 const logger = new Logger(module)
 
@@ -34,7 +35,7 @@ export class ServerWebsocket extends EventEmitter<ConnectionEvents> implements I
         this.onError = this.onError.bind(this)
 
         this.resourceURL = resourceURL
-        this.connectionId = new ConnectionID()
+        this.connectionId = createRandomConnectionId()
 
         socket.on('message', this.onMessage)
         socket.on('close', this.onClose)


### PR DESCRIPTION
Previously `ConnectionID` extended the `UUID` class, which we'll remove in a separate PR.