### PR TITLE
feat(trackerless-network): Version number in `NodeInfoResponse`

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -175,4 +175,5 @@ message NodeInfoResponse {
   dht.PeerDescriptor peerDescriptor = 1;
   repeated StreamPartitionInfo streamPartitions = 2;
   optional ControlLayerInfo controlLayer = 3;
+  string version = 4;
 }

--- a/packages/trackerless-network/src/logic/node-info/NodeInfoRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/node-info/NodeInfoRpcLocal.ts
@@ -2,6 +2,7 @@ import { NodeInfoRequest, NodeInfoResponse } from '../../proto/packages/trackerl
 import { INodeInfoRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { NetworkStack } from '../../NetworkStack'
 import { ListeningRpcCommunicator } from '@streamr/dht'
+import { version as localVersion } from '../../../package.json'
 
 export const NODE_INFO_RPC_SERVICE_ID = 'system/node-info-rpc'
 
@@ -28,7 +29,8 @@ export class NodeInfoRpcLocal implements INodeInfoRpc {
                 connections: this.stack.getLayer0Node().getConnections(),
                 neighbors: this.stack.getLayer0Node().getNeighbors()
             },
-            streamPartitions: this.stack.getStreamrNode().getNodeInfo()
+            streamPartitions: this.stack.getStreamrNode().getNodeInfo(),
+            version: localVersion
         }
     }
 

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -329,6 +329,10 @@ export interface NodeInfoResponse {
      * @generated from protobuf field: optional ControlLayerInfo controlLayer = 3;
      */
     controlLayer?: ControlLayerInfo;
+    /**
+     * @generated from protobuf field: string version = 4;
+     */
+    version: string;
 }
 /**
  * @generated from protobuf enum StreamMessageType
@@ -673,7 +677,8 @@ class NodeInfoResponse$Type extends MessageType<NodeInfoResponse> {
         super("NodeInfoResponse", [
             { no: 1, name: "peerDescriptor", kind: "message", T: () => PeerDescriptor },
             { no: 2, name: "streamPartitions", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => StreamPartitionInfo },
-            { no: 3, name: "controlLayer", kind: "message", T: () => ControlLayerInfo }
+            { no: 3, name: "controlLayer", kind: "message", T: () => ControlLayerInfo },
+            { no: 4, name: "version", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
@@ -95,7 +95,8 @@ describe('NetworkStack NodeInfoRpc', () => {
                     controlLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)],
                     deliveryLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)]
                 }
-            ]
+            ],
+            version: expect.any(String)
         })
         expect(result.streamPartitions.length).toEqual(2)
     })

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -6,7 +6,8 @@
     },
     "include": [
         "src/**/*",
-        "test/**/*"
+        "test/**/*",
+        "package.json"
     ],
     "references": [
         { "path": "../protocol/tsconfig.node.json" },

--- a/packages/trackerless-network/tsconfig.node.json
+++ b/packages/trackerless-network/tsconfig.node.json
@@ -7,7 +7,8 @@
     "include": [
         "src/**/*",
         "test/benchmark/first-message.ts",
-        "test/utils/utils.ts"
+        "test/utils/utils.ts",
+        "package.json"
     ],
     "references": [
         { "path": "../protocol/tsconfig.node.json" },


### PR DESCRIPTION
Add `version` field to `NodeInfoResponse`. It contains the application version number.
