### PR TITLE
chore(ci): workflow to publish to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,24 @@
+name: publish npm
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: choice
+        required: true
+        default: latest
+        options:
+          - latest
+          - beta
+          - alpha
+          - internal
+          - testnet-three
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build (cached)
+        uses: ./.github/workflows/reusable/cached-build
+      - run: bash release.sh ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,4 +21,4 @@ jobs:
         uses: ./.github/workflows/reusable/cached-build
       - run: bash release.sh ${{ github.event.inputs.tag }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/reusable/cached-build/action.yml
+++ b/.github/workflows/reusable/cached-build/action.yml
@@ -9,6 +9,7 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'npm'
         cache-dependency-path: package-lock.json
+        registry-url: 'https://registry.npmjs.org'
     - name: cache node_modules
       id: cache-node-modules
       uses: actions/cache@v3


### PR DESCRIPTION
## Summary

Add a workflow for publishing packages to NPM. It is triggered manually (for now). It uses the existing release.sh script. 

TODO: run this thing for real

## Limitations and future improvements

- Make it automatically run after tests?
    - For every push to main? Other branhces?
    - For tagged commits only?
    - Which tag to use?
- Alternatively: put both Docker & NPM releases behind a button.
    - More control over release process
    - Annoying to manually click?
    - Continous dev builds can be nice for catching issues early though.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
