### PR TITLE
fix(DHT): reduce Handshaker HandshakeRequest parse error log level

### DIFF
--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -54,7 +54,7 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
                 }
             }
         } catch (err) {
-            logger.error('error while parsing handshake message', err)
+            logger.debug('error while parsing handshake message', err)
         }
         
     }


### PR DESCRIPTION
## Summary

Reduced log level of failed HandshakeRequest parsing from  `error` to `debug`