### PR TITLE
refactor(network): NET-1271 lock/unlock connections based on neighbor events in RandomGraphNode

### DIFF
--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -4,7 +4,8 @@ import { DeliveryRpcRemote } from './DeliveryRpcRemote'
 import { EventEmitter } from 'eventemitter3'
 
 export interface Events {
-    nodeAdded: (id: DhtAddress, remote: DeliveryRpcRemote) => any
+    nodeAdded: (id: DhtAddress, remote: DeliveryRpcRemote) => void
+    nodeRemoved: (id: DhtAddress, remote: DeliveryRpcRemote) => void
 }
 
 const getValuesOfIncludedKeys = (nodes: Map<DhtAddress, DeliveryRpcRemote>, exclude: DhtAddress[]): DeliveryRpcRemote[] => {
@@ -40,7 +41,11 @@ export class NodeList extends EventEmitter<Events> {
     }
 
     remove(nodeId: DhtAddress): void {
-        this.nodes.delete(nodeId)
+        if (this.nodes.has(nodeId)) {
+            const remote = this.nodes.get(nodeId)!
+            this.nodes.delete(nodeId)
+            this.emit('nodeRemoved', nodeId, remote)
+        }   
     }
 
     has(nodeId: DhtAddress): boolean {

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -52,6 +52,7 @@ export class NodeList extends EventEmitter<Events> {
         return this.nodes.has(nodeId)
     }
 
+    // Replace nodes does not emit nodeRemoved events, use with caution
     replaceAll(neighbors: DeliveryRpcRemote[]): void {
         this.nodes.clear()
         const limited = neighbors.splice(0, this.limit)

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -98,7 +98,6 @@ export class RandomGraphNode extends EventEmitter<Events> {
                     this.config.layer1Node.removeContact(sourceId)
                     this.config.neighbors.remove(sourceId)
                     this.config.nearbyNodeView.remove(sourceId)
-                    this.config.connectionLocker.unlockConnection(contact.getPeerDescriptor(), this.config.streamPartId)
                     this.config.neighborFinder.start([sourceId])
                     this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)
                 }
@@ -146,9 +145,18 @@ export class RandomGraphNode extends EventEmitter<Events> {
         addManagedEventListener(
             this.config.neighbors,
             'nodeAdded',
-            (id, _remote) => {
+            (id, remote) => {
                 this.config.propagation.onNeighborJoined(id)
+                this.config.connectionLocker.lockConnection(remote.getPeerDescriptor(), this.config.streamPartId)
                 this.emit('neighborConnected', id)
+            },
+            this.abortController.signal
+        )
+        addManagedEventListener(
+            this.config.neighbors,
+            'nodeRemoved',
+            (_id, remote) => {
+                this.config.connectionLocker.unlockConnection(remote.getPeerDescriptor(), this.config.streamPartId)
             },
             this.abortController.signal
         )
@@ -263,7 +271,6 @@ export class RandomGraphNode extends EventEmitter<Events> {
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
         if (this.config.neighbors.has(nodeId)) {
             this.config.neighbors.remove(nodeId)
-            this.config.connectionLocker.unlockConnection(peerDescriptor, this.config.streamPartId)
             this.config.neighborFinder.start([nodeId])
             this.config.temporaryConnectionRpcLocal.removeNode(nodeId)
         }

--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -65,7 +65,6 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
     const handshaker = config.handshaker ?? new Handshaker({
         localPeerDescriptor: config.localPeerDescriptor,
         streamPartId: config.streamPartId,
-        connectionLocker: config.connectionLocker,
         rpcCommunicator,
         nearbyNodeView,
         randomNodeView,
@@ -89,7 +88,6 @@ const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGr
         rpcCommunicator,
         neighborUpdateInterval,
         neighborTargetCount,
-        connectionLocker: config.connectionLocker,
         ongoingHandshakes
     })
     const inspector = config.inspector ?? new Inspector({

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -1,4 +1,4 @@
-import { ConnectionLocker, DhtAddress, PeerDescriptor, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, PeerDescriptor, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NodeList } from '../NodeList'
 import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
 import {
@@ -19,7 +19,6 @@ import { StreamPartID } from '@streamr/protocol'
 interface HandshakerConfig {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
-    connectionLocker: ConnectionLocker
     neighbors: NodeList
     nearbyNodeView: NodeList
     randomNodeView: NodeList
@@ -43,7 +42,6 @@ export class Handshaker {
         this.rpcLocal = new HandshakeRpcLocal({
             streamPartId: this.config.streamPartId,
             neighbors: this.config.neighbors,
-            connectionLocker: this.config.connectionLocker,
             ongoingHandshakes: this.config.ongoingHandshakes,
             ongoingInterleaves: new Set(),
             maxNeighborCount: this.config.maxNeighborCount,
@@ -131,7 +129,6 @@ export class Handshaker {
         )
         if (result.accepted) {
             this.config.neighbors.add(this.createDeliveryRpcRemote(neighbor.getPeerDescriptor()))
-            this.config.connectionLocker.lockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
         }
         if (result.interleaveTargetDescriptor) {
             await this.handshakeWithInterleaving(result.interleaveTargetDescriptor, targetNodeId)
@@ -152,7 +149,6 @@ export class Handshaker {
         )
         if (result.accepted) {
             this.config.neighbors.add(this.createDeliveryRpcRemote(neighbor.getPeerDescriptor()))
-            this.config.connectionLocker.lockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
         }
         this.config.ongoingHandshakes.delete(targetNodeId)
         return result.accepted

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -1,5 +1,5 @@
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { ConnectionLocker, DhtAddress, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { Logger, scheduleAtInterval } from '@streamr/utils'
 import { NeighborFinder } from './NeighborFinder'
@@ -13,7 +13,6 @@ interface NeighborUpdateManagerConfig {
     neighbors: NodeList
     nearbyNodeView: NodeList
     neighborFinder: NeighborFinder
-    connectionLocker: ConnectionLocker
     streamPartId: StreamPartID
     rpcCommunicator: ListeningRpcCommunicator
     neighborUpdateInterval: number
@@ -53,7 +52,6 @@ export class NeighborUpdateManager {
             if (res.removeMe) {
                 const nodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
                 this.config.neighbors.remove(nodeId)
-                this.config.connectionLocker.unlockConnection(neighbor.getPeerDescriptor(), this.config.streamPartId)
                 this.config.neighborFinder.start([nodeId])
             }
         }))

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { ConnectionLocker, DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { INeighborUpdateRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
@@ -14,7 +14,6 @@ interface NeighborUpdateRpcLocalConfig {
     neighbors: NodeList
     nearbyNodeView: NodeList
     neighborFinder: NeighborFinder
-    connectionLocker: ConnectionLocker
     rpcCommunicator: ListeningRpcCommunicator
     neighborTargetCount: number
     ongoingHandshakes: Set<DhtAddress>
@@ -69,7 +68,6 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
                 this.config.neighborFinder.start()
             } else {
                 this.config.neighbors.remove(senderId)
-                this.config.connectionLocker.unlockConnection(senderPeerDescriptor, this.config.streamPartId)
             }
             return this.createResponse(isOverNeighborCount)
         }

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -11,7 +11,6 @@ import {
     HandshakeRpcClient
 } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { NodeList } from '../../src/logic/NodeList'
-import { mockConnectionLocker } from '../utils/utils'
 import { StreamPartHandshakeRequest, StreamPartHandshakeResponse } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { HandshakeRpcRemote } from '../../src/logic/neighbor-discovery/HandshakeRpcRemote'
 import { StreamPartIDUtils } from '@streamr/protocol'
@@ -90,7 +89,6 @@ describe('Handshakes', () => {
             nearbyNodeView: nodeView,
             randomNodeView: nodeView,
             neighbors,
-            connectionLocker: mockConnectionLocker,
             rpcCommunicator: rpcCommunicator2,
             maxNeighborCount: 4,
             ongoingHandshakes: new Set()

--- a/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
@@ -2,7 +2,7 @@ import { DhtAddress, NodeType, getNodeIdFromPeerDescriptor, getRawFromDhtAddress
 import { NodeList } from '../../src/logic/NodeList'
 import { HandshakeRpcLocal } from '../../src/logic/neighbor-discovery/HandshakeRpcLocal'
 import { InterleaveRequest, StreamPartHandshakeRequest } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
-import { createMockPeerDescriptor, createMockHandshakeRpcRemote, createMockDeliveryRpcRemote, mockConnectionLocker } from '../utils/utils'
+import { createMockPeerDescriptor, createMockHandshakeRpcRemote, createMockDeliveryRpcRemote } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('stream#0')
@@ -26,7 +26,6 @@ describe('HandshakeRpcLocal', () => {
 
         rpcLocal = new HandshakeRpcLocal({
             streamPartId: STREAM_PART_ID,
-            connectionLocker: mockConnectionLocker,
             ongoingHandshakes,
             ongoingInterleaves,
             createRpcRemote: (_p) => createMockHandshakeRpcRemote(),

--- a/packages/trackerless-network/test/unit/Handshaker.test.ts
+++ b/packages/trackerless-network/test/unit/Handshaker.test.ts
@@ -2,7 +2,7 @@ import { ListeningRpcCommunicator, Simulator, SimulatorTransport, getNodeIdFromP
 import { range } from 'lodash'
 import { NodeList } from '../../src/logic/NodeList'
 import { Handshaker } from '../../src/logic/neighbor-discovery/Handshaker'
-import { createMockPeerDescriptor, createMockDeliveryRpcRemote, mockConnectionLocker } from '../utils/utils'
+import { createMockPeerDescriptor, createMockDeliveryRpcRemote } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 
 describe('Handshaker', () => {
@@ -34,7 +34,6 @@ describe('Handshaker', () => {
         handshaker = new Handshaker({
             localPeerDescriptor: peerDescriptor,
             streamPartId,
-            connectionLocker: mockConnectionLocker,
             neighbors,
             nearbyNodeView,
             randomNodeView,

--- a/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
@@ -40,9 +40,6 @@ describe('NeighborUpdateRpcLocal', () => {
         neighborFinder = {
             start: jest.fn()
         } as any
-        const connectionLocker = {
-            unlockConnection: jest.fn()
-        } as any
         ongoingHandshakes = new Set()
 
         rpcLocal = new NeighborUpdateRpcLocal({
@@ -53,7 +50,6 @@ describe('NeighborUpdateRpcLocal', () => {
             streamPartId,
             rpcCommunicator,
             neighborTargetCount,
-            connectionLocker,
             ongoingHandshakes
         })
     })


### PR DESCRIPTION
## Summary

Lock and unlock connections in Layer2 based on nodeAdded and nodeRemoved events in RandomGraphNode instead of doing the operation saparetely each time nodes are removed or added to the neighbor struct

## Future improvements

Add a parameter for enabling emitting nodeRemoved events in the replaceNodes method. 
