### PR TITLE
refactor(dht): Use `ConnectionLocker` instead of `ConnectionManager`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -59,6 +59,9 @@ export interface ConnectionLocker {
     unlockConnection(targetDescriptor: PeerDescriptor, lockId: LockID): void
     weakLockConnection(nodeId: DhtAddress, lockId: LockID): void
     weakUnlockConnection(nodeId: DhtAddress, lockId: LockID): void
+    getLocalLockedConnectionCount(): number
+    getRemoteLockedConnectionCount(): number
+    getWeakLockedConnectionCount(): number
 }
 
 export interface PortRange {
@@ -330,14 +333,6 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 + ' ' + message.serviceId + ' ' + message.messageId)
             this.emit('message', message)
         }
-    }
-
-    public handleIncomingMessage(message: Message): boolean {
-        if (message.serviceId === INTERNAL_SERVICE_ID) {
-            this.rpcCommunicator?.handleMessageFromPeer(message)
-            return true
-        }
-        return false
     }
 
     private onData(data: Uint8Array, peerDescriptor: PeerDescriptor): void {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -8,7 +8,7 @@ import {
 import { EventEmitter } from 'eventemitter3'
 import { sample } from 'lodash'
 import { MarkRequired } from 'ts-essentials'
-import { ConnectionManager, PortRange, TlsCertificate } from '../connection/ConnectionManager'
+import { ConnectionLocker, ConnectionManager, PortRange, TlsCertificate } from '../connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../connection/ConnectorFacade'
 import { IceServer } from '../connection/webrtc/WebrtcConnector'
 import { isBrowserEnvironment } from '../helpers/browser/isBrowserEnvironment'
@@ -130,7 +130,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private recursiveOperationManager?: RecursiveOperationManager
     private peerDiscovery?: PeerDiscovery
     private peerManager?: PeerManager
-    public connectionManager?: ConnectionManager
+    public connectionLocker?: ConnectionLocker
     private region?: number
     private started = false
     private abortController = new AbortController()
@@ -198,7 +198,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.transport = this.config.transport
             this.localPeerDescriptor = this.transport.getLocalPeerDescriptor()
             if (this.config.transport instanceof ConnectionManager) {
-                this.connectionManager = this.config.transport
+                this.connectionLocker = this.config.transport
             }
         } else {
             const connectorFacadeConfig: DefaultConnectorFacadeConfig = {
@@ -237,7 +237,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 metricsContext: this.config.metricsContext
             })
             await connectionManager.start()
-            this.connectionManager = connectionManager
+            this.connectionLocker = connectionManager
             this.transport = connectionManager
         }
 
@@ -258,7 +258,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             joinTimeout: this.config.dhtJoinTimeout,
             serviceId: this.config.serviceId,
             parallelism: this.config.joinParallelism,
-            connectionManager: this.connectionManager,
+            connectionLocker: this.connectionLocker,
             peerManager: this.peerManager!
         })
         this.router = new Router({
@@ -310,9 +310,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             maxContactListSize: this.config.maxNeighborListSize,
             localNodeId: this.getNodeId(),
             localPeerDescriptor: this.localPeerDescriptor!,
-            connectionManager: this.connectionManager!,
+            connectionLocker: this.connectionLocker!,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
-            isLayer0: (this.connectionManager !== undefined),
+            isLayer0: (this.connectionLocker !== undefined),
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
             lockId: this.config.serviceId
         })
@@ -417,8 +417,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private handleMessageFromRouter(message: Message): void {
         if (message.serviceId === this.config.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
-        } else if (this.connectionManager?.handleIncomingMessage(message)) {
-            // message was handled by connectionManager
         } else {
             this.emit('message', message)
         }
@@ -559,15 +557,15 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getLocalLockedConnectionCount(): number {
-        return this.connectionManager!.getLocalLockedConnectionCount()
+        return this.connectionLocker!.getLocalLockedConnectionCount()
     }
 
     public getRemoteLockedConnectionCount(): number {
-        return this.connectionManager!.getRemoteLockedConnectionCount()
+        return this.connectionLocker!.getRemoteLockedConnectionCount()
     }
 
     public getWeakLockedConnectionCount(): number {
-        return this.connectionManager!.getWeakLockedConnectionCount()
+        return this.connectionLocker!.getWeakLockedConnectionCount()
     }
 
     public async waitForNetworkConnectivity(): Promise<void> {
@@ -603,7 +601,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             await this.transport!.stop()
         }
         this.transport = undefined
-        this.connectionManager = undefined
+        this.connectionLocker = undefined
         this.removeAllListeners()
     }
 

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -2,7 +2,7 @@ import { DiscoverySession } from './DiscoverySession'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { Logger, scheduleAtInterval, setAbortableTimeout } from '@streamr/utils'
-import { ConnectionManager } from '../../connection/ConnectionManager'
+import { ConnectionLocker } from '../../connection/ConnectionManager'
 import { PeerManager } from '../PeerManager'
 import { DhtAddress, areEqualPeerDescriptors, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../identifiers'
 import { ServiceID } from '../../types/ServiceID'
@@ -16,7 +16,7 @@ interface PeerDiscoveryConfig {
     serviceId: ServiceID
     parallelism: number
     joinTimeout: number
-    connectionManager?: ConnectionManager
+    connectionLocker?: ConnectionLocker
     peerManager: PeerManager
 }
 
@@ -78,7 +78,7 @@ export class PeerDiscovery {
         if (areEqualPeerDescriptors(entryPointDescriptor, this.config.localPeerDescriptor)) {
             return
         }
-        this.config.connectionManager?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
+        this.config.connectionLocker?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
         this.config.peerManager.addContact(entryPointDescriptor)
         const targetId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
         const sessions = [this.createSession(targetId, contactedPeers)]
@@ -86,7 +86,7 @@ export class PeerDiscovery {
             sessions.push(this.createSession(createDistantDhtAddress(targetId), additionalDistantJoin.contactedPeers))
         }
         await this.runSessions(sessions, entryPointDescriptor, retry)
-        this.config.connectionManager?.unlockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
+        this.config.connectionLocker?.unlockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
 
     }
 

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -31,7 +31,10 @@ export const mockConnectionLocker: ConnectionLocker = {
     lockConnection: () => {},
     unlockConnection: () => {},
     weakLockConnection: () => {},
-    weakUnlockConnection: () => {}
+    weakUnlockConnection: () => {},
+    getLocalLockedConnectionCount: () => 0,
+    getRemoteLockedConnectionCount: () => 0,
+    getWeakLockedConnectionCount: () => 0,
 }
 
 export const createMockRandomGraphNodeAndDhtNode = async (


### PR DESCRIPTION
Why `handleIncomingMessage` is no longer needed in `DhtNode`?  There is no need to pass messages to `ConnectionManager` as none of the message is for `ConnectionManager`'s service ID. 

PR #2375 already fixed problems related to calling `ConnectionManager#handleIncomingMessage` from the `DhtNode`. In this PR the method was completely removed as it was observed that the call is completely redundant.