### PR TITLE
feat(DHT): validate explicit peer descriptor nodeId length

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -157,6 +157,11 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 throw new Error(`Invalid nodeId, the length of the nodeId should be ${expectedNodeIdLength}`)
             }
         }
+        if (this.config.peerDescriptor !== undefined) {
+            if (this.config.peerDescriptor.nodeId.length !== KADEMLIA_ID_LENGTH_IN_BYTES) {
+                throw new Error(`Invalid peerDescriptor, the length of the nodeId should be ${KADEMLIA_ID_LENGTH_IN_BYTES} bytes`)
+            }
+        }
     }
 
     public async start(): Promise<void> {

--- a/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/random-graph-with-real-connections.test.ts
@@ -1,7 +1,7 @@
-import { ConnectionManager, DhtNode, PeerDescriptor, NodeType } from '@streamr/dht'
+import { ConnectionManager, DhtNode, PeerDescriptor } from '@streamr/dht'
 import { RandomGraphNode } from '../../src/logic/RandomGraphNode'
 import { waitForCondition } from '@streamr/utils'
-import { createStreamMessage } from '../utils/utils'
+import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
@@ -10,11 +10,9 @@ import { Layer1Node } from '../../src/logic/Layer1Node'
 
 describe('random graph with real connections', () => {
 
-    const epPeerDescriptor: PeerDescriptor = {
-        nodeId: Uint8Array.from([1, 2, 3]),
-        type: NodeType.NODEJS,
+    const epPeerDescriptor: PeerDescriptor = createMockPeerDescriptor({
         websocket: { host: '127.0.0.1', port: 12221, tls: false }
-    }
+    })
 
     const streamPartId = StreamPartIDUtils.parse('random-graph#0')
     // Currently the nodes here are practically layer0 nodes acting as layer1 nodes, for the purpose of this test

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -1,4 +1,4 @@
-import { NodeType, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
+import { PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import {
     ContentType,
     EncryptionType,
@@ -10,6 +10,7 @@ import {
 } from '@streamr/protocol'
 import { EthereumAddress, hexToBinary, utf8ToBinary, waitForCondition } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
+import { createMockPeerDescriptor } from '../utils/utils'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('test#0')
 
@@ -21,15 +22,9 @@ describe('NetworkNode', () => {
     let node1: NetworkNode
     let node2: NetworkNode
 
-    const pd1: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS
-    }
+    const pd1: PeerDescriptor = createMockPeerDescriptor()
 
-    const pd2: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
+    const pd2: PeerDescriptor = createMockPeerDescriptor()
 
     beforeEach(async () => {
         const simulator = new Simulator()

--- a/packages/trackerless-network/test/integration/StreamrNode.test.ts
+++ b/packages/trackerless-network/test/integration/StreamrNode.test.ts
@@ -1,13 +1,7 @@
-import {
-    DhtNode,
-    PeerDescriptor,
-    Simulator,
-    SimulatorTransport,
-    NodeType
-} from '@streamr/dht'
+import { DhtNode, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import { StreamrNode, Events } from '../../src/logic/StreamrNode'
 import { waitForEvent3, waitForCondition } from '@streamr/utils'
-import { createStreamMessage } from '../utils/utils'
+import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { Layer0Node } from '../../src/logic/Layer0Node'
@@ -21,14 +15,8 @@ describe('StreamrNode', () => {
     let node1: StreamrNode
     let node2: StreamrNode
 
-    const peerDescriptor1: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS
-    }
-    const peerDescriptor2: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
+    const peerDescriptor1: PeerDescriptor = createMockPeerDescriptor()
+    const peerDescriptor2: PeerDescriptor = createMockPeerDescriptor()
     const STREAM_PART_ID = StreamPartIDUtils.parse('test#0')
 
     const msg = createStreamMessage(

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -1,9 +1,9 @@
-import { NodeType, PeerDescriptor, Simulator, SimulatorTransport, LatencyType, getRandomRegion } from '@streamr/dht'
+import { PeerDescriptor, Simulator, SimulatorTransport, LatencyType } from '@streamr/dht'
 import { NetworkStack } from '../../src/NetworkStack'
 import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { Any } from '../../src/proto/google/protobuf/any'
-import { createStreamMessage } from '../utils/utils'
+import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { waitForCondition } from '@streamr/utils'
 import { randomEthereumAddress } from '@streamr/test-utils'
 
@@ -11,35 +11,11 @@ const STREAM_PART_ID = StreamPartIDUtils.parse('stream#0')
 
 describe('Joining stream parts on offline nodes', () => {
 
-    const entryPointPeerDescriptor: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
-
-    const node1PeerDescriptor: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
-
-    const node2PeerDescriptor: PeerDescriptor = {
-        nodeId: new Uint8Array([2, 2, 2]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
-
-    const offlineDescriptor1: PeerDescriptor = {
-        nodeId: new Uint8Array([3, 3, 3]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
-
-    const offlineDescriptor2: PeerDescriptor = {
-        nodeId: new Uint8Array([4, 4, 4]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
+    const entryPointPeerDescriptor: PeerDescriptor = createMockPeerDescriptor()
+    const node1PeerDescriptor: PeerDescriptor = createMockPeerDescriptor()
+    const node2PeerDescriptor: PeerDescriptor = createMockPeerDescriptor()
+    const offlineDescriptor1: PeerDescriptor = createMockPeerDescriptor()
+    const offlineDescriptor2: PeerDescriptor = createMockPeerDescriptor()
 
     let entryPoint: NetworkStack
     let node1: NetworkStack

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -1,4 +1,4 @@
-import { LatencyType, NodeType, PeerDescriptor, Simulator, SimulatorTransport, getRandomRegion } from '@streamr/dht'
+import { LatencyType, PeerDescriptor, Simulator, SimulatorTransport } from '@streamr/dht'
 import {
     ContentType,
     EncryptionType,
@@ -22,11 +22,7 @@ describe('stream without default entrypoints', () => {
     let entrypoint: NetworkNode
     let nodes: NetworkNode[]
     let receivedMessageCount: number
-    const entryPointPeerDescriptor: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 2, 3]),
-        type: NodeType.NODEJS,
-        region: getRandomRegion()
-    }
+    const entryPointPeerDescriptor: PeerDescriptor = createMockPeerDescriptor()
 
     const streamMessage = new StreamMessage({
         messageId: new MessageID(

--- a/packages/trackerless-network/test/unit/InspectSession.test.ts
+++ b/packages/trackerless-network/test/unit/InspectSession.test.ts
@@ -2,8 +2,7 @@ import { InspectSession, Events } from '../../src/logic/inspect/InspectSession'
 import { MessageID } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { waitForEvent3 } from '../../../utils/dist/src/waitForEvent3'
 import { utf8ToBinary } from '@streamr/utils'
-import { createRandomNodeId } from '../utils/utils'
-import { DhtAddress } from '@streamr/dht'
+import { DhtAddress, createRandomDhtAddress } from '@streamr/dht'
 
 describe('InspectSession', () => {
 
@@ -31,8 +30,8 @@ describe('InspectSession', () => {
     }
 
     beforeEach(() => {
-        inspectedNode = createRandomNodeId()
-        anotherNode = createRandomNodeId()
+        inspectedNode = createRandomDhtAddress()
+        anotherNode = createRandomDhtAddress()
         inspectSession = new InspectSession({
             inspectedNode
         })

--- a/packages/trackerless-network/test/unit/Inspector.test.ts
+++ b/packages/trackerless-network/test/unit/Inspector.test.ts
@@ -1,8 +1,8 @@
-import { ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ListeningRpcCommunicator, createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { utf8ToBinary } from '@streamr/utils'
 import { Inspector } from '../../src/logic/inspect/Inspector'
 import { MockTransport } from '../utils/mock/Transport'
-import { createMockPeerDescriptor, createRandomNodeId, mockConnectionLocker } from '../utils/utils'
+import { createMockPeerDescriptor, mockConnectionLocker } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 
 describe('Inspector', () => {
@@ -12,7 +12,7 @@ describe('Inspector', () => {
 
     const inspectedDescriptor = createMockPeerDescriptor()
 
-    const nodeId = createRandomNodeId()
+    const nodeId = createRandomDhtAddress()
     let mockConnect: jest.Mock
 
     const messageRef = {

--- a/packages/trackerless-network/test/unit/NeighborFinder.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborFinder.test.ts
@@ -3,12 +3,12 @@ import { NodeList } from '../../src/logic/NodeList'
 import { waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { expect } from 'expect'
-import { createMockDeliveryRpcRemote, createRandomNodeId } from '../utils/utils'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { createMockDeliveryRpcRemote } from '../utils/utils'
+import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 
 describe('NeighborFinder', () => {
 
-    const nodeId = createRandomNodeId()
+    const nodeId = createRandomDhtAddress()
     let neighbors: NodeList
     let nearbyNodeView: NodeList
     let neighborFinder: NeighborFinder

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -2,6 +2,7 @@ import {
     ListeningRpcCommunicator,
     NodeType,
     PeerDescriptor,
+    createRandomDhtAddress,
     getDhtAddressFromRaw,
     getNodeIdFromPeerDescriptor,
 } from '@streamr/dht'
@@ -11,7 +12,7 @@ import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
 import { NodeList } from '../../src/logic/NodeList'
 import { formStreamPartDeliveryServiceId } from '../../src/logic/formStreamPartDeliveryServiceId'
 import { DeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
-import { createMockPeerDescriptor, createRandomNodeId } from '../utils/utils'
+import { createMockPeerDescriptor } from '../utils/utils'
 import { MockTransport } from '../utils/mock/Transport'
 
 const streamPartId = StreamPartIDUtils.parse('stream#0')
@@ -25,7 +26,7 @@ describe('NodeList', () => {
         new Uint8Array([1, 1, 4]),
         new Uint8Array([1, 1, 5])
     ]
-    const ownId = createRandomNodeId()
+    const ownId = createRandomDhtAddress()
     let nodeList: NodeList
 
     const createRemoteGraphNode = (peerDescriptor: PeerDescriptor) => {
@@ -135,7 +136,7 @@ describe('NodeList', () => {
     })
 
     it('items are in insertion order', () => {
-        const list = new NodeList(createRandomNodeId(), 100)
+        const list = new NodeList(createRandomDhtAddress(), 100)
         const item1 = createRemoteGraphNode(createMockPeerDescriptor())
         const item2 = createRemoteGraphNode(createMockPeerDescriptor())
         const item3 = createRemoteGraphNode(createMockPeerDescriptor())

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -1,13 +1,11 @@
-import { randomBytes } from 'crypto'
 import { 
     ConnectionLocker,
-    DhtAddress,
     DhtNode,
     NodeType,
     PeerDescriptor,
     Simulator,
     SimulatorTransport,
-    getDhtAddressFromRaw,
+    createRandomDhtAddress,
     getRandomRegion,
     getRawFromDhtAddress
 } from '@streamr/dht'
@@ -91,14 +89,10 @@ export const createStreamMessage = (
     return msg
 }
 
-export const createRandomNodeId = (): DhtAddress => {
-    return getDhtAddressFromRaw(randomBytes(20))
-}
-
 export const createMockPeerDescriptor = (opts?: Omit<Partial<PeerDescriptor>, 'nodeId' | 'type'>): PeerDescriptor => {
     return {
         ...opts,
-        nodeId: getRawFromDhtAddress(createRandomNodeId()),
+        nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
         type: NodeType.NODEJS,
         region: getRandomRegion()
     }

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -92,7 +92,7 @@ export const createStreamMessage = (
 }
 
 export const createRandomNodeId = (): DhtAddress => {
-    return getDhtAddressFromRaw(randomBytes(10))
+    return getDhtAddressFromRaw(randomBytes(20))
 }
 
 export const createMockPeerDescriptor = (opts?: Omit<Partial<PeerDescriptor>, 'nodeId' | 'type'>): PeerDescriptor => {


### PR DESCRIPTION
## Summary

Validate length of the nodeId if an explicit PeerDescriptor is given to the DhtNode.
