### PR TITLE
ci: run eslint & versions & check separately from build phase

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -30,6 +30,7 @@ jobs:
       - name: build (cached)
         uses: ./.github/workflows/reusable/cached-build
       - run: npm run check
+        working-directory: 'packages/${{ inputs.package }}'
       - name: start docker services
         if: ${{ inputs.docker-services != '' }}
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: build (cached)
         uses: ./.github/workflows/reusable/cached-build
+      - run: npm run check
       - name: start docker services
         if: ${{ inputs.docker-services != '' }}
         uses: streamr-dev/streamr-docker-dev-action@v1.0.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         uses: ./.github/workflows/reusable/cached-build
-      - run: npm run check
-  eslint:
+  lint:
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,9 +21,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: build
         uses: ./.github/workflows/reusable/cached-build
-      - run: npm run versions
       - run: npm run check
+  eslint:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build (cached)
+        uses: ./.github/workflows/reusable/cached-build
       - run: npm run eslint
+      - run: npm run versions
   test-utils:
     needs: build
     uses: ./.github/workflows/test-setup.yml


### PR DESCRIPTION
## Summary

Increase parallelization of CI validation run by spinning off linting (and `npm run versions`) into its own job and running `npm run check` on each individual package in each package's own test run.

Currently this saves around 30 seconds to 1 minute in total wait time. If we implement eslint rules that require type-information in the future (very likely) the eslint runs will become much slower warranting the need for this change even more. 

## Limitations and future improvements

- `npm run check` gets run multiple time for packages that have multiple test jobs defined. This is a _minor_ issue imo since the command's run time is negligible and I feel like making an optional argument for excluding the run would introduce more complexity than is worth. 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
