### PR TITLE
fix: attempt to fix flaky test storage-node.test.ts

### DIFF
--- a/packages/cli-tools/test/storage-node.test.ts
+++ b/packages/cli-tools/test/storage-node.test.ts
@@ -2,6 +2,7 @@ import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import 'jest-extended'
 import { StreamID } from 'streamr-client'
 import { DOCKER_DEV_STORAGE_NODE, createTestClient, runCommand } from './utils'
+import { waitForCondition } from '@streamr/utils'
 
 const isStored = async (streamId: StreamID): Promise<boolean> => {
     const output = await runCommand(`storage-node list-streams ${DOCKER_DEV_STORAGE_NODE}`)
@@ -18,11 +19,11 @@ describe('storage node', () => {
         await runCommand(`storage-node add-stream ${DOCKER_DEV_STORAGE_NODE} ${stream.id}`, {
             privateKey
         })
-        expect(await isStored(stream.id)).toBeTrue()
+        await waitForCondition(async () => await isStored(stream.id) === true, 15 * 1000, 1000)
         await runCommand(`storage-node remove-stream ${DOCKER_DEV_STORAGE_NODE} ${stream.id}`, {
             privateKey
         })
-        expect(await isStored(stream.id)).toBeFalse()
+        await waitForCondition(async () => await isStored(stream.id) === false, 15 * 1000, 1000)
     }, 80 * 1000)
 
     it('list nodes', async () => {


### PR DESCRIPTION
## Summary

We can't be 100% sure that the storage node (un-)assignment has been picked up by The Graph after running the command. So we should `waitForCondition` until it has.

_Pair programmed so merging without review._