### PR TITLE
refactor(trackerless-network): `StreamMessage` structure

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -69,17 +69,24 @@ enum SignatureType {
 }
 
 message StreamMessage {
-  StreamMessageType messageType = 1;
+  // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
+  MessageID messageId = 1;
+  optional MessageRef previousMessageRef = 2;
+  bytes signature = 3;
+  SignatureType signatureType = 4;
+  oneof body {
+    ContentMessage contentMessage = 5;
+    GroupKeyRequest groupKeyRequest = 6;
+    GroupKeyResponse groupKeyResponse = 7;
+  }
+}
+
+message ContentMessage {
+  bytes content = 1;
   ContentType contentType = 2;
   EncryptionType encryptionType = 3;
-  bytes content = 4;
-  SignatureType signatureType = 5;
-  bytes signature = 6;
-  // this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-  MessageID messageId = 7;
-  optional MessageRef previousMessageRef = 8;
-  optional string groupKeyId = 9;
-  optional GroupKey newGroupKey = 10;
+  optional string groupKeyId = 4;
+  optional GroupKey newGroupKey = 5;
 }
 
 message GroupKeyRequest {

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -1,4 +1,4 @@
-import { 
+import {
     ConnectionManager,
     DhtNode,
     DhtNodeOptions,
@@ -6,15 +6,15 @@ import {
     PeerDescriptor,
     areEqualPeerDescriptors
 } from '@streamr/dht'
-import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
-import { Logger, MetricsContext, waitForCondition } from '@streamr/utils'
 import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
-import { NodeInfoResponse, ProxyDirection, StreamMessage, StreamMessageType } from './proto/packages/trackerless-network/protos/NetworkRpc'
-import { Layer0Node } from './logic/Layer0Node'
+import { Logger, MetricsContext, waitForCondition } from '@streamr/utils'
 import { pull } from 'lodash'
-import { NODE_INFO_RPC_SERVICE_ID, NodeInfoRpcLocal } from './logic/node-info/NodeInfoRpcLocal'
-import { NodeInfoClient } from './logic/node-info/NodeInfoClient'
 import { version as localVersion } from '../package.json'
+import { Layer0Node } from './logic/Layer0Node'
+import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
+import { NodeInfoClient } from './logic/node-info/NodeInfoClient'
+import { NODE_INFO_RPC_SERVICE_ID, NodeInfoRpcLocal } from './logic/node-info/NodeInfoRpcLocal'
+import { NodeInfoResponse, ProxyDirection, StreamMessage } from './proto/packages/trackerless-network/protos/NetworkRpc'
 
 export interface NetworkOptions {
     layer0?: DhtNodeOptions
@@ -90,7 +90,7 @@ export class NetworkStack {
 
     async broadcast(msg: StreamMessage): Promise<void> {
         const streamPartId = toStreamPartID(msg.messageId!.streamId as StreamID, msg.messageId!.streamPartition)
-        if (this.getStreamrNode().isProxiedStreamPart(streamPartId, ProxyDirection.SUBSCRIBE) && (msg.messageType === StreamMessageType.MESSAGE)) {
+        if (this.getStreamrNode().isProxiedStreamPart(streamPartId, ProxyDirection.SUBSCRIBE) && (msg.body.oneofKind === 'contentMessage')) {
             throw new Error(`Cannot broadcast to ${streamPartId} as proxy subscribe connections have been set`)
         }
         // TODO could combine these two calls to isProxiedStreamPart?

--- a/packages/trackerless-network/src/logic/StreamrNode.ts
+++ b/packages/trackerless-network/src/logic/StreamrNode.ts
@@ -113,8 +113,10 @@ export class StreamrNode extends EventEmitter<Events> {
         logger.debug(`Broadcasting to stream part ${streamPartId}`)
         this.joinStreamPart(streamPartId)
         this.streamParts.get(streamPartId)!.broadcast(msg)
-        this.metrics.broadcastMessagesPerSecond.record(1)
-        this.metrics.broadcastBytesPerSecond.record(msg.content.length)
+        if (msg.body.oneofKind === 'contentMessage') {
+            this.metrics.broadcastMessagesPerSecond.record(1)
+            this.metrics.broadcastBytesPerSecond.record(msg.body.contentMessage.content.length)
+        }
     }
 
     async leaveStreamPart(streamPartId: StreamPartID): Promise<void> {

--- a/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
@@ -1,11 +1,9 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { 
-    GroupKeyRequest,
     ProxyConnectionRequest,
     ProxyConnectionResponse,
     ProxyDirection,
-    StreamMessage,
-    StreamMessageType
+    StreamMessage
 } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { IProxyConnectionRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
@@ -64,9 +62,9 @@ export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IPr
     }
 
     getPropagationTargets(msg: StreamMessage): DhtAddress[] {
-        if (msg.messageType === StreamMessageType.GROUP_KEY_REQUEST) {
+        if (msg.body.oneofKind === 'groupKeyRequest') {
             try {
-                const recipientId = GroupKeyRequest.fromBinary(msg.content).recipientId
+                const recipientId = msg.body.groupKeyRequest.recipientId
                 return this.getNodeIdsForUserId(toEthereumAddress(binaryToHex(recipientId, true)))
             } catch (err) {
                 logger.trace(`Could not parse GroupKeyRequest: ${err}`)

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -52,9 +52,56 @@ export interface MessageRef {
  */
 export interface StreamMessage {
     /**
-     * @generated from protobuf field: StreamMessageType messageType = 1;
+     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
+     *
+     * @generated from protobuf field: MessageID messageId = 1;
      */
-    messageType: StreamMessageType;
+    messageId?: MessageID;
+    /**
+     * @generated from protobuf field: optional MessageRef previousMessageRef = 2;
+     */
+    previousMessageRef?: MessageRef;
+    /**
+     * @generated from protobuf field: bytes signature = 3;
+     */
+    signature: Uint8Array;
+    /**
+     * @generated from protobuf field: SignatureType signatureType = 4;
+     */
+    signatureType: SignatureType;
+    /**
+     * @generated from protobuf oneof: body
+     */
+    body: {
+        oneofKind: "contentMessage";
+        /**
+         * @generated from protobuf field: ContentMessage contentMessage = 5;
+         */
+        contentMessage: ContentMessage;
+    } | {
+        oneofKind: "groupKeyRequest";
+        /**
+         * @generated from protobuf field: GroupKeyRequest groupKeyRequest = 6;
+         */
+        groupKeyRequest: GroupKeyRequest;
+    } | {
+        oneofKind: "groupKeyResponse";
+        /**
+         * @generated from protobuf field: GroupKeyResponse groupKeyResponse = 7;
+         */
+        groupKeyResponse: GroupKeyResponse;
+    } | {
+        oneofKind: undefined;
+    };
+}
+/**
+ * @generated from protobuf message ContentMessage
+ */
+export interface ContentMessage {
+    /**
+     * @generated from protobuf field: bytes content = 1;
+     */
+    content: Uint8Array;
     /**
      * @generated from protobuf field: ContentType contentType = 2;
      */
@@ -64,33 +111,11 @@ export interface StreamMessage {
      */
     encryptionType: EncryptionType;
     /**
-     * @generated from protobuf field: bytes content = 4;
-     */
-    content: Uint8Array;
-    /**
-     * @generated from protobuf field: SignatureType signatureType = 5;
-     */
-    signatureType: SignatureType;
-    /**
-     * @generated from protobuf field: bytes signature = 6;
-     */
-    signature: Uint8Array;
-    /**
-     * this is a required field but in generated NetworkRpc.ts it is incorrectly annotated as optional (NET-1082)
-     *
-     * @generated from protobuf field: MessageID messageId = 7;
-     */
-    messageId?: MessageID;
-    /**
-     * @generated from protobuf field: optional MessageRef previousMessageRef = 8;
-     */
-    previousMessageRef?: MessageRef;
-    /**
-     * @generated from protobuf field: optional string groupKeyId = 9;
+     * @generated from protobuf field: optional string groupKeyId = 4;
      */
     groupKeyId?: string;
     /**
-     * @generated from protobuf field: optional GroupKey newGroupKey = 10;
+     * @generated from protobuf field: optional GroupKey newGroupKey = 5;
      */
     newGroupKey?: GroupKey;
 }
@@ -437,16 +462,13 @@ export const MessageRef = new MessageRef$Type();
 class StreamMessage$Type extends MessageType<StreamMessage> {
     constructor() {
         super("StreamMessage", [
-            { no: 1, name: "messageType", kind: "enum", T: () => ["StreamMessageType", StreamMessageType] },
-            { no: 2, name: "contentType", kind: "enum", T: () => ["ContentType", ContentType] },
-            { no: 3, name: "encryptionType", kind: "enum", T: () => ["EncryptionType", EncryptionType] },
-            { no: 4, name: "content", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 5, name: "signatureType", kind: "enum", T: () => ["SignatureType", SignatureType] },
-            { no: 6, name: "signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 7, name: "messageId", kind: "message", T: () => MessageID },
-            { no: 8, name: "previousMessageRef", kind: "message", T: () => MessageRef },
-            { no: 9, name: "groupKeyId", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 10, name: "newGroupKey", kind: "message", T: () => GroupKey }
+            { no: 1, name: "messageId", kind: "message", T: () => MessageID },
+            { no: 2, name: "previousMessageRef", kind: "message", T: () => MessageRef },
+            { no: 3, name: "signature", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "signatureType", kind: "enum", T: () => ["SignatureType", SignatureType] },
+            { no: 5, name: "contentMessage", kind: "message", oneof: "body", T: () => ContentMessage },
+            { no: 6, name: "groupKeyRequest", kind: "message", oneof: "body", T: () => GroupKeyRequest },
+            { no: 7, name: "groupKeyResponse", kind: "message", oneof: "body", T: () => GroupKeyResponse }
         ]);
     }
 }
@@ -454,6 +476,22 @@ class StreamMessage$Type extends MessageType<StreamMessage> {
  * @generated MessageType for protobuf message StreamMessage
  */
 export const StreamMessage = new StreamMessage$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ContentMessage$Type extends MessageType<ContentMessage> {
+    constructor() {
+        super("ContentMessage", [
+            { no: 1, name: "content", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contentType", kind: "enum", T: () => ["ContentType", ContentType] },
+            { no: 3, name: "encryptionType", kind: "enum", T: () => ["EncryptionType", EncryptionType] },
+            { no: 4, name: "groupKeyId", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "newGroupKey", kind: "message", T: () => GroupKey }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message ContentMessage
+ */
+export const ContentMessage = new ContentMessage$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class GroupKeyRequest$Type extends MessageType<GroupKeyRequest> {
     constructor() {

--- a/packages/trackerless-network/test/unit/Propagation.test.ts
+++ b/packages/trackerless-network/test/unit/Propagation.test.ts
@@ -3,8 +3,7 @@ import {
     EncryptionType,
     MessageID,
     SignatureType,
-    StreamMessage,
-    StreamMessageType,
+    StreamMessage
 } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { Propagation } from '../../src/logic/propagation/Propagation'
 import { hexToBinary, toEthereumAddress, utf8ToBinary, wait } from '@streamr/utils'
@@ -23,12 +22,16 @@ function makeMsg(streamId: string, partition: number, ts: number, msgNo: number)
     }
     return {
         messageId,
-        content: new Uint8Array([1]),
-        contentType: ContentType.JSON,
-        encryptionType: EncryptionType.NONE,
         signature: hexToBinary('0x1111'),
-        messageType: StreamMessageType.MESSAGE,
-        signatureType: SignatureType.SECP256K1
+        signatureType: SignatureType.SECP256K1,
+        body: {
+            oneofKind: 'contentMessage',
+            contentMessage: {
+                content: new Uint8Array([1]),
+                contentType: ContentType.JSON,
+                encryptionType: EncryptionType.NONE
+            }
+        }
     }
 }
 

--- a/packages/trackerless-network/test/unit/StreamMessageTranslator.test.ts
+++ b/packages/trackerless-network/test/unit/StreamMessageTranslator.test.ts
@@ -9,7 +9,6 @@ import {
 } from '@streamr/protocol'
 import { binaryToHex, binaryToUtf8, hexToBinary, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
 import { StreamMessageTranslator } from '../../src/logic/protocol-integration/stream-message/StreamMessageTranslator'
-import { StreamMessageType } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { createStreamMessage } from '../utils/utils'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('TEST#0')
@@ -49,10 +48,10 @@ describe('StreamMessageTranslator', () => {
         expect(translated.messageId!.sequenceNumber).toEqual(0)
         expect(binaryToHex(translated.messageId!.publisherId, true)).toEqual('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
         expect(translated.previousMessageRef).toEqual(undefined)
-        expect(translated.messageType).toEqual(StreamMessageType.MESSAGE)
-        expect(translated.groupKeyId).toEqual(undefined)
+        expect(translated.body.oneofKind).toEqual('contentMessage')
+        expect((translated.body as any).contentMessage.groupKeyId).toEqual(undefined)
         expect(translated.signature).toStrictEqual(signature)
-        expect(JSON.parse(binaryToUtf8(translated.content))).toEqual({ hello: 'WORLD' })
+        expect(JSON.parse(binaryToUtf8((translated.body as any).contentMessage.content))).toEqual({ hello: 'WORLD' })
     })
 
     it('translates protobuf to old protocol', () => {

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -15,8 +15,7 @@ import {
     EncryptionType,
     MessageID,
     SignatureType,
-    StreamMessage,
-    StreamMessageType
+    StreamMessage
 } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
@@ -78,13 +77,17 @@ export const createStreamMessage = (
         messageChainId: 'messageChain0',
     }
     const msg: StreamMessage = {
-        messageType: StreamMessageType.MESSAGE,
-        encryptionType: EncryptionType.NONE,
-        content: utf8ToBinary(content),
-        contentType: ContentType.JSON,
         messageId,
-        signature: hexToBinary('0x1234'),
         signatureType: SignatureType.SECP256K1,
+        signature: hexToBinary('0x1234'),
+        body: {
+            oneofKind: 'contentMessage',
+            contentMessage: {
+                encryptionType: EncryptionType.NONE,
+                contentType: ContentType.JSON,
+                content: utf8ToBinary(content)
+            }
+        }
     }
     return msg
 }


### PR DESCRIPTION
## Summary

Divided `StreamMessage` entity to three sub entities: `ContentMessage`, `GroupKeyRequest` and `GroupKeyResponse`:

```proto
message StreamMessage {
  MessageID messageId = 1;
  optional MessageRef previousMessageRef = 2;
  bytes signature = 3;
  SignatureType signatureType = 4;
  oneof body {
    ContentMessage contentMessage = 5;
    GroupKeyRequest groupKeyRequest = 6;
    GroupKeyResponse groupKeyResponse = 7;
  }
}
```

The similar structure was already used in the `DhtRpc.proto`'s `Message` entity.

## Other changes

Small change in broadcast metrics: we now include only stream messages, not group key messages. This makes sense, as we already reported just the message content length, i.e. we didn't include e.g. the message headers or other kind of control data. The reason for this change is that there is no longer `content` field in group key messages from which we could calculate the content length.

## Open questions

Should the `previousMessageRef` field be in the`StreamMessage` entity or in the `ContentMessage`? Only content messages have references to previous messages, but maybe some messages in the future could also have that kind of sequencing. If we move it, it would make sense to move the `messageId#messageChainId` too as the previous message reference is always `messageChain`-specific. Therefore it would maybe be most consistent if we keep it in the `StreamMessage` (i.e. as it is now in this PR).

## Future improvements

The `DhtRpc.proto`'s `Message` entity has a separate `messageType` field. That is maybe not needed as we can infer the type from the `oneof` object (e.g. `if (msg.body.oneofKind === 'contentMessage') ...`).