### PR TITLE
fix(DHT): Performance: no longer add the source of a routed message as a contact

### DIFF
--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
@@ -28,7 +28,6 @@ export class RecursiveOperationRpcLocal implements IRecursiveOperationRpc {
         }
         const senderId = getNodeIdFromPeerDescriptor(getPreviousPeer(routedMessage) ?? routedMessage.sourcePeer!)
         logger.trace(`Received routeRequest call from ${senderId}`)
-        this.config.addContact(routedMessage.sourcePeer!, true)
         this.config.addToDuplicateDetector(routedMessage.requestId)
         return this.config.doRouteRequest(routedMessage)
     }

--- a/packages/dht/src/dht/routing/RouterRpcLocal.ts
+++ b/packages/dht/src/dht/routing/RouterRpcLocal.ts
@@ -40,7 +40,6 @@ export class RouterRpcLocal implements IRouterRpc {
             return createRouteMessageAck(routedMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received routeMessage ${routedMessage.requestId}`)
-        this.config.addContact(routedMessage.sourcePeer!, true)
         this.config.duplicateRequestDetector.add(routedMessage.requestId)
         if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, routedMessage.target)) {
             logger.trace(`routing message targeted to self ${routedMessage.requestId}`)
@@ -59,7 +58,6 @@ export class RouterRpcLocal implements IRouterRpc {
             return createRouteMessageAck(forwardMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received forward routeMessage ${forwardMessage.requestId}`)
-        this.config.addContact(forwardMessage.sourcePeer!, true)
         this.config.duplicateRequestDetector.add(forwardMessage.requestId)
         if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, forwardMessage.target)) {
             return this.forwardToDestination(forwardMessage)


### PR DESCRIPTION
## Summary

No longer add the source of a routed message as a contact. In cases where the contact never fits the routing node's contact lists the CPU cost for continuous attempting can be significant
