### PR TITLE
fix(DHT): reduce duplicate detector max size

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -96,7 +96,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     private config: ConnectionManagerConfig
     private readonly metricsContext: MetricsContext
     // TODO use config option or named constant?
-    private readonly duplicateMessageDetector: DuplicateDetector = new DuplicateDetector(100000)
+    private readonly duplicateMessageDetector: DuplicateDetector = new DuplicateDetector(10000)
     private readonly metrics: ConnectionManagerMetrics
     private locks = new ConnectionLockHandler()
     private connections: Map<DhtAddress, ManagedConnection> = new Map()

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -29,7 +29,7 @@ export class Router {
     private readonly forwardingTable: Map<DhtAddress, ForwardingTableEntry> = new Map()
     private ongoingRoutingSessions: Map<string, RoutingSession> = new Map()
     // TODO use config option or named constant?
-    private readonly duplicateRequestDetector: DuplicateDetector = new DuplicateDetector(100000)
+    private readonly duplicateRequestDetector: DuplicateDetector = new DuplicateDetector(10000)
     private stopped = false
     private readonly config: RouterConfig
 


### PR DESCRIPTION
## Summary

Reduce max size of the duplicate detectors in Router and ConnectionManager

## Future Improvements

Is the duplicate detector in ConnectionManager needed anymore? There should always only be a single connection. Should be possible after #2375
