### PR TITLE
fix(network): StreamPartID data keys to 160 bits

### DIFF
--- a/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
+++ b/packages/trackerless-network/src/logic/EntryPointDiscovery.ts
@@ -13,7 +13,7 @@ import { Any } from '../proto/google/protobuf/any'
 import { Layer1Node } from './Layer1Node'
 
 export const streamPartIdToDataKey = (streamPartId: StreamPartID): DhtAddress => {
-    return getDhtAddressFromRaw(new Uint8Array(createHash('md5').update(streamPartId).digest()))
+    return getDhtAddressFromRaw(new Uint8Array((createHash('sha1').update(streamPartId).digest())))
 }
 
 const parseEntryPointData = (dataEntries: DataEntry[]): PeerDescriptor[] => {

--- a/packages/trackerless-network/test/benchmark/StreamPartIdDataKeyDistribution.test.ts
+++ b/packages/trackerless-network/test/benchmark/StreamPartIdDataKeyDistribution.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable no-console */
+
+import { groupBy, range } from 'lodash'
+import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { StreamPartIDUtils } from '@streamr/protocol'
+import { DhtAddress } from '@streamr/dht'
+
+describe('StreamPartIdDataKeyDistribution', () => {
+
+    it('partitions are well distributed', () => {
+
+        const streamId = 'stream'
+        const dataKeys = range(100).map((i) => {
+            const streamPartId = StreamPartIDUtils.parse(streamId + '#' + i)
+            return streamPartIdToDataKey(streamPartId)
+        })
+        
+        const byInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0])
+        expect(Object.keys(byInitials).length).toEqual(16)
+        console.log(Object.values(byInitials).map((a) => a.length))
+    })
+
+    it('streamIds are well distributed', () => {
+        const dataKeys = range(10000).map(() => {
+            const streamPartId = StreamPartIDUtils.parse(Math.random().toString(32).substr(2, 32) + '#0')
+            return streamPartIdToDataKey(streamPartId)
+        })
+        const byInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0])
+        expect(Object.keys(byInitials).length).toEqual(16)
+        console.log(Object.values(byInitials).map((a) => a.length))
+    })
+
+    it('streamPartIds are well distributed', () => {
+        const streamIds = range(10000).map(() => Math.random().toString(32).substr(2, 32))
+        const dataKeys: DhtAddress[] = []
+        streamIds.forEach((streamId) => {
+            range(100).forEach((i) => {
+                const streamPartId = StreamPartIDUtils.parse(streamId + '#' + i)
+                dataKeys.push(streamPartIdToDataKey(streamPartId))
+            })
+        })
+
+        const byInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0])
+        expect(Object.keys(byInitials).length).toEqual(16)
+        console.log(Object.values(byInitials).map((a) => a.length))
+    
+        const byTwoInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0] + dataKey[1])
+        expect(Object.keys(byTwoInitials).length).toEqual(16 * 16)
+        console.log(Object.values(byTwoInitials).map((a) => a.length))
+
+        const byThreeInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0] + dataKey[1] + dataKey[2])
+        expect(Object.keys(byThreeInitials).length).toEqual(16 * 16 * 16)
+        console.log(Object.values(byThreeInitials).map((a) => a.length))
+
+        const byFourInitials = groupBy(dataKeys, (dataKey: DhtAddress) => dataKey[0] + dataKey[1] + dataKey[2] + dataKey[3])
+        expect(Object.keys(byFourInitials).length).toEqual(16 * 16 * 16 * 16)
+        console.log(Object.values(byFourInitials).map((a) => a.length))
+    })
+
+})

--- a/packages/trackerless-network/test/unit/StreamPartIDDataKey.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartIDDataKey.test.ts
@@ -1,0 +1,12 @@
+import { StreamPartIDUtils } from '@streamr/protocol'
+import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+
+describe('StreamPartIDtoDataKey', () => {
+
+    it('generated key length is correct (160 bits)', () => {
+        const streamPartId = StreamPartIDUtils.parse('stream#0')
+        const dataKey = streamPartIdToDataKey(streamPartId)
+        expect(dataKey.length).toEqual(40)
+    })
+
+})


### PR DESCRIPTION
## Summary

The data keys generated from StreamPartIDs that are used to store entry point data in the DHT are now 160 bit long.

In practice the hashing algorithm was changed from md5 to sha-1

Backwards incompatible for testnet3.

## Future improvements

- Enforce the key length in the DHT 