### PR TITLE
refactor(client): Use `urls` storage node metadata field

### DIFF
--- a/packages/broker/test/utils.ts
+++ b/packages/broker/test/utils.ts
@@ -138,7 +138,7 @@ export async function startStorageNode(
     })
     try {
         await client.setStorageNodeMetadata({
-            http: `http://127.0.0.1:${httpPort}`
+            urls: [`http://127.0.0.1:${httpPort}`]
         })
         await createAssignmentStream(client)
     } finally {

--- a/packages/client/src/registry/StorageNodeRegistry.ts
+++ b/packages/client/src/registry/StorageNodeRegistry.ts
@@ -11,7 +11,7 @@ import NodeRegistryArtifact from '../ethereumArtifacts/NodeRegistryAbi.json'
 import { queryAllReadonlyContracts, waitForTx } from '../utils/contract'
 
 export interface StorageNodeMetadata {
-    http: string
+    urls: string[]
 }
 
 /**

--- a/packages/client/src/subscribe/Resends.ts
+++ b/packages/client/src/subscribe/Resends.ts
@@ -2,6 +2,7 @@ import { StreamID, StreamMessage, StreamPartID, StreamPartIDUtils } from '@strea
 import { EthereumAddress, Logger, randomString, toEthereumAddress } from '@streamr/utils'
 import random from 'lodash/random'
 import without from 'lodash/without'
+import sample from 'lodash/sample'
 import { Lifecycle, delay, inject, scoped } from 'tsyringe'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
 import { StreamrClientError } from '../StreamrClientError'
@@ -176,8 +177,8 @@ export class Resends {
             throw new StreamrClientError(`no storage assigned: ${streamId}`, 'NO_STORAGE_NODES')
         }
         const nodeAddress = nodeAddresses[random(0, nodeAddresses.length - 1)]
-        const nodeUrl = (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).http
-        const url = createUrl(nodeUrl, resendType, streamPartId, query)
+        const nodeUrls = (await this.storageNodeRegistry.getStorageNodeMetadata(nodeAddress)).urls
+        const url = createUrl(sample(nodeUrls)!, resendType, streamPartId, query)
         const messageStream = raw ? new PushPipeline<StreamMessage, StreamMessage>() : this.messagePipelineFactory.createMessagePipeline({
             streamPartId,
             /*

--- a/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry.test.ts
@@ -71,7 +71,7 @@ describe('StorageNodeRegistry', () => {
                 }
             }
         })
-        await storageNodeManager.setStorageNodeMetadata({ http: 'mock-url' })
+        await storageNodeManager.setStorageNodeMetadata({ urls: ['mock-url'] })
         const stored = await creatorClient.getStoredStreams(storageNodeWallet.address)
         expect(stored.streams).toEqual([])
         expect(stored.blockNumber).toBeNumber()

--- a/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/client/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -36,10 +36,10 @@ describe('StorageNodeRegistry2', () => {
     it('creates a node', async () => {
         const url = `http://mock.com/${Date.now()}`
         await storageNodeClient.setStorageNodeMetadata({
-            http: url
+            urls: [url]
         })
         const metadata = await storageNodeClient.getStorageNodeMetadata(storageNodeAddress)
-        expect(metadata.http).toEqual(url)
+        expect(metadata.urls).toEqual([url])
     })
 
     it('add stream to storage node', async () => {

--- a/packages/client/test/test-utils/fake/FakeStorageNode.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNode.ts
@@ -108,7 +108,7 @@ export class FakeStorageNode extends FakeNetworkNode {
         })
         const port = (this.server.address() as AddressInfo).port
         this.chain.storageNodeMetadatas.set(this.getAddress(), {
-            http: `http://127.0.0.1:${port}`
+            urls: [`http://127.0.0.1:${port}`]
         })
         const storageNodeAssignmentStreamPermissions = new Multimap<EthereumAddress, StreamPermission>()
         storageNodeAssignmentStreamPermissions.add(this.getAddress(), StreamPermission.PUBLISH)

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -20,7 +20,7 @@ import { convertStreamMessageToBytes } from '@streamr/trackerless-network'
 const createResends = (serverUrl: string) => {
     return new Resends(
         {
-            getStorageNodeMetadata: async () => ({ http: serverUrl })
+            getStorageNodeMetadata: async () => ({ urls: [serverUrl] })
         } as any,
         undefined as any,
         undefined as any,


### PR DESCRIPTION
Use `urls` field from storage node metadata to read the URL of the storage node. The field contains a `string` array. Previously the URL was stored in the `http` field and it contained only one URL instead of an array of URLs.

With this change we can configure different URLs for 1.0 clients and Brubeck era clients in the same contract.

From the url list we pick a random item. We don't currently support any retry logic within one storage node. (We already have a retry logic if there are multiple storage nodes.)

## Future improvements

- If there is no `urls` field in the metadata, the resend `Promise` rejects with an error `StreamrClientError`: Only absolute URLs are supported, code=`STORAGE_NODE_ERROR`. Maybe the error message could describe the root cause.
- We could maybe retry the resend by using another URL if a resend fails a randomly picked URL.