### PR TITLE
chore(client): build both production & dev webpacks in release

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,6 +23,7 @@
     "prebuild": "node bin/generate-config-validator.js && bash vendor-hack.sh",
     "postbuild": "bash copy-package.sh && bash fix-esm.sh",
     "build": "tsc --build ./tsconfig.node.json",
+    "build-browser": "npm run build-browser-development && npm run build-browser-production",
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
     "check": "tsc -p ./tsconfig.jest.json --noEmit",

--- a/release.sh
+++ b/release.sh
@@ -11,7 +11,7 @@ npm run build
 
 # Build client's webpack bundle
 cd packages/client || exit
-npm run build-browser-production
+npm run build-browser
 if [ $? -ne 0 ]
 then
     echo


### PR DESCRIPTION
## Summary

Include `dev` version of webpack build in release. It is referred to in the client's package.json exports and relied upon by the front-end code.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
