### PR TITLE
refactor(dht): Optimize `SortedContactList#addContact`

### DIFF
--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -51,8 +51,6 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         if (!this.contactsById.has(contactId)) {
             if ((this.config.maxSize === undefined) || (this.contactIds.length < this.config.maxSize)) {
                 this.contactsById.set(contactId, new ContactState(contact))
-
-                // eslint-disable-next-line max-len
                 const index = sortedIndexBy(this.contactIds, contactId, (id: DhtAddress) => { return this.distanceToReferenceId(id) })
                 this.contactIds.splice(index, 0, contactId)
                 if (this.config.emitEvents) {
@@ -67,8 +65,6 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 const removedContact = this.contactsById.get(removedId!)!.contact
                 this.contactsById.delete(removedId!)
                 this.contactsById.set(contactId, new ContactState(contact))
-
-                // eslint-disable-next-line max-len
                 const index = sortedIndexBy(this.contactIds, contactId, (id: DhtAddress) => { return this.distanceToReferenceId(id) })
                 this.contactIds.splice(index, 0, contactId)
                 if (this.config.emitEvents) {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -40,21 +40,21 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
     }
 
     public addContact(contact: C): void {
-        if (this.config.excludedNodeIds !== undefined && this.config.excludedNodeIds.has(contact.getNodeId())) {
+        const contactId = contact.getNodeId()
+        if (this.config.excludedNodeIds !== undefined && this.config.excludedNodeIds.has(contactId)) {
             return
         }
-
-        if ((!this.config.allowToContainReferenceId && (this.config.referenceId === contact.getNodeId())) ||
-            (this.config.nodeIdDistanceLimit !== undefined && this.compareIds(this.config.nodeIdDistanceLimit, contact.getNodeId()) < 0)) {
+        if ((!this.config.allowToContainReferenceId && (this.config.referenceId === contactId)) ||
+            (this.config.nodeIdDistanceLimit !== undefined && this.compareIds(this.config.nodeIdDistanceLimit, contactId) < 0)) {
             return
         }
-        if (!this.contactsById.has(contact.getNodeId())) {
+        if (!this.contactsById.has(contactId)) {
             if ((this.config.maxSize === undefined) || (this.contactIds.length < this.config.maxSize)) {
-                this.contactsById.set(contact.getNodeId(), new ContactState(contact))
+                this.contactsById.set(contactId, new ContactState(contact))
 
                 // eslint-disable-next-line max-len
-                const index = sortedIndexBy(this.contactIds, contact.getNodeId(), (id: DhtAddress) => { return this.distanceToReferenceId(id) })
-                this.contactIds.splice(index, 0, contact.getNodeId())
+                const index = sortedIndexBy(this.contactIds, contactId, (id: DhtAddress) => { return this.distanceToReferenceId(id) })
+                this.contactIds.splice(index, 0, contactId)
                 if (this.config.emitEvents) {
                     this.emit(
                         'contactAdded',
@@ -62,15 +62,15 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                         this.getClosestContacts()
                     )
                 }
-            } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contact.getNodeId()) > 0) {
+            } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contactId) > 0) {
                 const removedId = this.contactIds.pop()
                 const removedContact = this.contactsById.get(removedId!)!.contact
                 this.contactsById.delete(removedId!)
-                this.contactsById.set(contact.getNodeId(), new ContactState(contact))
+                this.contactsById.set(contactId, new ContactState(contact))
 
                 // eslint-disable-next-line max-len
-                const index = sortedIndexBy(this.contactIds, contact.getNodeId(), (id: DhtAddress) => { return this.distanceToReferenceId(id) })
-                this.contactIds.splice(index, 0, contact.getNodeId())
+                const index = sortedIndexBy(this.contactIds, contactId, (id: DhtAddress) => { return this.distanceToReferenceId(id) })
+                this.contactIds.splice(index, 0, contactId)
                 if (this.config.emitEvents) {
                     const closestContacts = this.getClosestContacts()
                     this.emit(


### PR DESCRIPTION
Store `contact.getNodeId()` to a local variable so that it is not calculate multiple times.

Also remove obsolete `eslint-ignore` comments.

## Benchmark

This takes 5-10% less time to run:
```typescript
const list = new SortedContactList({
    referenceId: createRandomDhtAddress(),
    nodeIdDistanceLimit: createRandomDhtAddress(),
    maxSize: 100,
    allowToContainReferenceId: true,
    emitEvents: false
})
console.time('timer')
const peerDescriptors = range(100000).map(() => createMockPeerDescriptor())
for (const peerDescriptor of peerDescriptors) {
    list.addContact({
        getNodeId: () => {
            return getNodeIdFromPeerDescriptor(peerDescriptor)
        }
    })
}
console.timeLog('timer')
```