### PR TITLE
refactor(dht): Simplify `PeerManager#addContact`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -265,7 +265,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
-            addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addContact(contact, setActive),
             handleMessage: (message: Message) => this.handleMessageFromRouter(message),
         })
         this.recursiveOperationManager = new RecursiveOperationManager({

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -265,7 +265,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
-            addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addContact([contact], setActive),
+            addContact: (contact: PeerDescriptor, setActive?: boolean) => this.peerManager!.addContact(contact, setActive),
             handleMessage: (message: Message) => this.handleMessageFromRouter(message),
         })
         this.recursiveOperationManager = new RecursiveOperationManager({
@@ -275,7 +275,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             connections: this.peerManager!.connections,
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
-            addContact: (contact: PeerDescriptor) => this.peerManager!.addContact([contact]),
+            addContact: (contact: PeerDescriptor) => this.peerManager!.addContact(contact),
             localDataStore: this.localDataStore
         })
         this.storeManager = new StoreManager({
@@ -376,7 +376,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             getClosestRingPeersTo: (ringIdRaw: RingIdRaw, limit: number) => {
                 return this.getClosestRingContactsTo(ringIdRaw, limit)
             },
-            addContact: (contact: PeerDescriptor) => this.peerManager!.addContact([contact]),
+            addContact: (contact: PeerDescriptor) => this.peerManager!.addContact(contact),
             removeContact: (nodeId: DhtAddress) => this.removeContact(nodeId)
         })
         this.rpcCommunicator!.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers',

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -175,7 +175,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
         const closest = this.getClosestActiveContactNotInBucket()
         if (closest) {
-            this.addContact([closest.getPeerDescriptor()])
+            this.addContact(closest.getPeerDescriptor())
         }
     }
 
@@ -305,35 +305,33 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.contacts.setActive(nodeId)
     }
 
-    addContact(peerDescriptors: PeerDescriptor[], setActive?: boolean): void {
+    addContact(peerDescriptor: PeerDescriptor, setActive?: boolean): void {
         if (this.stopped) {
             return
         }
-        peerDescriptors.forEach((contact) => {
-            const nodeId = getNodeIdFromPeerDescriptor(contact)
-            if (nodeId !== this.config.localNodeId) {
-                logger.trace(`Adding new contact ${nodeId}`)
-                const remote = this.config.createDhtNodeRpcRemote(contact)
-                const isInBucket = (this.bucket.get(contact.nodeId) !== null)
-                const isInContacts = (this.contacts.getContact(nodeId) !== undefined)
-                const isInRingContacts = this.ringContacts.getContact(contact) !== undefined
+        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        if (nodeId !== this.config.localNodeId) {
+            logger.trace(`Adding new contact ${nodeId}`)
+            const remote = this.config.createDhtNodeRpcRemote(peerDescriptor)
+            const isInBucket = (this.bucket.get(peerDescriptor.nodeId) !== null)
+            const isInContacts = (this.contacts.getContact(nodeId) !== undefined)
+            const isInRingContacts = this.ringContacts.getContact(peerDescriptor) !== undefined
 
-                if (isInBucket || isInContacts) {
-                    this.randomPeers.addContact(remote)
-                }
-                if (!isInBucket) {
-                    this.bucket.add(remote)
-                }
-                if (!isInContacts) {
-                    this.contacts.addContact(remote)
-                }
-                if (setActive) {
-                    this.contacts.setActive(nodeId)
-                }
-                if (!isInRingContacts) {
-                    this.ringContacts.addContact(remote)
-                }
+            if (isInBucket || isInContacts) {
+                this.randomPeers.addContact(remote)
             }
-        })
+            if (!isInBucket) {
+                this.bucket.add(remote)
+            }
+            if (!isInContacts) {
+                this.contacts.addContact(remote)
+            }
+            if (setActive) {
+                this.contacts.setActive(nodeId)
+            }
+            if (!isInRingContacts) {
+                this.ringContacts.addContact(remote)
+            }
+        }
     }
 }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -305,7 +305,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.contacts.setActive(nodeId)
     }
 
-    addContact(peerDescriptor: PeerDescriptor, setActive?: boolean): void {
+    addContact(peerDescriptor: PeerDescriptor): void {
         if (this.stopped) {
             return
         }
@@ -325,9 +325,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             }
             if (!isInContacts) {
                 this.contacts.addContact(remote)
-            }
-            if (setActive) {
-                this.contacts.setActive(nodeId)
             }
             if (!isInRingContacts) {
                 this.ringContacts.addContact(remote)

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -38,7 +38,9 @@ export class DiscoverySession {
         if (this.stopped) {
             return
         }
-        this.config.peerManager.addContact(contacts)
+        for (const contact of contacts) {
+            this.config.peerManager.addContact(contact)
+        }
     }
 
     private async getClosestPeersFromContact(contact: DhtNodeRpcRemote): Promise<PeerDescriptor[]> {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -79,7 +79,7 @@ export class PeerDiscovery {
             return
         }
         this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
-        this.config.peerManager.addContact([entryPointDescriptor])
+        this.config.peerManager.addContact(entryPointDescriptor)
         const targetId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const sessions = [this.createSession(targetId, contactedPeers)]
         if (additionalDistantJoin.enabled) {
@@ -196,7 +196,9 @@ export class PeerDiscovery {
         await Promise.allSettled(
             nodes.map(async (peer: DhtNodeRpcRemote) => {
                 const contacts = await peer.getClosestPeers(localNodeId)
-                this.config.peerManager.addContact(contacts)
+                for (const contact of contacts) {
+                    this.config.peerManager.addContact(contact)
+                }
             })
         )
     }

--- a/packages/dht/src/dht/discovery/RingDiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/RingDiscoverySession.ts
@@ -43,7 +43,9 @@ export class RingDiscoverySession {
         if (this.stopped) {
             return
         }
-        this.config.peerManager.addContact(contacts)
+        for (const contact of contacts) {
+            this.config.peerManager.addContact(contact)
+        }
     }
 
     private async getClosestPeersFromContact(contact: DhtNodeRpcRemote): Promise<RingContacts> {

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -13,7 +13,6 @@ export interface RouterConfig {
     rpcCommunicator: RoutingRpcCommunicator
     localPeerDescriptor: PeerDescriptor
     connections: Map<DhtAddress, DhtNodeRpcRemote>
-    addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     handleMessage: (message: Message) => void
 }
 
@@ -42,7 +41,6 @@ export class Router {
     private registerLocalRpcMethods() {
         const rpcLocal = new RouterRpcLocal({
             doRouteMessage: (routedMessage: RouteMessageWrapper, mode?: RoutingMode) => this.doRouteMessage(routedMessage, mode),
-            addContact: (contact: PeerDescriptor, setActive: boolean) => this.config.addContact(contact, setActive),
             setForwardingEntries: (routedMessage: RouteMessageWrapper) => this.setForwardingEntries(routedMessage),
             duplicateRequestDetector: this.duplicateRequestDetector,
             localPeerDescriptor: this.config.localPeerDescriptor,

--- a/packages/dht/src/dht/routing/RouterRpcLocal.ts
+++ b/packages/dht/src/dht/routing/RouterRpcLocal.ts
@@ -8,7 +8,6 @@ import { v4 } from 'uuid'
 
 interface RouterRpcLocalConfig {
     doRouteMessage: (routedMessage: RouteMessageWrapper, mode?: RoutingMode) => RouteMessageAck
-    addContact: (contact: PeerDescriptor, setActive: boolean) => void
     setForwardingEntries: (routedMessage: RouteMessageWrapper) => void
     handleMessage: (message: Message) => void
     duplicateRequestDetector: DuplicateDetector

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -18,7 +18,10 @@ describe('PeerManager', () => {
                 return new DhtNodeRpcRemote(undefined as any, peerDescriptor, undefined as any, new MockRpcCommunicator())
             }
         } as any)
-        manager.addContact(nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS })))
+        const contacts = nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS }))
+        for (const contact of contacts) {
+            manager.addContact(contact)
+        }
 
         const referenceId = createRandomDhtAddress()
         const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -50,7 +50,6 @@ describe('Router', () => {
         router = new Router({
             localPeerDescriptor: peerDescriptor1,
             rpcCommunicator: rpcCommunicator as any,
-            addContact: (_contact) => {},
             connections,
             handleMessage: () => {}
         })


### PR DESCRIPTION
- now takes only one contact as an argument, not an array of contacts
- removed obsolete `setActive` parameter 
  - that parameter was previously used in `RouterRpcLocal`, but the functionality was removed in PR #2332)
  - removed also the obsolete router config options related to this change
