### PR TITLE
fix(broker) [NET-1266]: add missing catch to voting

### DIFF
--- a/packages/broker/src/plugins/operator/reviewSuspectNode.ts
+++ b/packages/broker/src/plugins/operator/reviewSuspectNode.ts
@@ -72,6 +72,15 @@ export const reviewSuspectNode = async ({
         const results = await consumeResults()
         const kick = results.filter((b) => b).length <= results.length / 2
         logger.info('Vote on flag', { sponsorshipAddress, targetOperator, kick })
-        await contractFacade.voteOnFlag(sponsorshipAddress, targetOperator, kick)
+        try {
+            await contractFacade.voteOnFlag(sponsorshipAddress, targetOperator, kick)
+        } catch (err) {
+            logger.warn('Encountered error while voting on flag', {
+                sponsorshipAddress,
+                targetOperator,
+                kick,
+                reason: err?.message
+            })
+        }
     }, timeUntilVoteInMs, abortSignal)
 }


### PR DESCRIPTION
## Summary

A catch was missing on the promise returned by `contractFacade.voteOnFlag` when reviewing an operator.

In practice someone ran into this error in a case where the vote has already been cast.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
