### PR TITLE
chore(broker): [ETH-729] increase gas limit of vote on flag

### DIFF
--- a/packages/broker/src/plugins/operator/ContractFacade.ts
+++ b/packages/broker/src/plugins/operator/ContractFacade.ts
@@ -469,7 +469,7 @@ export class ContractFacade {
             sponsorship,
             targetOperator,
             voteData,
-            { ...this.getEthersOverrides(), gasLimit: '200000' }
+            { ...this.getEthersOverrides(), gasLimit: '1000000' }
         )).wait()
     }
 


### PR DESCRIPTION
## Summary

Increase gas limit to ensure flag voting (as well as closing flags) do not run out of gas in Polygon.
