### PR TITLE
fix(dht): Provide all parameters to `NodeWebrtcConnection`

### DIFF
--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -26,7 +26,7 @@ export interface Params {
     bufferThresholdLow?: number
     connectingTimeout?: number
     maxMessageSize?: number
-    iceServers?: IceServer[]
+    iceServers?: IceServer[]  // TODO make this parameter required (empty array is a good fallback which can be set by the caller if needed)
     portRange?: PortRange
 }
 

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -75,6 +75,7 @@ export class WebrtcConnector {
         onNewConnection: (connection: ManagedConnection) => boolean
     ) {
         const localRpc = new WebrtcConnectorRpcLocal({
+            createConnection: (targetPeerDescriptor: PeerDescriptor) => this.createConnection(targetPeerDescriptor),
             connect: (targetPeerDescriptor: PeerDescriptor) => this.connect(targetPeerDescriptor),
             onNewConnection,
             ongoingConnectAttempts: this.ongoingConnectAttempts,
@@ -133,14 +134,7 @@ export class WebrtcConnector {
             return existingConnection
         }
 
-        const connection = new NodeWebrtcConnection({
-            remotePeerDescriptor: targetPeerDescriptor,
-            iceServers: this.config.iceServers,
-            bufferThresholdLow: this.config.bufferThresholdLow,
-            bufferThresholdHigh: this.config.bufferThresholdHigh,
-            connectingTimeout: this.config.connectionTimeout,
-            portRange: this.config.portRange
-        })
+        const connection = this.createConnection(targetPeerDescriptor)
 
         const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor!)
         const targetNodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
@@ -197,6 +191,18 @@ export class WebrtcConnector {
         }
 
         return managedConnection
+    }
+
+    private createConnection(targetPeerDescriptor: PeerDescriptor): NodeWebrtcConnection {
+        return new NodeWebrtcConnection({
+            remotePeerDescriptor: targetPeerDescriptor,
+            iceServers: this.config.iceServers,
+            bufferThresholdLow: this.config.bufferThresholdLow,
+            bufferThresholdHigh: this.config.bufferThresholdHigh,
+            connectingTimeout: this.config.connectionTimeout,
+            portRange: this.config.portRange
+            // TODO should we pass maxMessageSize?
+        })
     }
 
     setLocalPeerDescriptor(peerDescriptor: PeerDescriptor): void {

--- a/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
@@ -24,6 +24,7 @@ import { ConnectionID } from '../IConnection'
 const logger = new Logger(module)
 
 interface WebrtcConnectorRpcLocalConfig {
+    createConnection: (targetPeerDescriptor: PeerDescriptor) => NodeWebrtcConnection 
     connect: (targetPeerDescriptor: PeerDescriptor) => ManagedConnection 
     onNewConnection: (connection: ManagedConnection) => boolean
     // TODO pass accessor methods instead of passing a mutable entity
@@ -59,7 +60,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
         let connection = managedConnection?.getWebrtcConnection()
 
         if (!managedConnection) {
-            connection = new NodeWebrtcConnection({ remotePeerDescriptor: remotePeer })
+            connection = this.config.createConnection(remotePeer)
             managedConnection = new ManagedWebrtcConnection(this.config.getLocalPeerDescriptor(), undefined, connection)
             managedConnection.setRemotePeerDescriptor(remotePeer)
             this.config.ongoingConnectAttempts.set(nodeId, managedConnection)


### PR DESCRIPTION
## Summary

If there a WebRTC answerer behind a NAT, it doesn't connect to STUN server.

When `WebrtcConnectorLocalRpc` created connection instances, it ignored most of the constructor parameter which we should pass to `NodeWebrtcConnection`. It passed just the remote peer, but e.g. not ICE servers:
```ts
new NodeWebrtcConnection({ remotePeerDescriptor: remotePeer })
```

## Changes

Moved the connection construction out of `WebrtcConnectorLocalRpc` by introducing `config.createConnection()` function.

## Open questions

- Some tests are failing, maybe as a consequence of this change: https://github.com/streamr-dev/network/actions/runs/8140879404/job/22246994771?pr=2414

## Future improvements

- Improve test coverage so that we test also situations which use STUN servers. 
- Should mark `iceServers` config option and maybe other options as required so that we can avoid this kind of bug in the future. For arrays we can use explicit empty array.