### PR TITLE
fix(dht): Remove also from `randomPeers` when peer is unresponsive

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -279,8 +279,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     }
 
     handlePeerUnresponsive(nodeId: DhtAddress): void {
-        this.bucket.remove(getRawFromDhtAddress(nodeId))
-        this.contacts.removeContact(nodeId)
+        this.removeContact(nodeId)
     }
 
     handleNewPeers(peerDescriptors: PeerDescriptor[], setActive?: boolean): void { 


### PR DESCRIPTION
The `PeerManager#handlePeerUnresponsive` calls `removeContact`, i.e. it removes the contact also from the `randomPeers` list. (As contacts should contain all nodes, the `randomPeers` list must not contain a node after we've removed it from the `contacts` list.)