### PR TITLE
fix(trackerless-network): fix connection locking in streams

### DIFF
--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -100,7 +100,7 @@ export class NodeList extends EventEmitter<Events> {
     }
 
     stop(): void {
-        this.nodes.clear()
+        this.nodes.forEach((node) => this.remove(getNodeIdFromPeerDescriptor(node.getPeerDescriptor())))
         this.removeAllListeners()
     }
 }


### PR DESCRIPTION
## Summary

Fixed connection locking in streams. Typescript did not pick up on inproper typing in the event lisnteners due to any typing.