### PR TITLE
protocol: make `encryptionType` field mandatory

### DIFF
--- a/packages/broker/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/broker/test/integration/plugins/storage/Storage.test.ts
@@ -40,7 +40,8 @@ export function buildMsg({
         messageId: new MessageID(toStreamID(streamId), streamPartition, timestamp, sequenceNumber, publisherId, msgChainId),
         content: Buffer.from(utf8ToBinary(JSON.stringify(content))),
         signature: Buffer.from(hexToBinary('0x1234')),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 

--- a/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/broker/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -5,7 +5,7 @@ import { Readable, PassThrough } from 'stream'
 import { Storage } from '../../../../src/plugins/storage/Storage'
 import { startCassandraStorage } from '../../../../src/plugins/storage/Storage'
 import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
-import { ContentType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
 import { convertBytesToStreamMessage } from '@streamr/trackerless-network'
 
 const contactPoints = [STREAMR_DOCKER_DEV_HOST]
@@ -22,7 +22,8 @@ const createMockMessage = (i: number) => {
             value: i
         })),
         signature: hexToBinary('0x1234'),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 const MOCK_MESSAGES = [1, 2, 3].map((contentValue: number) => createMockMessage(contentValue))

--- a/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
+++ b/packages/broker/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
@@ -3,7 +3,7 @@ import toArray from 'stream-to-array'
 import { BucketId } from '../../../../src/plugins/storage/Bucket'
 import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
 import { startCassandraStorage, Storage } from '../../../../src/plugins/storage/Storage'
-import { ContentType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { hexToBinary, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
 
@@ -64,7 +64,8 @@ async function storeMockMessages({
             ),
             content: utf8ToBinary(JSON.stringify({})),
             signature: hexToBinary('0x1234'),
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
         storePromises.push(storage.store(msg))
     }

--- a/packages/broker/test/unit/plugins/storage/dataQueryEndpoint.test.ts
+++ b/packages/broker/test/unit/plugins/storage/dataQueryEndpoint.test.ts
@@ -9,7 +9,7 @@ import {
 import { toObject } from '../../../../src/plugins/storage/DataQueryFormat'
 import { Storage } from '../../../../src/plugins/storage/Storage'
 import { Readable } from 'stream'
-import { ContentType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
 import { MetricsContext, toEthereumAddress, hexToBinary, utf8ToBinary, toLengthPrefixedFrame } from '@streamr/utils'
 import { convertStreamMessageToBytes } from '@streamr/trackerless-network'
 
@@ -39,7 +39,8 @@ describe('dataQueryEndpoint', () => {
             ),
             content: utf8ToBinary(JSON.stringify(content)),
             signature: hexToBinary('0x1234'),
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
     }
 

--- a/packages/client/test/integration/Subscriber2.test.ts
+++ b/packages/client/test/integration/Subscriber2.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { ContentType, MessageID, StreamID, StreamMessage } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamID, StreamMessage } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { Defer, collect, waitForCondition, utf8ToBinary } from '@streamr/utils'
 import sample from 'lodash/sample'
@@ -54,7 +54,8 @@ describe('Subscriber', () => {
             messageId: new MessageID(streamId, 0, timestamp, 0, await publisher.getAddress(), 'msgChainId'),
             content,
             authentication: publisherAuthentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE,
         })
     }
 

--- a/packages/client/test/integration/waitForStorage.test.ts
+++ b/packages/client/test/integration/waitForStorage.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 
 import { toEthereumAddress } from '@streamr/utils'
-import { MessageID, ContentType } from '@streamr/protocol'
+import { MessageID, ContentType, EncryptionType } from '@streamr/protocol'
 import { Authentication } from '../../src/Authentication'
 import { StreamPermission } from '../../src/permission'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
@@ -71,7 +71,8 @@ describe('waitForStorage', () => {
             messageId: new MessageID(stream.id, 0, Date.now(), 0, PUBLISHER_ID, 'msgChainId'),
             content: MOCK_CONTENT,
             authentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         }))
         await expect(() => client.waitForStorage(msg, {
             interval: 50,
@@ -88,7 +89,8 @@ describe('waitForStorage', () => {
             messageId: new MessageID(stream.id, 0, Date.now(), 0, PUBLISHER_ID, 'msgChainId'),
             content: MOCK_CONTENT,
             authentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         }))
         await expect(() => client.waitForStorage(msg, {
             messageMatchFn: () => {

--- a/packages/client/test/unit/GapFiller.test.ts
+++ b/packages/client/test/unit/GapFiller.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, MessageID, MessageRef, StreamMessage, StreamPartIDUtils } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, MessageRef, StreamMessage, StreamPartIDUtils } from '@streamr/protocol'
 import { Defer, EthereumAddress, toEthereumAddress, wait, waitForCondition, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import { OrderedMessageChain } from '../../src/subscribe/ordering/OrderedMessageChain'
 import { GapFiller, GapFillStrategy } from '../../src/subscribe/ordering/GapFiller'
@@ -25,7 +25,8 @@ const createMessage = (timestamp: number, hasPrevRef = true) => {
         prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : null,
         content: utf8ToBinary('{}'),
         signature: hexToBinary('0x1324'),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE,
     })
 }
 

--- a/packages/client/test/unit/MessageStream.test.ts
+++ b/packages/client/test/unit/MessageStream.test.ts
@@ -1,5 +1,5 @@
 import { toEthereumAddress, utf8ToBinary } from '@streamr/utils'
-import { ContentType, MessageID, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, toStreamID } from '@streamr/protocol'
 import { Authentication } from '../../src/Authentication'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
 import { MessageStream } from '../../src/subscribe/MessageStream'
@@ -20,7 +20,8 @@ describe('MessageStream', () => {
             messageId: new MessageID(streamId, 0, 0, 0, PUBLISHER_ID, 'msgChainId'),
             content: utf8ToBinary(JSON.stringify(Msg())),
             authentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
     }
 

--- a/packages/client/test/unit/OrderMessages.test.ts
+++ b/packages/client/test/unit/OrderMessages.test.ts
@@ -1,4 +1,14 @@
-import { ContentType, MessageID, MessageRef, StreamID, StreamMessage, StreamPartID, StreamPartIDUtils, toStreamID } from '@streamr/protocol'
+import {
+    ContentType,
+    EncryptionType,
+    MessageID,
+    MessageRef,
+    StreamID,
+    StreamMessage,
+    StreamPartID,
+    StreamPartIDUtils,
+    toStreamID
+} from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { EthereumAddress, collect, waitForCondition, hexToBinary } from '@streamr/utils'
 import last from 'lodash/last'
@@ -47,7 +57,8 @@ const createMessage = (timestamp: number) => {
         prevMsgRef: new MessageRef(timestamp - 1000, 0),
         content: MOCK_CONTENT,
         signature: hexToBinary('0x1234'),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 

--- a/packages/client/test/unit/OrderMessages2.test.ts
+++ b/packages/client/test/unit/OrderMessages2.test.ts
@@ -1,5 +1,5 @@
 import {
-    ContentType,
+    ContentType, EncryptionType,
     MessageID,
     MessageRef,
     StreamMessage,
@@ -93,7 +93,8 @@ function createMsg({ publisherId, timestamp }: MessageInfo): StreamMessage {
         prevMsgRef,
         content: MOCK_CONTENT,
         signature: hexToBinary('0x1234'),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 

--- a/packages/client/test/unit/OrderedMessageChain.test.ts
+++ b/packages/client/test/unit/OrderedMessageChain.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, MessageID, MessageRef, StreamMessage, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, MessageRef, StreamMessage, toStreamID } from '@streamr/protocol'
 import { toEthereumAddress, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import { Gap, OrderedMessageChain } from '../../src/subscribe/ordering/OrderedMessageChain'
 
@@ -12,7 +12,8 @@ const createMessage = (timestamp: number, hasPrevRef = true) => {
         prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : null,
         content: utf8ToBinary('{}'),
         signature: hexToBinary('0x1234'),
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 

--- a/packages/client/test/unit/PushPipeline.test.ts
+++ b/packages/client/test/unit/PushPipeline.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamMessage, toStreamID } from '@streamr/protocol'
 import { collect, toEthereumAddress, wait, utf8ToBinary } from '@streamr/utils'
 import { Authentication } from '../../src/Authentication'
 import { createSignedMessage } from '../../src/publish/MessageFactory'
@@ -22,7 +22,8 @@ describe('PushPipeline', () => {
             messageId: new MessageID(streamId, 0, 0, 0, PUBLISHER_ID, 'msgChainId'),
             content: utf8ToBinary(JSON.stringify(Msg())),
             authentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
     }
 
@@ -87,7 +88,8 @@ describe('PushPipeline', () => {
             messageId: new MessageID(streamId, 0, 1, 0, PUBLISHER_ID, 'msgChainId'),
             content: utf8ToBinary(JSON.stringify(testMessage)),
             authentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
         leaksDetector.add('streamMessage', streamMessage)
         const s = new PushPipeline<StreamMessage>()

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { ContentType, MessageID, StreamMessage, StreamPartIDUtils, toStreamID } from '@streamr/protocol'
+import { ContentType, EncryptionType, MessageID, StreamMessage, StreamPartIDUtils, toStreamID } from '@streamr/protocol'
 import { randomEthereumAddress, startTestServer } from '@streamr/test-utils'
 import { collect, toLengthPrefixedFrame } from '@streamr/utils'
 import range from 'lodash/range'
@@ -63,7 +63,8 @@ describe('Resends', () => {
                     messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisherId, ''),
                     content: MOCK_CONTENT,
                     signature: hexToBinary('0x1234'),
-                    contentType: ContentType.JSON
+                    contentType: ContentType.JSON,
+                    encryptionType: EncryptionType.NONE
                 })
                 res.write(toLengthPrefixedFrame(convertStreamMessageToBytes(msg)))
             }

--- a/packages/client/test/unit/messagePipeline.test.ts
+++ b/packages/client/test/unit/messagePipeline.test.ts
@@ -51,6 +51,7 @@ describe('messagePipeline', () => {
             content: opts.contentType === ContentType.BINARY ? opts.content! : utf8ToBinary(JSON.stringify(CONTENT)),
             authentication: createPrivateKeyAuthentication(publisher.privateKey, undefined as any),
             contentType: opts.contentType ?? ContentType.JSON,
+            encryptionType: EncryptionType.NONE,
             ...opts
         })
     }

--- a/packages/client/test/unit/validateStreamMessage2.test.ts
+++ b/packages/client/test/unit/validateStreamMessage2.test.ts
@@ -10,7 +10,7 @@ import {
     toStreamID,
     serializeGroupKeyRequest,
     serializeGroupKeyResponse,
-    StreamMessageType
+    StreamMessageType, EncryptionType
 } from '@streamr/protocol'
 import { EthereumAddress, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import assert from 'assert'
@@ -36,6 +36,7 @@ const groupKeyMessageToStreamMessage = async (
             ? StreamMessageType.GROUP_KEY_REQUEST
             : StreamMessageType.GROUP_KEY_RESPONSE,
         contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE,
         authentication
     })
 }
@@ -85,7 +86,8 @@ describe('Validator2', () => {
             messageId: new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'),
             content: MOCK_CONTENT,
             authentication: publisherAuthentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
 
         msgWithNewGroupKey = await createSignedMessage({
@@ -93,7 +95,8 @@ describe('Validator2', () => {
             content: MOCK_CONTENT,
             newGroupKey: new EncryptedGroupKey('groupKeyId', hexToBinary('0x1111')),
             authentication: publisherAuthentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
         assert.notStrictEqual(msg.signature, msgWithNewGroupKey.signature)
 
@@ -102,7 +105,8 @@ describe('Validator2', () => {
             content: MOCK_CONTENT,
             prevMsgRef: new MessageRef(1000, 0),
             authentication: publisherAuthentication,
-            contentType: ContentType.JSON
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE
         })
         assert.notStrictEqual(msg.signature, msgWithPrevMsgRef.signature)
 

--- a/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/client/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -1,6 +1,6 @@
 import { waitForAssignmentsToPropagate } from '../../src/utils/waitForAssignmentsToPropagate'
 import {
-    ContentType,
+    ContentType, EncryptionType,
     MessageID,
     StreamID,
     StreamMessage,
@@ -21,7 +21,8 @@ async function makeMsg(ts: number, content: unknown): Promise<StreamMessage> {
         messageId: new MessageID(toStreamID('assignmentStreamId'), 0, ts, 0, await authentication.getAddress(), 'msgChain'),
         content: utf8ToBinary(JSON.stringify(content)),
         authentication,
-        contentType: ContentType.JSON
+        contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE
     })
 }
 

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -33,7 +33,7 @@ export interface StreamMessageOptions {
     content: Uint8Array
     messageType?: StreamMessageType
     contentType: ContentType
-    encryptionType?: EncryptionType
+    encryptionType: EncryptionType
     groupKeyId?: string | null
     newGroupKey?: EncryptedGroupKey | null
     signature: Uint8Array
@@ -85,7 +85,7 @@ export default class StreamMessage {
         content,
         messageType = StreamMessageType.MESSAGE,
         contentType,
-        encryptionType = EncryptionType.NONE,
+        encryptionType,
         groupKeyId = null,
         newGroupKey = null,
         signature,

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -62,6 +62,7 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: utf8ToBinary(JSON.stringify(content)),
                 contentType: ContentType.JSON,
+                encryptionType: EncryptionType.NONE,
                 signature
             })
             assert.strictEqual(streamMessage.getStreamId(), 'streamId')
@@ -85,6 +86,7 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: new Uint8Array([1, 2, 3]),
                 contentType: ContentType.BINARY,
+                encryptionType: EncryptionType.NONE,
                 signature
             })
             assert.strictEqual(streamMessage.getStreamId(), 'streamId')
@@ -108,6 +110,7 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: utf8ToBinary(JSON.stringify(content)),
                 contentType: ContentType.JSON,
+                encryptionType: EncryptionType.NONE,
                 signature
             })
             expect(StreamMessage.isAESEncrypted(streamMessage)).toBe(false)
@@ -245,6 +248,7 @@ describe('StreamMessage', () => {
                 messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
                 content: utf8ToBinary(JSON.stringify(content)),
                 contentType: ContentType.JSON,
+                encryptionType: EncryptionType.NONE,
                 signature
             })
             const streamMessageClone = streamMessage.clone()

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -1,8 +1,16 @@
 /* eslint-disable no-console */
 
-import { DhtNode, LatencyType, Simulator, getNodeIdFromPeerDescriptor, getRandomRegion } from '@streamr/dht'
+import {
+    DhtNode,
+    getNodeIdFromPeerDescriptor,
+    getRandomRegion,
+    LatencyType,
+    PeerDescriptor,
+    Simulator
+} from '@streamr/dht'
 import {
     ContentType,
+    EncryptionType,
     MessageID,
     StreamMessage,
     StreamMessageType,
@@ -13,7 +21,6 @@ import {
 } from '@streamr/protocol'
 import { hexToBinary, utf8ToBinary, waitForEvent3 } from '@streamr/utils'
 import fs from 'fs'
-import { PeerDescriptor } from '@streamr/dht'
 import { NetworkNode } from '../../src/NetworkNode'
 import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
 import { createMockPeerDescriptor, createNetworkNodeWithSimulator } from '../utils/utils'
@@ -93,6 +100,7 @@ const measureJoiningTime = async () => {
             })),
             messageType: StreamMessageType.MESSAGE,
             contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE,
             signature: hexToBinary('0x1234'),
         })
         streamParts.get(stream)!.broadcast(streamMessage)

--- a/packages/trackerless-network/test/end-to-end/inspect.test.ts
+++ b/packages/trackerless-network/test/end-to-end/inspect.test.ts
@@ -1,4 +1,12 @@
-import { ContentType, MessageID, MessageRef, StreamMessage, StreamMessageType, StreamPartIDUtils } from '@streamr/protocol'
+import {
+    ContentType,
+    EncryptionType,
+    MessageID,
+    MessageRef,
+    StreamMessage,
+    StreamMessageType,
+    StreamPartIDUtils
+} from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { hexToBinary, utf8ToBinary, waitForCondition } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
@@ -53,6 +61,7 @@ describe('inspect', () => {
         })),
         messageType: StreamMessageType.MESSAGE,
         contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE,
         signature: hexToBinary('0x1234'),
     })
     

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -1,4 +1,13 @@
-import { ContentType, MessageID, MessageRef, StreamMessage, StreamMessageType, StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
+import {
+    ContentType,
+    EncryptionType,
+    MessageID,
+    MessageRef,
+    StreamMessage,
+    StreamMessageType,
+    StreamPartID,
+    StreamPartIDUtils
+} from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { hexToBinary, utf8ToBinary, waitForEvent3 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
@@ -23,6 +32,7 @@ const createMessage = (streamPartId: StreamPartID): StreamMessage => {
         })),
         messageType: StreamMessageType.MESSAGE,
         contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE,
         signature: hexToBinary('0x1234'),
     })
 }

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -1,4 +1,12 @@
-import { ContentType, MessageID, MessageRef, StreamMessage, StreamMessageType, StreamPartIDUtils } from '@streamr/protocol'
+import {
+    ContentType,
+    EncryptionType,
+    MessageID,
+    MessageRef,
+    StreamMessage,
+    StreamMessageType,
+    StreamPartIDUtils
+} from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { hexToBinary, utf8ToBinary, wait, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
@@ -24,6 +32,7 @@ const MESSAGE = new StreamMessage({
         hello: 'world'
     })),
     messageType: StreamMessageType.MESSAGE,
+    encryptionType: EncryptionType.NONE,
     signature: hexToBinary('0x1234'),
     contentType: ContentType.JSON
 })

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -1,6 +1,6 @@
 import { NodeType, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import {
-    ContentType,
+    ContentType, EncryptionType,
     MessageID,
     MessageRef,
     StreamMessage,
@@ -81,6 +81,7 @@ describe('NetworkNode', () => {
             })),
             contentType: ContentType.JSON,
             messageType: StreamMessageType.MESSAGE,
+            encryptionType: EncryptionType.NONE,
             signature: hexToBinary('0x1234'),
         })
 

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -1,6 +1,6 @@
 import { LatencyType, NodeType, PeerDescriptor, Simulator, SimulatorTransport, getRandomRegion } from '@streamr/dht'
 import {
-    ContentType,
+    ContentType, EncryptionType,
     MessageID,
     MessageRef,
     StreamMessage,
@@ -41,6 +41,7 @@ describe('stream without default entrypoints', () => {
         })),
         messageType: StreamMessageType.MESSAGE,
         contentType: ContentType.JSON,
+        encryptionType: EncryptionType.NONE,
         signature: hexToBinary('0x1234'),
     })
 


### PR DESCRIPTION
## Summary

Make `encryptionType` field mandatory in `StreamMessage` constructor. This allows us to get rid of a default value assumption in #2283. Also it could be argued that there is no natural default value.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
