### PR TITLE
feat(trackerless-network): Export node info types and functions

### DIFF
--- a/packages/trackerless-network/src/exports.ts
+++ b/packages/trackerless-network/src/exports.ts
@@ -1,7 +1,8 @@
 export { NetworkStack, NetworkOptions } from './NetworkStack'
 export { NetworkNode, createNetworkNode } from './NetworkNode'
 export { StreamrNodeConfig } from './logic/StreamrNode'
-export { ProxyDirection } from './proto/packages/trackerless-network/protos/NetworkRpc'
+export { ProxyDirection, NodeInfoResponse } from './proto/packages/trackerless-network/protos/NetworkRpc'
+export { streamPartIdToDataKey } from './logic/EntryPointDiscovery'
 export {
     convertStreamMessageToBytes,
     convertBytesToStreamMessage


### PR DESCRIPTION
Export `NodeInfoResponse` type and `streamPartIdToDataKey` utility functions which are needed by the crawler.