### PR TITLE
feat(DHT): connectivity check even if websocket server was not started

### DIFF
--- a/packages/dht/src/connection/connectivityRequestHandler.ts
+++ b/packages/dht/src/connection/connectivityRequestHandler.ts
@@ -36,7 +36,19 @@ export const attachConnectivityRequestHandler = (connectionToListenTo: ServerWeb
 const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, connectivityRequest: ConnectivityRequest): Promise<void> => {
     const host = connectivityRequest.host ?? connection.getRemoteAddress()
     const ipAddress = connection.getRemoteIp()
-    const connectivityResponse = await connectivityProbe(connectivityRequest, ipAddress, host)
+    let connectivityResponse: ConnectivityResponse
+    if (connectivityRequest.port === 0) {
+        logger.trace('ConnectivityRequest port is 0, replying without connectivityProbe')
+        connectivityResponse = {
+            host,
+            natType: NatType.UNKNOWN,
+            ipAddress: ipv4ToNumber(ipAddress),
+            version: localVersion
+        }
+    } else {
+        connectivityResponse = await connectivityProbe(connectivityRequest, ipAddress, host)
+    }
+
     const msg: Message = {
         serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
         messageType: MessageType.CONNECTIVITY_RESPONSE,

--- a/packages/dht/src/connection/connectivityRequestHandler.ts
+++ b/packages/dht/src/connection/connectivityRequestHandler.ts
@@ -37,7 +37,9 @@ const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, co
     const host = connectivityRequest.host ?? connection.getRemoteAddress()
     const ipAddress = connection.getRemoteIp()
     let connectivityResponse: ConnectivityResponse
-    if (connectivityRequest.port === 0) {
+    if (connectivityRequest.port !== 0) {
+        connectivityResponse = await connectivityProbe(connectivityRequest, ipAddress, host)
+    } else {
         logger.trace('ConnectivityRequest port is 0, replying without connectivityProbe')
         connectivityResponse = {
             host,
@@ -45,10 +47,7 @@ const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, co
             ipAddress: ipv4ToNumber(ipAddress),
             version: localVersion
         }
-    } else {
-        connectivityResponse = await connectivityProbe(connectivityRequest, ipAddress, host)
     }
-
     const msg: Message = {
         serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
         messageType: MessageType.CONNECTIVITY_RESPONSE,

--- a/packages/dht/src/connection/connectivityRequestHandler.ts
+++ b/packages/dht/src/connection/connectivityRequestHandler.ts
@@ -11,6 +11,8 @@ import { ServerWebsocket } from './websocket/ServerWebsocket'
 import { connectivityMethodToWebsocketUrl } from './websocket/WebsocketConnector'
 import { version as localVersion } from '../../package.json'
 
+export const DISABLE_CONNECTIVITY_PROBE = 0
+
 const logger = new Logger(module)
 
 export const attachConnectivityRequestHandler = (connectionToListenTo: ServerWebsocket): void => {
@@ -37,7 +39,7 @@ const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, co
     const host = connectivityRequest.host ?? connection.getRemoteAddress()
     const ipAddress = connection.getRemoteIp()
     let connectivityResponse: ConnectivityResponse
-    if (connectivityRequest.port !== 0) {
+    if (connectivityRequest.port !== DISABLE_CONNECTIVITY_PROBE) {
         connectivityResponse = await connectivityProbe(connectivityRequest, ipAddress, host)
     } else {
         logger.trace('ConnectivityRequest port is 0, replying without connectivityProbe')

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -180,33 +180,32 @@ export class WebsocketConnector {
         if (this.abortController.signal.aborted) {
             return noServerConnectivityResponse
         }
+        if (!this.config.entrypoints || this.config.entrypoints.length === 0) {
+            // return connectivity info given in config
+            const preconfiguredConnectivityResponse: ConnectivityResponse = {
+                host: this.host!,
+                natType: NatType.OPEN_INTERNET,
+                websocket: { host: this.host!, port: this.selectedPort!, tls: this.config.tlsCertificate !== undefined },
+                // TODO: maybe do a DNS lookup here?
+                ipAddress: ipv4ToNumber('127.0.0.1'),
+                version: localVersion
+            }
+            return preconfiguredConnectivityResponse
+        }
         for (const reattempt of range(ENTRY_POINT_CONNECTION_ATTEMPTS)) {
             const entryPoint = sample(this.config.entrypoints)!
             try {
-                if (!this.config.entrypoints || this.config.entrypoints.length === 0) {
-                    // return connectivity info given in config
-                    const preconfiguredConnectivityResponse: ConnectivityResponse = {
-                        host: this.host!,
-                        natType: NatType.OPEN_INTERNET,
-                        websocket: { host: this.host!, port: this.selectedPort!, tls: this.config.tlsCertificate !== undefined },
-                        // TODO: maybe do a DNS lookup here?
-                        ipAddress: ipv4ToNumber('127.0.0.1'),
-                        version: localVersion
-                    }
-                    return preconfiguredConnectivityResponse
+                // Do real connectivity checking
+                const connectivityRequest = {
+                    port: this.selectedPort ?? 0,
+                    host: this.host,
+                    tls: this.websocketServer ? this.config.serverEnableTls : false,
+                    selfSigned
+                }
+                if (!this.abortController.signal.aborted) {
+                    return await sendConnectivityRequest(connectivityRequest, entryPoint, localVersion)
                 } else {
-                    // Do real connectivity checking
-                    const connectivityRequest = {
-                        port: this.selectedPort ?? 0,
-                        host: this.host,
-                        tls: this.websocketServer ? this.config.serverEnableTls : false,
-                        selfSigned
-                    }
-                    if (!this.abortController.signal.aborted) {
-                        return await sendConnectivityRequest(connectivityRequest, entryPoint, localVersion)
-                    } else {
-                        throw new Err.ConnectionFailed('ConnectivityChecker is destroyed')
-                    }
+                    throw new Err.ConnectionFailed('ConnectivityChecker is destroyed')
                 }
             } catch (err) {
                 if (reattempt < ENTRY_POINT_CONNECTION_ATTEMPTS) {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -424,6 +424,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started || this.abortController.signal.aborted) {
             return
         }
+
         const reachableThrough = this.peerDiscovery!.isJoinOngoing() ? this.getConnectedEntryPoints() : []
         this.router!.send(msg, reachableThrough)
     }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -424,7 +424,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (!this.started || this.abortController.signal.aborted) {
             return
         }
-
         const reachableThrough = this.peerDiscovery!.isJoinOngoing() ? this.getConnectedEntryPoints() : []
         this.router!.send(msg, reachableThrough)
     }

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -28,22 +28,26 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         const layer0Node1Id = createRandomDhtAddress()
         layer0Node1 = new DhtNode({
-            nodeId: layer0Node1Id
+            nodeId: layer0Node1Id,
+            entryPoints: [entrypointDescriptor]
         })
 
         const layer0Node2Id = createRandomDhtAddress()
         layer0Node2 = new DhtNode({
-            nodeId: layer0Node2Id
+            nodeId: layer0Node2Id,
+            entryPoints: [entrypointDescriptor]
         })
 
         const layer0Node3Id = createRandomDhtAddress()
         layer0Node3 = new DhtNode({
-            nodeId: layer0Node3Id
+            nodeId: layer0Node3Id,
+            entryPoints: [entrypointDescriptor]
         })
 
         const layer0Node4Id = createRandomDhtAddress()
         layer0Node4 = new DhtNode({
-            nodeId: layer0Node4Id
+            nodeId: layer0Node4Id,
+            entryPoints: [entrypointDescriptor]
         })
 
         layer1EntryPoint = new DhtNode({

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -30,8 +30,8 @@ describe('memory leak', () => {
         })
         await entryPoint.start()
         await entryPoint.joinDht([entryPointDescriptor])
-        let sender: DhtNode | undefined = new DhtNode({})
-        let receiver: DhtNode | undefined = new DhtNode({})
+        let sender: DhtNode | undefined = new DhtNode({ entryPoints: [entryPointDescriptor] })
+        let receiver: DhtNode | undefined = new DhtNode({ entryPoints: [entryPointDescriptor] })
         await Promise.all([
             (async () => {
                 await sender.start()
@@ -77,5 +77,5 @@ describe('memory leak', () => {
         const detector3 = new LeakDetector(receiver)
         receiver = undefined
         expect(await detector3.isLeaking()).toBe(false)
-    })
+    }, 10000)
 })

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -47,7 +47,7 @@ describe('proxy group key exchange', () => {
         proxyNode.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
         publisher = createNetworkNode({
             layer0: {
-                entryPoints: [publisherDescriptor],
+                entryPoints: [proxyNodeDescriptor],
                 peerDescriptor: publisherDescriptor,
             }
         })
@@ -55,7 +55,7 @@ describe('proxy group key exchange', () => {
 
         subscriber = createNetworkNode({
             layer0: {
-                entryPoints: [subscriberDescriptor],
+                entryPoints: [proxyNodeDescriptor],
                 peerDescriptor: subscriberDescriptor,
             }
         })


### PR DESCRIPTION
## Summary

Run connectivity check to discover own IP address even when WS server was not started. Fixes a clustering around NodeIds starting with 85 for all nodes without a WS server as they use ip `127.0.0.1`.

Configuring entry points is now necessary when running a DhtNode without a WS server, unless the node is configured with the proper values to generate a PeerDescriptor without a ConnectivityCheck.

(Is backwards compatible)

## Future improvements

- Could refactor ConnectivityRequestHandler further
- Change ConnectivityRequest port to an optional field
- Perhaps ConnectivityCheck could be renamed to reflect that any kind of checking is no longer done. The point is to find out the node's connectivity information
- Could rename the entry point config in the connection layer? Entry point still makes since since ConnectivityChecks are an operation that all entry points should support.