### PR TITLE
fix(DHT): clean up hanging invalid connections from the ConnectionManagers state

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -153,8 +153,15 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             allowToContainReferenceId: false,
             emitEvents: false
         })
-        this.connections.forEach((connection) => {
-            if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsed() > lastUsedLimit) {
+        this.connections.forEach((connection, key) => {
+            // TODO: Investigate why multiple invalid WS client connections to the same
+            // server with a different nodeId can remain in the this.connections map.
+            // Seems to only happen if the ConnectionManager acting as client is not running a WS server itself.
+            if (connection.getPeerDescriptor() !== undefined && !this.hasConnection(getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!))) {
+                logger.trace(`Attempting to disconnect a hanging connection to ${getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!)}`)
+                connection.close(false).catch(() => {})
+                this.connections.delete(key)
+            } else if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsed() > lastUsedLimit) {
                 logger.trace('disconnecting in timeout interval: ' + getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()))
                 disconnectionCandidates.addContact(connection)
             }


### PR DESCRIPTION
## Summary

WebSocket client connections can sometimes remain hanging in the connection managers state if the ConnectionManager acting as a client is not running a WebSocket server itself. The client connections appear to be targeted to the same WS server with a different nodeId. Something could be going wrong with the handshake that should be rejecting new connections if the nodeId does not mtach the server side.

Implementing this patch solution as the problem is rare and is thus difficult to debug. The hanging connections don't seem to hinder the nodes operation by that much but it is best to clean them up to avoid memory leaks.
