### PR TITLE
Rename `RecursiveOperation#FIND_NODE`

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -107,7 +107,7 @@ message RecursiveOperationRequest {
 }
 
 enum RecursiveOperation {
-  FIND_NODE = 0;
+  FIND_CLOSEST_NODES = 0;
   FETCH_DATA = 1;
   DELETE_DATA = 2;
 }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -492,7 +492,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     async findClosestNodesFromDht(key: DhtAddress): Promise<PeerDescriptor[]> {
-        const result = await this.recursiveOperationManager!.execute(key, RecursiveOperation.FIND_NODE)
+        const result = await this.recursiveOperationManager!.execute(key, RecursiveOperation.FIND_CLOSEST_NODES)
         return result.closestNodes
     }
 

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -98,7 +98,7 @@ export class StoreManager {
 
     public async storeDataToDht(key: DhtAddress, data: Any, creator: DhtAddress): Promise<PeerDescriptor[]> {
         logger.debug(`Storing data to DHT ${this.config.serviceId}`)
-        const result = await this.config.recursiveOperationManager.execute(key, RecursiveOperation.FIND_NODE)
+        const result = await this.config.recursiveOperationManager.execute(key, RecursiveOperation.FIND_CLOSEST_NODES)
         const closestNodes = result.closestNodes
         const successfulNodes: PeerDescriptor[] = []
         const ttl = this.config.highestTtl // ToDo: make TTL decrease according to some nice curve

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -563,9 +563,9 @@ export interface ExternalFindDataResponse {
  */
 export enum RecursiveOperation {
     /**
-     * @generated from protobuf enum value: FIND_NODE = 0;
+     * @generated from protobuf enum value: FIND_CLOSEST_NODES = 0;
      */
-    FIND_NODE = 0,
+    FIND_CLOSEST_NODES = 0,
     /**
      * @generated from protobuf enum value: FETCH_DATA = 1;
      */

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -83,9 +83,9 @@ describe('RecursiveOperationManager', () => {
         recursiveOperationManager.stop()
     })
 
-    it('startFind with mode Node returns self if no peers', async () => {
+    it('find closest nodes returns self if no peers', async () => {
         const recursiveOperationManager = createRecursiveOperationManager()
-        const res = await recursiveOperationManager.execute(createRandomDhtAddress(), RecursiveOperation.FIND_NODE)
+        const res = await recursiveOperationManager.execute(createRandomDhtAddress(), RecursiveOperation.FIND_CLOSEST_NODES)
         expect(areEqualPeerDescriptors(res.closestNodes[0], peerDescriptor1)).toEqual(true)
         recursiveOperationManager.stop()
     })

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -4,11 +4,11 @@ import {
     MessageType,
     RouteMessageAck,
     RouteMessageError,
-    RouteMessageWrapper
+    RouteMessageWrapper,
+    RecursiveOperationRequest
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import {
     createWrappedClosestPeersRequest,
-    createFindRequest,
     createMockPeerDescriptor
 } from '../utils/utils'
 import { RecursiveOperationManager } from '../../src/dht/recursive-operation/RecursiveOperationManager'
@@ -33,11 +33,20 @@ const createMockRouter = (error?: RouteMessageError): Partial<Router> => {
         addToDuplicateDetector: () => {}
     }
 }
+
+const createRequest = (): RecursiveOperationRequest => {
+    const request: RecursiveOperationRequest = {
+        operation: RecursiveOperation.FIND_CLOSEST_NODES,
+        sessionId: v4()
+    }
+    return request
+}
+
 describe('RecursiveOperationManager', () => {
 
     const peerDescriptor1 = createMockPeerDescriptor()
     const peerDescriptor2 = createMockPeerDescriptor()
-    const recursiveOperationRequest = createFindRequest()
+    const recursiveOperationRequest = createRequest()
     const message: Message = {
         serviceId: 'unknown',
         messageId: v4(),

--- a/packages/dht/test/unit/RecursiveOperationSession.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationSession.test.ts
@@ -39,7 +39,7 @@ describe('RecursiveOperationSession', () => {
             targetId: createRandomDhtAddress(),
             localPeerDescriptor,
             waitedRoutingPathCompletions: 3,
-            operation: RecursiveOperation.FIND_NODE,
+            operation: RecursiveOperation.FIND_CLOSEST_NODES,
             doRouteRequest
         })
         const onCompleted = jest.fn()

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -109,7 +109,7 @@ export const createWrappedClosestPeersRequest = (
 
 export const createFindRequest = (): RecursiveOperationRequest => {
     const request: RecursiveOperationRequest = {
-        operation: RecursiveOperation.FIND_NODE,
+        operation: RecursiveOperation.FIND_CLOSEST_NODES,
         sessionId: v4()
     }
     return request

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -9,9 +9,7 @@ import {
     RouteMessageAck,
     RouteMessageWrapper,
     StoreDataRequest,
-    StoreDataResponse,
-    RecursiveOperationRequest, 
-    RecursiveOperation
+    StoreDataResponse
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import {
@@ -105,14 +103,6 @@ export const createWrappedClosestPeersRequest = (
         requestId: v4()
     }
     return rpcWrapper
-}
-
-export const createFindRequest = (): RecursiveOperationRequest => {
-    const request: RecursiveOperationRequest = {
-        operation: RecursiveOperation.FIND_CLOSEST_NODES,
-        sessionId: v4()
-    }
-    return request
 }
 
 interface IDhtRpcWithError extends IDhtNodeRpc {

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -563,9 +563,9 @@ export interface ExternalFindDataResponse {
  */
 export enum RecursiveOperation {
     /**
-     * @generated from protobuf enum value: FIND_NODE = 0;
+     * @generated from protobuf enum value: FIND_CLOSEST_NODES = 0;
      */
-    FIND_NODE = 0,
+    FIND_CLOSEST_NODES = 0,
     /**
      * @generated from protobuf enum value: FETCH_DATA = 1;
      */


### PR DESCRIPTION
Rename `RecursiveOperation#FIND_NODE`  enum value to `FIND_CLOSEST_NODES` as it returns multiple nodes.

## Future improvements

- Maybe `RecursiveOperationResult` could have two sub-interfaces: one having `closestNodes` fields and another having `dataEntries` fields. (Also could fine-tune the type of `dataEntries` field: it is never `undefined`.)
