### PR TITLE
quickfix: only accept regular incoming websocket connections if localPeerDescriptor has been set

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -153,7 +153,12 @@ export class WebsocketConnector {
                 } else if (action === 'connectivityProbe') {
                     // no-op
                 } else {
-                    this.attachHandshaker(connection)
+                    if (this.localPeerDescriptor !== undefined) {
+                        this.attachHandshaker(connection)
+                    } else {
+                        // ToDo: figure out should we close the connection here or not?
+                        connection.close(false).then(() => { return }).catch(() => {})
+                    }
                 }
             })
             const port = await this.websocketServer.start()


### PR DESCRIPTION
* only accept regular incoming websocket connections if localPeerDescriptor has been set

ToDo: figure out whether closing the incoming connection when localPeerDescriptor is undefined is the right thing to do