### PR TITLE
fix(DHT): send leave notices to ring contacts

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -235,6 +235,10 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             this.bucket.remove(rpcRemote.id)
         })
         this.bucket.removeAllListeners()
+        this.ringContacts.getAllContacts().forEach((rpcRemote) => {
+            rpcRemote.leaveNotice()
+            this.ringContacts.removeContact(rpcRemote)
+        })
         this.contacts.stop()
         this.randomPeers.stop()
         this.connections.clear()


### PR DESCRIPTION
## Summary

Send leave notices to ring contacts. This will ensure that stale contacts will be cleared from the DHT.

`test/integration/streamEntryPointReplacing.test.ts` in trackerless-network passed 100 times in a row with this change
