### PR TITLE
chore(ci): tweak release.sh and remove `prepublishOnly` NPM scripts

### DIFF
--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -16,8 +16,7 @@
     "build": "tsc -b tsconfig.node.json",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
-    "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json"
+    "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
   "dependencies": {
     "@protobuf-ts/runtime-rpc": "^2.8.2",

--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -20,7 +20,6 @@
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "jest test/unit test/integration",
     "test-unit": "jest test/unit",
     "test-integration": "jest test/integration"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,7 +23,6 @@
     "prebuild": "node bin/generate-config-validator.js && bash vendor-hack.sh",
     "postbuild": "bash copy-package.sh && bash fix-esm.sh",
     "build": "tsc --build ./tsconfig.node.json",
-    "build-production": "npm run clean; NODE_ENV=production npm run build && npm run build-browser-production",
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -18,7 +18,6 @@
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -18,7 +18,6 @@
     "check": "tsc -p ./tsconfig.jest.json --noEmit",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
-    "prepublishOnly": "npm run clean && NODE_ENV=production tsc -b tsconfig.node.json",
     "test": "npm run test-unit && npm run test-integration",
     "test-browser": "karma start karma.config.js",
     "test-unit": "jest test/unit",

--- a/release.sh
+++ b/release.sh
@@ -7,56 +7,60 @@ if [[ "$1" == "" ]]; then
     exit 1
 fi
 
-cd packages/utils
-npm publish --access public --tag $NPM_TAG
-cd ../..
+npm run build
 
-cd packages/test-utils
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/protocol
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/proto-rpc
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/autocertifier-client
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/dht
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/autocertifier-server
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-cd packages/trackerless-network
-npm publish --access public --tag $NPM_TAG
-cd ../..
-
-# Publishing client is a bit more complicated
-cd packages/client
-npm run build-production
-if [ $? -ne 0 ] 
+# Build client's webpack bundle
+cd packages/client || exit
+npm run build-browser-production
+if [ $? -ne 0 ]
 then
     echo
     echo 'Client build failed, did not publish all packages!'
     echo
     exit 1
 fi
-cd dist
+cd ../..
+
+cd packages/utils || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/test-utils || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/protocol || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/proto-rpc || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/autocertifier-client || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/dht || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/autocertifier-server || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/trackerless-network || exit
+npm publish --access public --tag $NPM_TAG
+cd ../..
+
+cd packages/client/dist || exit # Notice: dist folder
 npm publish --tag $NPM_TAG
 cd ../../..
 
-cd packages/broker
+cd packages/broker || exit
 npm publish --tag $NPM_TAG --access public
 cd ../..
 
-cd packages/cli-tools
+cd packages/cli-tools || exit
 npm publish --tag $NPM_TAG --access public
 cd ../..


### PR DESCRIPTION
## Summary

In bash script release.sh:
- Use `cd packages/<PKG> || exit` pattern. Safer to exit than to run `npm publish` in an unintended dir.
- Build all packages in the very beginning (not strictly necessary if following instructions, but maybe a good "just to be safe" thing to do, it's a reasonably fast command anyway given that packages should be built already at this point)
- Build client webpack first, then only start the release process. (Kinda of sucks to have half of packages be published only to later realize client webpack doesn't even compile.  🤦 That being said, this shouldn't really happen if you are being patient and waiting for CI to go green as the instructions recommend.) 

NPM scripts:
- Remove `prepublishOnly` scripts from packages. (It's kind of a safeguard, could be argued that it should be kept in. However we release the monorepo as a whole, so you go thru the release.sh script anyway ensuring everything is built. I would remove it here to make the release process ever so slightly faster.)
- Remove client's `build-production`. (Enough to build webpack since the node version will be built already, no point in rebuilding). 

## Checklist before requesting a review

Tested it by hand by adding `--dry-run` to NPM publish commands and then removing them before comitting.

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
