### PR TITLE
refactor(dht): Rename `ContactList#newContact` event 

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -297,13 +297,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.peerManager.on('contactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) => {
             this.emit('contactRemoved', peerDescriptor, activeContacts)
         })
-        this.peerManager.on('newContact', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
+        this.peerManager.on('contactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
             this.emit('newContact', peerDescriptor, activeContacts)
         )
         this.peerManager.on('randomContactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
             this.emit('randomContactRemoved', peerDescriptor, activeContacts)
         )
-        this.peerManager.on('newRandomContact', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
+        this.peerManager.on('randomContactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
             this.emit('newRandomContact', peerDescriptor, activeContacts)
         )
         this.peerManager.on('kBucketEmpty', () => {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -48,9 +48,9 @@ import { StoreRpcRemote } from './store/StoreRpcRemote'
 import { createPeerDescriptor } from '../helpers/createPeerDescriptor'
 
 export interface DhtNodeEvents {
-    newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    newRandomContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
 }
 
@@ -278,7 +278,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 )
             }
         })
-        this.on('newContact', (peerDescriptor: PeerDescriptor) => {
+        this.on('contactAdded', (peerDescriptor: PeerDescriptor) => {
             this.storeManager!.onNewContact(peerDescriptor)
         })
         this.bindRpcLocalMethods()
@@ -298,13 +298,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.emit('contactRemoved', peerDescriptor, activeContacts)
         })
         this.peerManager.on('contactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
-            this.emit('newContact', peerDescriptor, activeContacts)
+            this.emit('contactAdded', peerDescriptor, activeContacts)
         )
         this.peerManager.on('randomContactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
             this.emit('randomContactRemoved', peerDescriptor, activeContacts)
         )
         this.peerManager.on('randomContactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
-            this.emit('newRandomContact', peerDescriptor, activeContacts)
+            this.emit('randomContactAdded', peerDescriptor, activeContacts)
         )
         this.peerManager.on('kBucketEmpty', () => {
             if (!this.peerDiscovery!.isJoinOngoing()

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -279,7 +279,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             }
         })
         this.on('contactAdded', (peerDescriptor: PeerDescriptor) => {
-            this.storeManager!.onNewContact(peerDescriptor)
+            this.storeManager!.onContactAdded(peerDescriptor)
         })
         this.bindRpcLocalMethods()
     }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -342,7 +342,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 return this.peerManager!.getClosestNeighborsTo(nodeId, limit)
                     .map((dhtPeer: DhtNodeRpcRemote) => dhtPeer.getPeerDescriptor())
             },
-            addNewContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
+            addContact: (contact: PeerDescriptor) => this.peerManager!.handleNewPeers([contact]),
             removeContact: (nodeId: DhtAddress) => this.removeContact(nodeId)
         })
         this.rpcCommunicator!.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers',

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -15,7 +15,7 @@ import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '.
 interface DhtNodeRpcLocalConfig {
     peerDiscoveryQueryBatchSize: number
     getClosestPeersTo: (nodeId: DhtAddress, limit: number) => PeerDescriptor[]
-    addNewContact: (contact: PeerDescriptor) => void
+    addContact: (contact: PeerDescriptor) => void
     removeContact: (nodeId: DhtAddress) => void
 }
 
@@ -30,7 +30,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     }
 
     async getClosestPeers(request: ClosestPeersRequest, context: ServerCallContext): Promise<ClosestPeersResponse> {
-        this.config.addNewContact((context as DhtCallContext).incomingSourceDescriptor!)
+        this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
         const response = {
             peers: this.config.getClosestPeersTo(getDhtAddressFromRaw(request.nodeId), this.config.peerDiscoveryQueryBatchSize),
             requestId: request.requestId
@@ -41,7 +41,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     async ping(request: PingRequest, context: ServerCallContext): Promise<PingResponse> {
         logger.trace('received ping request: ' + getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!))
         setImmediate(() => {
-            this.config.addNewContact((context as DhtCallContext).incomingSourceDescriptor!)
+            this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
         })
         const response: PingResponse = {
             requestId: request.requestId

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -25,9 +25,9 @@ interface PeerManagerConfig {
 }
 
 export interface PeerManagerEvents {
-    newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    newRandomContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     kBucketEmpty: () => void
 }
@@ -82,14 +82,14 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             this.randomPeers.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
         })
         this.contacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newContact', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+            this.emit('contactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
         this.randomPeers = new RandomContactList(this.config.localNodeId, this.config.maxContactListSize)
         this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
         this.randomPeers.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newRandomContact', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+            this.emit('randomContactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
     }
 

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -81,15 +81,15 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             this.emit('contactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
             this.randomPeers.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
         })
-        this.contacts.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.contacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+            this.emit('newContact', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
         this.randomPeers = new RandomContactList(this.config.localNodeId, this.config.maxContactListSize)
         this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
-        this.randomPeers.on('newContact', (newContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('newRandomContact', newContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.randomPeers.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+            this.emit('newRandomContact', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
     }
 

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -13,7 +13,7 @@ export class ContactState<C> {
 
 export interface Events<C> {
     contactRemoved: (removedContact: C, closestContacts: C[]) => void
-    newContact: (newContact: C, closestContacts: C[]) => void
+    contactAdded: (contactAdded: C, closestContacts: C[]) => void
 }
 
 export class ContactList<C extends { getNodeId: () => DhtAddress }> extends EventEmitter<Events<C>> {

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -29,7 +29,7 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
                 this.contactIds.push(contact.getNodeId())
                 this.contactsById.set(contact.getNodeId(), new ContactState(contact))
                 this.emit(
-                    'newContact',
+                    'contactAdded',
                     contact,
                     this.getContacts()
                 )

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -57,7 +57,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 this.contactIds.splice(index, 0, contact.getNodeId())
                 if (this.config.emitEvents) {
                     this.emit(
-                        'newContact',
+                        'contactAdded',
                         contact,
                         this.getClosestContacts()
                     )
@@ -79,7 +79,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                         closestContacts
                     )
                     this.emit(
-                        'newContact',
+                        'contactAdded',
                         contact,
                         closestContacts
                     )

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -34,7 +34,7 @@ export class DiscoverySession {
         this.config = config
     }
 
-    private addNewContacts(contacts: PeerDescriptor[]): void {
+    private addContacts(contacts: PeerDescriptor[]): void {
         if (this.stopped) {
             return
         }
@@ -60,7 +60,7 @@ export class DiscoverySession {
         const targetId = getRawFromDhtAddress(this.config.targetId)
         const oldClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(this.config.targetId, 1)[0]
         const oldClosestDistance = getDistance(targetId, getRawFromDhtAddress(oldClosestNeighbor.getNodeId()))
-        this.addNewContacts(contacts)
+        this.addContacts(contacts)
         const newClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(this.config.targetId, 1)[0]
         const newClosestDistance = getDistance(targetId, getRawFromDhtAddress(newClosestNeighbor.getNodeId()))
         if (newClosestDistance >= oldClosestDistance) {

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -53,7 +53,7 @@ export class StoreManager {
             (request: ReplicateDataRequest, context: ServerCallContext) => rpcLocal.replicateData(request, context))
     }
 
-    onNewContact(peerDescriptor: PeerDescriptor): void {
+    onContactAdded(peerDescriptor: PeerDescriptor): void {
         for (const dataEntry of this.config.localDataStore.values()) {
             this.replicateAndUpdateStaleState(dataEntry, peerDescriptor)
         }

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -119,15 +119,15 @@ describe('SortedContactList', () => {
         expect(list.getActiveContacts()).toEqual([item2, item3, item4])
     })
 
-    it('does not emit newContact if contact did not fit the structure', () => {
+    it('does not emit contactAdded if contact did not fit the structure', () => {
         const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 2, allowToContainReferenceId: false, emitEvents: true })
-        const onNewContact = jest.fn()
-        list.on('newContact', onNewContact)
+        const onContactAdded = jest.fn()
+        list.on('contactAdded', onContactAdded)
         list.addContact(item1)
         list.addContact(item2)
-        expect(onNewContact).toBeCalledTimes(2)
+        expect(onContactAdded).toBeCalledTimes(2)
         list.addContact(item3)
-        expect(onNewContact).toBeCalledTimes(2)
+        expect(onContactAdded).toBeCalledTimes(2)
         expect(list.getAllContacts().length).toEqual(2)
     })
 

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -59,7 +59,7 @@ describe('StoreManager', () => {
                     replicateData,
                     setStale
                 )
-                manager.onNewContact({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[2]), type: NodeType.NODEJS })
+                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[2]), type: NodeType.NODEJS })
                 await waitForCondition(() => replicateData.mock.calls.length === 1)
                 expect(replicateData).toHaveBeenCalledWith({
                     entry: DATA_ENTRY
@@ -76,7 +76,7 @@ describe('StoreManager', () => {
                     replicateData,
                     setStale
                 )
-                manager.onNewContact({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setStale).not.toHaveBeenCalled()
@@ -94,7 +94,7 @@ describe('StoreManager', () => {
                     replicateData,
                     setStale
                 )
-                manager.onNewContact({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setStale).not.toHaveBeenCalled()
@@ -109,7 +109,7 @@ describe('StoreManager', () => {
                     replicateData,
                     setStale
                 )
-                manager.onNewContact({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setStale).toHaveBeenCalledTimes(1)
@@ -125,7 +125,7 @@ describe('StoreManager', () => {
                     replicateData,
                     setStale
                 )
-                manager.onNewContact({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setStale).toHaveBeenCalledTimes(0)

--- a/packages/trackerless-network/src/logic/Layer1Node.ts
+++ b/packages/trackerless-network/src/logic/Layer1Node.ts
@@ -1,9 +1,9 @@
 import { DhtAddress, PeerDescriptor } from '@streamr/dht'
 
 export interface Layer1NodeEvents {
-    newContact: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
+    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
     contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    newRandomContact: (peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => void
     randomContactRemoved: (peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => void
 }
 

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -116,25 +116,25 @@ export class RandomGraphNode extends EventEmitter<Events> {
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'contactAdded',
-            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.newContact(closestPeers),
+            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.onContactAdded(closestPeers),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'contactRemoved',
-            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.removedContact(closestPeers),
+            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.onContactRemoved(closestPeers),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'randomContactAdded',
-            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.addedRandomContact(randomPeers),
+            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.onRandomContactAdded(randomPeers),
             this.abortController.signal
         )   
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'randomContactRemoved',
-            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.removedRandomContact(randomPeers),
+            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.onRandomContactRemoved(randomPeers),
             this.abortController.signal
         )   
         addManagedEventListener<any, any>(
@@ -162,7 +162,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         }
         const candidates = this.getNeighborCandidatesFromLayer1()
         if (candidates.length > 0) {
-            this.newContact(candidates)
+            this.onContactAdded(candidates)
         }
         this.config.neighborFinder.start()
         await this.config.neighborUpdateManager.start()
@@ -179,7 +179,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
             (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.closeConnection(req, context))
     }
 
-    private newContact(closestNodes: PeerDescriptor[]): void {
+    private onContactAdded(closestNodes: PeerDescriptor[]): void {
         logger.trace(`New nearby contact found`)
         if (this.isStopped()) {
             return
@@ -190,7 +190,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         }
     }
 
-    private removedContact(closestNodes: PeerDescriptor[]): void {
+    private onContactRemoved(closestNodes: PeerDescriptor[]): void {
         logger.trace(`Nearby contact removed`)
         if (this.isStopped()) {
             return
@@ -225,7 +225,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         }
     }
 
-    private addedRandomContact(randomNodes: PeerDescriptor[]): void {
+    private onRandomContactAdded(randomNodes: PeerDescriptor[]): void {
         if (this.isStopped()) {
             return
         }
@@ -243,7 +243,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         }
     }
 
-    private removedRandomContact(randomNodes: PeerDescriptor[]): void {
+    private onRandomContactRemoved(randomNodes: PeerDescriptor[]): void {
         logger.trace(`New nearby contact found`)
         if (this.isStopped()) {
             return

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -115,7 +115,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         this.registerDefaultServerMethods()
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
-            'newContact',
+            'contactAdded',
             (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.newContact(closestPeers),
             this.abortController.signal
         )
@@ -127,8 +127,8 @@ export class RandomGraphNode extends EventEmitter<Events> {
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
-            'newRandomContact',
-            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.newRandomContact(randomPeers),
+            'randomContactAdded',
+            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.addedRandomContact(randomPeers),
             this.abortController.signal
         )   
         addManagedEventListener<any, any>(
@@ -225,7 +225,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
         }
     }
 
-    private newRandomContact(randomNodes: PeerDescriptor[]): void {
+    private addedRandomContact(randomNodes: PeerDescriptor[]): void {
         if (this.isStopped()) {
             return
         }

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -66,19 +66,19 @@ describe('RandomGraphNode', () => {
         expect(ids[0]).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))
     })
 
-    it('Adds Closest Nodes from layer1 newContact event to nearbyNodeView', async () => {
+    it('Adds Closest Nodes from layer1 contactAdded event to nearbyNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.emit('newContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('contactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => nearbyNodeView.size() === 2)
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
     })
 
-    it('Adds Random Nodes from layer1 newRandomContact event to randomNodeView', async () => {
+    it('Adds Random Nodes from layer1 randomContactAdded event to randomNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.emit('newRandomContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('randomContactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => randomNodeView.size() === 2)
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
@@ -88,7 +88,7 @@ describe('RandomGraphNode', () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
         layer1Node.addNewRandomPeerToKBucket()
-        layer1Node.emit('newContact', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('contactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
         await waitForCondition(() => {
             return nearbyNodeView.size() === 3
         }, 20000)


### PR DESCRIPTION
Rename a `ContactList` event: `newContact` -> `contactAdded`

Renamed also related events/methods/fields in other classes.

## Future improvements

Rename `PeerManager` methods