### PR TITLE
refactor: "Immutable" `StreamMessage`

### DIFF
--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -1,5 +1,5 @@
 import crypto, { CipherKey } from 'crypto'
-import { EncryptionType, StreamMessage, StreamMessageError } from '@streamr/protocol'
+import { EncryptedGroupKey, EncryptionType, StreamMessage, StreamMessageError } from '@streamr/protocol'
 import { GroupKey } from './GroupKey'
 
 export class DecryptError extends StreamMessageError {
@@ -73,7 +73,7 @@ export class EncryptionUtil {
             ...streamMessage,
             content,
             encryptionType: EncryptionType.NONE,
-            newGroupKey: newGroupKey !== undefined ? { groupKeyId: newGroupKey.id, data: newGroupKey.data } : null,
+            newGroupKey: newGroupKey?.toEncryptedGroupKey() ?? null
         })
     }
 }

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -1,5 +1,5 @@
 import crypto, { CipherKey } from 'crypto'
-import { EncryptionType, StreamMessage, StreamMessageAESEncrypted, StreamMessageError } from '@streamr/protocol'
+import { StreamMessage, StreamMessageAESEncrypted, StreamMessageError } from '@streamr/protocol'
 import { GroupKey } from './GroupKey'
 
 export class DecryptError extends StreamMessageError {

--- a/packages/client/src/encryption/EncryptionUtil.ts
+++ b/packages/client/src/encryption/EncryptionUtil.ts
@@ -1,5 +1,5 @@
 import crypto, { CipherKey } from 'crypto'
-import { EncryptedGroupKey, EncryptionType, StreamMessage, StreamMessageError } from '@streamr/protocol'
+import { EncryptionType, StreamMessage, StreamMessageError } from '@streamr/protocol'
 import { GroupKey } from './GroupKey'
 
 export class DecryptError extends StreamMessageError {

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -60,10 +60,6 @@ export class GroupKey {
         }
     }
 
-    toEncryptedGroupKey(): EncryptedGroupKey {
-        return new EncryptedGroupKey(this.id, this.data)
-    }
-
     static generate(id = uuid('GroupKey')): GroupKey {
         const keyBytes = crypto.randomBytes(32)
         return new GroupKey(id, keyBytes)

--- a/packages/client/src/encryption/GroupKey.ts
+++ b/packages/client/src/encryption/GroupKey.ts
@@ -60,6 +60,10 @@ export class GroupKey {
         }
     }
 
+    toEncryptedGroupKey(): EncryptedGroupKey {
+        return new EncryptedGroupKey(this.id, this.data)
+    }
+
     static generate(id = uuid('GroupKey')): GroupKey {
         const keyBytes = crypto.randomBytes(32)
         return new GroupKey(id, keyBytes)

--- a/packages/client/src/encryption/decrypt.ts
+++ b/packages/client/src/encryption/decrypt.ts
@@ -31,14 +31,15 @@ export const decrypt = async (
     if (destroySignal.isDestroyed()) {
         return streamMessage
     }
-    const clone = streamMessage.clone()
-    EncryptionUtil.decryptStreamMessage(clone, groupKey)
-    if (streamMessage.newGroupKey) {
-        // newGroupKey has been converted into GroupKey
+    const decryptedStreamMessage = EncryptionUtil.decryptStreamMessage(streamMessage, groupKey)
+    if (decryptedStreamMessage.newGroupKey) {
         await groupKeyManager.addKeyToLocalStore(
-            clone.newGroupKey as unknown as GroupKey,
+            new GroupKey(
+                decryptedStreamMessage.newGroupKey.groupKeyId,
+                Buffer.from(decryptedStreamMessage.newGroupKey.data)
+            ),
             streamMessage.getPublisherId()
         )
     }
-    return clone
+    return decryptedStreamMessage
 }

--- a/packages/client/test/benchmarks/raw-pipeline.js
+++ b/packages/client/test/benchmarks/raw-pipeline.js
@@ -7,6 +7,7 @@ const { KeyServer } = require('@streamr/test-utils')
 
 // eslint-disable-next-line import/no-unresolved
 const StreamrClient = require('../../dist')
+const { StreamMessage } = require('@streamr/protocol')
 
 const { StorageNode, ConfigTest: clientOptions } = StreamrClient
 
@@ -114,7 +115,7 @@ async function run() {
         try {
             for (const streamMessage of streamMessages) {
                 // clone because pipeline mutates messages
-                const msg = streamMessage.clone()
+                const msg = new StreamMessage(streamMessage)
                 node.emit('streamr:node:unseen-message-received', msg)
             }
         } catch (err) {
@@ -228,4 +229,3 @@ run().catch((err) => {
     log(err)
     process.exit(1)
 })
-

--- a/packages/client/test/integration/update-encryption-key.test.ts
+++ b/packages/client/test/integration/update-encryption-key.test.ts
@@ -70,8 +70,7 @@ describe('update encryption key', () => {
         expect(msg2!.content).toEqual({
             mockId: 2
         })
-        // @ts-expect-error the type definition defines that newGroupKey EncryptedGroupKey (see EncryptionUtil:82)
-        expect(msg2!.streamMessage.newGroupKey!.id).toBe(rotatedKey.id)
+        expect(msg2!.streamMessage.newGroupKey!.groupKeyId).toBe(rotatedKey.id)
 
         await publisher.publish(streamPartId, {
             mockId: 3

--- a/packages/client/test/unit/Decrypt.test.ts
+++ b/packages/client/test/unit/Decrypt.test.ts
@@ -1,14 +1,43 @@
 import 'reflect-metadata'
 
-import { StreamPartIDUtils, StreamMessageAESEncrypted } from '@streamr/protocol'
+import { StreamPartIDUtils, StreamMessageAESEncrypted, StreamMessage, EncryptionType } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { DestroySignal } from '../../src/DestroySignal'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { decrypt } from '../../src/encryption/decrypt'
 import { createGroupKeyManager, createMockMessage } from '../test-utils/utils'
 import { createPrivateKeyAuthentication } from '../../src/Authentication'
+import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
+import { mock } from 'jest-mock-extended'
+import { utf8ToBinary } from '@streamr/utils'
 
 describe('Decrypt', () => {
+
+    it('happy path', async () => {
+        const groupKey = GroupKey.generate()
+        const groupKeyManager = mock<GroupKeyManager>()
+        groupKeyManager.fetchKey.mockResolvedValueOnce(groupKey)
+        const destroySignal = new DestroySignal()
+        // using Buffer to get around Jest's strict equality check
+        const unencryptedContent = Buffer.from(utf8ToBinary(JSON.stringify({ hello: 'world' })))
+        const encryptedMessage = await createMockMessage({
+            streamPartId: StreamPartIDUtils.parse('stream#0'),
+            publisher: fastWallet(),
+            encryptionKey: groupKey,
+            content: unencryptedContent
+        }) as StreamMessageAESEncrypted
+        const decryptedMessage = await decrypt(encryptedMessage, groupKeyManager, destroySignal)
+        expect(decryptedMessage).toEqual(new StreamMessage({
+            ...encryptedMessage,
+            encryptionType: EncryptionType.NONE,
+            content: unencryptedContent
+        }))
+        expect(groupKeyManager.fetchKey).toBeCalledWith(
+            encryptedMessage.getStreamPartID(),
+            encryptedMessage.groupKeyId,
+            encryptedMessage.getPublisherId()
+        )
+    })
 
     it('group key not available: timeout while waiting', async () => {
         const wallet = fastWallet()

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -51,12 +51,12 @@ describe('EncryptionUtil', () => {
             encryptionKey: key,
             nextEncryptionKey: nextKey
         })
-        EncryptionUtil.decryptStreamMessage(streamMessage, key)
+        const decryptedStreamMessage = EncryptionUtil.decryptStreamMessage(streamMessage, key)
         // Coparing this way as jest does not like comparing buffers to Uint8Arrays
-        expect(binaryToUtf8(streamMessage.content)).toStrictEqual('{"foo":"bar"}')
-        expect(streamMessage.encryptionType).toStrictEqual(EncryptionType.NONE)
-        expect(streamMessage.groupKeyId).toBe(key.id)
-        expect(streamMessage.newGroupKey).toEqual(nextKey)
+        expect(binaryToUtf8(decryptedStreamMessage.content)).toStrictEqual('{"foo":"bar"}')
+        expect(decryptedStreamMessage.encryptionType).toStrictEqual(EncryptionType.NONE)
+        expect(decryptedStreamMessage.groupKeyId).toBe(key.id)
+        expect(decryptedStreamMessage.newGroupKey).toEqual(nextKey.toEncryptedGroupKey())
     })
 
     it('StreamMessage decryption throws if newGroupKey invalid', async () => {

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -1,6 +1,7 @@
 import {
     EncryptedGroupKey,
     EncryptionType,
+    StreamMessage,
     StreamPartIDUtils,
     toStreamID,
     toStreamPartID
@@ -65,11 +66,10 @@ describe('EncryptionUtil', () => {
             streamPartId: toStreamPartID(STREAM_ID, 0),
             encryptionKey: key
         })
-        msg.newGroupKey = {
-            groupKeyId: 'mockId',
-            data: hexToBinary('0x1234'),
-            serialized: ''
-        } as EncryptedGroupKey
-        expect(() => EncryptionUtil.decryptStreamMessage(msg, key)).toThrow('Could not decrypt new group key')
+        const msg2 = new StreamMessage({
+            ...msg,
+            newGroupKey: new EncryptedGroupKey('mockId', hexToBinary('0x1234'))
+        })
+        expect(() => EncryptionUtil.decryptStreamMessage(msg2, key)).toThrow('Could not decrypt new group key')
     })
 })

--- a/packages/client/test/unit/EncryptionUtil.test.ts
+++ b/packages/client/test/unit/EncryptionUtil.test.ts
@@ -1,7 +1,7 @@
 import {
     EncryptedGroupKey,
-    EncryptionType,
     StreamMessage,
+    StreamMessageAESEncrypted,
     StreamPartIDUtils,
     toStreamID,
     toStreamPartID
@@ -50,13 +50,11 @@ describe('EncryptionUtil', () => {
             },
             encryptionKey: key,
             nextEncryptionKey: nextKey
-        })
-        const decryptedStreamMessage = EncryptionUtil.decryptStreamMessage(streamMessage, key)
+        }) as StreamMessageAESEncrypted
+        const [content, newGroupKey] = EncryptionUtil.decryptStreamMessage(streamMessage, key)
         // Coparing this way as jest does not like comparing buffers to Uint8Arrays
-        expect(binaryToUtf8(decryptedStreamMessage.content)).toStrictEqual('{"foo":"bar"}')
-        expect(decryptedStreamMessage.encryptionType).toStrictEqual(EncryptionType.NONE)
-        expect(decryptedStreamMessage.groupKeyId).toBe(key.id)
-        expect(decryptedStreamMessage.newGroupKey).toEqual(nextKey.toEncryptedGroupKey())
+        expect(binaryToUtf8(content)).toStrictEqual('{"foo":"bar"}')
+        expect(newGroupKey).toEqual(nextKey)
     })
 
     it('StreamMessage decryption throws if newGroupKey invalid', async () => {
@@ -69,7 +67,7 @@ describe('EncryptionUtil', () => {
         const msg2 = new StreamMessage({
             ...msg,
             newGroupKey: new EncryptedGroupKey('mockId', hexToBinary('0x1234'))
-        })
+        }) as StreamMessageAESEncrypted
         expect(() => EncryptionUtil.decryptStreamMessage(msg2, key)).toThrow('Could not decrypt new group key')
     })
 })

--- a/packages/client/test/unit/messagePipeline.test.ts
+++ b/packages/client/test/unit/messagePipeline.test.ts
@@ -142,8 +142,11 @@ describe('messagePipeline', () => {
     })
 
     it('error: invalid signature', async () => {
-        const msg = await createMessage()
-        msg.signature = hexToBinary('0x111111')
+        const originalMsg = await createMessage()
+        const msg = new StreamMessage({
+            ...originalMsg,
+            signature: hexToBinary('0x111111')
+        })
         await pipeline.push(msg)
         pipeline.endWrite()
         const onError = jest.fn()

--- a/packages/client/test/unit/validateStreamMessage.test.ts
+++ b/packages/client/test/unit/validateStreamMessage.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from '@ethersproject/wallet'
 import { EthereumAddress, toEthereumAddress, hexToBinary } from '@streamr/utils'
-import { toStreamID, toStreamPartID } from '@streamr/protocol'
+import { StreamMessage, toStreamID, toStreamPartID } from '@streamr/protocol'
 import { fastWallet } from '@streamr/test-utils'
 import { StreamRegistry } from '../../src/registry/StreamRegistry'
 import { Stream } from '../../src/Stream'
@@ -17,12 +17,15 @@ interface MessageOptions {
 }
 
 const validate = async (messageOptions: MessageOptions) => {
-    const msg = await createMockMessage({
+    let msg = await createMockMessage({
         streamPartId: toStreamPartID(toStreamID('streamId'), messageOptions.partition ?? 0),
         publisher: messageOptions.publisher ?? publisherWallet,
     })
     if (messageOptions.signature !== undefined) {
-        msg.signature = messageOptions.signature
+        msg = new StreamMessage({
+            ...msg,
+            signature: messageOptions.signature
+        })
     }
     const streamRegistry: Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'> = {
         getStream: async (): Promise<Stream> => ({

--- a/packages/client/test/unit/validateStreamMessage2.test.ts
+++ b/packages/client/test/unit/validateStreamMessage2.test.ts
@@ -156,27 +156,36 @@ describe('Validator2', () => {
         })
 
         it('rejects invalid signatures', async () => {
-            msg.signature = Buffer.from(msg.signature).reverse()
+            const invalidMsg = new StreamMessage({
+                ...msg,
+                signature: Buffer.from(msg.signature).reverse()
+            })
 
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
+            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 return true
             })
         })
 
         it('rejects tampered content', async () => {
-            msg.content = utf8ToBinary('{"attack":true}')
+            const invalidMsg = new StreamMessage({
+                ...msg,
+                content: utf8ToBinary('{"attack":true}')
+            })
 
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
+            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 return true
             })
         })
 
         it('rejects tampered newGroupKey', async () => {
-            msgWithNewGroupKey.newGroupKey = new EncryptedGroupKey('foo', msgWithNewGroupKey.newGroupKey!.data)
+            const invalidMsg = new StreamMessage({
+                ...msg,
+                newGroupKey: new EncryptedGroupKey('foo', msgWithNewGroupKey.newGroupKey!.data)
+            })
 
-            await assert.rejects(getValidator().validate(msgWithNewGroupKey), (err: Error) => {
+            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 return true
             })
@@ -227,9 +236,12 @@ describe('Validator2', () => {
         })
 
         it('rejects invalid signatures', async () => {
-            groupKeyRequest.signature = Buffer.from(groupKeyRequest.signature).reverse()
+            const invalidGroupKeyRequest = new StreamMessage({
+                ...groupKeyRequest,
+                signature: Buffer.from(groupKeyRequest.signature).reverse()
+            })
 
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
+            await assert.rejects(getValidator().validate(invalidGroupKeyRequest), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 return true
             })
@@ -282,9 +294,12 @@ describe('Validator2', () => {
         })
 
         it('rejects invalid signatures', async () => {
-            groupKeyResponse.signature = Buffer.from(groupKeyResponse.signature).reverse()
+            const invalidGroupKeyResponse = new StreamMessage({
+                ...groupKeyResponse,
+                signature: Buffer.from(groupKeyResponse.signature).reverse()
+            })
 
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
+            await assert.rejects(getValidator().validate(invalidGroupKeyResponse), (err: Error) => {
                 assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
                 return true
             })

--- a/packages/protocol/src/protocol/message_layer/MessageID.ts
+++ b/packages/protocol/src/protocol/message_layer/MessageID.ts
@@ -44,15 +44,4 @@ export default class MessageID {
     toMessageRef(): MessageRef {
         return new MessageRef(this.timestamp, this.sequenceNumber)
     }
-
-    clone(): MessageID {
-        return new MessageID(
-            this.streamId,
-            this.streamPartition,
-            this.timestamp,
-            this.sequenceNumber,
-            this.publisherId,
-            this.msgChainId
-        )
-    }
 }

--- a/packages/protocol/src/protocol/message_layer/MessageRef.ts
+++ b/packages/protocol/src/protocol/message_layer/MessageRef.ts
@@ -27,8 +27,4 @@ export default class MessageRef {
         }
         return 0
     }
-
-    clone(): MessageRef {
-        return new MessageRef(this.timestamp, this.sequenceNumber)
-    }
 }

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -63,12 +63,12 @@ export default class StreamMessage implements StreamMessageOptions {
     readonly prevMsgRef: MessageRef | null
     readonly messageType: StreamMessageType
     readonly contentType: ContentType
-    encryptionType: EncryptionType
-    groupKeyId: string | null
-    newGroupKey: EncryptedGroupKey | null
-    signature: Uint8Array
-    signatureType: SignatureType
-    content: Uint8Array
+    readonly encryptionType: EncryptionType
+    readonly groupKeyId: string | null
+    readonly newGroupKey: EncryptedGroupKey | null
+    readonly signature: Uint8Array
+    readonly signatureType: SignatureType
+    readonly content: Uint8Array
 
     constructor({
         messageId,

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -35,14 +35,14 @@ export enum SignatureType {
 export interface StreamMessageOptions {
     messageId: MessageID
     prevMsgRef?: MessageRef | null
-    content: Uint8Array
     messageType?: StreamMessageType
+    content: Uint8Array
     contentType: ContentType
+    signature: Uint8Array
+    signatureType: SignatureType
     encryptionType: EncryptionType
     groupKeyId?: string | null
     newGroupKey?: EncryptedGroupKey | null
-    signature: Uint8Array
-    signatureType: SignatureType
 }
 
 /**
@@ -62,25 +62,25 @@ export default class StreamMessage implements StreamMessageOptions {
     readonly messageId: MessageID
     readonly prevMsgRef: MessageRef | null
     readonly messageType: StreamMessageType
+    readonly content: Uint8Array
     readonly contentType: ContentType
+    readonly signature: Uint8Array
+    readonly signatureType: SignatureType
     readonly encryptionType: EncryptionType
     readonly groupKeyId: string | null
     readonly newGroupKey: EncryptedGroupKey | null
-    readonly signature: Uint8Array
-    readonly signatureType: SignatureType
-    readonly content: Uint8Array
 
     constructor({
         messageId,
         prevMsgRef = null,
-        content,
         messageType = StreamMessageType.MESSAGE,
+        content,
         contentType,
+        signature,
+        signatureType,
         encryptionType,
         groupKeyId = null,
         newGroupKey = null,
-        signature,
-        signatureType,
     }: StreamMessageOptions) {
         validateIsType('messageId', messageId, 'MessageID', MessageID)
         this.messageId = messageId

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -53,7 +53,7 @@ export type StreamMessageAESEncrypted = StreamMessage & {
     groupKeyId: string
 }
 
-export default class StreamMessage {
+export default class StreamMessage implements StreamMessageOptions {
     private static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessageType))
     private static VALID_CONTENT_TYPES = new Set(Object.values(ContentType))
     private static VALID_ENCRYPTIONS = new Set(Object.values(EncryptionType))
@@ -69,24 +69,6 @@ export default class StreamMessage {
     signature: Uint8Array
     signatureType: SignatureType
     content: Uint8Array
-
-    /**
-     * Create a new StreamMessage identical to the passed-in streamMessage.
-     */
-    clone(): StreamMessage {
-        return new StreamMessage({
-            messageId: this.messageId.clone(),
-            prevMsgRef: this.prevMsgRef ? this.prevMsgRef.clone() : null,
-            content: this.content,
-            messageType: this.messageType,
-            contentType: this.contentType,
-            encryptionType: this.encryptionType,
-            groupKeyId: this.groupKeyId,
-            newGroupKey: this.newGroupKey,
-            signature: this.signature,
-            signatureType: this.signatureType,
-        })
-    }
 
     constructor({
         messageId,

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -275,5 +275,33 @@ describe('StreamMessage', () => {
                 })
             })
         })
+
+        describe('copy constructor', () => {
+            it('can nullify fields', () => {
+                const message = new StreamMessage({
+                    messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
+                    content: new Uint8Array([1, 2, 3, 4, 5]),
+                    contentType: ContentType.BINARY,
+                    encryptionType: EncryptionType.AES,
+                    signatureType: SignatureType.SECP256K1,
+                    signature,
+                    groupKeyId: 'foo',
+                    newGroupKey: new EncryptedGroupKey('bar', new Uint8Array([1, 2, 3])),
+                    prevMsgRef: new MessageRef(1564046332168, 5),
+                })
+                const copyWithFieldsNullified = new StreamMessage({
+                    ...message,
+                    encryptionType: EncryptionType.NONE,
+                    groupKeyId: null,
+                    newGroupKey: null,
+                    prevMsgRef: null,
+                })
+                expect(copyWithFieldsNullified.messageId).toEqual(message.messageId)
+                expect(copyWithFieldsNullified.encryptionType).toEqual(EncryptionType.NONE)
+                expect(copyWithFieldsNullified.groupKeyId).toEqual(null)
+                expect(copyWithFieldsNullified.newGroupKey).toEqual(null)
+                expect(copyWithFieldsNullified.prevMsgRef).toEqual(null)
+            })
+        })
     })
 })

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -276,38 +276,4 @@ describe('StreamMessage', () => {
             })
         })
     })
-
-    describe('clone', () => {
-        it('works', () => {
-            const streamMessage = new StreamMessage({
-                messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
-                content: utf8ToBinary(JSON.stringify(content)),
-                contentType: ContentType.JSON,
-                encryptionType: EncryptionType.NONE,
-                signatureType: SignatureType.SECP256K1,
-                signature
-            })
-            const streamMessageClone = streamMessage.clone()
-            expect(streamMessageClone).not.toBe(streamMessage)
-        })
-
-        it('works with encrypted messages', () => {
-            const encryptedMessage = new StreamMessage({
-                messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
-                content: utf8ToBinary(JSON.stringify(content)),
-                contentType: ContentType.JSON,
-                signature,
-                encryptionType: EncryptionType.RSA,
-                signatureType: SignatureType.SECP256K1,
-                prevMsgRef: new MessageRef(1564046332168, 5),
-            })
-            const streamMessageClone = encryptedMessage.clone()
-            expect(streamMessageClone).not.toBe(encryptedMessage)
-            expect(streamMessageClone.messageId).not.toBe(encryptedMessage.messageId)
-            expect(streamMessageClone.prevMsgRef).not.toBe(encryptedMessage.prevMsgRef)
-            expect(encryptedMessage.encryptionType).toEqual(EncryptionType.RSA)
-            expect(streamMessageClone.encryptionType).toEqual(EncryptionType.RSA)
-            expect(streamMessageClone.encryptionType).toEqual(encryptedMessage.encryptionType)
-        })
-    })
 })


### PR DESCRIPTION
## Summary

- Make all fields of `StreamMessage` readonly (hinting towards but not necessarily enforcing immutability)
- Remove `StreamMessage#clone` prefer copy constructor pattern

## Limitations and future improvements
- There is a small risk of something breaking here but based on analysis of code this shouldn't occur. Basically after decryption we used to put the decrypted key in `newGroupKey` (against the type definition), now we fixed the code so that this doesn't happen which affects behavior but is more in line with the type system.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
