### PR TITLE
refactor: Remove `utf-8` argument

### DIFF
--- a/packages/broker/test/unit/ConfigWizard.test.ts
+++ b/packages/broker/test/unit/ConfigWizard.test.ts
@@ -120,7 +120,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -183,7 +183,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -256,7 +256,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -346,7 +346,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -404,7 +404,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -466,7 +466,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -528,7 +528,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -591,7 +591,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -654,7 +654,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -721,7 +721,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -794,7 +794,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -904,7 +904,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -981,7 +981,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -1043,7 +1043,7 @@ describe('Config wizard', () => {
 
         expect(existsSync(storagePath)).toBe(true)
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -1057,7 +1057,7 @@ describe('Config wizard', () => {
     it('overwrites the existing config file if told to', async () => {
         writeFileSync(storagePath, '{"FOOBAR":true}')
 
-        let config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        let config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             FOOBAR: true,
@@ -1085,7 +1085,7 @@ describe('Config wizard', () => {
 
         expect(existsSync(storagePath)).toBe(true)
 
-        config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -1099,7 +1099,7 @@ describe('Config wizard', () => {
     it('allows to change the storage location if the one they initially picked is taken', async () => {
         writeFileSync(storagePath, '{"FOOBAR":true}')
 
-        let config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        let config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             FOOBAR: true,
@@ -1131,13 +1131,13 @@ describe('Config wizard', () => {
             otherStoragePath,
         ])
 
-        config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             FOOBAR: true,
         })
 
-        config = JSON.parse(readFileSync(otherStoragePath).toString('utf-8'))
+        config = JSON.parse(readFileSync(otherStoragePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -1184,7 +1184,7 @@ describe('Config wizard', () => {
             storagePath,
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config).toMatchObject({
             client: {
@@ -1460,7 +1460,7 @@ describe('Config wizard', () => {
             Step.storage({ type: storagePath }, 'enter'),
         ])
 
-        const config = JSON.parse(readFileSync(storagePath).toString('utf-8'))
+        const config = JSON.parse(readFileSync(storagePath).toString())
 
         expect(config.apiAuthentication.keys).toEqual([
             'NWViZWNiY2Y1YWRmNGZjNjllOTk2MzFlOGU2NGNjOWI',

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -51,7 +51,7 @@ export async function* startCommand(commandLine: string, opts?: StartCommandOpti
 async function* lines(src: AsyncIterable<Buffer>): AsyncGenerator<string, any, any> {
     let buffer = ''
     for await (const chunk of src) {
-        buffer += chunk.toString('utf-8')
+        buffer += chunk.toString()
         while (true) {
             const delimeterPos = buffer.indexOf('\n')
             if (delimeterPos === -1) {

--- a/packages/client/src/utils/signingUtils.ts
+++ b/packages/client/src/utils/signingUtils.ts
@@ -19,7 +19,7 @@ const keccak = new Keccak(256)
 
 function hash(message: Uint8Array) {
     const prefixString = SIGN_MAGIC + message.length
-    const merged = Buffer.concat([Buffer.from(prefixString, 'utf-8'), message])
+    const merged = Buffer.concat([Buffer.from(prefixString), message])
     keccak.reset()
     keccak.update(merged)
     return keccak.digest('binary')

--- a/packages/utils/test/lengthPrefixFrameUtils.test.ts
+++ b/packages/utils/test/lengthPrefixFrameUtils.test.ts
@@ -5,7 +5,7 @@ describe('LengthPrefixedFrameUtils', () => {
 
     describe('toLengthPrefixedFrame', () => {
         it('prefixes length to payload', () => {
-            const payload = Buffer.from('Hello, world!', 'utf-8')
+            const payload = Buffer.from('Hello, world!')
             const frame = toLengthPrefixedFrame(payload)
             expect(frame.readUInt32BE(0)).toBe(payload.length)
             expect(frame.subarray(4)).toEqual(payload)
@@ -27,7 +27,7 @@ describe('LengthPrefixedFrameUtils', () => {
         })
 
         it('can decode a single frame', (done) => {
-            const payload = Buffer.from('Hello, world!', 'utf-8')
+            const payload = Buffer.from('Hello, world!')
             const frame = toLengthPrefixedFrame(payload)
 
             decoder.on('data', (data: Buffer) => {
@@ -39,8 +39,8 @@ describe('LengthPrefixedFrameUtils', () => {
         })
 
         it('can decode multiple frames in one chunk', (done) => {
-            const payload1 = Buffer.from('Hello, world!', 'utf-8')
-            const payload2 = Buffer.from('Goodbye, world!', 'utf-8')
+            const payload1 = Buffer.from('Hello, world!')
+            const payload2 = Buffer.from('Goodbye, world!')
             const chunk = Buffer.concat([
                 toLengthPrefixedFrame(payload1),
                 toLengthPrefixedFrame(payload2)
@@ -61,7 +61,7 @@ describe('LengthPrefixedFrameUtils', () => {
         })
 
         it('can decode a frame split across multiple chunks', (done) => {
-            const payload = Buffer.from('Hello, world!', 'utf-8')
+            const payload = Buffer.from('Hello, world!')
             const frame = toLengthPrefixedFrame(payload)
 
             decoder.on('data', (data: Buffer) => {
@@ -75,8 +75,8 @@ describe('LengthPrefixedFrameUtils', () => {
         })
 
         it('can decode multiple frames split across multiple chunks', (done) => {
-            const payload1 = Buffer.from('Hello, world!', 'utf-8')
-            const payload2 = Buffer.from('Goodbye, world!', 'utf-8')
+            const payload1 = Buffer.from('Hello, world!')
+            const payload2 = Buffer.from('Goodbye, world!')
             const frame1 = toLengthPrefixedFrame(payload1)
             const frame2 = toLengthPrefixedFrame(payload2)
 
@@ -99,7 +99,7 @@ describe('LengthPrefixedFrameUtils', () => {
         })
 
         it('can ignore an incomplete frame when stream ends', (done) => {
-            const payload = Buffer.from('Hello, world!', 'utf-8')
+            const payload = Buffer.from('Hello, world!')
             const frame = toLengthPrefixedFrame(payload)
 
             decoder.on('data', (data: Buffer) => {


### PR DESCRIPTION
No need to pass `utf-8` as an argument as it is the default value.