### PR TITLE
feat(dht): Optimize `PeerManager#getClosestContactsTo` and `PeerManager#getClosestNeighborsTo`

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -249,10 +249,11 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             referenceId,
             allowToContainReferenceId: true,
             emitEvents: false,
-            excludedNodeIds
+            excludedNodeIds,
+            maxSize: limit
         })
         this.bucket.toArray().forEach((contact) => closest.addContact(contact))
-        return closest.getClosestContacts(limit)
+        return closest.getAllContacts()
     }
 
     // TODO reduce copy-paste?
@@ -261,11 +262,11 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             referenceId,
             allowToContainReferenceId: true,
             emitEvents: false,
-            excludedNodeIds
+            excludedNodeIds,
+            maxSize: limit
         })
         this.contacts.getAllContacts().map((contact) => closest.addContact(contact))
-        // TODO should set the excludeSet and limit to SortedContactList constructor and remove these line
-        return closest.getClosestContacts(limit)
+        return closest.getAllContacts()
     }
 
     getClosestRingContactsTo(

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -6,29 +6,49 @@ import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 import { createMockPeerDescriptor } from '../utils/utils'
 
+const createPeerManager = (nodeIds: DhtAddress[]) => {
+    const peerDescriptor = createMockPeerDescriptor()
+    const manager = new PeerManager({
+        localNodeId: getNodeIdFromPeerDescriptor(peerDescriptor),
+        localPeerDescriptor: peerDescriptor,
+        createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => {
+            return new DhtNodeRpcRemote(undefined as any, peerDescriptor, undefined as any, new MockRpcCommunicator())
+        }
+    } as any)
+    const contacts = nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS }))
+    for (const contact of contacts) {
+        manager.addContact(contact)
+    }
+    return manager
+}
+
 describe('PeerManager', () => {
 
     it('getClosestContactsTo', () => {
         const nodeIds = range(10).map(() => createRandomDhtAddress())
-        const peerDescriptor = createMockPeerDescriptor()
-        const manager = new PeerManager({
-            localNodeId: getNodeIdFromPeerDescriptor(peerDescriptor),
-            localPeerDescriptor: peerDescriptor,
-            createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => {
-                return new DhtNodeRpcRemote(undefined as any, peerDescriptor, undefined as any, new MockRpcCommunicator())
-            }
-        } as any)
-        const contacts = nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS }))
-        for (const contact of contacts) {
-            manager.addContact(contact)
-        }
-
+        const manager = createPeerManager(nodeIds)
         const referenceId = createRandomDhtAddress()
         const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))
+
         const actual = manager.getClosestContactsTo(referenceId, 5, excluded)
 
         const expected = sortBy(
             without(nodeIds, ...Array.from(excluded.values())),
+            (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
+        ).slice(0, 5)
+        expect(actual.map((n) => n.getNodeId())).toEqual(expected)
+    })
+
+    it('getClosestNeighborsTo', () => {
+        const nodeIds = range(10).map(() => createRandomDhtAddress())
+        const manager = createPeerManager(nodeIds)
+        const referenceId = createRandomDhtAddress()
+        const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))
+
+        const actual = manager.getClosestNeighborsTo(referenceId, 5, excluded)
+
+        const expected = sortBy(
+            without(manager.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n)), ...Array.from(excluded.values())),
             (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
         ).slice(0, 5)
         expect(actual.map((n) => n.getNodeId())).toEqual(expected)


### PR DESCRIPTION
Optimized the methods by defining `maxSize` for `SortedContactList` instances.

## Benchmarks

- 200 contacts in the `PeerManager`
- find 5 closest  nodes
- 2 random nodes excluded
- default settings (`maxNeighborListSize`: 200, `numberOfNodesPerKBucket`: 8)
- do 1000 queries

`getClosestContactsTo`:
- before: ~3500 ms
- after: ~1500 ms

`getClosestNeighborsTo`:
- before: ~580 ms
- after: ~280 ms