### PR TITLE
test(broker): make integration test ContractFacade.test.ts slightly faster

### DIFF
--- a/packages/broker/test/integration/plugins/operator/ContractFacade.test.ts
+++ b/packages/broker/test/integration/plugins/operator/ContractFacade.test.ts
@@ -1,72 +1,93 @@
 import { Contract } from '@ethersproject/contracts'
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { OperatorFactory, operatorFactoryABI } from '@streamr/network-contracts'
+import { OperatorFactory, operatorFactoryABI, type Sponsorship } from '@streamr/network-contracts'
 import { toEthereumAddress, waitForCondition } from '@streamr/utils'
 import { ContractFacade } from '../../../../src/plugins/operator/ContractFacade'
 import {
     createTheGraphClient,
     delegate,
     deploySponsorshipContract,
-    generateWalletWithGasAndTokens, getAdminWallet, setupOperatorContract, sponsor,
+    getAdminWallet,
+    setupOperatorContract,
+    SetupOperatorContractReturnType,
+    sponsor,
     stake
 } from './contractUtils'
 import { createClient, createTestStream } from '../../../utils'
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 
+async function createStream(): Promise<string> {
+    const client = createClient(await fetchPrivateKeyWithGas())
+    const streamId = (await createTestStream(client, module)).id
+    await client.destroy()
+    return streamId
+}
+
 describe('ContractFacade', () => {
+    let streamId1: string
+    let streamId2: string
+    let sponsorship1: Sponsorship
+    let sponsorship2: Sponsorship
+    let deployedOperator: SetupOperatorContractReturnType
+
+    beforeAll(async () => {
+        const parallel = await Promise.all([
+            createStream(),
+            createStream(),
+            setupOperatorContract({ nodeCount: 1 })
+        ])
+        streamId1 = parallel[0]
+        streamId2 = parallel[1]
+        deployedOperator = parallel[2]
+
+        sponsorship1 = await deploySponsorshipContract({
+            streamId: streamId1,
+            deployer: deployedOperator.operatorWallet
+        })
+        sponsorship2 = await deploySponsorshipContract({
+            streamId: streamId2,
+            deployer: deployedOperator.operatorWallet
+        })
+
+    }, 90 * 1000)
 
     it('getRandomOperator', async () => {
-        const deployConfig = {
-            operatorConfig: {
-                operatorsCutPercent: 10
-            }
-        }
-        const { operatorContract, operatorServiceConfig, nodeWallets } = await setupOperatorContract({ nodeCount: 1, ...deployConfig })
-        // deploy another operator to make sure there are at least 2 operators
-        await setupOperatorContract(deployConfig)
-
         const contractFacade = ContractFacade.createInstance({
-            ...operatorServiceConfig,
-            signer: nodeWallets[0]
+            ...deployedOperator.operatorServiceConfig,
+            signer: deployedOperator.nodeWallets[0]
         })
         const randomOperatorAddress = await contractFacade.getRandomOperator()
         expect(randomOperatorAddress).toBeDefined()
+        expect(randomOperatorAddress).not.toEqual(deployedOperator.operatorContract.address) // should not be me
 
         // check it's a valid operator, deployed by the OperatorFactory
         const operatorFactory = new Contract(
             CHAIN_CONFIG.dev2.contracts.OperatorFactory,
-            operatorFactoryABI, getAdminWallet()
+            operatorFactoryABI,
+            getAdminWallet()
         ) as unknown as OperatorFactory
         const isDeployedByFactory = (await operatorFactory.deploymentTimestamp(randomOperatorAddress!)).gt(0)
         expect(isDeployedByFactory).toBeTrue()
-        // check it's not my operator
-        expect(randomOperatorAddress).not.toEqual(operatorContract.address)
-    }, 60 * 1000)
+
+    }, 30 * 1000)
 
     it('getSponsorshipsOfOperator, getOperatorsInSponsorship', async () => {
-        const { operatorWallet, operatorContract, operatorServiceConfig } = await setupOperatorContract()
+        const operatorContractAddress = toEthereumAddress(deployedOperator.operatorContract.address)
+        await delegate(deployedOperator.operatorWallet, operatorContractAddress, 20000)
+        await stake(deployedOperator.operatorContract, sponsorship1.address, 10000)
+        await stake(deployedOperator.operatorContract, sponsorship2.address, 10000)
+
         const contractFacade = ContractFacade.createInstance({
-            ...operatorServiceConfig,
+            ...deployedOperator.operatorServiceConfig,
             signer: undefined as any
         })
 
-        const client = createClient(await fetchPrivateKeyWithGas())
-        const streamId1 = (await createTestStream(client, module)).id
-        const streamId2 = (await createTestStream(client, module)).id
-        await client.destroy()
-        const sponsorship1 = await deploySponsorshipContract({ streamId: streamId1, deployer: operatorWallet })
-        const sponsorship2 = await deploySponsorshipContract({ streamId: streamId2, deployer: operatorWallet })
-
-        await delegate(operatorWallet, operatorContract.address, 20000)
-        await stake(operatorContract, sponsorship1.address, 10000)
-        await stake(operatorContract, sponsorship2.address, 10000)
-
         await waitForCondition(async (): Promise<boolean> => {
-            const res = await contractFacade.getSponsorshipsOfOperator(toEthereumAddress(operatorContract.address))
+            const res = await contractFacade.getSponsorshipsOfOperator(toEthereumAddress(operatorContractAddress))
             return res.length === 2
         }, 10000, 500)
 
-        const sponsorships = await contractFacade.getSponsorshipsOfOperator(toEthereumAddress(operatorContract.address))
+        const sponsorships = await contractFacade.getSponsorshipsOfOperator(toEthereumAddress(operatorContractAddress))
         expect(sponsorships).toIncludeSameMembers([
             {
                 sponsorshipAddress: toEthereumAddress(sponsorship1.address),
@@ -81,29 +102,25 @@ describe('ContractFacade', () => {
         ])
 
         const operators = await contractFacade.getOperatorsInSponsorship(toEthereumAddress(sponsorship1.address))
-        expect(operators).toEqual([toEthereumAddress(operatorContract.address)])
-    }, 90 * 1000)
+        expect(operators).toEqual([toEthereumAddress(deployedOperator.operatorContract.address)])
+    }, 30 * 1000)
 
     it('flag', async () => {
-        const flagger = await setupOperatorContract({ nodeCount: 1 })
+        const flagger = deployedOperator
         const target = await setupOperatorContract()
 
-        const client = createClient(await fetchPrivateKeyWithGas())
-        const streamId1 = (await createTestStream(client, module)).id
-        await client.destroy()
-        const sponsorship = await deploySponsorshipContract({ streamId: streamId1, deployer: await generateWalletWithGasAndTokens() })
-        await sponsor(flagger.operatorWallet, sponsorship.address, 50000)
+        await sponsor(flagger.operatorWallet, sponsorship2.address, 50000)
 
         await delegate(flagger.operatorWallet, flagger.operatorContract.address, 20000)
         await delegate(target.operatorWallet, target.operatorContract.address, 30000)
-        await stake(flagger.operatorContract, sponsorship.address, 15000)
-        await stake(target.operatorContract, sponsorship.address, 25000)
+        await stake(flagger.operatorContract, sponsorship2.address, 15000)
+        await stake(target.operatorContract, sponsorship2.address, 25000)
 
         const contractFacade = ContractFacade.createInstance({
             ...flagger.operatorServiceConfig,
             signer: flagger.nodeWallets[0]
         })
-        await contractFacade.flag(toEthereumAddress(sponsorship.address), toEthereumAddress(target.operatorContract.address), 2)
+        await contractFacade.flag(toEthereumAddress(sponsorship2.address), toEthereumAddress(target.operatorContract.address), 2)
 
         const graphClient = createTheGraphClient()
         await waitForCondition(async (): Promise<boolean> => {
@@ -135,5 +152,5 @@ describe('ContractFacade', () => {
             })
             return result.operator.flagsTargeted.length === 1
         }, 10000, 1000)
-    }, 90 * 1000)
+    }, 30 * 1000)
 })

--- a/packages/broker/test/integration/plugins/operator/ContractFacade.test.ts
+++ b/packages/broker/test/integration/plugins/operator/ContractFacade.test.ts
@@ -31,14 +31,14 @@ describe('ContractFacade', () => {
     let deployedOperator: SetupOperatorContractReturnType
 
     beforeAll(async () => {
-        const parallel = await Promise.all([
+        const concurrentTasks = await Promise.all([
             createStream(),
             createStream(),
             setupOperatorContract({ nodeCount: 1 })
         ])
-        streamId1 = parallel[0]
-        streamId2 = parallel[1]
-        deployedOperator = parallel[2]
+        streamId1 = concurrentTasks[0]
+        streamId2 = concurrentTasks[1]
+        deployedOperator = concurrentTasks[2]
 
         sponsorship1 = await deploySponsorshipContract({
             streamId: streamId1,


### PR DESCRIPTION
## Summary

By reusing shared contract objects that get created in `beforeAll` we can make the test slightly faster. The downside is that the test cases share more state which could make the tests harder to change.

Before:
> PASS test/integration/plugins/operator/ContractFacade.test.ts (61.277 s)

After:
> PASS test/integration/plugins/operator/ContractFacade.test.ts (42.071 s)

## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
