### PR TITLE
fix(DHT): NET-1242 fix flaky `integration/find.test.ts`

### DIFF
--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -5,7 +5,7 @@ import { createMockConnectionDhtNode, waitConnectionManagersReadyForTesting } fr
 import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
 
 const NUM_NODES = 100
-const K = 4
+const K = 8
 
 describe('Find correctness', () => {
 


### PR DESCRIPTION
## Summary

Fix the flaky test by increasing the number of nodes per K bucket to the production value of 8. This causes the test to take 2-3x longer to run but the network is in a much more stable state once the find operations are attempted.