### PR TITLE
refactor(trackerless-network): Rename `DeliveryRpc`

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -168,6 +168,7 @@ enum ProxyDirection {
 message StreamPartitionInfo {
   string id = 1;
   repeated dht.PeerDescriptor controlLayerNeighbors = 2;
+  // could be "contentDelivery" instead of "deliveryLayer", but that is a breaking change
   repeated dht.PeerDescriptor deliveryLayerNeighbors = 3;
 }
 

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -6,7 +6,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/any.proto";
 import "packages/dht/protos/DhtRpc.proto";
 
-service DeliveryRpc {
+service ContentDeliveryRpc {
   rpc sendStreamMessage (StreamMessage) returns (google.protobuf.Empty);
   rpc leaveStreamPartNotice (LeaveStreamPartNotice) returns (google.protobuf.Empty);
 }

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -168,8 +168,7 @@ enum ProxyDirection {
 message StreamPartitionInfo {
   string id = 1;
   repeated dht.PeerDescriptor controlLayerNeighbors = 2;
-  // could be "contentDelivery" instead of "deliveryLayer", but that is a breaking change
-  repeated dht.PeerDescriptor deliveryLayerNeighbors = 3;
+  repeated dht.PeerDescriptor contentDeliveryLayerNeighbors = 3;
 }
 
 message ControlLayerInfo {

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -296,7 +296,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             return {
                 id: streamPartId,
                 controlLayerNeighbors: stream.layer1Node.getNeighbors(),
-                deliveryLayerNeighbors: stream.node.getNeighbors()
+                contentDeliveryLayerNeighbors: stream.node.getNeighbors()
             }
         })
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -6,11 +6,11 @@ import {
     MessageRef,
     StreamMessage
 } from '../proto/packages/trackerless-network/protos/NetworkRpc'
-import { IDeliveryRpc } from '../proto/packages/trackerless-network/protos/NetworkRpc.server'
+import { IContentDeliveryRpc } from '../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { StreamPartID } from '@streamr/protocol'
 
-export interface DeliveryRpcLocalConfig {
+export interface ContentDeliveryRpcLocalConfig {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     markAndCheckDuplicate: (messageId: MessageID, previousMessageRef?: MessageRef) => boolean
@@ -20,11 +20,11 @@ export interface DeliveryRpcLocalConfig {
     rpcCommunicator: ListeningRpcCommunicator
 }
 
-export class DeliveryRpcLocal implements IDeliveryRpc {
+export class ContentDeliveryRpcLocal implements IContentDeliveryRpc {
     
-    private readonly config: DeliveryRpcLocalConfig
+    private readonly config: ContentDeliveryRpcLocalConfig
 
-    constructor(config: DeliveryRpcLocalConfig) {
+    constructor(config: ContentDeliveryRpcLocalConfig) {
         this.config = config
     }
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
@@ -4,12 +4,12 @@ import {
     LeaveStreamPartNotice,
     StreamMessage
 } from '../proto/packages/trackerless-network/protos/NetworkRpc'
-import { DeliveryRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { StreamPartID } from '@streamr/protocol'
 
 const logger = new Logger(module)
 
-export class DeliveryRpcRemote extends RpcRemote<DeliveryRpcClient> {
+export class ContentDeliveryRpcRemote extends RpcRemote<ContentDeliveryRpcClient> {
 
     async sendStreamMessage(msg: StreamMessage): Promise<void> {
         const options = this.formDhtRpcOptions({

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -1,14 +1,14 @@
 import { DhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { sample } from 'lodash'
-import { DeliveryRpcRemote } from './DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from './ContentDeliveryRpcRemote'
 import { EventEmitter } from 'eventemitter3'
 
 export interface Events {
-    nodeAdded: (id: DhtAddress, remote: DeliveryRpcRemote) => void
-    nodeRemoved: (id: DhtAddress, remote: DeliveryRpcRemote) => void
+    nodeAdded: (id: DhtAddress, remote: ContentDeliveryRpcRemote) => void
+    nodeRemoved: (id: DhtAddress, remote: ContentDeliveryRpcRemote) => void
 }
 
-const getValuesOfIncludedKeys = (nodes: Map<DhtAddress, DeliveryRpcRemote>, exclude: DhtAddress[]): DeliveryRpcRemote[] => {
+const getValuesOfIncludedKeys = (nodes: Map<DhtAddress, ContentDeliveryRpcRemote>, exclude: DhtAddress[]): ContentDeliveryRpcRemote[] => {
     return Array.from(nodes.entries())
         .filter(([id, _node]) => !exclude.includes(id))
         .map(([_id, node]) => node)
@@ -17,7 +17,7 @@ const getValuesOfIncludedKeys = (nodes: Map<DhtAddress, DeliveryRpcRemote>, excl
 // The items in the list are in the insertion order
 
 export class NodeList extends EventEmitter<Events> {
-    private readonly nodes: Map<DhtAddress, DeliveryRpcRemote>
+    private readonly nodes: Map<DhtAddress, ContentDeliveryRpcRemote>
     private readonly limit: number
     private ownId: DhtAddress
 
@@ -28,7 +28,7 @@ export class NodeList extends EventEmitter<Events> {
         this.ownId = ownId
     }
 
-    add(remote: DeliveryRpcRemote): void {
+    add(remote: ContentDeliveryRpcRemote): void {
         const nodeId = getNodeIdFromPeerDescriptor(remote.getPeerDescriptor())
         if ((this.ownId !== nodeId) && (this.nodes.size < this.limit)) {
             const isExistingNode = this.nodes.has(nodeId)
@@ -53,7 +53,7 @@ export class NodeList extends EventEmitter<Events> {
     }
 
     // Replace nodes does not emit nodeRemoved events, use with caution
-    replaceAll(neighbors: DeliveryRpcRemote[]): void {
+    replaceAll(neighbors: ContentDeliveryRpcRemote[]): void {
         this.nodes.clear()
         const limited = neighbors.splice(0, this.limit)
         limited.forEach((remote) => {
@@ -65,7 +65,7 @@ export class NodeList extends EventEmitter<Events> {
         return Array.from(this.nodes.keys())
     }
 
-    get(id: DhtAddress): DeliveryRpcRemote | undefined {
+    get(id: DhtAddress): ContentDeliveryRpcRemote | undefined {
         return this.nodes.get(id)
     }
 
@@ -73,16 +73,16 @@ export class NodeList extends EventEmitter<Events> {
         return Array.from(this.nodes.keys()).filter((node) => !exclude.includes(node)).length
     }
 
-    getRandom(exclude: DhtAddress[]): DeliveryRpcRemote | undefined {
+    getRandom(exclude: DhtAddress[]): ContentDeliveryRpcRemote | undefined {
         return sample(getValuesOfIncludedKeys(this.nodes, exclude))
     }
 
-    getFirst(exclude: DhtAddress[]): DeliveryRpcRemote | undefined {
+    getFirst(exclude: DhtAddress[]): ContentDeliveryRpcRemote | undefined {
         const included = getValuesOfIncludedKeys(this.nodes, exclude)
         return included[0]
     }
 
-    getFirstAndLast(exclude: DhtAddress[]): DeliveryRpcRemote[] {
+    getFirstAndLast(exclude: DhtAddress[]): ContentDeliveryRpcRemote[] {
         const included = getValuesOfIncludedKeys(this.nodes, exclude)
         if (included.length === 0) {
             return []
@@ -90,12 +90,12 @@ export class NodeList extends EventEmitter<Events> {
         return included.length > 1 ? [this.getFirst(exclude)!, this.getLast(exclude)!] : [this.getFirst(exclude)!]
     }
 
-    getLast(exclude: DhtAddress[]): DeliveryRpcRemote | undefined {
+    getLast(exclude: DhtAddress[]): ContentDeliveryRpcRemote | undefined {
         const included = getValuesOfIncludedKeys(this.nodes, exclude)
         return included[included.length - 1]
     }
 
-    getAll(): DeliveryRpcRemote[] {
+    getAll(): ContentDeliveryRpcRemote[] {
         return Array.from(this.nodes.values())
     }
 

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -279,7 +279,6 @@ export class RandomGraphNode extends EventEmitter<Events> {
                     this.config.rpcCommunicator,
                     ContentDeliveryRpcClient,
                     this.config.rpcRequestTimeout
-
                 )
             )
         }

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -18,16 +18,16 @@ import {
     CloseTemporaryConnection,
 } from '../proto/packages/trackerless-network/protos/NetworkRpc'
 import { NodeList } from './NodeList'
-import { DeliveryRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
-import { DeliveryRpcRemote } from './DeliveryRpcRemote'
-import { IDeliveryRpc } from '../proto/packages/trackerless-network/protos/NetworkRpc.server'
+import { ContentDeliveryRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcRemote } from './ContentDeliveryRpcRemote'
+import { IContentDeliveryRpc } from '../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { DuplicateMessageDetector } from './DuplicateMessageDetector'
 import { Logger, addManagedEventListener } from '@streamr/utils'
 import { Handshaker } from './neighbor-discovery/Handshaker'
 import { Propagation } from './propagation/Propagation'
 import { NeighborFinder } from './neighbor-discovery/NeighborFinder'
 import { NeighborUpdateManager } from './neighbor-discovery/NeighborUpdateManager'
-import { DeliveryRpcLocal } from './DeliveryRpcLocal'
+import { ContentDeliveryRpcLocal } from './ContentDeliveryRpcLocal'
 import { ProxyConnectionRpcLocal } from './proxy/ProxyConnectionRpcLocal'
 import { Inspector } from './inspect/Inspector'
 import { TemporaryConnectionRpcLocal } from './temporary-connection/TemporaryConnectionRpcLocal'
@@ -75,14 +75,14 @@ export class RandomGraphNode extends EventEmitter<Events> {
     private started = false
     private readonly duplicateDetectors: Map<string, DuplicateMessageDetector>
     private config: StrictRandomGraphNodeConfig
-    private readonly deliveryRpcLocal: IDeliveryRpc
+    private readonly contentDeliveryRpcLocal: IContentDeliveryRpc
     private abortController: AbortController = new AbortController()
 
     constructor(config: StrictRandomGraphNodeConfig) {
         super()
         this.config = config
         this.duplicateDetectors = new Map()
-        this.deliveryRpcLocal = new DeliveryRpcLocal({
+        this.contentDeliveryRpcLocal = new ContentDeliveryRpcLocal({
             localPeerDescriptor: this.config.localPeerDescriptor,
             streamPartId: this.config.streamPartId,
             rpcCommunicator: this.config.rpcCommunicator,
@@ -206,9 +206,9 @@ export class RandomGraphNode extends EventEmitter<Events> {
 
     private registerDefaultServerMethods(): void {
         this.config.rpcCommunicator.registerRpcNotification(StreamMessage, 'sendStreamMessage',
-            (msg: StreamMessage, context) => this.deliveryRpcLocal.sendStreamMessage(msg, context))
+            (msg: StreamMessage, context) => this.contentDeliveryRpcLocal.sendStreamMessage(msg, context))
         this.config.rpcCommunicator.registerRpcNotification(LeaveStreamPartNotice, 'leaveStreamPartNotice',
-            (req: LeaveStreamPartNotice, context) => this.deliveryRpcLocal.leaveStreamPartNotice(req, context))
+            (req: LeaveStreamPartNotice, context) => this.contentDeliveryRpcLocal.leaveStreamPartNotice(req, context))
         this.config.rpcCommunicator.registerRpcMethod(TemporaryConnectionRequest, TemporaryConnectionResponse, 'openConnection',
             (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.openConnection(req, context))
         this.config.rpcCommunicator.registerRpcNotification(CloseTemporaryConnection, 'closeConnection',
@@ -221,20 +221,20 @@ export class RandomGraphNode extends EventEmitter<Events> {
             return
         }
         this.config.leftNodeView.replaceAll(ringPeers.left.map((peer) => 
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient,
+                ContentDeliveryRpcClient,
                 this.config.rpcRequestTimeout
             )
         ))
         this.config.rightNodeView.replaceAll(ringPeers.right.map((peer) =>
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient,
+                ContentDeliveryRpcClient,
                 this.config.rpcRequestTimeout
             )
         ))
@@ -261,11 +261,11 @@ export class RandomGraphNode extends EventEmitter<Events> {
 
     private updateNearbyNodeView(nodes: PeerDescriptor[]) {
         this.config.nearbyNodeView.replaceAll(Array.from(nodes).map((descriptor) =>
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 descriptor,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient,
+                ContentDeliveryRpcClient,
                 this.config.rpcRequestTimeout
             )
         ))
@@ -274,11 +274,11 @@ export class RandomGraphNode extends EventEmitter<Events> {
                 break
             }
             this.config.nearbyNodeView.add(
-                new DeliveryRpcRemote(
+                new ContentDeliveryRpcRemote(
                     this.config.localPeerDescriptor,
                     descriptor,
                     this.config.rpcCommunicator,
-                    DeliveryRpcClient,
+                    ContentDeliveryRpcClient,
                     this.config.rpcRequestTimeout
 
                 )
@@ -291,11 +291,11 @@ export class RandomGraphNode extends EventEmitter<Events> {
             return
         }
         this.config.randomNodeView.replaceAll(randomNodes.map((descriptor) =>
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 descriptor,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient,
+                ContentDeliveryRpcClient,
                 this.config.rpcRequestTimeout
             )
         ))
@@ -310,11 +310,11 @@ export class RandomGraphNode extends EventEmitter<Events> {
             return
         }
         this.config.randomNodeView.replaceAll(randomNodes.map((descriptor) =>
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 descriptor,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient,
+                ContentDeliveryRpcClient,
                 this.config.rpcRequestTimeout
             )
         ))

--- a/packages/trackerless-network/src/logic/RandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/RandomGraphNode.ts
@@ -20,7 +20,6 @@ import {
 import { NodeList } from './NodeList'
 import { ContentDeliveryRpcClient } from '../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { ContentDeliveryRpcRemote } from './ContentDeliveryRpcRemote'
-import { IContentDeliveryRpc } from '../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { DuplicateMessageDetector } from './DuplicateMessageDetector'
 import { Logger, addManagedEventListener } from '@streamr/utils'
 import { Handshaker } from './neighbor-discovery/Handshaker'
@@ -75,7 +74,7 @@ export class RandomGraphNode extends EventEmitter<Events> {
     private started = false
     private readonly duplicateDetectors: Map<string, DuplicateMessageDetector>
     private config: StrictRandomGraphNodeConfig
-    private readonly contentDeliveryRpcLocal: IContentDeliveryRpc
+    private readonly contentDeliveryRpcLocal: ContentDeliveryRpcLocal
     private abortController: AbortController = new AbortController()
 
     constructor(config: StrictRandomGraphNodeConfig) {

--- a/packages/trackerless-network/src/logic/createRandomGraphNode.ts
+++ b/packages/trackerless-network/src/logic/createRandomGraphNode.ts
@@ -10,7 +10,7 @@ import { MarkOptional } from 'ts-essentials'
 import { ProxyConnectionRpcLocal } from './proxy/ProxyConnectionRpcLocal'
 import { Inspector } from './inspect/Inspector'
 import { TemporaryConnectionRpcLocal } from './temporary-connection/TemporaryConnectionRpcLocal'
-import { formStreamPartDeliveryServiceId } from './formStreamPartDeliveryServiceId'
+import { formStreamPartContentDeliveryServiceId } from './formStreamPartDeliveryServiceId'
 
 type RandomGraphNodeConfig = MarkOptional<StrictRandomGraphNodeConfig,
     'nearbyNodeView' | 'randomNodeView' | 'neighbors' | 'leftNodeView' | 'rightNodeView' | 'propagation'
@@ -26,7 +26,7 @@ type RandomGraphNodeConfig = MarkOptional<StrictRandomGraphNodeConfig,
 const createConfigWithDefaults = (config: RandomGraphNodeConfig): StrictRandomGraphNodeConfig => {
     const ownNodeId = getNodeIdFromPeerDescriptor(config.localPeerDescriptor)
     const rpcCommunicator = config.rpcCommunicator ?? new ListeningRpcCommunicator(
-        formStreamPartDeliveryServiceId(config.streamPartId),
+        formStreamPartContentDeliveryServiceId(config.streamPartId),
         config.transport
     )
     const neighborTargetCount = config.neighborTargetCount ?? 4

--- a/packages/trackerless-network/src/logic/formStreamPartDeliveryServiceId.ts
+++ b/packages/trackerless-network/src/logic/formStreamPartDeliveryServiceId.ts
@@ -2,5 +2,6 @@ import { ServiceID } from '@streamr/dht'
 import { StreamPartID } from '@streamr/protocol'
 
 export const formStreamPartContentDeliveryServiceId = (streamPartId: StreamPartID): ServiceID => {
+    // could be "content-delivery" instead of "delivery", but that is a breaking change
     return `stream-part-delivery-${streamPartId}`
 }

--- a/packages/trackerless-network/src/logic/formStreamPartDeliveryServiceId.ts
+++ b/packages/trackerless-network/src/logic/formStreamPartDeliveryServiceId.ts
@@ -1,6 +1,6 @@
 import { ServiceID } from '@streamr/dht'
 import { StreamPartID } from '@streamr/protocol'
 
-export const formStreamPartDeliveryServiceId = (streamPartId: StreamPartID): ServiceID => {
+export const formStreamPartContentDeliveryServiceId = (streamPartId: StreamPartID): ServiceID => {
     return `stream-part-delivery-${streamPartId}`
 }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -16,7 +16,7 @@ import {
 } from '@streamr/dht'
 import { IHandshakeRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { HandshakeRpcRemote } from './HandshakeRpcRemote'
-import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../ContentDeliveryRpcRemote'
 import { Logger } from '@streamr/utils'
 import { StreamPartID } from '@streamr/protocol'
 
@@ -27,7 +27,7 @@ interface HandshakeRpcLocalConfig {
     ongoingInterleaves: Set<DhtAddress>
     maxNeighborCount: number
     createRpcRemote: (target: PeerDescriptor) => HandshakeRpcRemote
-    createDeliveryRpcRemote: (peerDescriptor: PeerDescriptor) => DeliveryRpcRemote
+    createContentDeliveryRpcRemote: (peerDescriptor: PeerDescriptor) => ContentDeliveryRpcRemote
     handshakeWithInterleaving: (target: PeerDescriptor, senderId: DhtAddress) => Promise<boolean>
 }
 
@@ -74,7 +74,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
             requestId: request.requestId,
             accepted: true
         }
-        this.config.neighbors.add(this.config.createDeliveryRpcRemote(requester))
+        this.config.neighbors.add(this.config.createContentDeliveryRpcRemote(requester))
         return res
     }
 
@@ -117,7 +117,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
                 this.config.ongoingInterleaves.delete(nodeId)
             })
         }
-        this.config.neighbors.add(this.config.createDeliveryRpcRemote(requester))
+        this.config.neighbors.add(this.config.createContentDeliveryRpcRemote(requester))
         return {
             requestId: request.requestId,
             accepted: true,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -11,7 +11,6 @@ import {
     StreamPartHandshakeResponse
 } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { Logger } from '@streamr/utils'
-import { IHandshakeRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { HandshakeRpcRemote, INTERLEAVE_REQUEST_TIMEOUT } from './HandshakeRpcRemote'
 import { HandshakeRpcLocal } from './HandshakeRpcLocal'
 import { StreamPartID } from '@streamr/protocol'
@@ -37,7 +36,7 @@ const PARALLEL_HANDSHAKE_COUNT = 2
 export class Handshaker {
 
     private config: HandshakerConfig
-    private readonly rpcLocal: IHandshakeRpc
+    private readonly rpcLocal: HandshakeRpcLocal
 
     constructor(config: HandshakerConfig) {
         this.config = config

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -1,8 +1,8 @@
 import { DhtAddress, PeerDescriptor, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NodeList } from '../NodeList'
-import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../ContentDeliveryRpcRemote'
 import {
-    DeliveryRpcClient, HandshakeRpcClient
+    ContentDeliveryRpcClient, HandshakeRpcClient
 } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import {
     InterleaveRequest,
@@ -49,7 +49,7 @@ export class Handshaker {
             maxNeighborCount: this.config.maxNeighborCount,
             handshakeWithInterleaving: (target: PeerDescriptor, senderId: DhtAddress) => this.handshakeWithInterleaving(target, senderId),
             createRpcRemote: (target: PeerDescriptor) => this.createRpcRemote(target),
-            createDeliveryRpcRemote: (target: PeerDescriptor) => this.createDeliveryRpcRemote(target)
+            createContentDeliveryRpcRemote: (target: PeerDescriptor) => this.createContentDeliveryRpcRemote(target)
         })
         this.config.rpcCommunicator.registerRpcMethod(InterleaveRequest, InterleaveResponse, 'interleaveRequest',
             (req: InterleaveRequest, context) => this.rpcLocal.interleaveRequest(req, context), { timeout: INTERLEAVE_REQUEST_TIMEOUT })
@@ -77,7 +77,7 @@ export class Handshaker {
     }
 
     private selectParallelTargets(excludedIds: DhtAddress[]): HandshakeRpcRemote[] {
-        const neighbors: Map<DhtAddress, DeliveryRpcRemote> = new Map()
+        const neighbors: Map<DhtAddress, ContentDeliveryRpcRemote> = new Map()
         // First add the closest left and then right contacts from the ring if possible.
         const left = this.config.leftNodeView.getFirst([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
         const right = this.config.rightNodeView.getFirst([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
@@ -152,7 +152,7 @@ export class Handshaker {
             concurrentNodeId
         )
         if (result.accepted) {
-            this.config.neighbors.add(this.createDeliveryRpcRemote(neighbor.getPeerDescriptor()))
+            this.config.neighbors.add(this.createContentDeliveryRpcRemote(neighbor.getPeerDescriptor()))
         }
         if (result.interleaveTargetDescriptor) {
             await this.handshakeWithInterleaving(result.interleaveTargetDescriptor, targetNodeId)
@@ -172,7 +172,7 @@ export class Handshaker {
             interleaveSourceId
         )
         if (result.accepted) {
-            this.config.neighbors.add(this.createDeliveryRpcRemote(neighbor.getPeerDescriptor()))
+            this.config.neighbors.add(this.createContentDeliveryRpcRemote(neighbor.getPeerDescriptor()))
         }
         this.config.ongoingHandshakes.delete(targetNodeId)
         return result.accepted
@@ -188,12 +188,12 @@ export class Handshaker {
         )
     }
 
-    private createDeliveryRpcRemote(targetPeerDescriptor: PeerDescriptor): DeliveryRpcRemote {
-        return new DeliveryRpcRemote(
+    private createContentDeliveryRpcRemote(targetPeerDescriptor: PeerDescriptor): ContentDeliveryRpcRemote {
+        return new ContentDeliveryRpcRemote(
             this.config.localPeerDescriptor,
             targetPeerDescriptor,
             this.config.rpcCommunicator,
-            DeliveryRpcClient,
+            ContentDeliveryRpcClient,
             this.config.rpcRequestTimeout
         )
     }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -1,10 +1,10 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
-import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { INeighborUpdateRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { NodeList } from '../NodeList'
-import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../ContentDeliveryRpcRemote'
 import { NeighborFinder } from './NeighborFinder'
 import { StreamPartID } from '@streamr/protocol'
 
@@ -34,11 +34,11 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
             return nodeId !== ownNodeId && !this.config.neighbors.getIds().includes(nodeId)
         })
         newPeerDescriptors.forEach((peerDescriptor) => this.config.nearbyNodeView.add(
-            new DeliveryRpcRemote(
+            new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peerDescriptor,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient
+                ContentDeliveryRpcClient
             ))
         )
     }

--- a/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
@@ -6,9 +6,9 @@ import {
     StreamMessage
 } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { IProxyConnectionRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
-import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../ContentDeliveryRpcRemote'
 import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
-import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { EventEmitter } from 'eventemitter3'
 import { EthereumAddress, Logger, binaryToHex, toEthereumAddress } from '@streamr/utils'
 import { StreamPartID } from '@streamr/protocol'
@@ -18,7 +18,7 @@ const logger = new Logger(module)
 interface ProxyConnection {
     direction: ProxyDirection // Direction is from the client's point of view
     userId: EthereumAddress
-    remote: DeliveryRpcRemote
+    remote: ContentDeliveryRpcRemote
 }
 
 interface ProxyConnectionRpcLocalConfig {
@@ -90,11 +90,11 @@ export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IPr
         this.connections.set(senderId, {
             direction: request.direction,
             userId: toEthereumAddress(binaryToHex(request.userId, true)),
-            remote: new DeliveryRpcRemote(
+            remote: new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 senderPeerDescriptor,
                 this.config.rpcCommunicator,
-                DeliveryRpcClient
+                ContentDeliveryRpcClient
             )
         })
         const response: ProxyConnectionResponse = {

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -20,6 +20,7 @@ interface TemporaryConnectionRpcLocalConfig {
     connectionLocker: ConnectionLocker
 } 
 
+// could be "content-delivery" instead of "delivery", but that is a breaking change
 const LOCK_ID_BASE = 'system/delivery/temporary-connection/'
 
 export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -6,9 +6,9 @@ import {
 } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { ITemporaryConnectionRpc } from '../../proto/packages/trackerless-network/protos/NetworkRpc.server'
 import { ConnectionLocker, DhtAddress, DhtCallContext, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
-import { DeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { NodeList } from '../NodeList'
-import { DeliveryRpcRemote } from '../DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../ContentDeliveryRpcRemote'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { Empty } from '../../proto/google/protobuf/empty'
 import { StreamPartID } from '@streamr/protocol'
@@ -52,11 +52,11 @@ export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
         context: ServerCallContext
     ): Promise<TemporaryConnectionResponse> {
         const sender = (context as DhtCallContext).incomingSourceDescriptor!
-        const remote = new DeliveryRpcRemote(
+        const remote = new ContentDeliveryRpcRemote(
             this.config.localPeerDescriptor,
             sender,
             this.config.rpcCommunicator,
-            DeliveryRpcClient
+            ContentDeliveryRpcClient
         )
         this.temporaryNodes.add(remote)
         this.config.connectionLocker.weakLockConnection(getNodeIdFromPeerDescriptor(sender), this.lockId)

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -20,8 +20,7 @@ interface TemporaryConnectionRpcLocalConfig {
     connectionLocker: ConnectionLocker
 } 
 
-// could be "content-delivery" instead of "delivery", but that is a breaking change
-const LOCK_ID_BASE = 'system/delivery/temporary-connection/'
+const LOCK_ID_BASE = 'system/content-delivery/temporary-connection/'
 
 export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
 

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -35,6 +35,8 @@ import type { Empty } from "../../../google/protobuf/empty";
 import type { LeaveNotice } from "./DhtRpc";
 import type { PingResponse } from "./DhtRpc";
 import type { PingRequest } from "./DhtRpc";
+import type { ClosestRingPeersResponse } from "./DhtRpc";
+import type { ClosestRingPeersRequest } from "./DhtRpc";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
 import type { ClosestPeersResponse } from "./DhtRpc";
 import type { ClosestPeersRequest } from "./DhtRpc";
@@ -48,6 +50,10 @@ export interface IDhtNodeRpcClient {
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(input: ClosestPeersRequest, options?: RpcOptions): UnaryCall<ClosestPeersRequest, ClosestPeersResponse>;
+    /**
+     * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
+     */
+    getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse>;
     /**
      * @generated from protobuf rpc: ping(dht.PingRequest) returns (dht.PingResponse);
      */
@@ -74,17 +80,24 @@ export class DhtNodeRpcClient implements IDhtNodeRpcClient, ServiceInfo {
         return stackIntercept<ClosestPeersRequest, ClosestPeersResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
+     */
+    getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse> {
+        const method = this.methods[1], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ClosestRingPeersRequest, ClosestRingPeersResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * @generated from protobuf rpc: ping(dht.PingRequest) returns (dht.PingResponse);
      */
     ping(input: PingRequest, options?: RpcOptions): UnaryCall<PingRequest, PingResponse> {
-        const method = this.methods[1], opt = this._transport.mergeOptions(options);
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
         return stackIntercept<PingRequest, PingResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: leaveNotice(dht.LeaveNotice) returns (google.protobuf.Empty);
      */
     leaveNotice(input: LeaveNotice, options?: RpcOptions): UnaryCall<LeaveNotice, Empty> {
-        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        const method = this.methods[3], opt = this._transport.mergeOptions(options);
         return stackIntercept<LeaveNotice, Empty>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -24,6 +24,8 @@ import { Empty } from "../../../google/protobuf/empty";
 import { LeaveNotice } from "./DhtRpc";
 import { PingResponse } from "./DhtRpc";
 import { PingRequest } from "./DhtRpc";
+import { ClosestRingPeersResponse } from "./DhtRpc";
+import { ClosestRingPeersRequest } from "./DhtRpc";
 import { ClosestPeersResponse } from "./DhtRpc";
 import { ClosestPeersRequest } from "./DhtRpc";
 import { ServerCallContext } from "@protobuf-ts/runtime-rpc";
@@ -35,6 +37,10 @@ export interface IDhtNodeRpc<T = ServerCallContext> {
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(request: ClosestPeersRequest, context: T): Promise<ClosestPeersResponse>;
+    /**
+     * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
+     */
+    getClosestRingPeers(request: ClosestRingPeersRequest, context: T): Promise<ClosestRingPeersResponse>;
     /**
      * @generated from protobuf rpc: ping(dht.PingRequest) returns (dht.PingResponse);
      */

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -134,6 +134,36 @@ export interface ClosestPeersResponse {
     requestId: string;
 }
 /**
+ * @generated from protobuf message dht.ClosestRingPeersRequest
+ */
+export interface ClosestRingPeersRequest {
+    /**
+     * @generated from protobuf field: bytes ringId = 1;
+     */
+    ringId: Uint8Array;
+    /**
+     * @generated from protobuf field: string requestId = 2;
+     */
+    requestId: string;
+}
+/**
+ * @generated from protobuf message dht.ClosestRingPeersResponse
+ */
+export interface ClosestRingPeersResponse {
+    /**
+     * @generated from protobuf field: repeated dht.PeerDescriptor leftPeers = 1;
+     */
+    leftPeers: PeerDescriptor[];
+    /**
+     * @generated from protobuf field: repeated dht.PeerDescriptor rightPeers = 2;
+     */
+    rightPeers: PeerDescriptor[];
+    /**
+     * @generated from protobuf field: string requestId = 3;
+     */
+    requestId: string;
+}
+/**
  * @generated from protobuf message dht.RecursiveOperationRequest
  */
 export interface RecursiveOperationRequest {
@@ -764,6 +794,33 @@ class ClosestPeersResponse$Type extends MessageType<ClosestPeersResponse> {
  */
 export const ClosestPeersResponse = new ClosestPeersResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class ClosestRingPeersRequest$Type extends MessageType<ClosestRingPeersRequest> {
+    constructor() {
+        super("dht.ClosestRingPeersRequest", [
+            { no: 1, name: "ringId", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.ClosestRingPeersRequest
+ */
+export const ClosestRingPeersRequest = new ClosestRingPeersRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ClosestRingPeersResponse$Type extends MessageType<ClosestRingPeersResponse> {
+    constructor() {
+        super("dht.ClosestRingPeersResponse", [
+            { no: 1, name: "leftPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
+            { no: 2, name: "rightPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
+            { no: 3, name: "requestId", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.ClosestRingPeersResponse
+ */
+export const ClosestRingPeersResponse = new ClosestRingPeersResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class RecursiveOperationRequest$Type extends MessageType<RecursiveOperationRequest> {
     constructor() {
         super("dht.RecursiveOperationRequest", [
@@ -1107,6 +1164,7 @@ export const ExternalFetchDataResponse = new ExternalFetchDataResponse$Type();
  */
 export const DhtNodeRpc = new ServiceType("dht.DhtNodeRpc", [
     { name: "getClosestPeers", options: {}, I: ClosestPeersRequest, O: ClosestPeersResponse },
+    { name: "getClosestRingPeers", options: {}, I: ClosestRingPeersRequest, O: ClosestRingPeersResponse },
     { name: "ping", options: {}, I: PingRequest, O: PingResponse },
     { name: "leaveNotice", options: {}, I: LeaveNotice, O: Empty }
 ]);

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.client.ts
@@ -20,7 +20,7 @@ import type { ProxyConnectionResponse } from "./NetworkRpc";
 import type { ProxyConnectionRequest } from "./NetworkRpc";
 import type { RpcTransport } from "@protobuf-ts/runtime-rpc";
 import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
-import { DeliveryRpc } from "./NetworkRpc";
+import { ContentDeliveryRpc } from "./NetworkRpc";
 import type { LeaveStreamPartNotice } from "./NetworkRpc";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
 import type { Empty } from "../../../google/protobuf/empty";
@@ -28,9 +28,9 @@ import type { StreamMessage } from "./NetworkRpc";
 import type { UnaryCall } from "@protobuf-ts/runtime-rpc";
 import type { RpcOptions } from "@protobuf-ts/runtime-rpc";
 /**
- * @generated from protobuf service DeliveryRpc
+ * @generated from protobuf service ContentDeliveryRpc
  */
-export interface IDeliveryRpcClient {
+export interface IContentDeliveryRpcClient {
     /**
      * @generated from protobuf rpc: sendStreamMessage(StreamMessage) returns (google.protobuf.Empty);
      */
@@ -41,12 +41,12 @@ export interface IDeliveryRpcClient {
     leaveStreamPartNotice(input: LeaveStreamPartNotice, options?: RpcOptions): UnaryCall<LeaveStreamPartNotice, Empty>;
 }
 /**
- * @generated from protobuf service DeliveryRpc
+ * @generated from protobuf service ContentDeliveryRpc
  */
-export class DeliveryRpcClient implements IDeliveryRpcClient, ServiceInfo {
-    typeName = DeliveryRpc.typeName;
-    methods = DeliveryRpc.methods;
-    options = DeliveryRpc.options;
+export class ContentDeliveryRpcClient implements IContentDeliveryRpcClient, ServiceInfo {
+    typeName = ContentDeliveryRpc.typeName;
+    methods = ContentDeliveryRpc.methods;
+    options = ContentDeliveryRpc.options;
     constructor(private readonly _transport: RpcTransport) {
     }
     /**

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.server.ts
@@ -18,9 +18,9 @@ import { Empty } from "../../../google/protobuf/empty";
 import { StreamMessage } from "./NetworkRpc";
 import { ServerCallContext } from "@protobuf-ts/runtime-rpc";
 /**
- * @generated from protobuf service DeliveryRpc
+ * @generated from protobuf service ContentDeliveryRpc
  */
-export interface IDeliveryRpc<T = ServerCallContext> {
+export interface IContentDeliveryRpc<T = ServerCallContext> {
     /**
      * @generated from protobuf rpc: sendStreamMessage(StreamMessage) returns (google.protobuf.Empty);
      */

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -725,9 +725,9 @@ class NodeInfoResponse$Type extends MessageType<NodeInfoResponse> {
  */
 export const NodeInfoResponse = new NodeInfoResponse$Type();
 /**
- * @generated ServiceType for protobuf service DeliveryRpc
+ * @generated ServiceType for protobuf service ContentDeliveryRpc
  */
-export const DeliveryRpc = new ServiceType("DeliveryRpc", [
+export const ContentDeliveryRpc = new ServiceType("ContentDeliveryRpc", [
     { name: "sendStreamMessage", options: {}, I: StreamMessage, O: Empty },
     { name: "leaveStreamPartNotice", options: {}, I: LeaveStreamPartNotice, O: Empty }
 ]);

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -316,9 +316,9 @@ export interface StreamPartitionInfo {
      */
     controlLayerNeighbors: PeerDescriptor[];
     /**
-     * @generated from protobuf field: repeated dht.PeerDescriptor deliveryLayerNeighbors = 3;
+     * @generated from protobuf field: repeated dht.PeerDescriptor contentDeliveryLayerNeighbors = 3;
      */
-    deliveryLayerNeighbors: PeerDescriptor[];
+    contentDeliveryLayerNeighbors: PeerDescriptor[];
 }
 /**
  * @generated from protobuf message ControlLayerInfo
@@ -678,7 +678,7 @@ class StreamPartitionInfo$Type extends MessageType<StreamPartitionInfo> {
         super("StreamPartitionInfo", [
             { no: 1, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "controlLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
-            { no: 3, name: "deliveryLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
+            { no: 3, name: "contentDeliveryLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }
         ]);
     }
 }

--- a/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
@@ -5,8 +5,8 @@ import {
     SimulatorTransport,
     NodeType
 } from '@streamr/dht'
-import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
-import { DeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
+import { ContentDeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import {
     LeaveStreamPartNotice,
     StreamMessage
@@ -17,10 +17,10 @@ import { createStreamMessage } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 
-describe('DeliveryRpcRemote', () => {
+describe('ContentDeliveryRpcRemote', () => {
     let mockServerRpc: ListeningRpcCommunicator
     let clientRpc: ListeningRpcCommunicator
-    let rpcRemote: DeliveryRpcRemote
+    let rpcRemote: ContentDeliveryRpcRemote
 
     const clientNode: PeerDescriptor = {
         nodeId: new Uint8Array([1, 1, 1]),
@@ -66,11 +66,11 @@ describe('DeliveryRpcRemote', () => {
             }
         )
 
-        rpcRemote = new DeliveryRpcRemote(
+        rpcRemote = new ContentDeliveryRpcRemote(
             clientNode,
             serverNode,
             clientRpc,
-            DeliveryRpcClient
+            ContentDeliveryRpcClient
         )
     })
 

--- a/packages/trackerless-network/test/integration/NetworkRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkRpc.test.ts
@@ -3,7 +3,7 @@ import {
     ProtoRpcClient,
     toProtoRpcClient
 } from '@streamr/proto-rpc'
-import { DeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { StreamMessage } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { waitForCondition } from '@streamr/utils'
 import { Empty } from '../../src/proto/google/protobuf/empty'
@@ -16,7 +16,7 @@ import { randomEthereumAddress } from '@streamr/test-utils'
 describe('Network RPC', () => {
     let rpcCommunicator1: RpcCommunicator<DhtCallContext>
     let rpcCommunicator2: RpcCommunicator<DhtCallContext>
-    let client: ProtoRpcClient<DeliveryRpcClient>
+    let client: ProtoRpcClient<ContentDeliveryRpcClient>
     let recvCounter = 0
 
     beforeEach(() => {
@@ -25,7 +25,7 @@ describe('Network RPC', () => {
         rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
             rpcCommunicator2.handleIncomingMessage(message)
         })
-        client = toProtoRpcClient(new DeliveryRpcClient(rpcCommunicator1.getRpcClientTransport()))
+        client = toProtoRpcClient(new ContentDeliveryRpcClient(rpcCommunicator1.getRpcClientTransport()))
         rpcCommunicator2.registerRpcNotification(
             StreamMessage,
             'sendStreamMessage',

--- a/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
@@ -88,12 +88,12 @@ describe('NetworkStack NodeInfoRpc', () => {
                 {
                     id: streamPartId1,
                     controlLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)],
-                    deliveryLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)]
+                    contentDeliveryLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)]
                 },
                 {
                     id: streamPartId2,
                     controlLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)],
-                    deliveryLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)]
+                    contentDeliveryLayerNeighbors: [normalizePeerDescriptor(otherPeerDescriptor)]
                 }
             ],
             version: expect.any(String)

--- a/packages/trackerless-network/test/unit/ContentDeliveryRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryRpcLocal.test.ts
@@ -1,14 +1,14 @@
 import { ListeningRpcCommunicator } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
-import { DeliveryRpcLocal } from '../../src/logic/DeliveryRpcLocal'
+import { ContentDeliveryRpcLocal } from '../../src/logic/ContentDeliveryRpcLocal'
 import { LeaveStreamPartNotice } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { MockTransport } from '../utils/mock/Transport'
 import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 
-describe('DeliveryRpcLocal', () => {
+describe('ContentDeliveryRpcLocal', () => {
 
-    let rpcLocal: DeliveryRpcLocal
+    let rpcLocal: ContentDeliveryRpcLocal
     const peerDescriptor = createMockPeerDescriptor()
 
     const mockSender = createMockPeerDescriptor()
@@ -30,7 +30,7 @@ describe('DeliveryRpcLocal', () => {
         mockOnLeaveNotice = jest.fn((_m) => {})
         mockMarkForInspection = jest.fn((_m) => {})
 
-        rpcLocal = new DeliveryRpcLocal({
+        rpcLocal = new ContentDeliveryRpcLocal({
             markAndCheckDuplicate: mockDuplicateCheck,
             broadcast: mockBroadcast,
             onLeaveNotice: mockOnLeaveNotice,

--- a/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
@@ -2,7 +2,7 @@ import { DhtAddress, NodeType, getNodeIdFromPeerDescriptor, getRawFromDhtAddress
 import { NodeList } from '../../src/logic/NodeList'
 import { HandshakeRpcLocal } from '../../src/logic/neighbor-discovery/HandshakeRpcLocal'
 import { InterleaveRequest, StreamPartHandshakeRequest } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
-import { createMockPeerDescriptor, createMockHandshakeRpcRemote, createMockDeliveryRpcRemote } from '../utils/utils'
+import { createMockPeerDescriptor, createMockHandshakeRpcRemote, createMockContentDeliveryRpcRemote } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('stream#0')
@@ -29,7 +29,7 @@ describe('HandshakeRpcLocal', () => {
             ongoingHandshakes,
             ongoingInterleaves,
             createRpcRemote: (_p) => createMockHandshakeRpcRemote(),
-            createDeliveryRpcRemote: (_p) => createMockDeliveryRpcRemote(),
+            createContentDeliveryRpcRemote: (_p) => createMockContentDeliveryRpcRemote(),
             handshakeWithInterleaving: async (_p, _t) => {
                 handshakeWithInterleaving()
                 return true
@@ -53,10 +53,10 @@ describe('HandshakeRpcLocal', () => {
     })
 
     it('handshake interleave', async () => {
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
         const req = StreamPartHandshakeRequest.create({
             streamPartId: STREAM_PART_ID,
             requestId: 'requestId'
@@ -110,10 +110,10 @@ describe('HandshakeRpcLocal', () => {
     })
 
     it('rejects handshakes if interleaving to the requestor is ongoing', async () => {
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
         const requestor = createMockPeerDescriptor()
         ongoingInterleaves.add(getNodeIdFromPeerDescriptor(requestor))
         const req = StreamPartHandshakeRequest.create({
@@ -130,10 +130,10 @@ describe('HandshakeRpcLocal', () => {
         const interleavingPeer1 = createMockPeerDescriptor()
         const interleavingPeer2 = createMockPeerDescriptor()
         const interleavingPeer3 = createMockPeerDescriptor()
-        neighbors.add(createMockDeliveryRpcRemote(interleavingPeer1))
-        neighbors.add(createMockDeliveryRpcRemote(interleavingPeer2))
-        neighbors.add(createMockDeliveryRpcRemote(interleavingPeer3))
-        neighbors.add(createMockDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote(interleavingPeer1))
+        neighbors.add(createMockContentDeliveryRpcRemote(interleavingPeer2))
+        neighbors.add(createMockContentDeliveryRpcRemote(interleavingPeer3))
+        neighbors.add(createMockContentDeliveryRpcRemote())
         ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer1))
         ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer2))
         ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer3))
@@ -149,11 +149,11 @@ describe('HandshakeRpcLocal', () => {
     })
 
     it('rejects handshakes if the requestor has more than maxNeighborCount neighbors', async () => {
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
-        neighbors.add(createMockDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
+        neighbors.add(createMockContentDeliveryRpcRemote())
         const req = StreamPartHandshakeRequest.create({
             streamPartId: STREAM_PART_ID,
             requestId: 'requestId'

--- a/packages/trackerless-network/test/unit/Handshaker.test.ts
+++ b/packages/trackerless-network/test/unit/Handshaker.test.ts
@@ -2,7 +2,7 @@ import { ListeningRpcCommunicator, Simulator, SimulatorTransport, getNodeIdFromP
 import { range } from 'lodash'
 import { NodeList } from '../../src/logic/NodeList'
 import { Handshaker } from '../../src/logic/neighbor-discovery/Handshaker'
-import { createMockPeerDescriptor, createMockDeliveryRpcRemote } from '../utils/utils'
+import { createMockPeerDescriptor, createMockContentDeliveryRpcRemote } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 
 describe('Handshaker', () => {
@@ -61,7 +61,7 @@ describe('Handshaker', () => {
     })
 
     it('attemptHandshakesOnContact with known nodes that cannot be connected to', async () => {
-        range(2).forEach(() => randomNodeView.add(createMockDeliveryRpcRemote()))
+        range(2).forEach(() => randomNodeView.add(createMockContentDeliveryRpcRemote()))
         const res = await handshaker.attemptHandshakesOnContacts([])
         expect(res.length).toEqual(2)
     })

--- a/packages/trackerless-network/test/unit/NeighborFinder.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborFinder.test.ts
@@ -3,7 +3,7 @@ import { NodeList } from '../../src/logic/NodeList'
 import { waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { expect } from 'expect'
-import { createMockDeliveryRpcRemote } from '../utils/utils'
+import { createMockContentDeliveryRpcRemote } from '../utils/utils'
 import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
 
 describe('NeighborFinder', () => {
@@ -18,7 +18,7 @@ describe('NeighborFinder', () => {
     beforeEach(() => {
         neighbors = new NodeList(nodeId, 15)
         nearbyNodeView = new NodeList(nodeId, 30)
-        range(30).forEach(() => nearbyNodeView.add(createMockDeliveryRpcRemote()))
+        range(30).forEach(() => nearbyNodeView.add(createMockContentDeliveryRpcRemote()))
         const mockDoFindNeighbors = async (excluded: DhtAddress[]) => {
             const target = nearbyNodeView.getRandom(excluded)
             if (Math.random() < 0.5) {

--- a/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
@@ -5,8 +5,8 @@ import { createMockPeerDescriptor } from '../utils/utils'
 import { NodeList } from '../../src/logic/NodeList'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { MockTransport } from '../utils/mock/Transport'
-import { DeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
-import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
+import { ContentDeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
 import { range } from 'lodash'
 
 describe('NeighborUpdateRpcLocal', () => {
@@ -24,11 +24,11 @@ describe('NeighborUpdateRpcLocal', () => {
 
     const addNeighbors = (count: number) => {
         for (let i = 0; i < count; i++) {
-            neighbors.add(new DeliveryRpcRemote(
+            neighbors.add(new ContentDeliveryRpcRemote(
                 localPeerDescriptor,
                 createMockPeerDescriptor(),
                 rpcCommunicator,
-                DeliveryRpcClient
+                ContentDeliveryRpcClient
             ))
         }
     }
@@ -81,11 +81,11 @@ describe('NeighborUpdateRpcLocal', () => {
 
     it('does not ask to be removed if caller is a neighbor', async () => {
         const caller = createMockPeerDescriptor()
-        const neighbor = new DeliveryRpcRemote(
+        const neighbor = new ContentDeliveryRpcRemote(
             localPeerDescriptor,
             caller,
             rpcCommunicator,
-            DeliveryRpcClient
+            ContentDeliveryRpcClient
         )
         neighbors.add(neighbor)
         const res = await rpcLocal.neighborUpdate({
@@ -108,11 +108,11 @@ describe('NeighborUpdateRpcLocal', () => {
 
     it('asks to be removed if caller is a neighbor and both have too many neighbors', async () => {
         const caller = createMockPeerDescriptor()
-        const neighbor = new DeliveryRpcRemote(
+        const neighbor = new ContentDeliveryRpcRemote(
             localPeerDescriptor,
             caller,
             rpcCommunicator,
-            DeliveryRpcClient
+            ContentDeliveryRpcClient
         )
         neighbors.add(neighbor)
         addNeighbors(neighborTargetCount)

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -8,10 +8,10 @@ import {
 } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { expect } from 'expect'
-import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
 import { NodeList } from '../../src/logic/NodeList'
-import { formStreamPartDeliveryServiceId } from '../../src/logic/formStreamPartDeliveryServiceId'
-import { DeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { formStreamPartContentDeliveryServiceId } from '../../src/logic/formStreamPartDeliveryServiceId'
+import { ContentDeliveryRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { MockTransport } from '../utils/mock/Transport'
 
@@ -30,12 +30,12 @@ describe('NodeList', () => {
     let nodeList: NodeList
 
     const createRemoteGraphNode = (peerDescriptor: PeerDescriptor) => {
-        const mockCommunicator = new ListeningRpcCommunicator(formStreamPartDeliveryServiceId(streamPartId), new MockTransport())
-        return new DeliveryRpcRemote(
+        const mockCommunicator = new ListeningRpcCommunicator(formStreamPartContentDeliveryServiceId(streamPartId), new MockTransport())
+        return new ContentDeliveryRpcRemote(
             createMockPeerDescriptor(),
             peerDescriptor,
             mockCommunicator,
-            DeliveryRpcClient
+            ContentDeliveryRpcClient
         )
     }
 

--- a/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
+++ b/packages/trackerless-network/test/unit/RandomGraphNode.test.ts
@@ -7,7 +7,7 @@ import { MockLayer1Node } from '../utils/mock/MockLayer1Node'
 import { MockNeighborFinder } from '../utils/mock/MockNeighborFinder'
 import { MockNeighborUpdateManager } from '../utils/mock/MockNeighborUpdateManager'
 import { MockTransport } from '../utils/mock/Transport'
-import { createMockPeerDescriptor, createMockDeliveryRpcRemote, mockConnectionLocker } from '../utils/utils'
+import { createMockPeerDescriptor, createMockContentDeliveryRpcRemote, mockConnectionLocker } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { getNodeIdFromPeerDescriptor } from '@streamr/dht'
 
@@ -53,14 +53,14 @@ describe('RandomGraphNode', () => {
     })
 
     it('getNeighbors', () => {
-        const mockRemote = createMockDeliveryRpcRemote()
+        const mockRemote = createMockContentDeliveryRpcRemote()
         neighbors.add(mockRemote)
         const result = randomGraphNode.getNeighbors()
         expect(getNodeIdFromPeerDescriptor(result[0])).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))
     })
 
     it('getNearbyNodeView', () => {
-        const mockRemote = createMockDeliveryRpcRemote()
+        const mockRemote = createMockContentDeliveryRpcRemote()
         nearbyNodeView.add(mockRemote)
         const ids = randomGraphNode.getNearbyNodeView().getIds()
         expect(ids[0]).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -17,14 +17,14 @@ import {
     SignatureType,
     StreamMessage
 } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
-import { DeliveryRpcRemote } from '../../src/logic/DeliveryRpcRemote'
+import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
 import { createRandomGraphNode } from '../../src/logic/createRandomGraphNode'
 import { HandshakeRpcRemote } from '../../src/logic/neighbor-discovery/HandshakeRpcRemote'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { EthereumAddress, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import { StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
 import { Layer1Node } from '../../src/logic/Layer1Node'
-import { DeliveryRpcClient, HandshakeRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
+import { ContentDeliveryRpcClient, HandshakeRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { RpcCommunicator } from '@streamr/proto-rpc'
 
 export const mockConnectionLocker: ConnectionLocker = {
@@ -101,12 +101,12 @@ export const createMockPeerDescriptor = (opts?: Omit<Partial<PeerDescriptor>, 'n
     }
 }
 
-export const createMockDeliveryRpcRemote = (remotePeerDescriptor?: PeerDescriptor): DeliveryRpcRemote => {
-    return new DeliveryRpcRemote(
+export const createMockContentDeliveryRpcRemote = (remotePeerDescriptor?: PeerDescriptor): ContentDeliveryRpcRemote => {
+    return new ContentDeliveryRpcRemote(
         createMockPeerDescriptor(),
         remotePeerDescriptor ?? createMockPeerDescriptor(),
         new RpcCommunicator(),
-        DeliveryRpcClient
+        ContentDeliveryRpcClient
     )
 }
 


### PR DESCRIPTION
Rename `DeliveryRpc` -> `ContentDeliveryRpc` so that the naming is consistent e.g. with the new 
`ContentDeliveryManager` class (https://github.com/streamr-dev/network/pull/2140).