### PR TITLE
refactor(protocol): rm runtime type validation from classes

### DIFF
--- a/packages/client/src/encryption/PublisherKeyExchange.ts
+++ b/packages/client/src/encryption/PublisherKeyExchange.ts
@@ -123,7 +123,7 @@ export class PublisherKeyExchange {
             ),
             content: serializeGroupKeyResponse(responseContent),
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
-            encryptionType: EncryptionType.RSA,
+            encryptionType: EncryptionType.NONE,
             authentication: this.authentication,
             contentType: ContentType.JSON,
             signatureType: SignatureType.SECP256K1,

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -57,7 +57,7 @@ describe('PublisherKeyExchange', () => {
             },
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
             contentType: ContentType.JSON,
-            encryptionType: EncryptionType.RSA,
+            encryptionType: EncryptionType.NONE,
             signature: expect.any(Uint8Array)
         })
         const encryptedGroupKeys = deserializeGroupKeyResponse(actualResponse.content).encryptedGroupKeys

--- a/packages/protocol/src/protocol/message_layer/EncryptedGroupKey.ts
+++ b/packages/protocol/src/protocol/message_layer/EncryptedGroupKey.ts
@@ -1,5 +1,3 @@
-import { validateIsType } from '../../utils/validations'
-
 export default class EncryptedGroupKey {
 
     readonly id: string
@@ -7,7 +5,6 @@ export default class EncryptedGroupKey {
 
     constructor(id: string, data: Uint8Array) {
         this.id = id
-        validateIsType('data', data, 'Uint8Array', Uint8Array)
         this.data = data
     }
 }

--- a/packages/protocol/src/protocol/message_layer/MessageID.ts
+++ b/packages/protocol/src/protocol/message_layer/MessageID.ts
@@ -1,4 +1,4 @@
-import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../utils/validations'
+import { validateIsNotNegativeInteger } from '../../utils/validations'
 
 import MessageRef from './MessageRef'
 import { StreamID } from '../../../src/utils/StreamID'
@@ -22,7 +22,6 @@ export default class MessageID {
         publisherId: EthereumAddress,
         msgChainId: string
     ) {
-        validateIsNotEmptyString('streamId', streamId)
         validateIsNotNegativeInteger('streamPartition', streamPartition)
         validateIsNotNegativeInteger('timestamp', timestamp)
         validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -22,7 +22,6 @@ export enum ContentType {
 
 export enum EncryptionType {
     NONE = 0,
-    RSA = 1,
     AES = 2
 }
 

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -1,13 +1,13 @@
 import InvalidJsonError from '../../errors/InvalidJsonError'
 import StreamMessageError from '../../errors/StreamMessageError'
-import ValidationError from '../../errors/ValidationError'
-import { validateIsDefined, validateIsNotEmptyByteArray, validateIsType } from '../../utils/validations'
+import { validateIsDefined, validateIsNotEmptyByteArray } from '../../utils/validations'
 import MessageRef from './MessageRef'
 import MessageID from './MessageID'
 import EncryptedGroupKey from './EncryptedGroupKey'
 import { StreamID } from '../../utils/StreamID'
 import { StreamPartID } from '../../utils/StreamPartID'
 import { EthereumAddress, binaryToUtf8 } from '@streamr/utils'
+import ValidationError from '../../errors/ValidationError'
 
 export enum StreamMessageType {
     MESSAGE = 27,
@@ -75,25 +75,22 @@ export default class StreamMessage implements StreamMessageOptions {
         groupKeyId,
         newGroupKey,
     }: StreamMessageOptions) {
-        validateIsType('messageId', messageId, 'MessageID', MessageID)
+        validateSequence(messageId, prevMsgRef)
+        validateIsNotEmptyByteArray('content', content)
+        if (encryptionType === EncryptionType.AES) {
+            validateIsDefined('groupKeyId', groupKeyId)
+        }
+
         this.messageId = messageId
-        validateIsType('prevMsgRef', prevMsgRef, 'MessageRef', MessageRef, true)
         this.prevMsgRef = prevMsgRef
         this.messageType = messageType
         this.contentType = contentType
         this.encryptionType = encryptionType
-        if (this.encryptionType === EncryptionType.AES) {
-            validateIsDefined('groupKeyId', groupKeyId)
-        }
         this.groupKeyId = groupKeyId
-        validateIsType('newGroupKey', newGroupKey, 'EncryptedGroupKey', EncryptedGroupKey, true)
         this.newGroupKey = newGroupKey
-        validateIsType('signature', signature, 'Uint8Array', Uint8Array)
         this.signature = signature
         this.signatureType = signatureType
-        validateIsNotEmptyByteArray('content', content)
         this.content = content
-        StreamMessage.validateSequence(this)
     }
 
     getStreamId(): StreamID {
@@ -150,28 +147,28 @@ export default class StreamMessage implements StreamMessageOptions {
     static isAESEncrypted(msg: StreamMessage): msg is StreamMessageAESEncrypted {
         return msg.encryptionType === EncryptionType.AES
     }
+}
 
-    private static validateSequence({ messageId, prevMsgRef }: { messageId: MessageID, prevMsgRef?: MessageRef }): void {
-        if (!prevMsgRef) {
-            return
-        }
+/**
+ * Validates that messageId is strictly after prevMsgRef in time.
+ */
+function validateSequence(messageId: MessageID, prevMsgRef: MessageRef | undefined): void {
+    if (prevMsgRef === undefined) {
+        return
+    }
 
-        const comparison = messageId.toMessageRef().compareTo(prevMsgRef)
+    const comparison = messageId.toMessageRef().compareTo(prevMsgRef)
 
-        // cannot have same timestamp + sequence
-        if (comparison === 0) {
-            throw new ValidationError(
-                // eslint-disable-next-line max-len
-                `prevMessageRef cannot be identical to current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
-            )
-        }
-
-        // previous cannot be newer
-        if (comparison < 0) {
-            throw new ValidationError(
-                // eslint-disable-next-line max-len
-                `prevMessageRef must come before current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
-            )
-        }
+    if (comparison === 0) {
+        throw new ValidationError(
+            // eslint-disable-next-line max-len
+            `prevMessageRef cannot be identical to current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
+        )
+    }
+    if (comparison < 0) {
+        throw new ValidationError(
+            // eslint-disable-next-line max-len
+            `prevMessageRef must come before current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
+        )
     }
 }

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -51,6 +51,30 @@ export type StreamMessageAESEncrypted = StreamMessage & {
     groupKeyId: string
 }
 
+/**
+ * Validates that messageId is strictly after prevMsgRef in time.
+ */
+function validateSequence(messageId: MessageID, prevMsgRef: MessageRef | undefined): void {
+    if (prevMsgRef === undefined) {
+        return
+    }
+
+    const comparison = messageId.toMessageRef().compareTo(prevMsgRef)
+
+    if (comparison === 0) {
+        throw new ValidationError(
+            // eslint-disable-next-line max-len
+            `prevMessageRef cannot be identical to current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
+        )
+    }
+    if (comparison < 0) {
+        throw new ValidationError(
+            // eslint-disable-next-line max-len
+            `prevMessageRef must come before current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
+        )
+    }
+}
+
 export default class StreamMessage implements StreamMessageOptions {
     readonly messageId: MessageID
     readonly prevMsgRef?: MessageRef
@@ -146,29 +170,5 @@ export default class StreamMessage implements StreamMessageOptions {
 
     static isAESEncrypted(msg: StreamMessage): msg is StreamMessageAESEncrypted {
         return msg.encryptionType === EncryptionType.AES
-    }
-}
-
-/**
- * Validates that messageId is strictly after prevMsgRef in time.
- */
-function validateSequence(messageId: MessageID, prevMsgRef: MessageRef | undefined): void {
-    if (prevMsgRef === undefined) {
-        return
-    }
-
-    const comparison = messageId.toMessageRef().compareTo(prevMsgRef)
-
-    if (comparison === 0) {
-        throw new ValidationError(
-            // eslint-disable-next-line max-len
-            `prevMessageRef cannot be identical to current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
-        )
-    }
-    if (comparison < 0) {
-        throw new ValidationError(
-            // eslint-disable-next-line max-len
-            `prevMessageRef must come before current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
-        )
     }
 }

--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -52,11 +52,6 @@ export type StreamMessageAESEncrypted = StreamMessage & {
 }
 
 export default class StreamMessage implements StreamMessageOptions {
-    private static VALID_MESSAGE_TYPES = new Set(Object.values(StreamMessageType))
-    private static VALID_CONTENT_TYPES = new Set(Object.values(ContentType))
-    private static VALID_ENCRYPTIONS = new Set(Object.values(EncryptionType))
-    private static VALID_SIGNATURE_TYPES = new Set(Object.values(SignatureType))
-
     readonly messageId: MessageID
     readonly prevMsgRef?: MessageRef
     readonly messageType: StreamMessageType
@@ -84,11 +79,8 @@ export default class StreamMessage implements StreamMessageOptions {
         this.messageId = messageId
         validateIsType('prevMsgRef', prevMsgRef, 'MessageRef', MessageRef, true)
         this.prevMsgRef = prevMsgRef
-        StreamMessage.validateMessageType(messageType)
         this.messageType = messageType
-        StreamMessage.validateContentType(contentType)
         this.contentType = contentType
-        StreamMessage.validateEncryptionType(encryptionType)
         this.encryptionType = encryptionType
         if (this.encryptionType === EncryptionType.AES) {
             validateIsDefined('groupKeyId', groupKeyId)
@@ -98,7 +90,6 @@ export default class StreamMessage implements StreamMessageOptions {
         this.newGroupKey = newGroupKey
         validateIsType('signature', signature, 'Uint8Array', Uint8Array)
         this.signature = signature
-        StreamMessage.validateSignatureType(signatureType)
         this.signatureType = signatureType
         validateIsNotEmptyByteArray('content', content)
         this.content = content
@@ -158,30 +149,6 @@ export default class StreamMessage implements StreamMessageOptions {
 
     static isAESEncrypted(msg: StreamMessage): msg is StreamMessageAESEncrypted {
         return msg.encryptionType === EncryptionType.AES
-    }
-
-    private static validateMessageType(messageType: StreamMessageType): void {
-        if (!StreamMessage.VALID_MESSAGE_TYPES.has(messageType)) {
-            throw new ValidationError(`Unsupported message type: ${messageType}`)
-        }
-    }
-
-    private static validateContentType(contentType: ContentType): void {
-        if (!StreamMessage.VALID_CONTENT_TYPES.has(contentType)) {
-            throw new ValidationError(`Unsupported content type: ${contentType}`)
-        }
-    }
-
-    private static validateEncryptionType(encryptionType: EncryptionType): void {
-        if (!StreamMessage.VALID_ENCRYPTIONS.has(encryptionType)) {
-            throw new ValidationError(`Unsupported encryption type: ${encryptionType}`)
-        }
-    }
-
-    private static validateSignatureType(signatureType: SignatureType): void {
-        if (!StreamMessage.VALID_SIGNATURE_TYPES.has(signatureType)) {
-            throw new ValidationError(`Unsupported signature type: ${signatureType}`)
-        }
     }
 
     private static validateSequence({ messageId, prevMsgRef }: { messageId: MessageID, prevMsgRef?: MessageRef }): void {

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -6,12 +6,6 @@ export function validateIsDefined(varName: string, varValue: unknown): void | ne
     }
 }
 
-export function validateIsNotEmptyString(varName: string, varValue: string): void | never {
-    if (varValue.length === 0) {
-        throw new ValidationError(`Expected ${varName} to not be an empty string.`)
-    }
-}
-
 export function validateIsNotNegativeInteger(varName: string, varValue?: number, allowUndefined = false): void | never {
     if (allowUndefined && varValue === undefined) {
         return
@@ -28,21 +22,5 @@ export function validateIsNotNegativeInteger(varName: string, varValue?: number,
 export function validateIsNotEmptyByteArray(varName: string, varValue: Uint8Array): void | never {
     if (!(varValue instanceof Uint8Array) || varValue.length === 0) {
         throw new ValidationError(`Expected ${varName} to be a non-empty byte array`)
-    }
-}
-
-export function validateIsType(
-    varName: string,
-    varValue: unknown,
-    typeName: string,
-    typeClass: unknown,
-    allowUndefined = false
-): void | never {
-    if (allowUndefined && varValue === undefined) {
-        return
-    }
-    if (!(varValue instanceof (typeClass as any))) {
-        const msg = `Expected ${varName} to be an instance of (${typeName}), but it was: ${JSON.stringify(varValue)}`
-        throw new ValidationError(msg)
     }
 }

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -180,13 +180,6 @@ describe('StreamMessage', () => {
             }))
         })
 
-        it('Throws with an invalid content type', () => {
-            assert.throws(() => msg({
-                // @ts-expect-error TODO
-                contentType: 999, // invalid
-            }), ValidationError)
-        })
-
         it('Throws with an invalid newGroupKey', () => {
             assert.throws(() => msg({
                 // @ts-expect-error TODO

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -180,13 +180,6 @@ describe('StreamMessage', () => {
             }))
         })
 
-        it('Throws with an invalid newGroupKey', () => {
-            assert.throws(() => msg({
-                // @ts-expect-error TODO
-                newGroupKey: 'foo', // invalid
-            }), ValidationError)
-        })
-
         it('Throws with an no group key for AES encrypted message', () => {
             assert.throws(() => msg({
                 encryptionType: EncryptionType.AES

--- a/packages/protocol/test/unit/utils/validations.test.ts
+++ b/packages/protocol/test/unit/utils/validations.test.ts
@@ -1,8 +1,4 @@
-import {
-    validateIsDefined,
-    validateIsNotEmptyString,
-    validateIsNotNegativeInteger
-} from '../../../src/utils/validations'
+import { validateIsDefined, validateIsNotNegativeInteger } from '../../../src/utils/validations'
 import ValidationError from '../../../src/errors/ValidationError'
 
 describe('validations', () => {
@@ -11,19 +7,6 @@ describe('validations', () => {
             expect(() => {
                 validateIsDefined('varName', undefined)
             }).toThrow(new ValidationError('Expected varName to not be undefined.'))
-        })
-    })
-
-    describe('validateIsNotEmptyString', () => {
-        it('throws on empty string', () => {
-            expect(() => {
-                validateIsNotEmptyString('varName', '')
-            }).toThrow(new ValidationError('Expected varName to not be an empty string.'))
-        })
-        it('does not throw on non-empty string', () => {
-            expect(() => {
-                validateIsNotEmptyString('varName', 'hello, world')
-            }).not.toThrow()
         })
     })
 

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -123,7 +123,7 @@ describe('proxy group key exchange', () => {
             ),
             messageType: StreamMessageType.GROUP_KEY_RESPONSE,
             contentType: ContentType.JSON,
-            encryptionType: EncryptionType.RSA,
+            encryptionType: EncryptionType.NONE,
             content: serializeGroupKeyResponse(groupKeyResponse),
             signatureType: SignatureType.SECP256K1,
             signature: hexToBinary('1234')


### PR DESCRIPTION
## Summary

Now that we don't de-serialize directly into `StreamMessage` but go thru the protobuf equivalent first, there is (imo) no need to do runtime type validation in the protocol class anymore. Semantic validation is still reasonable to keep around (e.g. `msgId` is strictly ahead of `prevMsgRef`, when using `AES` check that `groupKeyId` is present).

## Changes

- Remove `EncryptionType.RSA` (was only used internally, protobuf equivalent has only NONE / AES)
- Remove Enum runtime validation in StreamMessage (ContentType, MessageType, EncryptionType, SignatureType)
- Remove some runtime validation from `StreamMessage`, `MessageID`, and `EncrypedGroupKey`.

## Limitations and future improvements

- We could add validation that if `LEGACY_SECP256K1` is used then `BINARY` content type is disallowed.
- It is worth thinking thru where semantic validation should take place. It is kind of late in the process to validate it only here in `StreamMessage`, it could be argued that this should occur much earlier in the process of de-serializing messages.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
