### PR TITLE
fix(DHT): less emitted events due DhtNode - ConnectionManager circular dependency

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -332,7 +332,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }
     }
 
-    public handleMessageFromTransport(message: Message): boolean {
+    public handleIncomingMessage(message: Message): boolean {
         if (message.serviceId === INTERNAL_SERVICE_ID) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
             return true

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -311,7 +311,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         return this.locks.isRemoteLocked(nodeId)
     }
 
-    public handleMessage(message: Message): void {
+    private handleMessage(message: Message): void {
         logger.trace('Received message of type ' + message.messageType)
         if (message.messageType !== MessageType.RPC) {
             logger.trace('Filtered out non-RPC message of type ' + message.messageType)
@@ -330,6 +330,14 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)
         }
+    }
+
+    public handleMessageFromTransport(message: Message): boolean {
+        if (message.serviceId === INTERNAL_SERVICE_ID) {
+            this.rpcCommunicator?.handleMessageFromPeer(message)
+            return true
+        }
+        return false
     }
 
     private onData(data: Uint8Array, peerDescriptor: PeerDescriptor): void {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -383,7 +383,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (message.serviceId === this.config.serviceId) {
             logger.trace('calling this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.rpcCommunicator?.handleMessageFromPeer(message)
-        } else if (this.connectionManager?.handleMessageFromTransport(message)) {
+        } else if (this.connectionManager?.handleIncomingMessage(message)) {
             // message was handled by connectionManager
         } else {
             logger.trace('emit "message" ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -250,7 +250,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addContact([contact], setActive),
-            connectionManager: this.connectionManager
+            handleMessage: (message: Message) => this.handleMessage(message),
         })
         this.recursiveOperationManager = new RecursiveOperationManager({
             rpcCommunicator: this.rpcCommunicator,
@@ -383,6 +383,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (message.serviceId === this.config.serviceId) {
             logger.trace('calling this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.rpcCommunicator?.handleMessageFromPeer(message)
+        } else if (this.connectionManager?.handleMessageFromTransport(message)) {
+            // message was handled by connectionManager
         } else {
             logger.trace('emit "message" ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -231,7 +231,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             { rpcRequestTimeout: this.config.rpcRequestTimeout }
         )
 
-        this.transport.on('message', (message: Message) => this.handleMessage(message))
+        this.transport.on('message', (message: Message) => this.handleMessageFromTransport(message))
 
         this.initPeerManager()
 
@@ -250,7 +250,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addContact([contact], setActive),
-            handleMessage: (message: Message) => this.handleMessage(message),
+            handleMessage: (message: Message) => this.handleMessageFromRouter(message),
         })
         this.recursiveOperationManager = new RecursiveOperationManager({
             rpcCommunicator: this.rpcCommunicator,
@@ -378,15 +378,18 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         )
     }
 
-    private handleMessage(message: Message): void {
-        const nodeId = getNodeIdFromPeerDescriptor(message.sourceDescriptor!)
+    private handleMessageFromTransport(message: Message): void {
         if (message.serviceId === this.config.serviceId) {
-            logger.trace('calling this.handleMessageFromPeer ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
+            this.rpcCommunicator?.handleMessageFromPeer(message)
+        } 
+    }
+    
+    private handleMessageFromRouter(message: Message): void {
+        if (message.serviceId === this.config.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else if (this.connectionManager?.handleIncomingMessage(message)) {
             // message was handled by connectionManager
         } else {
-            logger.trace('emit "message" ' + nodeId + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)
         }
     }

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -3,7 +3,6 @@ import { RoutingMode, RoutingSession, RoutingSessionEvents } from './RoutingSess
 import { Logger, executeSafePromise, raceEvents3, withTimeout } from '@streamr/utils'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { DuplicateDetector } from './DuplicateDetector'
-import { ConnectionManager } from '../../connection/ConnectionManager'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { v4 } from 'uuid'
 import { RouterRpcLocal, createRouteMessageAck } from './RouterRpcLocal'
@@ -14,7 +13,7 @@ export interface RouterConfig {
     localPeerDescriptor: PeerDescriptor
     connections: Map<DhtAddress, DhtNodeRpcRemote>
     addContact: (contact: PeerDescriptor, setActive?: boolean) => void
-    connectionManager?: ConnectionManager
+    handleMessage: (message: Message) => void
 }
 
 interface ForwardingTableEntry {
@@ -45,7 +44,7 @@ export class Router {
             setForwardingEntries: (routedMessage: RouteMessageWrapper) => this.setForwardingEntries(routedMessage),
             duplicateRequestDetector: this.duplicateRequestDetector,
             localPeerDescriptor: this.config.localPeerDescriptor,
-            connectionManager: this.config.connectionManager
+            handleMessage: this.config.handleMessage
         })
         this.config.rpcCommunicator.registerRpcMethod(
             RouteMessageWrapper,

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -53,7 +53,8 @@ describe('Router', () => {
             localPeerDescriptor: peerDescriptor1,
             rpcCommunicator: rpcCommunicator as any,
             addContact: (_contact) => {},
-            connections
+            connections,
+            handleMessage: () => {}
         })
     })
 


### PR DESCRIPTION
## Summary

Reduce the amount of `message` events emitted in the ConnectionManager and DhtNode.