### PR TITLE
quickfix: only accept regular incoming websocket connections if local…

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -153,7 +153,13 @@ export class WebsocketConnector {
                 } else if (action === 'connectivityProbe') {
                     // no-op
                 } else {
-                    this.attachHandshaker(connection)
+                    if (this.localPeerDescriptor !== undefined) {
+                        this.attachHandshaker(connection)
+                    } else {
+                        logger.warn('incoming Websocket connection before localPeerDescriptor was set, closing connection')
+                        // ToDo: figure out should we close the connection here or not?
+                        connection.close(false).then(() => { return }).catch(() => {})
+                    }
                 }
             })
             const port = await this.websocketServer.start()


### PR DESCRIPTION
* No not accept incoming websocket connections if localPeerDescriptor is undefined, but close the connection instead

ToDo: find out whether closing the incoming connection is the right thing to do if localPeerDescriptor is undefined
