### PR TITLE
fix(network): unlock connections with removeMe in NeighborUpdates

### DIFF
--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -86,7 +86,8 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
         streamPartId: config.streamPartId,
         rpcCommunicator,
         neighborUpdateInterval,
-        neighborTargetCount
+        neighborTargetCount,
+        connectionLocker: config.connectionLocker
     })
     const inspector = config.inspector ?? new Inspector({
         localPeerDescriptor: config.localPeerDescriptor,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -1,5 +1,5 @@
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Logger, scheduleAtInterval } from '@streamr/utils'
 import { NeighborFinder } from './NeighborFinder'
@@ -13,6 +13,7 @@ interface NeighborUpdateManagerConfig {
     neighbors: NodeList
     nearbyNodeView: NodeList
     neighborFinder: NeighborFinder
+    connectionLocker: ConnectionLocker
     streamPartId: StreamPartID
     rpcCommunicator: ListeningRpcCommunicator
     neighborUpdateInterval: number
@@ -51,6 +52,7 @@ export class NeighborUpdateManager {
             if (res.removeMe) {
                 const nodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
                 this.config.neighbors.remove(nodeId)
+                this.config.connectionLocker.unlockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
                 this.config.neighborFinder.start([nodeId])
             }
         }))

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { INeighborUpdateRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
@@ -14,6 +14,7 @@ interface NeighborUpdateRpcLocalConfig {
     neighbors: NodeList
     nearbyNodeView: NodeList
     neighborFinder: NeighborFinder
+    connectionLocker: ConnectionLocker
     rpcCommunicator: ListeningRpcCommunicator
     neighborTargetCount: number
 }
@@ -67,6 +68,7 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
                 this.config.neighborFinder.start()
             } else {
                 this.config.neighbors.remove(senderId)
+                this.config.connectionLocker.unlockConnection(senderPeerDescriptor, this.config.streamPartId)
             }
             return this.createResponse(isOverNeighborCount)
         }

--- a/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
@@ -39,6 +39,9 @@ describe('NeighborUpdateRpcLocal', () => {
         neighborFinder = {
             start: jest.fn()
         } as any
+        const connectionLocker = {
+            unlockConnection: jest.fn()
+        } as any
 
         rpcLocal = new NeighborUpdateRpcLocal({
             localPeerDescriptor,
@@ -47,7 +50,8 @@ describe('NeighborUpdateRpcLocal', () => {
             neighborFinder,
             streamPartId,
             rpcCommunicator,
-            neighborTargetCount
+            neighborTargetCount,
+            connectionLocker
         })
     })
 


### PR DESCRIPTION
## Summary

unlock connections after receiving removeMe or after sending one and removing the neighbor. Fixes an issue with inflating numbers of connection locks on streams

## Future improvements

Should have better mechanisms to enforce releasing locks.

Could start using weakLocks for stream connections. Stream connections should be bidirectional so they would never be disconnected unless there's a bug somewhere

Ensure that proxy clients unlock connections when closed
