### PR TITLE
feat(ci) [NET-1274]: Automate `latest` tag for Docker image release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,10 @@ on:
       build_platforms:
         type: string
         required: true
+      include_latest_tag:
+        type: boolean
+        required: false
+        default: false
 
     secrets:
       dockerhub_username:
@@ -78,8 +82,9 @@ jobs:
             latest=false
           tags: |
             type=match,pattern=broker/(v.*),group=1,value=${{ env.broker_head_tag }}
-            type=raw,value=dev,enable=${{ inputs.branch == 'main' }}
             type=raw,value=${{ inputs.branch }},enable=${{ inputs.branch != 'main' }}
+            type=raw,value=dev,enable=${{ inputs.branch == 'main' }}
+            type=raw,value=latest,enable=${{ inputs.include_latest_tag }}
 
       - name: Build
         if: ${{!inputs.push_image}}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,6 +1,13 @@
 name: release docker
 on:
   workflow_dispatch:
+    inputs:
+      include_latest_tag:
+        type: choice
+        required: true
+        description: 'Include "latest" as one of the tags to be published'
+        default: 'false'
+        options: ['false', 'true']
 jobs:
   broker-docker-image:
     uses: ./.github/workflows/docker-build.yml
@@ -11,6 +18,7 @@ jobs:
       build_platforms: linux/amd64,linux/arm64
       branch: ${{ github.ref_name }}
       push_image: true
+      include_latest_tag: ${{ github.event.inputs.include_latest_tag == 'true' }}
     secrets:
       dockerhub_username: ${{secrets.DOCKERHUB_USERNAME}}
       dockerhub_token: ${{secrets.DOCKERHUB_TOKEN}}


### PR DESCRIPTION
## Summary

Add drop-down menu option `include_latest_tag` to `release_docker` workflow. When set to true, the Docker image will be published under `latest` tag (along with other applicable tags).

TODO: test manually on next release

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
