### PR TITLE
fix(client): Type definition file path

### DIFF
--- a/packages/client/copy-package.js
+++ b/packages/client/copy-package.js
@@ -10,6 +10,7 @@ pkg.types = `./${path.relative('./dist', pkg.types)}`
 pkg.main = `./${path.relative('./dist', pkg.main)}`
 pkg.browser = `./${path.relative('./dist', pkg.browser)}`
 pkg.exports.browser = `./${path.relative('./dist', pkg.exports.browser)}`
+pkg.exports.default.types = `./${path.relative('./dist', pkg.exports.default.types)}`
 pkg.exports.default.import = `./${path.relative('./dist', pkg.exports.default.import)}`
 pkg.exports.default.require = `./${path.relative('./dist', pkg.exports.default.require)}`
 


### PR DESCRIPTION
Fix `exports.default.types` definition in `package.json`. 

## Error

We get the following error message when building a TypeScript application which uses `NodeNext` module resolution:
```
Could not find a declaration file for module 'streamr-client'. .../node_modules/streamr-client/src/exports-commonjs.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/streamr-client` if it exists or add a new declaration (.d.ts) file containing `declare module 'streamr-client';`
```

## Background

When we release `streamr-client` package, we run `copy-package.js` via `postbuild` npm script. It modifies the `package.json`, e.g. by removing the "dist" prefix from some paths. 

The `exports.default.types` definition was not handled in that script, and therefore the in released packages the path contained extra "dist" prefix. The produced values were like this:
```
"types": "./types/src/index.d.ts",
"main": "./src/exports-commonjs.js",
"browser": "./streamr-client.web.js",
"exports": {
  "browser": "./streamr-client.web.js",
  "default": {
    "types": "./dist/types/src/index.d.ts",
    "import": "./src/exports-esm.mjs",
    "require": "./src/exports-commonjs.js"
  }
}
```

The definition was added in this PR: https://github.com/streamr-dev/network/pull/1788