### PR TITLE
refactor(dht, trackerless-network): Remove unnecessary type assertions

### DIFF
--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -176,8 +176,8 @@ describe('Route Message With Mock Connections', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: closestPeersRequest
             },
-            sourceDescriptor: sourceNode.getLocalPeerDescriptor()!,
-            targetDescriptor: destinationNode.getLocalPeerDescriptor()!
+            sourceDescriptor: sourceNode.getLocalPeerDescriptor(),
+            targetDescriptor: destinationNode.getLocalPeerDescriptor()
         }
 
         const routeMessageWrapper: RouteMessageWrapper = {
@@ -207,15 +207,15 @@ describe('Route Message With Mock Connections', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage
             },
-            sourceDescriptor: sourceNode.getLocalPeerDescriptor()!,
-            targetDescriptor: entryPoint.getLocalPeerDescriptor()!
+            sourceDescriptor: sourceNode.getLocalPeerDescriptor(),
+            targetDescriptor: entryPoint.getLocalPeerDescriptor()
         }
 
         const forwardedMessage: RouteMessageWrapper = {
             message: requestMessage,
             requestId: v4(),
             sourcePeer: sourceNode.getLocalPeerDescriptor(),
-            target: entryPoint.getLocalPeerDescriptor()!.nodeId,
+            target: entryPoint.getLocalPeerDescriptor().nodeId,
             reachableThrough: [],
             routingPath: [],
             parallelRootNodeIds: []

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -76,14 +76,14 @@ describe('LocalDataStore', () => {
             const storedEntry = createMockDataEntry({ creator: creator1 })
             localDataStore.storeEntry(storedEntry)
             const notDeletedData = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
-            expect(notDeletedData[0]!.deleted).toBeFalse()
+            expect(notDeletedData[0].deleted).toBeFalse()
             const returnValue = localDataStore.markAsDeleted(
                 getDhtAddressFromRaw(storedEntry.key),
                 creator1
             )
             expect(returnValue).toBe(true)
             const deletedData = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
-            expect(deletedData[0]!.deleted).toBeTrue()
+            expect(deletedData[0].deleted).toBeTrue()
         })
 
         it('data not stored', () => {

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -18,7 +18,7 @@ describe('PeerManager', () => {
         manager.addContact(nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS })))
 
         const referenceId = createRandomDhtAddress()
-        const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2)!)
+        const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))
         const actual = manager.getClosestContactsTo(referenceId, 5, excluded)
 
         const expected = sortBy(

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -73,7 +73,7 @@ export class NetworkNode {
     }
 
     setStreamPartEntryPoints(streamPartId: StreamPartID, contactPeerDescriptors: PeerDescriptor[]): void {
-        this.stack.getStreamrNode()!.setStreamPartEntryPoints(streamPartId, contactPeerDescriptors)
+        this.stack.getStreamrNode().setStreamPartEntryPoints(streamPartId, contactPeerDescriptors)
     }
 
     removeMessageListener(cb: (msg: StreamMessage) => void): void {

--- a/packages/trackerless-network/test/end-to-end/inspect.test.ts
+++ b/packages/trackerless-network/test/end-to-end/inspect.test.ts
@@ -96,9 +96,9 @@ describe('inspect', () => {
         await inspectedNode.start()
         await inspectorNode.start()
 
-        publisherNode.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
-        inspectedNode.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
-        inspectorNode.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
+        publisherNode.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
+        inspectedNode.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
+        inspectorNode.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
 
         await waitForCondition(() => 
             publisherNode.stack.getStreamrNode().getNeighbors(STREAM_PART_ID).length === 2 

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -65,11 +65,11 @@ describe('proxy and full node', () => {
             }
         })
         await proxyNode.start()
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(proxiedStreamPart)
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(regularStreamPart1)
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(regularStreamPart2)
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(regularStreamPart3)
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(regularStreamPart4)
+        proxyNode.stack.getStreamrNode().joinStreamPart(proxiedStreamPart)
+        proxyNode.stack.getStreamrNode().joinStreamPart(regularStreamPart1)
+        proxyNode.stack.getStreamrNode().joinStreamPart(regularStreamPart2)
+        proxyNode.stack.getStreamrNode().joinStreamPart(regularStreamPart3)
+        proxyNode.stack.getStreamrNode().joinStreamPart(regularStreamPart4)
 
         proxiedNode = createNetworkNode({
             layer0: {
@@ -90,14 +90,14 @@ describe('proxy and full node', () => {
         expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(false)
 
         await Promise.all([
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage'),
             proxiedNode.broadcast(createMessage(regularStreamPart1))
         ])
 
         expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(true)
 
         await Promise.all([
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage'),
             proxiedNode.broadcast(createMessage(proxiedStreamPart))
         ])
 
@@ -110,13 +110,13 @@ describe('proxy and full node', () => {
         expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(false)
 
         await Promise.all([
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage', 5000, 
                 (streamMessage: InternalStreamMessage) => streamMessage.messageId!.streamId === StreamPartIDUtils.getStreamID(regularStreamPart1)),
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage', 5000, 
                 (streamMessage: InternalStreamMessage) => streamMessage.messageId!.streamId === StreamPartIDUtils.getStreamID(regularStreamPart2)),
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage', 5000, 
                 (streamMessage: InternalStreamMessage) => streamMessage.messageId!.streamId === StreamPartIDUtils.getStreamID(regularStreamPart3)),
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage', 5000, 
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage', 5000, 
                 (streamMessage: InternalStreamMessage) => streamMessage.messageId!.streamId === StreamPartIDUtils.getStreamID(regularStreamPart4)),
             proxiedNode.broadcast(createMessage(regularStreamPart1)),
             proxiedNode.broadcast(createMessage(regularStreamPart2)),
@@ -127,7 +127,7 @@ describe('proxy and full node', () => {
         expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(true)
 
         await Promise.all([
-            waitForEvent3(proxyNode.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(proxyNode.stack.getStreamrNode() as any, 'newMessage'),
             proxiedNode.broadcast(createMessage(proxiedStreamPart))
         ])
 

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -46,14 +46,14 @@ describe('Proxy connections', () => {
     let proxiedNode: NetworkNode
 
     const hasConnectionFromProxy = (proxyNode: NetworkNode): boolean => {
-        const delivery = proxyNode.stack.getStreamrNode()!.getStreamPartDelivery(STREAM_PART_ID)
+        const delivery = proxyNode.stack.getStreamrNode().getStreamPartDelivery(STREAM_PART_ID)
         return (delivery !== undefined)
             ? ((delivery as { node: RandomGraphNode }).node).hasProxyConnection(proxiedNode.getNodeId())
             : false
     }
     
     const hasConnectionToProxy = (proxyNodeId: DhtAddress, direction: ProxyDirection): boolean => {
-        const client = (proxiedNode.stack.getStreamrNode()!.getStreamPartDelivery(STREAM_PART_ID) as { client: ProxyClient }).client
+        const client = (proxiedNode.stack.getStreamrNode().getStreamPartDelivery(STREAM_PART_ID) as { client: ProxyClient }).client
         return client.hasConnection(proxyNodeId, direction)
     }
 
@@ -77,7 +77,7 @@ describe('Proxy connections', () => {
         })
         await proxyNode1.start()
         proxyNode1.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
-        proxyNode1.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
+        proxyNode1.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
         proxyNode2 = createNetworkNode({
             layer0: {
                 entryPoints: [proxyNodeDescriptor1],
@@ -90,7 +90,7 @@ describe('Proxy connections', () => {
         })
         await proxyNode2.start()
         proxyNode2.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
-        proxyNode2.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
+        proxyNode2.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
         proxiedNode = createNetworkNode({
             layer0: {
                 entryPoints: [proxyNode1.getPeerDescriptor()],
@@ -109,7 +109,7 @@ describe('Proxy connections', () => {
     it('happy path publishing', async () => {
         await proxiedNode.setProxies(STREAM_PART_ID, [proxyNode1.getPeerDescriptor()], ProxyDirection.PUBLISH, PROXIED_NODE_USER_ID, 1)
         await Promise.all([
-            waitForEvent3(proxyNode1.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(proxyNode1.stack.getStreamrNode() as any, 'newMessage'),
             proxiedNode.broadcast(MESSAGE)
         ])
     })
@@ -117,7 +117,7 @@ describe('Proxy connections', () => {
     it('happy path subscribing', async () => {
         await proxiedNode.setProxies(STREAM_PART_ID, [proxyNode1.getPeerDescriptor()], ProxyDirection.SUBSCRIBE, PROXIED_NODE_USER_ID, 1)
         await Promise.all([
-            waitForEvent3(proxiedNode.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(proxiedNode.stack.getStreamrNode() as any, 'newMessage'),
             proxyNode1.broadcast(MESSAGE)
         ])
     })
@@ -196,7 +196,7 @@ describe('Proxy connections', () => {
         await proxyNode1.leave(STREAM_PART_ID)
         await waitForCondition(() => hasConnectionToProxy(proxyNode1.getNodeId(), ProxyDirection.SUBSCRIBE))
         expect(hasConnectionFromProxy(proxyNode1)).toBe(false)
-        proxyNode1.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
+        proxyNode1.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
         await waitForCondition(() => hasConnectionToProxy(proxyNode1.getNodeId(), ProxyDirection.SUBSCRIBE), 25000)
         // TODO why wait is needed?
         await wait(100)

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -44,7 +44,7 @@ describe('proxy group key exchange', () => {
         })
         await proxyNode.start()
         proxyNode.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor])
-        proxyNode.stack.getStreamrNode()!.joinStreamPart(STREAM_PART_ID)
+        proxyNode.stack.getStreamrNode().joinStreamPart(STREAM_PART_ID)
         publisher = createNetworkNode({
             layer0: {
                 entryPoints: [proxyNodeDescriptor],
@@ -98,7 +98,7 @@ describe('proxy group key exchange', () => {
         })
 
         await Promise.all([
-            waitForEvent3(publisher.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(publisher.stack.getStreamrNode() as any, 'newMessage'),
             subscriber.broadcast(request)
         ])
     })
@@ -130,7 +130,7 @@ describe('proxy group key exchange', () => {
         })
 
         await Promise.all([
-            waitForEvent3(subscriber.stack.getStreamrNode()! as any, 'newMessage'),
+            waitForEvent3(subscriber.stack.getStreamrNode() as any, 'newMessage'),
             publisher.broadcast(response)
         ])
     })

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -33,8 +33,8 @@ describe('Full node network with WebRTC connections', () => {
             }
         })
         await entryPoint.start()
-        entryPoint.getStreamrNode()!.setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
-        entryPoint.getStreamrNode()!.joinStreamPart(streamPartId)
+        entryPoint.getStreamrNode().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
+        entryPoint.getStreamrNode().joinStreamPart(streamPartId)
 
         await Promise.all(range(NUM_OF_NODES).map(async () => {
             const peerDescriptor = createMockPeerDescriptor()
@@ -62,15 +62,15 @@ describe('Full node network with WebRTC connections', () => {
     it('happy path', async () => {
         await Promise.all(nodes.map((node) =>
             waitForCondition(() => {
-                return node.getStreamrNode()!.getNeighbors(streamPartId).length >= 3
+                return node.getStreamrNode().getNeighbors(streamPartId).length >= 3
             }
             , 30000)
         ))
         let receivedMessageCount = 0
         const successIds: string[] = []
         nodes.forEach((node) => {
-            node.getStreamrNode()!.on('newMessage', () => {
-                successIds.push(getNodeIdFromPeerDescriptor(node.getStreamrNode()!.getPeerDescriptor()))
+            node.getStreamrNode().on('newMessage', () => {
+                successIds.push(getNodeIdFromPeerDescriptor(node.getStreamrNode().getPeerDescriptor()))
                 receivedMessageCount += 1
             })
         })
@@ -79,7 +79,7 @@ describe('Full node network with WebRTC connections', () => {
             streamPartId,
             randomEthereumAddress()
         )
-        entryPoint.getStreamrNode()!.broadcast(msg)
+        entryPoint.getStreamrNode().broadcast(msg)
         await waitForCondition(() => receivedMessageCount === NUM_OF_NODES)
     }, 120000)
 

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -30,8 +30,8 @@ describe('Full node network with WebSocket connections only', () => {
             }
         })
         await entryPoint.start()
-        entryPoint.getStreamrNode()!.setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
-        entryPoint.getStreamrNode()!.joinStreamPart(streamPartId)
+        entryPoint.getStreamrNode().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
+        entryPoint.getStreamrNode().joinStreamPart(streamPartId)
 
         await Promise.all(range(NUM_OF_NODES).map(async (i) => {
             const node = new NetworkStack({
@@ -60,15 +60,15 @@ describe('Full node network with WebSocket connections only', () => {
     it('happy path', async () => {
         await Promise.all(nodes.map((node) =>
             waitForCondition(() => {
-                return node.getStreamrNode()!.getNeighbors(streamPartId).length >= 4
+                return node.getStreamrNode().getNeighbors(streamPartId).length >= 4
             }
             , 30000)
         ))
         let receivedMessageCount = 0
         const successIds: string[] = []
         nodes.forEach((node) => {
-            node.getStreamrNode()!.on('newMessage', () => {
-                successIds.push(getNodeIdFromPeerDescriptor(node.getStreamrNode()!.getPeerDescriptor()))
+            node.getStreamrNode().on('newMessage', () => {
+                successIds.push(getNodeIdFromPeerDescriptor(node.getStreamrNode().getPeerDescriptor()))
                 receivedMessageCount += 1
             })
         })
@@ -78,7 +78,7 @@ describe('Full node network with WebSocket connections only', () => {
             streamPartId,
             randomEthereumAddress()
         )
-        entryPoint.getStreamrNode()!.broadcast(msg)
+        entryPoint.getStreamrNode().broadcast(msg)
         await waitForCondition(() => receivedMessageCount === NUM_OF_NODES)
     }, 220000)
 

--- a/packages/trackerless-network/test/integration/NetworkStack.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkStack.test.ts
@@ -34,9 +34,9 @@ describe('NetworkStack', () => {
         })
 
         await stack1.start()
-        stack1.getStreamrNode()!.setStreamPartEntryPoints(STREAM_PART_ID, [epDescriptor])
+        stack1.getStreamrNode().setStreamPartEntryPoints(STREAM_PART_ID, [epDescriptor])
         await stack2.start()
-        stack2.getStreamrNode()!.setStreamPartEntryPoints(STREAM_PART_ID, [epDescriptor])
+        stack2.getStreamrNode().setStreamPartEntryPoints(STREAM_PART_ID, [epDescriptor])
     })
 
     afterEach(async () => {

--- a/packages/trackerless-network/test/unit/GroupKeyResponseTranslator.test.ts
+++ b/packages/trackerless-network/test/unit/GroupKeyResponseTranslator.test.ts
@@ -15,7 +15,7 @@ describe('GroupKeyResponseTranslator', () => {
     })
     const newGroupKey: GroupKey = {
         id: 'id',
-        data: hexToBinary('0000')!
+        data: hexToBinary('0000')
     }
     const newGroupKeyResponse: GroupKeyResponse = {
         requestId: 'request',


### PR DESCRIPTION
Removed some unnecessary type assertions. These assertions would be `@typescript-eslint/no-unnecessary-type-assertion` errors  when we land  https://github.com/streamr-dev/network/pull/2364

## Open questions

Why e.g. this line in `LocalDataStore.test.ts` no longer needs type assertion? We used to have exclamation mark to assert that the `notDeletedData[0]` is not `undefined` if the array would not contain any items:
```ts
const notDeletedData = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
expect(notDeletedData[0].deleted).toBeFalse()
```