### PR TITLE
chore(broker): remove self-check from entry-point.ts

### DIFF
--- a/packages/broker/bin/entry-point.ts
+++ b/packages/broker/bin/entry-point.ts
@@ -17,7 +17,7 @@ const main = async () => {
             max: entryPoint.websocket.port
         },
         websocketServerEnableTls: false,
-        entryPoints: [peerDescriptor]
+        entryPoints: []
     })
     await dhtNode.start()
     await dhtNode.joinDht([peerDescriptor])


### PR DESCRIPTION
## Summary

Remove self-connectivity check from `entry-point.ts` script as it prevents the `entry-point` docker container from starting successfully in the streamr-docker-dev stack. The problem is that within docker containers themselves the IP address `10.200.10.1` is not mapped so the entry-point connectivity check never passes and thus the script crashes before the service can start. 

The downside of this change is that we lose the self-connectivity check ensuring the entrypoint can be connected to.

## Limitations and future improvements

If we were using the `entry-point.ts` script more broadly (i.e. in production and such), I would suggest we make disabling the self-connectivity check into a flag `--disable-self-connecitivty-check`. But since this is not the case, I see more cost than benefit to adding an exceptional case to the script? 

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
