### PR TITLE
fix(network): remove as unknown casting from NodeInfoRpcRemote

### DIFF
--- a/packages/trackerless-network/src/logic/node-info/NodeInfoRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/node-info/NodeInfoRpcRemote.ts
@@ -5,9 +5,7 @@ import { RpcRemote } from '@streamr/dht'
 export class NodeInfoRpcRemote extends RpcRemote<NodeInfoRpcClient> {
 
     async getInfo(): Promise<NodeInfoResponse> {
-        // TODO: Why does TS think this is Promise<void>: https://github.com/streamr-dev/network/pull/2293
-        const result = await this.getClient().getInfo({}, this.formDhtRpcOptions())
-        return result as unknown as NodeInfoResponse
+        return this.getClient().getInfo({}, this.formDhtRpcOptions())
     }
 
 }


### PR DESCRIPTION
## Summary

Remove TODO comment and related as unknown casting after the underlying issue was fixed after #2293
