### PR TITLE
fix(DHT): Reject WS server connections during start

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -153,6 +153,9 @@ export class WebsocketConnector {
                 } else if (action === 'connectivityProbe') {
                     // no-op
                 } else {
+                    // The localPeerDescriptor can be undefined here as the WS server is used for connectivity checks
+                    // before the localPeerDescriptor is set during start.
+                    // Handshaked connections should be rejected before the localPeerDescriptor is set.
                     if (this.localPeerDescriptor !== undefined) {
                         this.attachHandshaker(connection)
                     } else {

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -156,9 +156,8 @@ export class WebsocketConnector {
                     if (this.localPeerDescriptor !== undefined) {
                         this.attachHandshaker(connection)
                     } else {
-                        logger.warn('incoming Websocket connection before localPeerDescriptor was set, closing connection')
-                        // ToDo: figure out should we close the connection here or not?
-                        connection.close(false).then(() => { return }).catch(() => {})
+                        logger.trace('incoming Websocket connection before localPeerDescriptor was set, closing connection')
+                        connection.close(false).catch(() => {})
                     }
                 }
             })

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -153,7 +153,13 @@ export class WebsocketConnector {
                 } else if (action === 'connectivityProbe') {
                     // no-op
                 } else {
-                    this.attachHandshaker(connection)
+                    if (this.localPeerDescriptor !== undefined) {
+                        this.attachHandshaker(connection)
+                    } else {
+                        logger.warn('incoming Websocket connection before localPeerDescriptor was set, closing connection')
+                        // ToDo: figure out should we close the connection here or not?
+                        connection.close(false).then(() => { return }).catch(() => {})
+                    }
                 }
             })
             const port = await this.websocketServer.start()


### PR DESCRIPTION
## Summary

Immediately close close on WS server if local PeerDescriptor has not been set. This reduces the likelihood of hanging connections in the entry points.
