### PR TITLE
refactor(dht): Remove unnecessary `SortedContactList` checks

### DIFF
--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -105,25 +105,17 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
     }
 
     public getClosestContacts(limit?: number): C[] {
-        const ret: C[] = []
-        this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId)
-            if (contact) {
-                ret.push(contact.contact)
-            }
-        })
-        if (limit === undefined) {
-            return ret
-        } else {
-            return ret.slice(0, limit)
-        }
+        const ret = this.getAllContacts()
+        return (limit === undefined) 
+            ? ret 
+            : ret.slice(0, limit)
     }
 
     public getUncontactedContacts(num: number): C[] {
         const ret: C[] = []
         for (const contactId of this.contactIds) {
-            const contact = this.contactsById.get(contactId)
-            if (contact && !contact.contacted) {
+            const contact = this.contactsById.get(contactId)!
+            if (!contact.contacted) {
                 ret.push(contact.contact)
                 if (ret.length >= num) {
                     return ret
@@ -136,8 +128,8 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
     public getActiveContacts(limit?: number): C[] {
         const ret: C[] = []
         this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId)
-            if (contact && contact.active) {
+            const contact = this.contactsById.get(contactId)!
+            if (contact.active) {
                 ret.push(contact.contact)
             }
         })


### PR DESCRIPTION
When there is an item in `contactIds` there must always be a corresponding key in the `contactsById` map. Therefore we don't need tho do the `if (contact)` checks.

Also refactored `getClosestContacts` to use `getAllContacts`.

## Future improvements

In some places where `SortedContactList#getAllContacts` is called, the caller should actually call `getClosestContacts` as the result is expected to be in the sorted order. Maybe we should remove `getAllContacts`? Or optimize it by so that it just returns the keys of `contactsById`?