### PR TITLE
fix(network): NeighborUpdateRpcLocal does not reply with removeMe if handshake is ongoing

### DIFF
--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -37,6 +37,7 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
     const nearbyNodeView = config.nearbyNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const randomNodeView = config.randomNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const neighbors = config.neighbors ?? new NodeList(ownNodeId, maxContactCount)
+    const ongoingHandshakes = new Set<DhtAddress>()
 
     const temporaryConnectionRpcLocal = new TemporaryConnectionRpcLocal({
         rpcCommunicator,
@@ -70,7 +71,8 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
         randomNodeView,
         neighbors,
         maxNeighborCount: neighborTargetCount,
-        rpcRequestTimeout: config.rpcRequestTimeout
+        rpcRequestTimeout: config.rpcRequestTimeout,
+        ongoingHandshakes
     })
     const neighborFinder = config.neighborFinder ?? new NeighborFinder({
         neighbors,
@@ -87,7 +89,8 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
         rpcCommunicator,
         neighborUpdateInterval,
         neighborTargetCount,
-        connectionLocker: config.connectionLocker
+        connectionLocker: config.connectionLocker,
+        ongoingHandshakes
     })
     const inspector = config.inspector ?? new Inspector({
         localPeerDescriptor: config.localPeerDescriptor,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -25,6 +25,7 @@ interface HandshakerConfig {
     randomNodeView: NodeList
     rpcCommunicator: ListeningRpcCommunicator
     maxNeighborCount: number
+    ongoingHandshakes: Set<DhtAddress>
     rpcRequestTimeout?: number
 }
 
@@ -34,7 +35,6 @@ const PARALLEL_HANDSHAKE_COUNT = 2
 
 export class Handshaker {
 
-    private readonly ongoingHandshakes: Set<DhtAddress> = new Set()
     private config: HandshakerConfig
     private readonly rpcLocal: IHandshakeRpc
 
@@ -44,7 +44,7 @@ export class Handshaker {
             streamPartId: this.config.streamPartId,
             neighbors: this.config.neighbors,
             connectionLocker: this.config.connectionLocker,
-            ongoingHandshakes: this.ongoingHandshakes,
+            ongoingHandshakes: this.config.ongoingHandshakes,
             ongoingInterleaves: new Set(),
             maxNeighborCount: this.config.maxNeighborCount,
             handshakeWithInterleaving: (target: PeerDescriptor, senderId: DhtAddress) => this.handshakeWithInterleaving(target, senderId),
@@ -59,10 +59,10 @@ export class Handshaker {
 
     async attemptHandshakesOnContacts(excludedIds: DhtAddress[]): Promise<DhtAddress[]> {
         // TODO use config option or named constant? or why the value 2?
-        if (this.config.neighbors.size() + this.ongoingHandshakes.size < this.config.maxNeighborCount - 2) {
+        if (this.config.neighbors.size() + this.config.ongoingHandshakes.size < this.config.maxNeighborCount - 2) {
             logger.trace(`Attempting parallel handshakes with ${PARALLEL_HANDSHAKE_COUNT} targets`)
             return this.selectParallelTargetsAndHandshake(excludedIds)
-        } else if (this.config.neighbors.size() + this.ongoingHandshakes.size < this.config.maxNeighborCount) {
+        } else if (this.config.neighbors.size() + this.config.ongoingHandshakes.size < this.config.maxNeighborCount) {
             logger.trace(`Attempting handshake with new target`)
             return this.selectNewTargetAndHandshake(excludedIds)
         }
@@ -72,7 +72,7 @@ export class Handshaker {
     private async selectParallelTargetsAndHandshake(excludedIds: DhtAddress[]): Promise<DhtAddress[]> {
         const exclude = excludedIds.concat(this.config.neighbors.getIds())
         const neighbors = this.selectParallelTargets(exclude)
-        neighbors.forEach((contact) => this.ongoingHandshakes.add(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
+        neighbors.forEach((contact) => this.config.ongoingHandshakes.add(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
         return this.doParallelHandshakes(neighbors, exclude)
     }
 
@@ -118,7 +118,7 @@ export class Handshaker {
 
     private async handshakeWithTarget(neighbor: HandshakeRpcRemote, concurrentNodeId?: DhtAddress): Promise<boolean> {
         const targetNodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
-        this.ongoingHandshakes.add(targetNodeId)
+        this.config.ongoingHandshakes.add(targetNodeId)
         const result = await neighbor.handshake(
             this.config.streamPartId,
             this.config.neighbors.getIds(),
@@ -131,14 +131,14 @@ export class Handshaker {
         if (result.interleaveTargetDescriptor) {
             await this.handshakeWithInterleaving(result.interleaveTargetDescriptor, targetNodeId)
         }
-        this.ongoingHandshakes.delete(targetNodeId)
+        this.config.ongoingHandshakes.delete(targetNodeId)
         return result.accepted
     }
 
     private async handshakeWithInterleaving(target: PeerDescriptor, interleaveSourceId: DhtAddress): Promise<boolean> {
         const neighbor = this.createRpcRemote(target)
         const targetNodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
-        this.ongoingHandshakes.add(targetNodeId)
+        this.config.ongoingHandshakes.add(targetNodeId)
         const result = await neighbor.handshake(
             this.config.streamPartId,
             this.config.neighbors.getIds(),
@@ -149,7 +149,7 @@ export class Handshaker {
             this.config.neighbors.add(this.createDeliveryRpcRemote(neighbor.getPeerDescriptor()))
             this.config.connectionLocker.lockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
         }
-        this.ongoingHandshakes.delete(targetNodeId)
+        this.config.ongoingHandshakes.delete(targetNodeId)
         return result.accepted
     }
 
@@ -174,7 +174,7 @@ export class Handshaker {
     }
 
     getOngoingHandshakes(): Set<DhtAddress> {
-        return this.ongoingHandshakes
+        return this.config.ongoingHandshakes
     }
 
 }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -1,5 +1,5 @@
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { ConnectionLocker, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, DhtAddress, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Logger, scheduleAtInterval } from '@streamr/utils'
 import { NeighborFinder } from './NeighborFinder'
@@ -18,6 +18,7 @@ interface NeighborUpdateManagerConfig {
     rpcCommunicator: ListeningRpcCommunicator
     neighborUpdateInterval: number
     neighborTargetCount: number
+    ongoingHandshakes: Set<DhtAddress>
 }
 
 const logger = new Logger(module)
@@ -54,6 +55,9 @@ export class NeighborUpdateManager {
                 this.config.neighbors.remove(nodeId)
                 this.config.connectionLocker.unlockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
                 this.config.neighborFinder.start([nodeId])
+                // if (this.config.neighbors.size() < this.config.neighborTargetCount) {
+                //     console.log(this.config.neighbors.size(), "WHOOPSIE")   
+                // }
             }
         }))
     }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -55,9 +55,6 @@ export class NeighborUpdateManager {
                 this.config.neighbors.remove(nodeId)
                 this.config.connectionLocker.unlockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
                 this.config.neighborFinder.start([nodeId])
-                // if (this.config.neighbors.size() < this.config.neighborTargetCount) {
-                //     console.log(this.config.neighbors.size(), "WHOOPSIE")   
-                // }
             }
         }))
     }

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -92,7 +92,8 @@ describe('Handshakes', () => {
             neighbors,
             connectionLocker: mockConnectionLocker,
             rpcCommunicator: rpcCommunicator2,
-            maxNeighborCount: 4
+            maxNeighborCount: 4,
+            ongoingHandshakes: new Set()
         })
 
     })

--- a/packages/trackerless-network/test/unit/Handshaker.test.ts
+++ b/packages/trackerless-network/test/unit/Handshaker.test.ts
@@ -40,7 +40,8 @@ describe('Handshaker', () => {
             randomNodeView,
             rpcCommunicator,
             maxNeighborCount,
-            rpcRequestTimeout: 5000
+            rpcRequestTimeout: 5000,
+            ongoingHandshakes: new Set()
         })
     })
 

--- a/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
@@ -1,4 +1,4 @@
-import { ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborFinder } from '../../src/logic/neighbor-discovery/NeighborFinder'
 import { NeighborUpdateRpcLocal } from '../../src/logic/neighbor-discovery/NeighborUpdateRpcLocal'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -20,6 +20,7 @@ describe('NeighborUpdateRpcLocal', () => {
     let nearbyNodeView: NodeList
     let neighborFinder: NeighborFinder
     let rpcCommunicator: ListeningRpcCommunicator
+    let ongoingHandshakes: Set<DhtAddress>
 
     const addNeighbors = (count: number) => {
         for (let i = 0; i < count; i++) {
@@ -42,6 +43,7 @@ describe('NeighborUpdateRpcLocal', () => {
         const connectionLocker = {
             unlockConnection: jest.fn()
         } as any
+        ongoingHandshakes = new Set()
 
         rpcLocal = new NeighborUpdateRpcLocal({
             localPeerDescriptor,
@@ -51,7 +53,8 @@ describe('NeighborUpdateRpcLocal', () => {
             streamPartId,
             rpcCommunicator,
             neighborTargetCount,
-            connectionLocker
+            connectionLocker,
+            ongoingHandshakes
         })
     })
 
@@ -124,6 +127,17 @@ describe('NeighborUpdateRpcLocal', () => {
         }, { incomingSourceDescriptor: caller } as any)
         expect(res.removeMe).toEqual(true)
         expect(neighbors.has(getNodeIdFromPeerDescriptor(caller))).toEqual(false)
+    })
+
+    it('does not ask to be removed if there is an ongoing handshake to the caller', async () => {
+        const caller = createMockPeerDescriptor()
+        ongoingHandshakes.add(getNodeIdFromPeerDescriptor(caller))
+        const res = await rpcLocal.neighborUpdate({
+            streamPartId,
+            neighborDescriptors: [localPeerDescriptor],
+            removeMe: false
+        }, { incomingSourceDescriptor: caller } as any)
+        expect(res.removeMe).toEqual(false)
     })
 
 })


### PR DESCRIPTION
## Summary

Fixed a bad timing where a handshake could still be ongoing to a node that sent a neighbor update. In such cases receiving neighbor would ask the sender remove the receiver from the sender's neighbor structure. This change makes the creation on bidirectional connections in the graph more reliable. Additionally, the test case `happy path 64 nodes` in `RandomGraphNode-Layer1Node-Latencies.test.ts` and `RandomGraphNode-Layer1Node.test.ts` are approaching non-flakyness with the mismatch counter set to 0.

## Future improvements

- Investigate the cause for why unidirectinal connections still happen (although they are increasingly more rare)
- Try to come up with a deterministic mechanism to avoid cases where a node is unlucky and multiple nodes cut connections to it at the same time due to it having too many connections at once.
  - Why are there more than 5 connections in nodes in the first place?