### PR TITLE
refactor(utils): Do not export `recoverSignature`

### DIFF
--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -42,7 +42,7 @@ import { binaryToHex, binaryToUtf8, hexToBinary, utf8ToBinary, areEqualBinaries 
 import { filePathToNodeFormat } from './filePathToNodeFormat'
 import { retry } from './retry'
 import { toLengthPrefixedFrame, LengthPrefixedFrameDecoder } from './lengthPrefixedFrameUtils'
-import { verifySignature, createSignature, recoverSignature } from './signingUtils'
+import { verifySignature, createSignature } from './signingUtils'
 
 export {
     BrandedString,
@@ -100,8 +100,7 @@ export {
     LengthPrefixedFrameDecoder,
     toLengthPrefixedFrame,
     createSignature,
-    verifySignature,
-    recoverSignature
+    verifySignature
 }
 
 export {

--- a/packages/utils/src/signingUtils.ts
+++ b/packages/utils/src/signingUtils.ts
@@ -48,7 +48,7 @@ export function createSignature(payload: Uint8Array, privateKeyAsHex: string): U
     return result
 }
 
-export function recoverSignature(signature: Uint8Array, payload: Uint8Array): string {
+function recoverSignature(signature: Uint8Array, payload: Uint8Array): string {
     const publicKey = recoverPublicKey(signature, payload)
     const pubKeyWithoutFirstByte = publicKey.subarray(1, publicKey.length)
     keccak.reset()

--- a/packages/utils/test/SigningUtil.test.ts
+++ b/packages/utils/test/SigningUtil.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import assert from 'assert'
-import { createSignature, recoverSignature, verifySignature } from '../src/signingUtils'
+import { createSignature, verifySignature } from '../src/signingUtils'
 import { toEthereumAddress } from '../src/EthereumAddress'
 import { hexToBinary } from '../src/binaryUtils'
 
@@ -11,38 +11,6 @@ describe('createSignature', () => {
         const payload = Buffer.from('data-to-sign')
         const signature = createSignature(payload, privateKey)
         expect(signature).toStrictEqual(hexToBinary('787cd72924153c88350e808de68b68c88030cbc34d053a5c696a5893d5e6fec1687c1b6205ec99aeb3375a81bf5cb8857ae39c1b55a41b32ed6399ae8da456a61b'))
-    })
-})
-
-describe('recoverSignature', () => {
-    it('recovers correct address', async () => {
-        const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-        const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
-        const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
-        const recoveredAddress = recoverSignature(signature, payload)
-        assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
-    })
-
-    it('can handle missing 0x in signature', async () => {
-        const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-        const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
-        const signature = hexToBinary('c97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
-        const recoveredAddress = recoverSignature(signature, payload)
-        assert.strictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
-    })
-
-    it('throws if the address can not be recovered (invalid signature)', async () => {
-        const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
-        const signature = hexToBinary('0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
-        expect(() => recoverSignature(signature, payload)).toThrowError()
-    })
-
-    it('returns a different address if the content is tampered', async () => {
-        const address = '0x752C8dCAC0788759aCB1B4BB7A9103596BEe3e6c'
-        const payload = Buffer.from('foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
-        const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
-        const recoveredAddress = recoverSignature(signature, payload)
-        assert.notStrictEqual(recoveredAddress.toLowerCase(), address.toLowerCase())
     })
 })
 


### PR DESCRIPTION
The `recoverSignature` is a helper function of `verifySignature`. Removed test cases as that functionality is covered by `verifySignature` test cases.