### PR TITLE
fix(DHT) off handshaker onData after handshake is completed.

### DIFF
--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -57,6 +57,7 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
                 } else {
                     this.emit('handshakeCompleted', handshake.sourcePeerDescriptor!)
                 }
+                this.connection.off('data', (data: Uint8Array) => this.onData(data))
             }
         } catch (err) {
             logger.error('error while parsing handshake message', err)

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -57,7 +57,6 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
                 } else {
                     this.emit('handshakeCompleted', handshake.sourcePeerDescriptor!)
                 }
-                this.connection.off('data', (data: Uint8Array) => this.onData(data))
             }
         } catch (err) {
             logger.error('error while parsing handshake message', err)
@@ -101,5 +100,9 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
         }
         this.connection.send(Message.toBinary(msg))
         logger.trace('handshake response sent')
+    }
+
+    public stop(): void {
+        this.connection.off('data', (data: Uint8Array) => this.onData(data))
     }
 }

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -22,7 +22,7 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
     private static readonly HANDSHAKER_SERVICE_ID = 'system/handshaker'
     private localPeerDescriptor: PeerDescriptor
     private connection: IConnection
-
+    private readonly onDataListener: (data: Uint8Array) => void
     constructor(
         localPeerDescriptor: PeerDescriptor,
         connection: IConnection
@@ -30,7 +30,8 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
         super()
         this.localPeerDescriptor = localPeerDescriptor
         this.connection = connection
-        this.connection.on('data', (data: Uint8Array) => this.onData(data))
+        this.onDataListener = (data: Uint8Array) => this.onData(data)
+        this.connection.on('data', this.onDataListener)
     }
 
     private onData(data: Uint8Array) {
@@ -103,6 +104,6 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
     }
 
     public stop(): void {
-        this.connection.off('data', (data: Uint8Array) => this.onData(data))
+        this.connection.off('data', this.onDataListener)
     }
 }

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -177,6 +177,7 @@ export class ManagedConnection extends EventEmitter<Events> {
 
         this.setRemotePeerDescriptor(peerDescriptor)
         this.handshakeCompleted = true
+        this.handshaker!.stop()
 
         while (this.outputBuffer.length > 0) {
             logger.trace('emptying outputBuffer')


### PR DESCRIPTION
## Summary

The handshaker would remain listening to data from managed connections, parsing data, until the connection would be closed. Now the handshaker will stop listening to data once connection is handshaked.
