### PR TITLE
refactor(protocol): `StreamMessage` field types `null` -> `undefined`

### DIFF
--- a/packages/broker/src/plugins/storage/DataQueryFormat.ts
+++ b/packages/broker/src/plugins/storage/DataQueryFormat.ts
@@ -29,7 +29,7 @@ const createBinaryFormat = (formatMessage: (bytes: Uint8Array) => Uint8Array): F
 
 export const toObject = (msg: StreamMessage): any => {
     const parsedContent = msg.getParsedContent()
-    return {
+    const result: any = {
         streamId: msg.getStreamId(),
         streamPartition: msg.getStreamPartition(),
         timestamp: msg.getTimestamp(),
@@ -39,10 +39,13 @@ export const toObject = (msg: StreamMessage): any => {
         messageType: msg.messageType,
         contentType: msg.contentType,
         encryptionType: msg.encryptionType,
-        groupKeyId: msg.groupKeyId,
         content: parsedContent instanceof Uint8Array ? binaryToHex(parsedContent) : parsedContent,
         signature: binaryToHex(msg.signature),
     }
+    if (msg.groupKeyId !== undefined) {
+        result.groupKeyId = msg.groupKeyId
+    }
+    return result
 }
 
 const FORMATS: Record<string, Format> = {

--- a/packages/client/src/subscribe/ordering/OrderedMessageChain.ts
+++ b/packages/client/src/subscribe/ordering/OrderedMessageChain.ts
@@ -186,7 +186,7 @@ export class OrderedMessageChain {
 
     private isNextOrderedMessage(msg: StreamMessage) {
         const previousRef = msg.prevMsgRef
-        return (this.lastOrderedMsg === undefined) || (previousRef === null) || areEqualRefs(previousRef, this.lastOrderedMsg.getMessageRef())
+        return (this.lastOrderedMsg === undefined) || (previousRef === undefined) || areEqualRefs(previousRef, this.lastOrderedMsg.getMessageRef())
     }
 
     private isStaleMessage(msg: StreamMessage): boolean {

--- a/packages/client/test/integration/parallel-publish.test.ts
+++ b/packages/client/test/integration/parallel-publish.test.ts
@@ -56,10 +56,10 @@ describe('parallel publish', () => {
             return (timestampDiff !== 0) ? timestampDiff : (m1.getSequenceNumber() - m2.getSequenceNumber())
         })
         expect(uniq(sortedMessages.map((m) => m.getMsgChainId()))).toHaveLength(1)
-        expect(sortedMessages[0].prevMsgRef).toBeNull()
+        expect(sortedMessages[0].prevMsgRef).toBeUndefined()
         expect(sortedMessages.every((m, i) => {
             if (i === 0) {
-                return m.prevMsgRef === null
+                return m.prevMsgRef === undefined
             } else {
                 const previous = sortedMessages[i - 1]
                 return (m.prevMsgRef!.timestamp === previous.getTimestamp()) && (m.prevMsgRef!.sequenceNumber === previous.getSequenceNumber())

--- a/packages/client/test/unit/GapFiller.test.ts
+++ b/packages/client/test/unit/GapFiller.test.ts
@@ -30,7 +30,7 @@ const createMessage = (timestamp: number, hasPrevRef = true) => {
             CONTEXT.publisherId, 
             CONTEXT.msgChainId
         ),
-        prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : null,
+        prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : undefined,
         content: utf8ToBinary('{}'),
         signature: hexToBinary('0x1324'),
         contentType: ContentType.JSON,

--- a/packages/client/test/unit/MessageFactory.test.ts
+++ b/packages/client/test/unit/MessageFactory.test.ts
@@ -67,11 +67,11 @@ describe('MessageFactory', () => {
                 streamPartition: expect.toBeWithin(0, PARTITION_COUNT),
                 timestamp: TIMESTAMP
             },
-            prevMsgRef: null,
+            prevMsgRef: undefined,
             messageType: StreamMessageType.MESSAGE,
             encryptionType: EncryptionType.AES,
             groupKeyId: GROUP_KEY.id,
-            newGroupKey: null,
+            newGroupKey: undefined,
             signature: expect.any(Uint8Array),
             contentType: ContentType.JSON,
             content: expect.any(Uint8Array)
@@ -87,7 +87,7 @@ describe('MessageFactory', () => {
         const msg = await createMessage({}, messageFactory)
         expect(msg).toMatchObject({
             encryptionType: EncryptionType.NONE,
-            groupKeyId: null,
+            groupKeyId: undefined,
             content: utf8ToBinary(JSON.stringify(CONTENT))
         })
     })
@@ -137,7 +137,7 @@ describe('MessageFactory', () => {
         const messageFactory = await createMessageFactory()
         const msg = await createMessage({}, messageFactory, utf8ToBinary('mock-content'))
         expect(msg).toMatchObject({
-            contentType: ContentType.BINARY,
+            contentType: ContentType.BINARY
         })
     })
 
@@ -220,8 +220,8 @@ describe('MessageFactory', () => {
             const msg3 = await createMessage({ msgChainId: msg2.getMsgChainId(), explicitPartition: 20 }, messageFactory)
             expect(msg2.messageId.msgChainId).not.toBe(msg1.messageId.msgChainId)
             expect(msg3.messageId.msgChainId).not.toBe(msg1.messageId.msgChainId)
-            expect(msg2.prevMsgRef).toBe(null)
-            expect(msg3.prevMsgRef).toBe(null)
+            expect(msg2.prevMsgRef).toBe(undefined)
+            expect(msg3.prevMsgRef).toBe(undefined)
         })
 
         it('explicit msgChainId', async () => {
@@ -231,7 +231,7 @@ describe('MessageFactory', () => {
             const msg3 = await createMessage({ msgChainId: 'mock-id' }, messageFactory)
             expect(msg1.messageId.msgChainId).toBe('mock-id')
             expect(msg2.messageId.msgChainId).not.toBe('mock-id')
-            expect(msg2.prevMsgRef).toBe(null)
+            expect(msg2.prevMsgRef).toBe(undefined)
             expect(msg3.messageId.msgChainId).toBe('mock-id')
             expect(msg3.prevMsgRef).toEqual(msg1.getMessageRef())
         })

--- a/packages/client/test/unit/OrderMessages2.test.ts
+++ b/packages/client/test/unit/OrderMessages2.test.ts
@@ -87,7 +87,7 @@ function formChainOfMessages(publisherId: EthereumAddress): Array<MessageInfo> {
 
 function createMsg({ publisherId, timestamp }: MessageInfo): StreamMessage {
     const messageId = new MessageID(toStreamID('streamId'), 0, timestamp, 0, publisherId, '')
-    const prevMsgRef = timestamp > 1 ? new MessageRef(timestamp - 1, 0) : null
+    const prevMsgRef = timestamp > 1 ? new MessageRef(timestamp - 1, 0) : undefined
     return new StreamMessage({
         messageId,
         prevMsgRef,

--- a/packages/client/test/unit/OrderedMessageChain.test.ts
+++ b/packages/client/test/unit/OrderedMessageChain.test.ts
@@ -17,7 +17,7 @@ const MSG_CHAIN_ID = 'msgChainId'
 const createMessage = (timestamp: number, hasPrevRef = true) => {
     return new StreamMessage({
         messageId: new MessageID(STREAM_ID, 0, timestamp, 0, PUBLISHER_ID, MSG_CHAIN_ID),
-        prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : null,
+        prevMsgRef: hasPrevRef ? new MessageRef(timestamp - 1, 0) : undefined,
         content: utf8ToBinary('{}'),
         signature: hexToBinary('0x1234'),
         contentType: ContentType.JSON,

--- a/packages/client/test/unit/validateStreamMessage2.test.ts
+++ b/packages/client/test/unit/validateStreamMessage2.test.ts
@@ -24,7 +24,7 @@ import { createRandomAuthentication, MOCK_CONTENT } from '../test-utils/utils'
 const groupKeyMessageToStreamMessage = async (
     groupKeyMessage: GroupKeyRequest | GroupKeyResponse,
     messageId: MessageID,
-    prevMsgRef: MessageRef | null,
+    prevMsgRef: MessageRef | undefined,
     authentication: Authentication
 ): Promise<StreamMessage> => {
     return createSignedMessage({
@@ -120,7 +120,7 @@ describe('Validator2', () => {
             recipient: publisher,
             rsaPublicKey: 'rsaPublicKey',
             groupKeyIds: ['groupKeyId1', 'groupKeyId2']
-        }), new MessageID(toStreamID('streamId'), 0, 0, 0, subscriber, 'msgChainId'), null, subscriberAuthentication)
+        }), new MessageID(toStreamID('streamId'), 0, 0, 0, subscriber, 'msgChainId'), undefined, subscriberAuthentication)
 
         groupKeyResponse = await groupKeyMessageToStreamMessage(new GroupKeyResponse({
             requestId: 'requestId',
@@ -129,7 +129,7 @@ describe('Validator2', () => {
                 new EncryptedGroupKey('groupKeyId1', hexToBinary('0x1111')),
                 new EncryptedGroupKey('groupKeyId2', hexToBinary('0x2222'))
             ],
-        }), new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'), null, publisherAuthentication)
+        }), new MessageID(toStreamID('streamId'), 0, 0, 0, publisher, 'msgChainId'), undefined, publisherAuthentication)
     })
 
     describe('validate(unknown message type)', () => {

--- a/packages/protocol/src/protocol/message_layer/EncryptedGroupKey.ts
+++ b/packages/protocol/src/protocol/message_layer/EncryptedGroupKey.ts
@@ -1,4 +1,4 @@
-import { validateIsString, validateIsType } from '../../utils/validations'
+import { validateIsType } from '../../utils/validations'
 
 export default class EncryptedGroupKey {
 
@@ -6,9 +6,7 @@ export default class EncryptedGroupKey {
     readonly data: Uint8Array
 
     constructor(id: string, data: Uint8Array) {
-        validateIsString('id', id)
         this.id = id
-
         validateIsType('data', data, 'Uint8Array', Uint8Array)
         this.data = data
     }

--- a/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
@@ -1,5 +1,3 @@
-import { validateIsArray } from '../../utils/validations'
-
 import StreamMessage, { StreamMessageType } from './StreamMessage'
 import { EthereumAddress } from '@streamr/utils'
 
@@ -20,7 +18,6 @@ export default class GroupKeyRequest {
         this.requestId = requestId
         this.recipient = recipient
         this.rsaPublicKey = rsaPublicKey
-        validateIsArray('groupKeyIds', groupKeyIds)
         this.groupKeyIds = groupKeyIds
     }
 

--- a/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyRequest.ts
@@ -1,4 +1,4 @@
-import { validateIsArray, validateIsString } from '../../utils/validations'
+import { validateIsArray } from '../../utils/validations'
 
 import StreamMessage, { StreamMessageType } from './StreamMessage'
 import { EthereumAddress } from '@streamr/utils'
@@ -17,15 +17,9 @@ export default class GroupKeyRequest {
     readonly groupKeyIds: ReadonlyArray<string>
 
     constructor({ requestId, recipient, rsaPublicKey, groupKeyIds }: Options) {
-        validateIsString('requestId', requestId)
         this.requestId = requestId
-
-        validateIsString('recipient', recipient)
         this.recipient = recipient
-
-        validateIsString('rsaPublicKey', rsaPublicKey)
         this.rsaPublicKey = rsaPublicKey
-
         validateIsArray('groupKeyIds', groupKeyIds)
         this.groupKeyIds = groupKeyIds
     }

--- a/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
@@ -1,4 +1,3 @@
-import { validateIsArray } from '../../utils/validations'
 import ValidationError from '../../errors/ValidationError'
 
 import StreamMessage, { StreamMessageType } from './StreamMessage'
@@ -19,7 +18,6 @@ export default class GroupKeyResponse {
     constructor({ requestId, recipient, encryptedGroupKeys }: Options) {
         this.requestId = requestId
         this.recipient = recipient
-        validateIsArray('encryptedGroupKeys', encryptedGroupKeys)
         this.encryptedGroupKeys = encryptedGroupKeys
         // Validate content of encryptedGroupKeys
         this.encryptedGroupKeys.forEach((it: EncryptedGroupKey) => {

--- a/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
+++ b/packages/protocol/src/protocol/message_layer/GroupKeyResponse.ts
@@ -1,4 +1,4 @@
-import { validateIsArray, validateIsString } from '../../utils/validations'
+import { validateIsArray } from '../../utils/validations'
 import ValidationError from '../../errors/ValidationError'
 
 import StreamMessage, { StreamMessageType } from './StreamMessage'
@@ -17,15 +17,10 @@ export default class GroupKeyResponse {
     readonly encryptedGroupKeys: ReadonlyArray<EncryptedGroupKey>
 
     constructor({ requestId, recipient, encryptedGroupKeys }: Options) {
-        validateIsString('requestId', requestId)
         this.requestId = requestId
-
-        validateIsString('recipient', recipient)
         this.recipient = recipient
-
         validateIsArray('encryptedGroupKeys', encryptedGroupKeys)
         this.encryptedGroupKeys = encryptedGroupKeys
-
         // Validate content of encryptedGroupKeys
         this.encryptedGroupKeys.forEach((it: EncryptedGroupKey) => {
             if (!(it instanceof EncryptedGroupKey)) {

--- a/packages/protocol/src/protocol/message_layer/MessageID.ts
+++ b/packages/protocol/src/protocol/message_layer/MessageID.ts
@@ -1,4 +1,4 @@
-import { validateIsNotEmptyString, validateIsNotNegativeInteger, validateIsString } from '../../utils/validations'
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../utils/validations'
 
 import MessageRef from './MessageRef'
 import { StreamID } from '../../../src/utils/StreamID'
@@ -26,9 +26,6 @@ export default class MessageID {
         validateIsNotNegativeInteger('streamPartition', streamPartition)
         validateIsNotNegativeInteger('timestamp', timestamp)
         validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)
-        validateIsString('publisherId', publisherId)
-        validateIsString('msgChainId', msgChainId)
-
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.timestamp = timestamp

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -1,8 +1,7 @@
 import InvalidJsonError from '../../errors/InvalidJsonError'
 import StreamMessageError from '../../errors/StreamMessageError'
 import ValidationError from '../../errors/ValidationError'
-import { validateIsNotEmptyByteArray, validateIsString, validateIsType } from '../../utils/validations'
-
+import { validateIsDefined, validateIsNotEmptyByteArray, validateIsType } from '../../utils/validations'
 import MessageRef from './MessageRef'
 import MessageID from './MessageID'
 import EncryptedGroupKey from './EncryptedGroupKey'
@@ -84,34 +83,26 @@ export default class StreamMessage implements StreamMessageOptions {
     }: StreamMessageOptions) {
         validateIsType('messageId', messageId, 'MessageID', MessageID)
         this.messageId = messageId
-
         validateIsType('prevMsgRef', prevMsgRef, 'MessageRef', MessageRef, true)
         this.prevMsgRef = prevMsgRef
-
         StreamMessage.validateMessageType(messageType)
         this.messageType = messageType
-
         StreamMessage.validateContentType(contentType)
         this.contentType = contentType
-
         StreamMessage.validateEncryptionType(encryptionType)
         this.encryptionType = encryptionType
-
-        validateIsString('groupKeyId', groupKeyId, this.encryptionType !== EncryptionType.AES)
+        if (this.encryptionType === EncryptionType.AES) {
+            validateIsDefined('groupKeyId', groupKeyId)
+        }
         this.groupKeyId = groupKeyId
-
         validateIsType('newGroupKey', newGroupKey, 'EncryptedGroupKey', EncryptedGroupKey, true)
         this.newGroupKey = newGroupKey
-
         validateIsType('signature', signature, 'Uint8Array', Uint8Array)
         this.signature = signature
-
         StreamMessage.validateSignatureType(signatureType)
         this.signatureType = signatureType
-
         validateIsNotEmptyByteArray('content', content)
         this.content = content
-
         StreamMessage.validateSequence(this)
     }
 

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -34,15 +34,15 @@ export enum SignatureType {
 
 export interface StreamMessageOptions {
     messageId: MessageID
-    prevMsgRef?: MessageRef | null
+    prevMsgRef?: MessageRef
     messageType?: StreamMessageType
     content: Uint8Array
     contentType: ContentType
     signature: Uint8Array
     signatureType: SignatureType
     encryptionType: EncryptionType
-    groupKeyId?: string | null
-    newGroupKey?: EncryptedGroupKey | null
+    groupKeyId?: string
+    newGroupKey?: EncryptedGroupKey
 }
 
 /**
@@ -60,27 +60,27 @@ export default class StreamMessage implements StreamMessageOptions {
     private static VALID_SIGNATURE_TYPES = new Set(Object.values(SignatureType))
 
     readonly messageId: MessageID
-    readonly prevMsgRef: MessageRef | null
+    readonly prevMsgRef?: MessageRef
     readonly messageType: StreamMessageType
     readonly content: Uint8Array
     readonly contentType: ContentType
     readonly signature: Uint8Array
     readonly signatureType: SignatureType
     readonly encryptionType: EncryptionType
-    readonly groupKeyId: string | null
-    readonly newGroupKey: EncryptedGroupKey | null
+    readonly groupKeyId?: string
+    readonly newGroupKey?: EncryptedGroupKey
 
     constructor({
         messageId,
-        prevMsgRef = null,
+        prevMsgRef,
         messageType = StreamMessageType.MESSAGE,
         content,
         contentType,
         signature,
         signatureType,
         encryptionType,
-        groupKeyId = null,
-        newGroupKey = null,
+        groupKeyId,
+        newGroupKey,
     }: StreamMessageOptions) {
         validateIsType('messageId', messageId, 'MessageID', MessageID)
         this.messageId = messageId

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -194,7 +194,7 @@ export default class StreamMessage implements StreamMessageOptions {
         }
     }
 
-    private static validateSequence({ messageId, prevMsgRef }: { messageId: MessageID, prevMsgRef?: MessageRef | null }): void {
+    private static validateSequence({ messageId, prevMsgRef }: { messageId: MessageID, prevMsgRef?: MessageRef }): void {
         if (!prevMsgRef) {
             return
         }

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -32,16 +32,6 @@ export function validateIsNotEmptyByteArray(varName: string, varValue: Uint8Arra
     }
 }
 
-export function validateIsArray(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsDefined(varName, varValue)
-    if (!Array.isArray(varValue)) {
-        throw new ValidationError(`Expected ${varName} to be an array but was a ${typeof varValue} (${varValue}).`)
-    }
-}
-
 export function validateIsDirection(varName: string, varValue: unknown, allowUndefined = false): void | never {
     if (allowUndefined && varValue === undefined) {
         return

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -1,5 +1,4 @@
 import ValidationError from '../errors/ValidationError'
-import { ProxyDirection } from './types'
 
 export function validateIsDefined(varName: string, varValue: unknown): void | never {
     if (varValue === undefined) {
@@ -29,16 +28,6 @@ export function validateIsNotNegativeInteger(varName: string, varValue?: number,
 export function validateIsNotEmptyByteArray(varName: string, varValue: Uint8Array): void | never {
     if (!(varValue instanceof Uint8Array) || varValue.length === 0) {
         throw new ValidationError(`Expected ${varName} to be a non-empty byte array`)
-    }
-}
-
-export function validateIsDirection(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsDefined(varName, varValue)
-    if (varValue as ProxyDirection in ProxyDirection) {
-        throw new ValidationError(`Expected ${varName} to be a ProxyDirection but was a ${typeof varValue} (${varValue}).`)
     }
 }
 

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -1,27 +1,24 @@
 import ValidationError from '../errors/ValidationError'
 import { ProxyDirection } from './types'
 
-export function validateIsNotNullOrUndefined(varName: string, varValue: unknown): void | never {
+export function validateIsDefined(varName: string, varValue: unknown): void | never {
     if (varValue === undefined) {
         throw new ValidationError(`Expected ${varName} to not be undefined.`)
     }
-    if (varValue == null) {
-        throw new ValidationError(`Expected ${varName} to not be null.`)
-    }
 }
 
-export function validateIsString(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsString(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (typeof varValue !== 'string' && !(varValue instanceof String)) {
         throw new ValidationError(`Expected ${varName} to be a string but was a ${typeof varValue} (${varValue}).`)
     }
 }
 
-export function validateIsNotEmptyString(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsNotEmptyString(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
     validateIsString(varName, varValue)
@@ -30,18 +27,18 @@ export function validateIsNotEmptyString(varName: string, varValue: unknown, all
     }
 }
 
-export function validateIsInteger(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsInteger(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (!Number.isInteger(varValue)) {
         throw new ValidationError(`Expected ${varName} to be an integer but was a ${typeof varValue} (${varValue}).`)
     }
 }
 
-export function validateIsNotNegativeInteger(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsNotNegativeInteger(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
     validateIsInteger(varName, varValue)
@@ -50,31 +47,31 @@ export function validateIsNotNegativeInteger(varName: string, varValue: unknown,
     }
 }
 
-export function validateIsNotEmptyByteArray(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsNotEmptyByteArray(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (!(varValue instanceof Uint8Array) || varValue.length === 0) {
         throw new ValidationError(`Expected ${varName} to be a non-empty byte array`)
     }
 }
 
-export function validateIsArray(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsArray(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (!Array.isArray(varValue)) {
         throw new ValidationError(`Expected ${varName} to be an array but was a ${typeof varValue} (${varValue}).`)
     }
 }
 
-export function validateIsDirection(varName: string, varValue: unknown, allowNull = false): void | never {
-    if (allowNull && varValue == null) {
+export function validateIsDirection(varName: string, varValue: unknown, allowUndefined = false): void | never {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (varValue as ProxyDirection in ProxyDirection) {
         throw new ValidationError(`Expected ${varName} to be a ProxyDirection but was a ${typeof varValue} (${varValue}).`)
     }
@@ -85,9 +82,9 @@ export function validateIsType(
     varValue: unknown,
     typeName: string,
     typeClass: unknown,
-    allowNull = false
+    allowUndefined = false
 ): void | never {
-    if (allowNull && varValue == null) {
+    if (allowUndefined && varValue === undefined) {
         return
     }
     if (!(varValue instanceof (typeClass as any))) {
@@ -100,12 +97,12 @@ export function validateIsOneOf(
     varName: string,
     varValue: unknown,
     validValues: ReadonlyArray<any>,
-    allowNull = false
+    allowUndefined = false
 ): void | never {
-    if (allowNull && varValue == null) {
+    if (allowUndefined && varValue === undefined) {
         return
     }
-    validateIsNotNullOrUndefined(varName, varValue)
+    validateIsDefined(varName, varValue)
     if (!validValues.includes(varValue)) {
         const msg = `Expected ${varName} to be one of ${JSON.stringify(validValues)} but was (${varValue}).`
         throw new ValidationError(msg)

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -26,11 +26,7 @@ export function validateIsNotNegativeInteger(varName: string, varValue?: number,
     }
 }
 
-export function validateIsNotEmptyByteArray(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsDefined(varName, varValue)
+export function validateIsNotEmptyByteArray(varName: string, varValue: Uint8Array): void | never {
     if (!(varValue instanceof Uint8Array) || varValue.length === 0) {
         throw new ValidationError(`Expected ${varName} to be a non-empty byte array`)
     }

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -46,19 +46,3 @@ export function validateIsType(
         throw new ValidationError(msg)
     }
 }
-
-export function validateIsOneOf(
-    varName: string,
-    varValue: unknown,
-    validValues: ReadonlyArray<any>,
-    allowUndefined = false
-): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsDefined(varName, varValue)
-    if (!validValues.includes(varValue)) {
-        const msg = `Expected ${varName} to be one of ${JSON.stringify(validValues)} but was (${varValue}).`
-        throw new ValidationError(msg)
-    }
-}

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -13,7 +13,7 @@ export function validateIsNotEmptyString(varName: string, varValue: string): voi
     }
 }
 
-export function validateIsInteger(varName: string, varValue: unknown, allowUndefined = false): void | never {
+export function validateIsNotNegativeInteger(varName: string, varValue?: number, allowUndefined = false): void | never {
     if (allowUndefined && varValue === undefined) {
         return
     }
@@ -21,14 +21,7 @@ export function validateIsInteger(varName: string, varValue: unknown, allowUndef
     if (!Number.isInteger(varValue)) {
         throw new ValidationError(`Expected ${varName} to be an integer but was a ${typeof varValue} (${varValue}).`)
     }
-}
-
-export function validateIsNotNegativeInteger(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsInteger(varName, varValue)
-    if ((varValue as number) < 0) {
+    if (varValue! < 0) {
         throw new ValidationError(`Expected ${varName} to not be negative (${varValue}).`)
     }
 }

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -7,22 +7,8 @@ export function validateIsDefined(varName: string, varValue: unknown): void | ne
     }
 }
 
-export function validateIsString(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsDefined(varName, varValue)
-    if (typeof varValue !== 'string' && !(varValue instanceof String)) {
-        throw new ValidationError(`Expected ${varName} to be a string but was a ${typeof varValue} (${varValue}).`)
-    }
-}
-
-export function validateIsNotEmptyString(varName: string, varValue: unknown, allowUndefined = false): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    validateIsString(varName, varValue)
-    if ((varValue as string).length === 0) {
+export function validateIsNotEmptyString(varName: string, varValue: string): void | never {
+    if (varValue.length === 0) {
         throw new ValidationError(`Expected ${varName} to not be an empty string.`)
     }
 }

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -292,15 +292,15 @@ describe('StreamMessage', () => {
                 const copyWithFieldsNullified = new StreamMessage({
                     ...message,
                     encryptionType: EncryptionType.NONE,
-                    groupKeyId: null,
-                    newGroupKey: null,
-                    prevMsgRef: null,
+                    groupKeyId: undefined,
+                    newGroupKey: undefined,
+                    prevMsgRef: undefined,
                 })
                 expect(copyWithFieldsNullified.messageId).toEqual(message.messageId)
                 expect(copyWithFieldsNullified.encryptionType).toEqual(EncryptionType.NONE)
-                expect(copyWithFieldsNullified.groupKeyId).toEqual(null)
-                expect(copyWithFieldsNullified.newGroupKey).toEqual(null)
-                expect(copyWithFieldsNullified.prevMsgRef).toEqual(null)
+                expect(copyWithFieldsNullified.groupKeyId).toEqual(undefined)
+                expect(copyWithFieldsNullified.newGroupKey).toEqual(undefined)
+                expect(copyWithFieldsNullified.prevMsgRef).toEqual(undefined)
             })
         })
     })

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -12,7 +12,7 @@ import StreamMessage, {
 } from '../../../../src/protocol/message_layer/StreamMessage'
 import { toStreamID } from '../../../../src/utils/StreamID'
 import { StreamPartIDUtils } from '../../../../src/utils/StreamPartID'
-import { merge, hexToBinary } from '@streamr/utils'
+import { hexToBinary } from '@streamr/utils'
 
 const content = {
     hello: 'world',
@@ -22,22 +22,18 @@ const newGroupKey = new EncryptedGroupKey('groupKeyId', hexToBinary('1234'))
 const signature = hexToBinary('0x123123')
 
 const msg = ({ timestamp = 1564046332168, sequenceNumber = 10, ...overrides } = {}) => {
-    return new StreamMessage(
-        merge(
-            {
-                messageId: new MessageID(toStreamID('streamId'), 0, timestamp, sequenceNumber, PUBLISHER_ID, 'msgChainId'),
-                prevMsgRef: new MessageRef(timestamp, 5),
-                content: utf8ToBinary(JSON.stringify(content)),
-                contentType: ContentType.JSON,
-                messageType: StreamMessageType.MESSAGE,
-                encryptionType: EncryptionType.NONE,
-                signatureType: SignatureType.SECP256K1,
-                signature,
-                newGroupKey
-            },
-            overrides
-        )
-    )
+    return new StreamMessage({
+        messageId: new MessageID(toStreamID('streamId'), 0, timestamp, sequenceNumber, PUBLISHER_ID, 'msgChainId'),
+        prevMsgRef: new MessageRef(timestamp, 5),
+        content: utf8ToBinary(JSON.stringify(content)),
+        contentType: ContentType.JSON,
+        messageType: StreamMessageType.MESSAGE,
+        encryptionType: EncryptionType.NONE,
+        signatureType: SignatureType.SECP256K1,
+        signature,
+        newGroupKey,
+        ...overrides
+    })
 }
 
 const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
@@ -56,7 +52,7 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
             assert.strictEqual(streamMessage.contentType, ContentType.JSON)
             assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, null)
+            assert.strictEqual(streamMessage.groupKeyId, undefined)
             assert.deepStrictEqual(streamMessage.getParsedContent(), content)
             expect(streamMessage.content).toEqual(utf8ToBinary(JSON.stringify(content)))
             assert.strictEqual(streamMessage.signature, signature)
@@ -78,11 +74,11 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getSequenceNumber(), 10)
             assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
             assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, null)
+            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
             assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
             assert.strictEqual(streamMessage.contentType, ContentType.JSON)
             assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, null)
+            assert.strictEqual(streamMessage.groupKeyId, undefined)
             assert.deepStrictEqual(streamMessage.getParsedContent(), content)
             expect(streamMessage.content).toEqual(utf8ToBinary(JSON.stringify(content)))
             assert.strictEqual(streamMessage.signature, signature)
@@ -103,11 +99,11 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getSequenceNumber(), 10)
             assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
             assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, null)
+            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
             assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
             assert.strictEqual(streamMessage.contentType, ContentType.BINARY)
             assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, null)
+            assert.strictEqual(streamMessage.groupKeyId, undefined)
             assert.deepStrictEqual(streamMessage.content, new Uint8Array([1, 2, 3]))
             expect(streamMessage.content).toEqual(new Uint8Array([1, 2, 3]))
             assert.strictEqual(streamMessage.signature, signature)
@@ -128,13 +124,13 @@ describe('StreamMessage', () => {
             assert.strictEqual(streamMessage.getSequenceNumber(), 10)
             assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
             assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, null)
+            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
             assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
             assert.strictEqual(streamMessage.contentType, ContentType.BINARY)
             assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, null)
+            assert.strictEqual(streamMessage.groupKeyId, undefined)
             assert.deepStrictEqual(streamMessage.content, new Uint8Array([1, 2, 3]))
-            assert.strictEqual(streamMessage.newGroupKey, null)
+            assert.strictEqual(streamMessage.newGroupKey, undefined)
             assert.strictEqual(streamMessage.signature, signature)
         })
 
@@ -200,8 +196,7 @@ describe('StreamMessage', () => {
 
         it('Throws with an no group key for AES encrypted message', () => {
             assert.throws(() => msg({
-                encryptionType: EncryptionType.AES,
-                groupKeyId: null
+                encryptionType: EncryptionType.AES
             } as any), ValidationError)
         })
 
@@ -271,7 +266,7 @@ describe('StreamMessage', () => {
                     timestamp: ts,
                     sequenceNumber: 0,
                     // @ts-expect-error TODO
-                    prevMsgRef: null
+                    prevMsgRef: undefined
                 })
             })
         })

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -1,5 +1,5 @@
 import {
-    validateIsNotNullOrUndefined,
+    validateIsDefined,
     validateIsString,
     validateIsNotEmptyString,
     validateIsInteger,
@@ -10,41 +10,26 @@ import {
 import ValidationError from '../../../src/errors/ValidationError'
 
 describe('validations', () => {
-    describe('validateIsNotNullOrUndefined', () => {
+    describe('validateIsDefined', () => {
         it('throws ValidationError on undefined', () => {
             expect(() => {
-                validateIsNotNullOrUndefined('varName', undefined)
+                validateIsDefined('varName', undefined)
             }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-        })
-        it('throws ValidationError on null', () => {
-            expect(() => {
-                validateIsNotNullOrUndefined('varName', null)
-            }).toThrow(new ValidationError('Expected varName to not be null.'))
         })
     })
 
     describe('validateIsString', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsString('varName', undefined)
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsString('varName', null)
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsString('varName', undefined, true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsString('varName', null, true)
                 }).not.toThrow()
             })
         })
@@ -73,27 +58,17 @@ describe('validations', () => {
     })
 
     describe('validateIsNotEmptyString', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsNotEmptyString('varName', undefined)
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsNotEmptyString('varName', null)
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsNotEmptyString('varName', undefined, true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsNotEmptyString('varName', null, true)
                 }).not.toThrow()
             })
         })
@@ -122,27 +97,17 @@ describe('validations', () => {
     })
 
     describe('validateIsInteger', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsInteger('varName', undefined)
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsInteger('varName', null)
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsInteger('varName', undefined, true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsInteger('varName', null, true)
                 }).not.toThrow()
             })
         })
@@ -196,27 +161,17 @@ describe('validations', () => {
     })
 
     describe('validateIsNotNegativeInteger', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsNotNegativeInteger('varName', undefined)
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsNotNegativeInteger('varName', null)
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsNotNegativeInteger('varName', undefined, true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsNotNegativeInteger('varName', null, true)
                 }).not.toThrow()
             })
         })
@@ -270,27 +225,17 @@ describe('validations', () => {
     })
 
     describe('validateIsArray', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsArray('varName', undefined)
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsArray('varName', null)
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsArray('varName', undefined, true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsArray('varName', null, true)
                 }).not.toThrow()
             })
         })
@@ -324,27 +269,17 @@ describe('validations', () => {
     })
 
     describe('validateIsOneOf', () => {
-        describe('when allowNull = false (default)', () => {
+        describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
                 expect(() => {
                     validateIsOneOf('varName', undefined, [])
                 }).toThrow(new ValidationError('Expected varName to not be undefined.'))
             })
-            it('throws ValidationError on null', () => {
-                expect(() => {
-                    validateIsOneOf('varName', null, [])
-                }).toThrow(new ValidationError('Expected varName to not be null.'))
-            })
         })
-        describe('when allowNull = true', () => {
+        describe('when allowUndefined = true', () => {
             it('does not throw on undefined', () => {
                 expect(() => {
                     validateIsOneOf('varName', undefined, [], true)
-                }).not.toThrow()
-            })
-            it('does not throw on null', () => {
-                expect(() => {
-                    validateIsOneOf('varName', null, [], true)
                 }).not.toThrow()
             })
         })

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -1,7 +1,6 @@
 import {
     validateIsDefined,
     validateIsNotEmptyString,
-    validateIsInteger,
     validateIsNotNegativeInteger,
     validateIsArray,
     validateIsOneOf
@@ -30,70 +29,6 @@ describe('validations', () => {
         })
     })
 
-    describe('validateIsInteger', () => {
-        describe('when allowUndefined = false (default)', () => {
-            it('throws ValidationError on undefined', () => {
-                expect(() => {
-                    validateIsInteger('varName', undefined)
-                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-            })
-        })
-        describe('when allowUndefined = true', () => {
-            it('does not throw on undefined', () => {
-                expect(() => {
-                    validateIsInteger('varName', undefined, true)
-                }).not.toThrow()
-            })
-        })
-        it('throws ValidationError on string', () => {
-            expect(() => {
-                validateIsInteger('varName', 'string')
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a string (string).'))
-        })
-        it('throws ValidationError on object', () => {
-            expect(() => {
-                validateIsInteger('varName', {
-                    hello: 'world',
-                })
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a object ([object Object]).'))
-        })
-        it('throws ValidationError on NaN', () => {
-            expect(() => {
-                validateIsInteger('varName', NaN)
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (NaN).'))
-        })
-        it('throws ValidationError on infinity', () => {
-            expect(() => {
-                validateIsInteger('varName', Number.POSITIVE_INFINITY)
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (Infinity).'))
-        })
-        it('throws ValidationError on number that is not representable as an integer', () => {
-            expect(() => {
-                validateIsInteger('varName', 6.66)
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (6.66).'))
-        })
-        it('does not throw on negative integer', () => {
-            expect(() => {
-                validateIsInteger('varName', -10)
-            }).not.toThrow()
-        })
-        it('does not throw on zero integer', () => {
-            expect(() => {
-                validateIsInteger('varName', 0)
-            }).not.toThrow()
-        })
-        it('does not throw on positive integer', () => {
-            expect(() => {
-                validateIsInteger('varName', 10)
-            }).not.toThrow()
-        })
-        it('does not throw on number that is representable as an integer', () => {
-            expect(() => {
-                validateIsInteger('varName', 10.00)
-            }).not.toThrow()
-        })
-    })
-
     describe('validateIsNotNegativeInteger', () => {
         describe('when allowUndefined = false (default)', () => {
             it('throws ValidationError on undefined', () => {
@@ -108,18 +43,6 @@ describe('validations', () => {
                     validateIsNotNegativeInteger('varName', undefined, true)
                 }).not.toThrow()
             })
-        })
-        it('throws ValidationError on string', () => {
-            expect(() => {
-                validateIsNotNegativeInteger('varName', 'string')
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a string (string).'))
-        })
-        it('throws ValidationError on object', () => {
-            expect(() => {
-                validateIsNotNegativeInteger('varName', {
-                    hello: 'world',
-                })
-            }).toThrow(new ValidationError('Expected varName to be an integer but was a object ([object Object]).'))
         })
         it('throws ValidationError on NaN', () => {
             expect(() => {

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -1,6 +1,5 @@
 import {
     validateIsDefined,
-    validateIsString,
     validateIsNotEmptyString,
     validateIsInteger,
     validateIsNotNegativeInteger,
@@ -18,72 +17,7 @@ describe('validations', () => {
         })
     })
 
-    describe('validateIsString', () => {
-        describe('when allowUndefined = false (default)', () => {
-            it('throws ValidationError on undefined', () => {
-                expect(() => {
-                    validateIsString('varName', undefined)
-                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-            })
-        })
-        describe('when allowUndefined = true', () => {
-            it('does not throw on undefined', () => {
-                expect(() => {
-                    validateIsString('varName', undefined, true)
-                }).not.toThrow()
-            })
-        })
-        it('throws ValidationError on number', () => {
-            expect(() => {
-                validateIsString('varName', 10)
-            }).toThrow(new ValidationError('Expected varName to be a string but was a number (10).'))
-        })
-        it('throws ValidationError on object', () => {
-            expect(() => {
-                validateIsString('varName', {
-                    hello: 'world',
-                })
-            }).toThrow(new ValidationError('Expected varName to be a string but was a object ([object Object]).'))
-        })
-        it('does not throw on empty string', () => {
-            expect(() => {
-                validateIsString('varName', '')
-            }).not.toThrow()
-        })
-        it('does not throw on non-empty string', () => {
-            expect(() => {
-                validateIsString('varName', 'hello, world')
-            }).not.toThrow()
-        })
-    })
-
     describe('validateIsNotEmptyString', () => {
-        describe('when allowUndefined = false (default)', () => {
-            it('throws ValidationError on undefined', () => {
-                expect(() => {
-                    validateIsNotEmptyString('varName', undefined)
-                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-            })
-        })
-        describe('when allowUndefined = true', () => {
-            it('does not throw on undefined', () => {
-                expect(() => {
-                    validateIsNotEmptyString('varName', undefined, true)
-                }).not.toThrow()
-            })
-        })
-        it('throws ValidationError on number', () => {
-            expect(() => {
-                validateIsNotEmptyString('varName', 10)
-            }).toThrow(new ValidationError('Expected varName to be a string but was a number (10).'))
-        })
-        it('throws ValidationError on object', () => {
-            expect(() => {
-                validateIsNotEmptyString('varName', {
-                    hello: 'world',
-                })
-            }).toThrow(new ValidationError('Expected varName to be a string but was a object ([object Object]).'))
-        })
         it('throws on empty string', () => {
             expect(() => {
                 validateIsNotEmptyString('varName', '')

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -1,8 +1,7 @@
 import {
     validateIsDefined,
     validateIsNotEmptyString,
-    validateIsNotNegativeInteger,
-    validateIsOneOf
+    validateIsNotNegativeInteger
 } from '../../../src/utils/validations'
 import ValidationError from '../../../src/errors/ValidationError'
 
@@ -76,33 +75,6 @@ describe('validations', () => {
         it('does not throw on number that is representable as an integer', () => {
             expect(() => {
                 validateIsNotNegativeInteger('varName', 10.00)
-            }).not.toThrow()
-        })
-    })
-
-    describe('validateIsOneOf', () => {
-        describe('when allowUndefined = false (default)', () => {
-            it('throws ValidationError on undefined', () => {
-                expect(() => {
-                    validateIsOneOf('varName', undefined, [])
-                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-            })
-        })
-        describe('when allowUndefined = true', () => {
-            it('does not throw on undefined', () => {
-                expect(() => {
-                    validateIsOneOf('varName', undefined, [], true)
-                }).not.toThrow()
-            })
-        })
-        it('throws ValidationError when value not in list', () => {
-            expect(() => {
-                validateIsOneOf('varName', 'not-in-list', ['a', 'b', 'c'])
-            }).toThrow(new ValidationError('Expected varName to be one of ["a","b","c"] but was (not-in-list).'))
-        })
-        it('does not throw on included value', () => {
-            expect(() => {
-                validateIsOneOf('varName', 'b', ['a', 'b', 'c'])
             }).not.toThrow()
         })
     })

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -2,7 +2,6 @@ import {
     validateIsDefined,
     validateIsNotEmptyString,
     validateIsNotNegativeInteger,
-    validateIsArray,
     validateIsOneOf
 } from '../../../src/utils/validations'
 import ValidationError from '../../../src/errors/ValidationError'
@@ -77,50 +76,6 @@ describe('validations', () => {
         it('does not throw on number that is representable as an integer', () => {
             expect(() => {
                 validateIsNotNegativeInteger('varName', 10.00)
-            }).not.toThrow()
-        })
-    })
-
-    describe('validateIsArray', () => {
-        describe('when allowUndefined = false (default)', () => {
-            it('throws ValidationError on undefined', () => {
-                expect(() => {
-                    validateIsArray('varName', undefined)
-                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-            })
-        })
-        describe('when allowUndefined = true', () => {
-            it('does not throw on undefined', () => {
-                expect(() => {
-                    validateIsArray('varName', undefined, true)
-                }).not.toThrow()
-            })
-        })
-        it('throws ValidationError on number', () => {
-            expect(() => {
-                validateIsArray('varName', 10)
-            }).toThrow(new ValidationError('Expected varName to be an array but was a number (10).'))
-        })
-        it('throws ValidationError on object', () => {
-            expect(() => {
-                validateIsArray('varName', {
-                    hello: 'world',
-                })
-            }).toThrow(new ValidationError('Expected varName to be an array but was a object ([object Object]).'))
-        })
-        it('throws ValidationError on string', () => {
-            expect(() => {
-                validateIsArray('varName', 'string')
-            }).toThrow(new ValidationError('Expected varName to be an array but was a string (string).'))
-        })
-        it('does not throw on empty array', () => {
-            expect(() => {
-                validateIsArray('varName', [])
-            }).not.toThrow()
-        })
-        it('does not throw on array', () => {
-            expect(() => {
-                validateIsArray('varName', ['a', 'b', 'c', 'd'])
             }).not.toThrow()
         })
     })

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -95,7 +95,6 @@ const measureJoiningTime = async () => {
                 '2222' as any,
                 'msgChainId'
             ),
-            prevMsgRef: null,
             content: utf8ToBinary(JSON.stringify({
                 hello: 'world'
             })),

--- a/packages/trackerless-network/test/unit/StreamMessageTranslator.test.ts
+++ b/packages/trackerless-network/test/unit/StreamMessageTranslator.test.ts
@@ -33,7 +33,6 @@ describe('StreamMessageTranslator', () => {
     )
     const oldProtocolMsg = new OldStreamMessage({
         messageId,
-        prevMsgRef: null,
         content: utf8ToBinary(JSON.stringify({ hello: 'WORLD' })),
         contentType: ContentType.JSON,
         messageType: OldStreamMessageType.MESSAGE,
@@ -63,10 +62,10 @@ describe('StreamMessageTranslator', () => {
         expect(translated.messageId.timestamp).toBeGreaterThanOrEqual(0)
         expect(translated.messageId.sequenceNumber).toEqual(0)
         expect(translated.getPublisherId()).toEqual('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-        expect(translated.prevMsgRef).toEqual(null)
+        expect(translated.prevMsgRef).toEqual(undefined)
         expect(translated.messageType).toEqual(OldStreamMessageType.MESSAGE)
         expect(translated.contentType).toEqual(0)
-        expect(translated.groupKeyId).toEqual(null)
+        expect(translated.groupKeyId).toEqual(undefined)
         expect(translated.signature).toStrictEqual(signature)
         expect(translated.getParsedContent()).toEqual({ hello: 'WORLD' })
     })


### PR DESCRIPTION
Use `undefined` instead of `null` in `StreamMessage` class.

Also removed some validation rules from `protocol`'s `validation.ts` which just asserted the field types.