### PR TITLE
feat(trackerless-network): Application version in node info

### DIFF
--- a/packages/dht/src/exports.ts
+++ b/packages/dht/src/exports.ts
@@ -27,4 +27,3 @@ export {
     areEqualPeerDescriptors,
     getNodeIdFromPeerDescriptor
 } from './identifiers'
-export { LOCAL_PROTOCOL_VERSION } from './helpers/version'

--- a/packages/dht/test/integration/ConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/ConnectivityChecking.test.ts
@@ -4,7 +4,7 @@ import { DefaultConnectorFacade } from '../../src/connection/ConnectorFacade'
 import { MockTransport } from '../utils/mock/Transport'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { sendConnectivityRequest } from '../../src/connection/connectivityChecker'
-import { LOCAL_PROTOCOL_VERSION } from '../../src/exports'
+import { LOCAL_PROTOCOL_VERSION } from '../../src/helpers/version'
 
 describe('ConnectivityChecking', () => {
 

--- a/packages/dht/test/unit/connectivityRequestHandler.test.ts
+++ b/packages/dht/test/unit/connectivityRequestHandler.test.ts
@@ -6,7 +6,7 @@ import { server as WsServer } from 'websocket'
 import { CONNECTIVITY_CHECKER_SERVICE_ID } from '../../src/connection/connectivityChecker'
 import { attachConnectivityRequestHandler } from '../../src/connection/connectivityRequestHandler'
 import { Message } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { LOCAL_PROTOCOL_VERSION } from '../../src/exports'
+import { LOCAL_PROTOCOL_VERSION } from '../../src/helpers/version'
 
 const HOST = '127.0.0.1'
 const PORT = 15001

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -9,7 +9,7 @@ import {
 import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
 import { Logger, MetricsContext, waitForCondition } from '@streamr/utils'
 import { pull } from 'lodash'
-import { version as localVersion } from '../package.json'
+import { version as applicationVersion } from '../package.json'
 import { Layer0Node } from './logic/Layer0Node'
 import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
 import { NodeInfoClient } from './logic/node-info/NodeInfoClient'
@@ -168,7 +168,7 @@ export class NetworkStack {
                 neighbors: this.getLayer0Node().getNeighbors()
             },
             streamPartitions: this.getStreamrNode().getNodeInfo(),
-            version: localVersion
+            version: applicationVersion
         }
     }
 

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -2,7 +2,6 @@ import {
     ConnectionManager,
     DhtNode,
     DhtNodeOptions,
-    LOCAL_PROTOCOL_VERSION,
     ListeningRpcCommunicator,
     PeerDescriptor,
     areEqualPeerDescriptors
@@ -10,6 +9,7 @@ import {
 import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
 import { Logger, MetricsContext, waitForCondition } from '@streamr/utils'
 import { pull } from 'lodash'
+import { version as localVersion } from '../package.json'
 import { Layer0Node } from './logic/Layer0Node'
 import { StreamrNode, StreamrNodeConfig } from './logic/StreamrNode'
 import { NodeInfoClient } from './logic/node-info/NodeInfoClient'
@@ -168,7 +168,7 @@ export class NetworkStack {
                 neighbors: this.getLayer0Node().getNeighbors()
             },
             streamPartitions: this.getStreamrNode().getNodeInfo(),
-            version: LOCAL_PROTOCOL_VERSION
+            version: localVersion
         }
     }
 


### PR DESCRIPTION
The version field in `nodeInfo` RPC result contains application version instead of protocol version.

This PR reverts the node info related changes made in PR #2404. 