### PR TITLE
feat(client): Allow empty `StreamMessage` content

### DIFF
--- a/packages/protocol/src/protocol/message_layer/StreamMessage.ts
+++ b/packages/protocol/src/protocol/message_layer/StreamMessage.ts
@@ -1,6 +1,6 @@
 import InvalidJsonError from '../../errors/InvalidJsonError'
 import StreamMessageError from '../../errors/StreamMessageError'
-import { validateIsDefined, validateIsNotEmptyByteArray } from '../../utils/validations'
+import { validateIsDefined } from '../../utils/validations'
 import MessageRef from './MessageRef'
 import MessageID from './MessageID'
 import EncryptedGroupKey from './EncryptedGroupKey'
@@ -100,7 +100,6 @@ export default class StreamMessage implements StreamMessageOptions {
         newGroupKey,
     }: StreamMessageOptions) {
         validateSequence(messageId, prevMsgRef)
-        validateIsNotEmptyByteArray('content', content)
         if (encryptionType === EncryptionType.AES) {
             validateIsDefined('groupKeyId', groupKeyId)
         }

--- a/packages/protocol/src/utils/validations.ts
+++ b/packages/protocol/src/utils/validations.ts
@@ -18,9 +18,3 @@ export function validateIsNotNegativeInteger(varName: string, varValue?: number,
         throw new ValidationError(`Expected ${varName} to not be negative (${varValue}).`)
     }
 }
-
-export function validateIsNotEmptyByteArray(varName: string, varValue: Uint8Array): void | never {
-    if (!(varValue instanceof Uint8Array) || varValue.length === 0) {
-        throw new ValidationError(`Expected ${varName} to be a non-empty byte array`)
-    }
-}

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -164,13 +164,6 @@ describe('StreamMessage', () => {
             } as any), ValidationError)
         })
 
-        it('should throw if content is not defined', () => {
-            assert.throws(() => new StreamMessage({
-                messageId: new MessageID(toStreamID('streamId'), 0, 1564046332168, 10, PUBLISHER_ID, 'msgChainId'),
-                // missing content
-            } as any), ValidationError)
-        })
-
         it('should not throw when encrypted content', () => {
             assert.doesNotThrow(() => msg({
                 // @ts-expect-error TODO

--- a/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/packages/protocol/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -157,13 +157,6 @@ describe('StreamMessage', () => {
             expect(StreamMessage.isAESEncrypted(encryptedMessage)).toBe(true)
         })
 
-        it('should throw if required fields are not defined', () => {
-            assert.throws(() => new StreamMessage({
-                // missing messageId
-                content: JSON.stringify(content),
-            } as any), ValidationError)
-        })
-
         it('should not throw when encrypted content', () => {
             assert.doesNotThrow(() => msg({
                 // @ts-expect-error TODO


### PR DESCRIPTION
Removed the validation of content array length, as there is no reason to disallow empty arrays. 

Also removed test case "should throw if required fields are not defined" as no longer do type validation for `StreamMessage` objects (https://github.com/streamr-dev/network/pull/2299). The test didn't threw any exception after this change and therefore wasn't actually testing the described functionality.