### PR TITLE
fix(broker): Fix NPM `EPERM` error when starting broker in Docker

### DIFF
--- a/Dockerfile.broker
+++ b/Dockerfile.broker
@@ -28,4 +28,4 @@ EXPOSE 32200/tcp
 WORKDIR /home/streamr/network/packages/broker
 
 # start broker from default config (needs mounted volume, e.g. docker run -v $(cd ~/.streamr/config;pwd):/home/streamr/.streamr/config IMAGE
-CMD ["/usr/local/bin/npm", "exec", "streamr-broker"]
+CMD ["/usr/local/bin/npm", "exec", "-c", "streamr-broker"]


### PR DESCRIPTION
## Summary

The following error occurred when running Broker docker image

```
npm ERR! code EPERM
npm ERR! syscall chmod
npm ERR! path /home/streamr/.npm/_npx/df4d6d3e1893d317/node_modules/@streamr/node/dist/bin/broker.js
npm ERR! errno -1
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1000:1000 "/home/streamr/.npm"
```

I narrowed it down to the `npm exec streamr-broker` command. It looks like it goes sniffing for a non-existing `~/.npm` folder and then complains about permissions. Why it suddenly does this? Not sure, maybe NPM behavior has changed with an update? Anyways if we add flag `-c` to the command it doesn't go sniffing for the cache folder and the problem goes away.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
