### PR TITLE
fix(DHT): Only emit newContact if contact was added to SortedContactList

### DIFF
--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -72,15 +72,16 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 const index = sortedIndexBy(this.contactIds, contact.getNodeId(), (id: DhtAddress) => { return this.distanceToReferenceId(id) })
                 this.contactIds.splice(index, 0, contact.getNodeId())
                 if (this.config.emitEvents) {
+                    const closestContacts = this.getClosestContacts()
                     this.emit(
                         'contactRemoved',
                         removedContact,
-                        this.getClosestContacts()
+                        closestContacts
                     )
                     this.emit(
                         'newContact',
                         contact,
-                        this.getClosestContacts()
+                        closestContacts
                     )
                 }
             }

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -55,6 +55,13 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 // eslint-disable-next-line max-len
                 const index = sortedIndexBy(this.contactIds, contact.getNodeId(), (id: DhtAddress) => { return this.distanceToReferenceId(id) })
                 this.contactIds.splice(index, 0, contact.getNodeId())
+                if (this.config.emitEvents) {
+                    this.emit(
+                        'newContact',
+                        contact,
+                        this.getClosestContacts()
+                    )
+                }
             } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contact.getNodeId()) > 0) {
                 const removedId = this.contactIds.pop()
                 const removedContact = this.contactsById.get(removedId!)!.contact
@@ -70,14 +77,12 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                         removedContact,
                         this.getClosestContacts()
                     )
+                    this.emit(
+                        'newContact',
+                        contact,
+                        this.getClosestContacts()
+                    )
                 }
-            }
-            if (this.config.emitEvents) {
-                this.emit(
-                    'newContact',
-                    contact,
-                    this.getClosestContacts()
-                )
             }
         }
     }

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -118,4 +118,17 @@ describe('SortedContactList', () => {
         list.setActive(item4.getNodeId())
         expect(list.getActiveContacts()).toEqual([item2, item3, item4])
     })
+
+    it('does not emit newContact if contact did not fit the structure', () => {
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 2, allowToContainReferenceId: false, emitEvents: true })
+        const onNewContact = jest.fn()
+        list.on('newContact', onNewContact)
+        list.addContact(item1)
+        list.addContact(item2)
+        expect(onNewContact).toBeCalledTimes(2)
+        list.addContact(item3)
+        expect(onNewContact).toBeCalledTimes(2)
+        expect(list.getAllContacts().length).toEqual(2)
+    })
+
 })


### PR DESCRIPTION
## Summary

the `newContact` event is now only emitted if the contact was actually added to the contact list. Previously if a peer was outside the max length of the structure `newContact` was emitted each time it was seen. This caused performance problems in some nodes.

## Future Improvements

- Rename event to contactAdded