### PR TITLE
fix(network): fix default value for nearbyNodeViewSize

### DIFF
--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -34,7 +34,7 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
     const minPropagationTargets = config.minPropagationTargets ?? 2
     const acceptProxyConnections = config.acceptProxyConnections ?? false
     const neighborUpdateInterval = config.neighborUpdateInterval ?? 10000
-    const nearbyNodeView = config.nearbyNodeView ?? new NodeList(ownNodeId, neighborCount + 1)
+    const nearbyNodeView = config.nearbyNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const randomNodeView = config.randomNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const neighbors = config.neighbors ?? new NodeList(ownNodeId, maxContactCount)
 


### PR DESCRIPTION
## Summary

The default size for the nearbyNodeView was too low. This has lead to the number of nearby available peers to connect to being too low.