### PR TITLE
refactor(dht): Remove `Message#messageType`

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -184,8 +184,6 @@ enum RouteMessageError {
   STOPPED = 2;
 }
 
-// Correspond to the MessageType Enum
-
 message ConnectivityRequest {
   uint32 port = 1;
   bool tls = 2;
@@ -221,28 +219,18 @@ enum HandshakeError {
 
 // Wraps all messages
 
-enum MessageType {
-  RPC = 0;
-  CONNECTIVITY_REQUEST = 1;
-  CONNECTIVITY_RESPONSE = 2;
-  HANDSHAKE_REQUEST = 3;
-  HANDSHAKE_RESPONSE = 4;
-  RECURSIVE_OPERATION_REQUEST = 5;
-}
-
 message Message {
   string messageId = 1;
-  MessageType messageType = 2;
-  PeerDescriptor sourceDescriptor = 3;
-  PeerDescriptor targetDescriptor = 4;
-  string serviceId = 5; // id of the RPC service
+  PeerDescriptor sourceDescriptor = 2;
+  PeerDescriptor targetDescriptor = 3;
+  string serviceId = 4; // id of the RPC service
   oneof body {
+    protorpc.RpcMessage rpcMessage = 5;
     ConnectivityRequest connectivityRequest = 6;
     ConnectivityResponse connectivityResponse = 7;
     HandshakeRequest handshakeRequest = 8;
     HandshakeResponse handshakeResponse = 9;
-    protorpc.RpcMessage rpcMessage = 10;
-    RecursiveOperationRequest recursiveOperationRequest = 11;
+    RecursiveOperationRequest recursiveOperationRequest = 10;
   };
 }
 

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -9,7 +9,6 @@ import {
     LockRequest,
     LockResponse,
     Message,
-    MessageType,
     PeerDescriptor,
     UnlockRequest
 } from '../proto/packages/dht/protos/DhtRpc'
@@ -312,9 +311,10 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     }
 
     private handleMessage(message: Message): void {
-        logger.trace('Received message of type ' + message.messageType)
-        if (message.messageType !== MessageType.RPC) {
-            logger.trace('Filtered out non-RPC message of type ' + message.messageType)
+        const messageType = message.body.oneofKind
+        logger.trace('Received message of type ' + messageType)
+        if (messageType !== 'rpcMessage') {
+            logger.trace('Filtered out non-RPC message of type ' + messageType)
             return
         }
         if (this.duplicateMessageDetector.isMostLikelyDuplicate(message.messageId)) {

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
 import { v4 } from 'uuid'
-import { Message, HandshakeRequest, HandshakeResponse, MessageType, PeerDescriptor, HandshakeError } from '../proto/packages/dht/protos/DhtRpc'
+import { Message, HandshakeRequest, HandshakeResponse, PeerDescriptor, HandshakeError } from '../proto/packages/dht/protos/DhtRpc'
 import { IConnection } from './IConnection'
 import { version as localVersion } from '../../package.json'
 import { isCompatibleVersion } from '../helpers/versionCompatibility'
@@ -73,7 +73,6 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
         }
         const msg: Message = {
             serviceId: Handshaker.HANDSHAKER_SERVICE_ID,
-            messageType: MessageType.HANDSHAKE_REQUEST,
             messageId: v4(),
             body: {
                 oneofKind: 'handshakeRequest',
@@ -92,7 +91,6 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
         }
         const msg: Message = {
             serviceId: Handshaker.HANDSHAKER_SERVICE_ID,
-            messageType: MessageType.HANDSHAKE_RESPONSE,
             messageId: v4(),
             body: {
                 oneofKind: 'handshakeResponse',

--- a/packages/dht/src/connection/connectivityChecker.ts
+++ b/packages/dht/src/connection/connectivityChecker.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid'
 import * as Err from '../helpers/errors'
 import {
     ConnectivityRequest, ConnectivityResponse,
-    Message, MessageType, PeerDescriptor
+    Message, PeerDescriptor
 } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionEvents, IConnection } from './IConnection'
 import { ClientWebsocket } from './websocket/ClientWebsocket'
@@ -59,7 +59,7 @@ export const sendConnectivityRequest = async (
     // send connectivity request
     const msg: Message = {
         serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
-        messageType: MessageType.CONNECTIVITY_REQUEST, messageId: v4(),
+        messageId: v4(),
         body: {
             oneofKind: 'connectivityRequest',
             connectivityRequest: request

--- a/packages/dht/src/connection/connectivityRequestHandler.ts
+++ b/packages/dht/src/connection/connectivityRequestHandler.ts
@@ -1,8 +1,9 @@
 import { ipv4ToNumber, Logger } from '@streamr/utils'
 import { v4 } from 'uuid'
 import {
-    ConnectivityRequest, ConnectivityResponse,
-    Message, MessageType
+    ConnectivityRequest,
+    ConnectivityResponse,
+    Message
 } from '../proto/packages/dht/protos/DhtRpc'
 import { NatType } from './ConnectionManager'
 import { CONNECTIVITY_CHECKER_SERVICE_ID, connectAsync } from './connectivityChecker'
@@ -52,7 +53,6 @@ const handleIncomingConnectivityRequest = async (connection: ServerWebsocket, co
     }
     const msg: Message = {
         serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
-        messageType: MessageType.CONNECTIVITY_RESPONSE,
         messageId: v4(),
         body: {
             oneofKind: 'connectivityResponse',

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -8,8 +8,7 @@ import {
     RouteMessageWrapper,
     RouteMessageAck,
     RecursiveOperationRequest,
-    Message,
-    MessageType
+    Message
 } from '../../proto/packages/dht/protos/DhtRpc'
 import { ITransport } from '../../transport/ITransport'
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
@@ -90,7 +89,6 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
             operation: this.config.operation
         }
         const msg: Message = {
-            messageType: MessageType.RECURSIVE_OPERATION_REQUEST,
             messageId: v4(),
             serviceId,
             body: {

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -3,7 +3,7 @@
 // tslint:disable
 import { Empty } from "../../../google/protobuf/empty";
 import { ServiceType } from "@protobuf-ts/runtime-rpc";
-import { MessageType as MessageType$ } from "@protobuf-ts/runtime";
+import { MessageType } from "@protobuf-ts/runtime";
 import { RpcMessage } from "../../proto-rpc/protos/ProtoRpc";
 import { Timestamp } from "../../../google/protobuf/timestamp";
 import { Any } from "../../../google/protobuf/any";
@@ -378,6 +378,8 @@ export interface HandshakeResponse {
      */
     version: string;
 }
+// Wraps all messages
+
 /**
  * @generated from protobuf message dht.Message
  */
@@ -387,25 +389,27 @@ export interface Message {
      */
     messageId: string;
     /**
-     * @generated from protobuf field: dht.MessageType messageType = 2;
-     */
-    messageType: MessageType;
-    /**
-     * @generated from protobuf field: dht.PeerDescriptor sourceDescriptor = 3;
+     * @generated from protobuf field: dht.PeerDescriptor sourceDescriptor = 2;
      */
     sourceDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: dht.PeerDescriptor targetDescriptor = 4;
+     * @generated from protobuf field: dht.PeerDescriptor targetDescriptor = 3;
      */
     targetDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: string serviceId = 5;
+     * @generated from protobuf field: string serviceId = 4;
      */
     serviceId: string; // id of the RPC service
     /**
      * @generated from protobuf oneof: body
      */
     body: {
+        oneofKind: "rpcMessage";
+        /**
+         * @generated from protobuf field: protorpc.RpcMessage rpcMessage = 5;
+         */
+        rpcMessage: RpcMessage;
+    } | {
         oneofKind: "connectivityRequest";
         /**
          * @generated from protobuf field: dht.ConnectivityRequest connectivityRequest = 6;
@@ -430,15 +434,9 @@ export interface Message {
          */
         handshakeResponse: HandshakeResponse;
     } | {
-        oneofKind: "rpcMessage";
-        /**
-         * @generated from protobuf field: protorpc.RpcMessage rpcMessage = 10;
-         */
-        rpcMessage: RpcMessage;
-    } | {
         oneofKind: "recursiveOperationRequest";
         /**
-         * @generated from protobuf field: dht.RecursiveOperationRequest recursiveOperationRequest = 11;
+         * @generated from protobuf field: dht.RecursiveOperationRequest recursiveOperationRequest = 10;
          */
         recursiveOperationRequest: RecursiveOperationRequest;
     } | {
@@ -646,37 +644,6 @@ export enum HandshakeError {
      */
     UNSUPPORTED_VERSION = 2
 }
-// Wraps all messages
-
-/**
- * @generated from protobuf enum dht.MessageType
- */
-export enum MessageType {
-    /**
-     * @generated from protobuf enum value: RPC = 0;
-     */
-    RPC = 0,
-    /**
-     * @generated from protobuf enum value: CONNECTIVITY_REQUEST = 1;
-     */
-    CONNECTIVITY_REQUEST = 1,
-    /**
-     * @generated from protobuf enum value: CONNECTIVITY_RESPONSE = 2;
-     */
-    CONNECTIVITY_RESPONSE = 2,
-    /**
-     * @generated from protobuf enum value: HANDSHAKE_REQUEST = 3;
-     */
-    HANDSHAKE_REQUEST = 3,
-    /**
-     * @generated from protobuf enum value: HANDSHAKE_RESPONSE = 4;
-     */
-    HANDSHAKE_RESPONSE = 4,
-    /**
-     * @generated from protobuf enum value: RECURSIVE_OPERATION_REQUEST = 5;
-     */
-    RECURSIVE_OPERATION_REQUEST = 5
-}
 /**
  * @generated from protobuf enum dht.DisconnectMode
  */
@@ -691,7 +658,7 @@ export enum DisconnectMode {
     LEAVING = 1
 }
 // @generated message type with reflection information, may provide speed optimized methods
-class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
+class StoreDataRequest$Type extends MessageType<StoreDataRequest> {
     constructor() {
         super("dht.StoreDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -707,7 +674,7 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
  */
 export const StoreDataRequest = new StoreDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class StoreDataResponse$Type extends MessageType$<StoreDataResponse> {
+class StoreDataResponse$Type extends MessageType<StoreDataResponse> {
     constructor() {
         super("dht.StoreDataResponse", []);
     }
@@ -717,7 +684,7 @@ class StoreDataResponse$Type extends MessageType$<StoreDataResponse> {
  */
 export const StoreDataResponse = new StoreDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalStoreDataRequest$Type extends MessageType$<ExternalStoreDataRequest> {
+class ExternalStoreDataRequest$Type extends MessageType<ExternalStoreDataRequest> {
     constructor() {
         super("dht.ExternalStoreDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -730,7 +697,7 @@ class ExternalStoreDataRequest$Type extends MessageType$<ExternalStoreDataReques
  */
 export const ExternalStoreDataRequest = new ExternalStoreDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalStoreDataResponse$Type extends MessageType$<ExternalStoreDataResponse> {
+class ExternalStoreDataResponse$Type extends MessageType<ExternalStoreDataResponse> {
     constructor() {
         super("dht.ExternalStoreDataResponse", [
             { no: 1, name: "storers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
@@ -742,7 +709,7 @@ class ExternalStoreDataResponse$Type extends MessageType$<ExternalStoreDataRespo
  */
 export const ExternalStoreDataResponse = new ExternalStoreDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ReplicateDataRequest$Type extends MessageType$<ReplicateDataRequest> {
+class ReplicateDataRequest$Type extends MessageType<ReplicateDataRequest> {
     constructor() {
         super("dht.ReplicateDataRequest", [
             { no: 1, name: "entry", kind: "message", T: () => DataEntry }
@@ -754,7 +721,7 @@ class ReplicateDataRequest$Type extends MessageType$<ReplicateDataRequest> {
  */
 export const ReplicateDataRequest = new ReplicateDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DataEntry$Type extends MessageType$<DataEntry> {
+class DataEntry$Type extends MessageType<DataEntry> {
     constructor() {
         super("dht.DataEntry", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -773,7 +740,7 @@ class DataEntry$Type extends MessageType$<DataEntry> {
  */
 export const DataEntry = new DataEntry$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ClosestPeersRequest$Type extends MessageType$<ClosestPeersRequest> {
+class ClosestPeersRequest$Type extends MessageType<ClosestPeersRequest> {
     constructor() {
         super("dht.ClosestPeersRequest", [
             { no: 1, name: "nodeId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -786,7 +753,7 @@ class ClosestPeersRequest$Type extends MessageType$<ClosestPeersRequest> {
  */
 export const ClosestPeersRequest = new ClosestPeersRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ClosestPeersResponse$Type extends MessageType$<ClosestPeersResponse> {
+class ClosestPeersResponse$Type extends MessageType<ClosestPeersResponse> {
     constructor() {
         super("dht.ClosestPeersResponse", [
             { no: 1, name: "peers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
@@ -799,7 +766,7 @@ class ClosestPeersResponse$Type extends MessageType$<ClosestPeersResponse> {
  */
 export const ClosestPeersResponse = new ClosestPeersResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RecursiveOperationRequest$Type extends MessageType$<RecursiveOperationRequest> {
+class RecursiveOperationRequest$Type extends MessageType<RecursiveOperationRequest> {
     constructor() {
         super("dht.RecursiveOperationRequest", [
             { no: 1, name: "sessionId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -812,7 +779,7 @@ class RecursiveOperationRequest$Type extends MessageType$<RecursiveOperationRequ
  */
 export const RecursiveOperationRequest = new RecursiveOperationRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RecursiveOperationResponse$Type extends MessageType$<RecursiveOperationResponse> {
+class RecursiveOperationResponse$Type extends MessageType<RecursiveOperationResponse> {
     constructor() {
         super("dht.RecursiveOperationResponse", [
             { no: 1, name: "closestConnectedPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
@@ -827,7 +794,7 @@ class RecursiveOperationResponse$Type extends MessageType$<RecursiveOperationRes
  */
 export const RecursiveOperationResponse = new RecursiveOperationResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PingRequest$Type extends MessageType$<PingRequest> {
+class PingRequest$Type extends MessageType<PingRequest> {
     constructor() {
         super("dht.PingRequest", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -839,7 +806,7 @@ class PingRequest$Type extends MessageType$<PingRequest> {
  */
 export const PingRequest = new PingRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PingResponse$Type extends MessageType$<PingResponse> {
+class PingResponse$Type extends MessageType<PingResponse> {
     constructor() {
         super("dht.PingResponse", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -851,7 +818,7 @@ class PingResponse$Type extends MessageType$<PingResponse> {
  */
 export const PingResponse = new PingResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LeaveNotice$Type extends MessageType$<LeaveNotice> {
+class LeaveNotice$Type extends MessageType<LeaveNotice> {
     constructor() {
         super("dht.LeaveNotice", []);
     }
@@ -861,7 +828,7 @@ class LeaveNotice$Type extends MessageType$<LeaveNotice> {
  */
 export const LeaveNotice = new LeaveNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
+class PeerDescriptor$Type extends MessageType<PeerDescriptor> {
     constructor() {
         super("dht.PeerDescriptor", [
             { no: 1, name: "nodeId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -881,7 +848,7 @@ class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
  */
 export const PeerDescriptor = new PeerDescriptor$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityMethod$Type extends MessageType$<ConnectivityMethod> {
+class ConnectivityMethod$Type extends MessageType<ConnectivityMethod> {
     constructor() {
         super("dht.ConnectivityMethod", [
             { no: 1, name: "port", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
@@ -895,7 +862,7 @@ class ConnectivityMethod$Type extends MessageType$<ConnectivityMethod> {
  */
 export const ConnectivityMethod = new ConnectivityMethod$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
+class RouteMessageWrapper$Type extends MessageType<RouteMessageWrapper> {
     constructor() {
         super("dht.RouteMessageWrapper", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -913,7 +880,7 @@ class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
  */
 export const RouteMessageWrapper = new RouteMessageWrapper$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RouteMessageAck$Type extends MessageType$<RouteMessageAck> {
+class RouteMessageAck$Type extends MessageType<RouteMessageAck> {
     constructor() {
         super("dht.RouteMessageAck", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -926,7 +893,7 @@ class RouteMessageAck$Type extends MessageType$<RouteMessageAck> {
  */
 export const RouteMessageAck = new RouteMessageAck$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityRequest$Type extends MessageType$<ConnectivityRequest> {
+class ConnectivityRequest$Type extends MessageType<ConnectivityRequest> {
     constructor() {
         super("dht.ConnectivityRequest", [
             { no: 1, name: "port", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
@@ -941,7 +908,7 @@ class ConnectivityRequest$Type extends MessageType$<ConnectivityRequest> {
  */
 export const ConnectivityRequest = new ConnectivityRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityResponse$Type extends MessageType$<ConnectivityResponse> {
+class ConnectivityResponse$Type extends MessageType<ConnectivityResponse> {
     constructor() {
         super("dht.ConnectivityResponse", [
             { no: 1, name: "host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -957,7 +924,7 @@ class ConnectivityResponse$Type extends MessageType$<ConnectivityResponse> {
  */
 export const ConnectivityResponse = new ConnectivityResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class HandshakeRequest$Type extends MessageType$<HandshakeRequest> {
+class HandshakeRequest$Type extends MessageType<HandshakeRequest> {
     constructor() {
         super("dht.HandshakeRequest", [
             { no: 1, name: "sourcePeerDescriptor", kind: "message", T: () => PeerDescriptor },
@@ -971,7 +938,7 @@ class HandshakeRequest$Type extends MessageType$<HandshakeRequest> {
  */
 export const HandshakeRequest = new HandshakeRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class HandshakeResponse$Type extends MessageType$<HandshakeResponse> {
+class HandshakeResponse$Type extends MessageType<HandshakeResponse> {
     constructor() {
         super("dht.HandshakeResponse", [
             { no: 1, name: "sourcePeerDescriptor", kind: "message", T: () => PeerDescriptor },
@@ -985,20 +952,19 @@ class HandshakeResponse$Type extends MessageType$<HandshakeResponse> {
  */
 export const HandshakeResponse = new HandshakeResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class Message$Type extends MessageType$<Message> {
+class Message$Type extends MessageType<Message> {
     constructor() {
         super("dht.Message", [
             { no: 1, name: "messageId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "messageType", kind: "enum", T: () => ["dht.MessageType", MessageType] },
-            { no: 3, name: "sourceDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 4, name: "targetDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 5, name: "serviceId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "sourceDescriptor", kind: "message", T: () => PeerDescriptor },
+            { no: 3, name: "targetDescriptor", kind: "message", T: () => PeerDescriptor },
+            { no: 4, name: "serviceId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "rpcMessage", kind: "message", oneof: "body", T: () => RpcMessage },
             { no: 6, name: "connectivityRequest", kind: "message", oneof: "body", T: () => ConnectivityRequest },
             { no: 7, name: "connectivityResponse", kind: "message", oneof: "body", T: () => ConnectivityResponse },
             { no: 8, name: "handshakeRequest", kind: "message", oneof: "body", T: () => HandshakeRequest },
             { no: 9, name: "handshakeResponse", kind: "message", oneof: "body", T: () => HandshakeResponse },
-            { no: 10, name: "rpcMessage", kind: "message", oneof: "body", T: () => RpcMessage },
-            { no: 11, name: "recursiveOperationRequest", kind: "message", oneof: "body", T: () => RecursiveOperationRequest }
+            { no: 10, name: "recursiveOperationRequest", kind: "message", oneof: "body", T: () => RecursiveOperationRequest }
         ]);
     }
 }
@@ -1007,7 +973,7 @@ class Message$Type extends MessageType$<Message> {
  */
 export const Message = new Message$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class WebsocketConnectionRequest$Type extends MessageType$<WebsocketConnectionRequest> {
+class WebsocketConnectionRequest$Type extends MessageType<WebsocketConnectionRequest> {
     constructor() {
         super("dht.WebsocketConnectionRequest", []);
     }
@@ -1017,7 +983,7 @@ class WebsocketConnectionRequest$Type extends MessageType$<WebsocketConnectionRe
  */
 export const WebsocketConnectionRequest = new WebsocketConnectionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class WebrtcConnectionRequest$Type extends MessageType$<WebrtcConnectionRequest> {
+class WebrtcConnectionRequest$Type extends MessageType<WebrtcConnectionRequest> {
     constructor() {
         super("dht.WebrtcConnectionRequest", []);
     }
@@ -1027,7 +993,7 @@ class WebrtcConnectionRequest$Type extends MessageType$<WebrtcConnectionRequest>
  */
 export const WebrtcConnectionRequest = new WebrtcConnectionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RtcOffer$Type extends MessageType$<RtcOffer> {
+class RtcOffer$Type extends MessageType<RtcOffer> {
     constructor() {
         super("dht.RtcOffer", [
             { no: 1, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1040,7 +1006,7 @@ class RtcOffer$Type extends MessageType$<RtcOffer> {
  */
 export const RtcOffer = new RtcOffer$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RtcAnswer$Type extends MessageType$<RtcAnswer> {
+class RtcAnswer$Type extends MessageType<RtcAnswer> {
     constructor() {
         super("dht.RtcAnswer", [
             { no: 1, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1053,7 +1019,7 @@ class RtcAnswer$Type extends MessageType$<RtcAnswer> {
  */
 export const RtcAnswer = new RtcAnswer$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class IceCandidate$Type extends MessageType$<IceCandidate> {
+class IceCandidate$Type extends MessageType<IceCandidate> {
     constructor() {
         super("dht.IceCandidate", [
             { no: 1, name: "candidate", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1067,7 +1033,7 @@ class IceCandidate$Type extends MessageType$<IceCandidate> {
  */
 export const IceCandidate = new IceCandidate$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LockRequest$Type extends MessageType$<LockRequest> {
+class LockRequest$Type extends MessageType<LockRequest> {
     constructor() {
         super("dht.LockRequest", [
             { no: 1, name: "lockId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -1079,7 +1045,7 @@ class LockRequest$Type extends MessageType$<LockRequest> {
  */
 export const LockRequest = new LockRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class UnlockRequest$Type extends MessageType$<UnlockRequest> {
+class UnlockRequest$Type extends MessageType<UnlockRequest> {
     constructor() {
         super("dht.UnlockRequest", [
             { no: 1, name: "lockId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -1091,7 +1057,7 @@ class UnlockRequest$Type extends MessageType$<UnlockRequest> {
  */
 export const UnlockRequest = new UnlockRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LockResponse$Type extends MessageType$<LockResponse> {
+class LockResponse$Type extends MessageType<LockResponse> {
     constructor() {
         super("dht.LockResponse", [
             { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
@@ -1103,7 +1069,7 @@ class LockResponse$Type extends MessageType$<LockResponse> {
  */
 export const LockResponse = new LockResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
+class DisconnectNotice$Type extends MessageType<DisconnectNotice> {
     constructor() {
         super("dht.DisconnectNotice", [
             { no: 1, name: "disconnectMode", kind: "enum", T: () => ["dht.DisconnectMode", DisconnectMode] }
@@ -1115,7 +1081,7 @@ class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
  */
 export const DisconnectNotice = new DisconnectNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
+class ExternalFindDataRequest$Type extends MessageType<ExternalFindDataRequest> {
     constructor() {
         super("dht.ExternalFindDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
@@ -1127,7 +1093,7 @@ class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest>
  */
 export const ExternalFindDataRequest = new ExternalFindDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalFindDataResponse$Type extends MessageType$<ExternalFindDataResponse> {
+class ExternalFindDataResponse$Type extends MessageType<ExternalFindDataResponse> {
     constructor() {
         super("dht.ExternalFindDataResponse", [
             { no: 1, name: "entries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry }

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -1,4 +1,4 @@
-import { Message, MessageType, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
+import { Message, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { v4 } from 'uuid'
 import { RpcCommunicator, RpcCommunicatorConfig } from '@streamr/proto-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
@@ -35,7 +35,6 @@ export class RoutingRpcCommunicator extends RpcCommunicator<DhtCallContext> {
                     oneofKind: 'rpcMessage',
                     rpcMessage: msg
                 },
-                messageType: MessageType.RPC, 
                 targetDescriptor
             }
 

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -1,7 +1,7 @@
 import LeakDetector from 'jest-leak-detector'
 import { waitForCondition } from '@streamr/utils'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { Message, MessageType } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
@@ -48,7 +48,6 @@ describe('memory leak', () => {
         const msg: Message = {
             serviceId: 'mock-service-id',
             targetDescriptor: receiver.getLocalPeerDescriptor(),
-            messageType: MessageType.RPC,
             messageId: 'mock-message-id',
             body: {
                 oneofKind: 'rpcMessage',

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -6,7 +6,7 @@ import { Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import { createPeerDescriptor } from '../../src/helpers/createPeerDescriptor'
 import { createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
-import { ConnectivityResponse, Message, MessageType, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { ConnectivityResponse, Message, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { TransportEvents } from '../../src/transport/ITransport'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -134,7 +134,6 @@ describe('ConnectionManager', () => {
 
         const msg: Message = {
             serviceId: SERVICE_ID,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',
@@ -144,7 +143,7 @@ describe('ConnectionManager', () => {
 
         const promise = new Promise<void>((resolve, _reject) => {
             connectionManager2.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
@@ -193,7 +192,6 @@ describe('ConnectionManager', () => {
 
         const msg: Message = {
             serviceId: SERVICE_ID,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',
@@ -217,7 +215,7 @@ describe('ConnectionManager', () => {
 
         const promise = new Promise<void>((resolve, _reject) => {
             connectionManager2.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
@@ -244,7 +242,6 @@ describe('ConnectionManager', () => {
 
         const msg: Message = {
             serviceId: SERVICE_ID,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',
@@ -254,7 +251,7 @@ describe('ConnectionManager', () => {
 
         const dataPromise = new Promise<void>((resolve, _reject) => {
             connectionManager4.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
@@ -309,7 +306,6 @@ describe('ConnectionManager', () => {
         peerDescriptor.nodeId = new Uint8Array([12, 12, 12, 12])
         const msg: Message = {
             serviceId: SERVICE_ID,
-            messageType: MessageType.RPC,
             messageId: '1',
             targetDescriptor: peerDescriptor,
             body: {
@@ -360,7 +356,6 @@ describe('ConnectionManager', () => {
 
         const msg: Message = {
             serviceId: SERVICE_ID,
-            messageType: MessageType.RPC,
             messageId: '1',
             targetDescriptor: {
                 // This is not the correct nodeId of peerDescriptor2

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -159,7 +159,6 @@ describe('Layer1', () => {
     //                 const message: Message = {
     //                     serviceId: 'service',
     //                     messageId: v4(),
-    //                     messageType: MessageType.RPC,
     //                     body: {
     //                         oneofKind: 'rpcMessage',
     //                         rpcMessage: rpcWrapper

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode, Events as DhtNodeEvents } from '../../src/dht/DhtNode'
-import { Message, MessageType, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, NodeType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { Logger, runAndWaitForEvents3, waitForCondition } from '@streamr/utils'
 import { createMockConnectionDhtNode, createWrappedClosestPeersRequest } from '../utils/utils'
@@ -64,7 +64,6 @@ describe('Route Message With Mock Connections', () => {
         const message: Message = {
             serviceId: 'unknown',
             messageId: v4(),
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: rpcWrapper
@@ -98,7 +97,6 @@ describe('Route Message With Mock Connections', () => {
             const message: Message = {
                 serviceId: 'unknown',
                 messageId: v4(),
-                messageType: MessageType.RPC,
                 body: {
                     oneofKind: 'rpcMessage',
                     rpcMessage: rpcWrapper
@@ -136,7 +134,6 @@ describe('Route Message With Mock Connections', () => {
                         const message: Message = {
                             serviceId: 'nonexisting_service',
                             messageId: v4(),
-                            messageType: MessageType.RPC,
                             body: {
                                 oneofKind: 'rpcMessage',
                                 rpcMessage: rpcWrapper
@@ -171,7 +168,6 @@ describe('Route Message With Mock Connections', () => {
         const closestPeersRequestMessage: Message = {
             serviceId: 'unknown',
             messageId: v4(),
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: closestPeersRequest
@@ -202,7 +198,6 @@ describe('Route Message With Mock Connections', () => {
         const requestMessage: Message = {
             serviceId: 'layer0',
             messageId: v4(),
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage

--- a/packages/dht/test/integration/RouterRpcRemote.test.ts
+++ b/packages/dht/test/integration/RouterRpcRemote.test.ts
@@ -1,6 +1,6 @@
 import { RpcCommunicator } from '@streamr/proto-rpc'
 import { RouterRpcRemote } from '../../src/dht/routing/RouterRpcRemote'
-import { Message, MessageType, RouteMessageAck, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, RouteMessageAck, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RouterRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { createMockPeerDescriptor, createWrappedClosestPeersRequest, mockRouterRpc } from '../utils/utils'
@@ -34,7 +34,6 @@ describe('RemoteRouter', () => {
         const routed: Message = {
             serviceId: SERVICE_ID,
             messageId: 'routed',
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: rpcWrapper
@@ -58,7 +57,6 @@ describe('RemoteRouter', () => {
         const routed: Message = {
             serviceId: SERVICE_ID,
             messageId: 'routed',
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: rpcWrapper

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -3,7 +3,7 @@ import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../../src/connection/ConnectorFacade'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
-import { Message, MessageType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
@@ -12,7 +12,6 @@ import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 
 const BASE_MESSAGE: Message = {
     serviceId: 'serviceId',
-    messageType: MessageType.RPC,
     messageId: '1',
     body: {
         oneofKind: 'rpcMessage',
@@ -63,13 +62,13 @@ describe('SimultaneousConnections', () => {
 
         const promise1 = new Promise<void>((resolve, _reject) => {
             simTransport1.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
         const promise2 = new Promise<void>((resolve, _reject) => {
             simTransport2.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
@@ -142,13 +141,13 @@ describe('SimultaneousConnections', () => {
 
             const promise1 = new Promise<void>((resolve, _reject) => {
                 connectionManager1.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })
             const promise2 = new Promise<void>((resolve, _reject) => {
                 connectionManager2.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })
@@ -222,13 +221,13 @@ describe('SimultaneousConnections', () => {
 
             const promise1 = new Promise<void>((resolve, _reject) => {
                 connectionManager1.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })
             const promise2 = new Promise<void>((resolve, _reject) => {
                 connectionManager2.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })
@@ -290,13 +289,13 @@ describe('SimultaneousConnections', () => {
 
             const promise1 = new Promise<void>((resolve, _reject) => {
                 connectionManager1.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })
             const promise2 = new Promise<void>((resolve, _reject) => {
                 connectionManager2.on('message', async (message: Message) => {
-                    expect(message.messageType).toBe(MessageType.RPC)
+                    expect(message.body.oneofKind).toBe('rpcMessage')
                     resolve()
                 })
             })

--- a/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
@@ -1,6 +1,6 @@
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
-import { Message, MessageType, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { ConnectionType } from '../../src/connection/IConnection'
 import { ITransport } from '../../src/transport/ITransport'
@@ -63,7 +63,6 @@ describe('WebRTC Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer'
         }
 
@@ -87,7 +86,6 @@ describe('WebRTC Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             }, 
-            messageType: MessageType.RPC,
             messageId: 'mockerer'
         }
         manager1.on('message', (message: Message) => {
@@ -108,7 +106,6 @@ describe('WebRTC Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer'
         }
         dummyMessage.targetDescriptor = peerDescriptor1
@@ -120,7 +117,6 @@ describe('WebRTC Connection Management', () => {
     it('Connects and disconnects webrtc connections', async () => {
         const msg: Message = {
             serviceId,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',
@@ -130,14 +126,14 @@ describe('WebRTC Connection Management', () => {
 
         const dataPromise = new Promise<void>((resolve, _reject) => {
             manager2.on('message', async (message: Message) => {
-                expect(message.messageType).toBe(MessageType.RPC)
+                expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
 
         const connectedPromise1 = new Promise<void>((resolve, _reject) => {
             manager1.on('connected', () => {
-                //expect(message.messageType).toBe(MessageType.RPC)
+                //expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })
@@ -175,7 +171,6 @@ describe('WebRTC Connection Management', () => {
     it('Disconnects webrtcconnection while being connected', async () => {
         const msg: Message = {
             serviceId,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',
@@ -204,7 +199,6 @@ describe('WebRTC Connection Management', () => {
     it('failed connections are cleaned up', async () => {
         const msg: Message = {
             serviceId,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: {
                 oneofKind: 'rpcMessage',

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -7,7 +7,7 @@ import { ConnectionType } from '../../src/connection/IConnection'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import * as Err from '../../src/helpers/errors'
-import { Message, MessageType, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { TransportEvents } from '../../src/transport/ITransport'
 import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
@@ -98,7 +98,6 @@ describe('Websocket Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer',
             targetDescriptor: noWsServerConnectorPeerDescriptor
         }
@@ -124,7 +123,6 @@ describe('Websocket Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer',
             targetDescriptor: biggerNoWsServerConnectorPeerDescriptor
         }
@@ -150,7 +148,6 @@ describe('Websocket Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer',
             targetDescriptor: {
                 nodeId: new Uint8Array([1, 2, 4]),
@@ -172,7 +169,6 @@ describe('Websocket Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer',
             targetDescriptor: wsServerConnectorPeerDescriptor
         }
@@ -199,7 +195,6 @@ describe('Websocket Connection Management', () => {
                 oneofKind: 'rpcMessage',
                 rpcMessage: RpcMessage.create()
             },
-            messageType: MessageType.RPC,
             messageId: 'mockerer',
             targetDescriptor: noWsServerConnectorPeerDescriptor
         }

--- a/packages/dht/test/integration/rpc-connections-over-webrpc.test.ts
+++ b/packages/dht/test/integration/rpc-connections-over-webrpc.test.ts
@@ -133,14 +133,13 @@ describe('RPC connections over WebRTC', () => {
 
         const msg: Message = {
             serviceId,
-            messageType: MessageType.RPC,
             messageId: '1',
             body: RpcMessage.toBinary(rpcMessage)
         }
 
         const disconnectedPromise1 = new Promise<void>((resolve, _reject) => {
             manager1.on('disconnected', () => {
-                //expect(message.messageType).toBe(MessageType.RPC)
+                //expect(message.body.oneofKind).toBe('rpcMessage')
                 resolve()
             })
         })

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -1,7 +1,6 @@
 import {
     RecursiveOperation,
     Message,
-    MessageType,
     RouteMessageAck,
     RouteMessageError,
     RouteMessageWrapper
@@ -41,7 +40,6 @@ describe('RecursiveOperationManager', () => {
     const message: Message = {
         serviceId: 'unknown',
         messageId: v4(),
-        messageType: MessageType.RPC,
         body: {
             oneofKind: 'recursiveOperationRequest',
             recursiveOperationRequest
@@ -96,7 +94,6 @@ describe('RecursiveOperationManager', () => {
         const badMessage: Message = {
             serviceId: 'unknown',
             messageId: v4(),
-            messageType: MessageType.RPC,
             body: {
                 oneofKind: 'rpcMessage',
                 rpcMessage: rpcWrapper

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -3,7 +3,6 @@ import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { Router } from '../../src/dht/routing/Router'
 import { 
     Message,
-    MessageType,
     PeerDescriptor,
     RouteMessageAck,
     RouteMessageError,
@@ -23,7 +22,6 @@ describe('Router', () => {
     const message: Message = {
         serviceId: 'unknown',
         messageId: v4(),
-        messageType: MessageType.RPC,
         body: {
             oneofKind: 'rpcMessage',
             rpcMessage: rpcWrapper

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid'
 import { RoutingMode, RoutingSession } from '../../src/dht/routing/RoutingSession'
-import { Message, MessageType, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor, createWrappedClosestPeersRequest } from '../utils/utils'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
@@ -20,7 +20,6 @@ describe('RoutingSession', () => {
     const message: Message = {
         serviceId: 'unknown',
         messageId: v4(),
-        messageType: MessageType.RPC,
         body: {
             oneofKind: 'rpcMessage',
             rpcMessage: rpcWrapper

--- a/packages/dht/test/unit/connectivityRequestHandler.test.ts
+++ b/packages/dht/test/unit/connectivityRequestHandler.test.ts
@@ -5,7 +5,7 @@ import { Server as HttpServer, createServer as createHttpServer } from 'http'
 import { server as WsServer } from 'websocket'
 import { CONNECTIVITY_CHECKER_SERVICE_ID } from '../../src/connection/connectivityChecker'
 import { attachConnectivityRequestHandler } from '../../src/connection/connectivityRequestHandler'
-import { Message, MessageType } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { Message } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { version } from '../../package.json'
 
 const HOST = '127.0.0.1'
@@ -40,7 +40,6 @@ describe('connectivityRequestHandler', () => {
         attachConnectivityRequestHandler(connection)
         const request: Message = {
             serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
-            messageType: MessageType.CONNECTIVITY_REQUEST,
             messageId: 'mock-message-id',
             body: {
                 oneofKind: 'connectivityRequest',
@@ -68,7 +67,6 @@ describe('connectivityRequestHandler', () => {
                 oneofKind: 'connectivityResponse'
             },
             messageId: expect.any(String),
-            messageType: MessageType.CONNECTIVITY_RESPONSE,
             serviceId: 'system/connectivity-checker'
         })
     })
@@ -77,7 +75,6 @@ describe('connectivityRequestHandler', () => {
         attachConnectivityRequestHandler(connection)
         const request: Message = {
             serviceId: CONNECTIVITY_CHECKER_SERVICE_ID,
-            messageType: MessageType.CONNECTIVITY_REQUEST,
             messageId: 'mock-message-id',
             body: {
                 oneofKind: 'connectivityRequest',
@@ -100,7 +97,6 @@ describe('connectivityRequestHandler', () => {
                 oneofKind: 'connectivityResponse'
             },
             messageId: expect.any(String),
-            messageType: MessageType.CONNECTIVITY_RESPONSE,
             serviceId: 'system/connectivity-checker'
         })
     })

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -3,7 +3,7 @@
 // tslint:disable
 import { Empty } from "../../../google/protobuf/empty";
 import { ServiceType } from "@protobuf-ts/runtime-rpc";
-import { MessageType as MessageType$ } from "@protobuf-ts/runtime";
+import { MessageType } from "@protobuf-ts/runtime";
 import { RpcMessage } from "../../proto-rpc/protos/ProtoRpc";
 import { Timestamp } from "../../../google/protobuf/timestamp";
 import { Any } from "../../../google/protobuf/any";
@@ -378,6 +378,8 @@ export interface HandshakeResponse {
      */
     version: string;
 }
+// Wraps all messages
+
 /**
  * @generated from protobuf message dht.Message
  */
@@ -387,25 +389,27 @@ export interface Message {
      */
     messageId: string;
     /**
-     * @generated from protobuf field: dht.MessageType messageType = 2;
-     */
-    messageType: MessageType;
-    /**
-     * @generated from protobuf field: dht.PeerDescriptor sourceDescriptor = 3;
+     * @generated from protobuf field: dht.PeerDescriptor sourceDescriptor = 2;
      */
     sourceDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: dht.PeerDescriptor targetDescriptor = 4;
+     * @generated from protobuf field: dht.PeerDescriptor targetDescriptor = 3;
      */
     targetDescriptor?: PeerDescriptor;
     /**
-     * @generated from protobuf field: string serviceId = 5;
+     * @generated from protobuf field: string serviceId = 4;
      */
     serviceId: string; // id of the RPC service
     /**
      * @generated from protobuf oneof: body
      */
     body: {
+        oneofKind: "rpcMessage";
+        /**
+         * @generated from protobuf field: protorpc.RpcMessage rpcMessage = 5;
+         */
+        rpcMessage: RpcMessage;
+    } | {
         oneofKind: "connectivityRequest";
         /**
          * @generated from protobuf field: dht.ConnectivityRequest connectivityRequest = 6;
@@ -430,15 +434,9 @@ export interface Message {
          */
         handshakeResponse: HandshakeResponse;
     } | {
-        oneofKind: "rpcMessage";
-        /**
-         * @generated from protobuf field: protorpc.RpcMessage rpcMessage = 10;
-         */
-        rpcMessage: RpcMessage;
-    } | {
         oneofKind: "recursiveOperationRequest";
         /**
-         * @generated from protobuf field: dht.RecursiveOperationRequest recursiveOperationRequest = 11;
+         * @generated from protobuf field: dht.RecursiveOperationRequest recursiveOperationRequest = 10;
          */
         recursiveOperationRequest: RecursiveOperationRequest;
     } | {
@@ -646,37 +644,6 @@ export enum HandshakeError {
      */
     UNSUPPORTED_VERSION = 2
 }
-// Wraps all messages
-
-/**
- * @generated from protobuf enum dht.MessageType
- */
-export enum MessageType {
-    /**
-     * @generated from protobuf enum value: RPC = 0;
-     */
-    RPC = 0,
-    /**
-     * @generated from protobuf enum value: CONNECTIVITY_REQUEST = 1;
-     */
-    CONNECTIVITY_REQUEST = 1,
-    /**
-     * @generated from protobuf enum value: CONNECTIVITY_RESPONSE = 2;
-     */
-    CONNECTIVITY_RESPONSE = 2,
-    /**
-     * @generated from protobuf enum value: HANDSHAKE_REQUEST = 3;
-     */
-    HANDSHAKE_REQUEST = 3,
-    /**
-     * @generated from protobuf enum value: HANDSHAKE_RESPONSE = 4;
-     */
-    HANDSHAKE_RESPONSE = 4,
-    /**
-     * @generated from protobuf enum value: RECURSIVE_OPERATION_REQUEST = 5;
-     */
-    RECURSIVE_OPERATION_REQUEST = 5
-}
 /**
  * @generated from protobuf enum dht.DisconnectMode
  */
@@ -691,7 +658,7 @@ export enum DisconnectMode {
     LEAVING = 1
 }
 // @generated message type with reflection information, may provide speed optimized methods
-class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
+class StoreDataRequest$Type extends MessageType<StoreDataRequest> {
     constructor() {
         super("dht.StoreDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -707,7 +674,7 @@ class StoreDataRequest$Type extends MessageType$<StoreDataRequest> {
  */
 export const StoreDataRequest = new StoreDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class StoreDataResponse$Type extends MessageType$<StoreDataResponse> {
+class StoreDataResponse$Type extends MessageType<StoreDataResponse> {
     constructor() {
         super("dht.StoreDataResponse", []);
     }
@@ -717,7 +684,7 @@ class StoreDataResponse$Type extends MessageType$<StoreDataResponse> {
  */
 export const StoreDataResponse = new StoreDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalStoreDataRequest$Type extends MessageType$<ExternalStoreDataRequest> {
+class ExternalStoreDataRequest$Type extends MessageType<ExternalStoreDataRequest> {
     constructor() {
         super("dht.ExternalStoreDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -730,7 +697,7 @@ class ExternalStoreDataRequest$Type extends MessageType$<ExternalStoreDataReques
  */
 export const ExternalStoreDataRequest = new ExternalStoreDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalStoreDataResponse$Type extends MessageType$<ExternalStoreDataResponse> {
+class ExternalStoreDataResponse$Type extends MessageType<ExternalStoreDataResponse> {
     constructor() {
         super("dht.ExternalStoreDataResponse", [
             { no: 1, name: "storers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
@@ -742,7 +709,7 @@ class ExternalStoreDataResponse$Type extends MessageType$<ExternalStoreDataRespo
  */
 export const ExternalStoreDataResponse = new ExternalStoreDataResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ReplicateDataRequest$Type extends MessageType$<ReplicateDataRequest> {
+class ReplicateDataRequest$Type extends MessageType<ReplicateDataRequest> {
     constructor() {
         super("dht.ReplicateDataRequest", [
             { no: 1, name: "entry", kind: "message", T: () => DataEntry }
@@ -754,7 +721,7 @@ class ReplicateDataRequest$Type extends MessageType$<ReplicateDataRequest> {
  */
 export const ReplicateDataRequest = new ReplicateDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DataEntry$Type extends MessageType$<DataEntry> {
+class DataEntry$Type extends MessageType<DataEntry> {
     constructor() {
         super("dht.DataEntry", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -773,7 +740,7 @@ class DataEntry$Type extends MessageType$<DataEntry> {
  */
 export const DataEntry = new DataEntry$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ClosestPeersRequest$Type extends MessageType$<ClosestPeersRequest> {
+class ClosestPeersRequest$Type extends MessageType<ClosestPeersRequest> {
     constructor() {
         super("dht.ClosestPeersRequest", [
             { no: 1, name: "nodeId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -786,7 +753,7 @@ class ClosestPeersRequest$Type extends MessageType$<ClosestPeersRequest> {
  */
 export const ClosestPeersRequest = new ClosestPeersRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ClosestPeersResponse$Type extends MessageType$<ClosestPeersResponse> {
+class ClosestPeersResponse$Type extends MessageType<ClosestPeersResponse> {
     constructor() {
         super("dht.ClosestPeersResponse", [
             { no: 1, name: "peers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
@@ -799,7 +766,7 @@ class ClosestPeersResponse$Type extends MessageType$<ClosestPeersResponse> {
  */
 export const ClosestPeersResponse = new ClosestPeersResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RecursiveOperationRequest$Type extends MessageType$<RecursiveOperationRequest> {
+class RecursiveOperationRequest$Type extends MessageType<RecursiveOperationRequest> {
     constructor() {
         super("dht.RecursiveOperationRequest", [
             { no: 1, name: "sessionId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -812,7 +779,7 @@ class RecursiveOperationRequest$Type extends MessageType$<RecursiveOperationRequ
  */
 export const RecursiveOperationRequest = new RecursiveOperationRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RecursiveOperationResponse$Type extends MessageType$<RecursiveOperationResponse> {
+class RecursiveOperationResponse$Type extends MessageType<RecursiveOperationResponse> {
     constructor() {
         super("dht.RecursiveOperationResponse", [
             { no: 1, name: "closestConnectedPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
@@ -827,7 +794,7 @@ class RecursiveOperationResponse$Type extends MessageType$<RecursiveOperationRes
  */
 export const RecursiveOperationResponse = new RecursiveOperationResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PingRequest$Type extends MessageType$<PingRequest> {
+class PingRequest$Type extends MessageType<PingRequest> {
     constructor() {
         super("dht.PingRequest", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -839,7 +806,7 @@ class PingRequest$Type extends MessageType$<PingRequest> {
  */
 export const PingRequest = new PingRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PingResponse$Type extends MessageType$<PingResponse> {
+class PingResponse$Type extends MessageType<PingResponse> {
     constructor() {
         super("dht.PingResponse", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -851,7 +818,7 @@ class PingResponse$Type extends MessageType$<PingResponse> {
  */
 export const PingResponse = new PingResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LeaveNotice$Type extends MessageType$<LeaveNotice> {
+class LeaveNotice$Type extends MessageType<LeaveNotice> {
     constructor() {
         super("dht.LeaveNotice", []);
     }
@@ -861,7 +828,7 @@ class LeaveNotice$Type extends MessageType$<LeaveNotice> {
  */
 export const LeaveNotice = new LeaveNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
+class PeerDescriptor$Type extends MessageType<PeerDescriptor> {
     constructor() {
         super("dht.PeerDescriptor", [
             { no: 1, name: "nodeId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
@@ -881,7 +848,7 @@ class PeerDescriptor$Type extends MessageType$<PeerDescriptor> {
  */
 export const PeerDescriptor = new PeerDescriptor$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityMethod$Type extends MessageType$<ConnectivityMethod> {
+class ConnectivityMethod$Type extends MessageType<ConnectivityMethod> {
     constructor() {
         super("dht.ConnectivityMethod", [
             { no: 1, name: "port", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
@@ -895,7 +862,7 @@ class ConnectivityMethod$Type extends MessageType$<ConnectivityMethod> {
  */
 export const ConnectivityMethod = new ConnectivityMethod$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
+class RouteMessageWrapper$Type extends MessageType<RouteMessageWrapper> {
     constructor() {
         super("dht.RouteMessageWrapper", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -913,7 +880,7 @@ class RouteMessageWrapper$Type extends MessageType$<RouteMessageWrapper> {
  */
 export const RouteMessageWrapper = new RouteMessageWrapper$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RouteMessageAck$Type extends MessageType$<RouteMessageAck> {
+class RouteMessageAck$Type extends MessageType<RouteMessageAck> {
     constructor() {
         super("dht.RouteMessageAck", [
             { no: 1, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -926,7 +893,7 @@ class RouteMessageAck$Type extends MessageType$<RouteMessageAck> {
  */
 export const RouteMessageAck = new RouteMessageAck$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityRequest$Type extends MessageType$<ConnectivityRequest> {
+class ConnectivityRequest$Type extends MessageType<ConnectivityRequest> {
     constructor() {
         super("dht.ConnectivityRequest", [
             { no: 1, name: "port", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
@@ -941,7 +908,7 @@ class ConnectivityRequest$Type extends MessageType$<ConnectivityRequest> {
  */
 export const ConnectivityRequest = new ConnectivityRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ConnectivityResponse$Type extends MessageType$<ConnectivityResponse> {
+class ConnectivityResponse$Type extends MessageType<ConnectivityResponse> {
     constructor() {
         super("dht.ConnectivityResponse", [
             { no: 1, name: "host", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -957,7 +924,7 @@ class ConnectivityResponse$Type extends MessageType$<ConnectivityResponse> {
  */
 export const ConnectivityResponse = new ConnectivityResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class HandshakeRequest$Type extends MessageType$<HandshakeRequest> {
+class HandshakeRequest$Type extends MessageType<HandshakeRequest> {
     constructor() {
         super("dht.HandshakeRequest", [
             { no: 1, name: "sourcePeerDescriptor", kind: "message", T: () => PeerDescriptor },
@@ -971,7 +938,7 @@ class HandshakeRequest$Type extends MessageType$<HandshakeRequest> {
  */
 export const HandshakeRequest = new HandshakeRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class HandshakeResponse$Type extends MessageType$<HandshakeResponse> {
+class HandshakeResponse$Type extends MessageType<HandshakeResponse> {
     constructor() {
         super("dht.HandshakeResponse", [
             { no: 1, name: "sourcePeerDescriptor", kind: "message", T: () => PeerDescriptor },
@@ -985,20 +952,19 @@ class HandshakeResponse$Type extends MessageType$<HandshakeResponse> {
  */
 export const HandshakeResponse = new HandshakeResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class Message$Type extends MessageType$<Message> {
+class Message$Type extends MessageType<Message> {
     constructor() {
         super("dht.Message", [
             { no: 1, name: "messageId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "messageType", kind: "enum", T: () => ["dht.MessageType", MessageType] },
-            { no: 3, name: "sourceDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 4, name: "targetDescriptor", kind: "message", T: () => PeerDescriptor },
-            { no: 5, name: "serviceId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "sourceDescriptor", kind: "message", T: () => PeerDescriptor },
+            { no: 3, name: "targetDescriptor", kind: "message", T: () => PeerDescriptor },
+            { no: 4, name: "serviceId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "rpcMessage", kind: "message", oneof: "body", T: () => RpcMessage },
             { no: 6, name: "connectivityRequest", kind: "message", oneof: "body", T: () => ConnectivityRequest },
             { no: 7, name: "connectivityResponse", kind: "message", oneof: "body", T: () => ConnectivityResponse },
             { no: 8, name: "handshakeRequest", kind: "message", oneof: "body", T: () => HandshakeRequest },
             { no: 9, name: "handshakeResponse", kind: "message", oneof: "body", T: () => HandshakeResponse },
-            { no: 10, name: "rpcMessage", kind: "message", oneof: "body", T: () => RpcMessage },
-            { no: 11, name: "recursiveOperationRequest", kind: "message", oneof: "body", T: () => RecursiveOperationRequest }
+            { no: 10, name: "recursiveOperationRequest", kind: "message", oneof: "body", T: () => RecursiveOperationRequest }
         ]);
     }
 }
@@ -1007,7 +973,7 @@ class Message$Type extends MessageType$<Message> {
  */
 export const Message = new Message$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class WebsocketConnectionRequest$Type extends MessageType$<WebsocketConnectionRequest> {
+class WebsocketConnectionRequest$Type extends MessageType<WebsocketConnectionRequest> {
     constructor() {
         super("dht.WebsocketConnectionRequest", []);
     }
@@ -1017,7 +983,7 @@ class WebsocketConnectionRequest$Type extends MessageType$<WebsocketConnectionRe
  */
 export const WebsocketConnectionRequest = new WebsocketConnectionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class WebrtcConnectionRequest$Type extends MessageType$<WebrtcConnectionRequest> {
+class WebrtcConnectionRequest$Type extends MessageType<WebrtcConnectionRequest> {
     constructor() {
         super("dht.WebrtcConnectionRequest", []);
     }
@@ -1027,7 +993,7 @@ class WebrtcConnectionRequest$Type extends MessageType$<WebrtcConnectionRequest>
  */
 export const WebrtcConnectionRequest = new WebrtcConnectionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RtcOffer$Type extends MessageType$<RtcOffer> {
+class RtcOffer$Type extends MessageType<RtcOffer> {
     constructor() {
         super("dht.RtcOffer", [
             { no: 1, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1040,7 +1006,7 @@ class RtcOffer$Type extends MessageType$<RtcOffer> {
  */
 export const RtcOffer = new RtcOffer$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class RtcAnswer$Type extends MessageType$<RtcAnswer> {
+class RtcAnswer$Type extends MessageType<RtcAnswer> {
     constructor() {
         super("dht.RtcAnswer", [
             { no: 1, name: "description", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1053,7 +1019,7 @@ class RtcAnswer$Type extends MessageType$<RtcAnswer> {
  */
 export const RtcAnswer = new RtcAnswer$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class IceCandidate$Type extends MessageType$<IceCandidate> {
+class IceCandidate$Type extends MessageType<IceCandidate> {
     constructor() {
         super("dht.IceCandidate", [
             { no: 1, name: "candidate", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
@@ -1067,7 +1033,7 @@ class IceCandidate$Type extends MessageType$<IceCandidate> {
  */
 export const IceCandidate = new IceCandidate$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LockRequest$Type extends MessageType$<LockRequest> {
+class LockRequest$Type extends MessageType<LockRequest> {
     constructor() {
         super("dht.LockRequest", [
             { no: 1, name: "lockId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -1079,7 +1045,7 @@ class LockRequest$Type extends MessageType$<LockRequest> {
  */
 export const LockRequest = new LockRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class UnlockRequest$Type extends MessageType$<UnlockRequest> {
+class UnlockRequest$Type extends MessageType<UnlockRequest> {
     constructor() {
         super("dht.UnlockRequest", [
             { no: 1, name: "lockId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
@@ -1091,7 +1057,7 @@ class UnlockRequest$Type extends MessageType$<UnlockRequest> {
  */
 export const UnlockRequest = new UnlockRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class LockResponse$Type extends MessageType$<LockResponse> {
+class LockResponse$Type extends MessageType<LockResponse> {
     constructor() {
         super("dht.LockResponse", [
             { no: 1, name: "accepted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
@@ -1103,7 +1069,7 @@ class LockResponse$Type extends MessageType$<LockResponse> {
  */
 export const LockResponse = new LockResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
+class DisconnectNotice$Type extends MessageType<DisconnectNotice> {
     constructor() {
         super("dht.DisconnectNotice", [
             { no: 1, name: "disconnectMode", kind: "enum", T: () => ["dht.DisconnectMode", DisconnectMode] }
@@ -1115,7 +1081,7 @@ class DisconnectNotice$Type extends MessageType$<DisconnectNotice> {
  */
 export const DisconnectNotice = new DisconnectNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest> {
+class ExternalFindDataRequest$Type extends MessageType<ExternalFindDataRequest> {
     constructor() {
         super("dht.ExternalFindDataRequest", [
             { no: 1, name: "key", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
@@ -1127,7 +1093,7 @@ class ExternalFindDataRequest$Type extends MessageType$<ExternalFindDataRequest>
  */
 export const ExternalFindDataRequest = new ExternalFindDataRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ExternalFindDataResponse$Type extends MessageType$<ExternalFindDataResponse> {
+class ExternalFindDataResponse$Type extends MessageType<ExternalFindDataResponse> {
     constructor() {
         super("dht.ExternalFindDataResponse", [
             { no: 1, name: "entries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry }


### PR DESCRIPTION
Removed redundant `messageType` field from `DhtNode.proto`'s `Message` entity. We can infer the type from the `oneof` object, e.g. `if (message.body.oneofKind === 'rpcMessage')`.