### PR TITLE
feat(dht): Optimize `PeerManager#getContactCount`

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -281,13 +281,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     }
 
     getContactCount(excludedNodeIds?: Set<DhtAddress>): number {
-        return this.contacts.getAllContacts().filter((contact) => {
-            if (!excludedNodeIds) {
-                return true
-            } else {
-                return !excludedNodeIds.has(contact.getNodeId())
-            }
-        }).length
+        return this.contacts.getSize(excludedNodeIds)
     }
 
     getConnectionCount(): number {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -92,6 +92,10 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         return this.contactsById.get(id)
     }
 
+    has(id: DhtAddress): boolean {
+        return this.contactsById.has(id)
+    }
+
     public setContacted(contactId: DhtAddress): void {
         if (this.contactsById.has(contactId)) {
             this.contactsById.get(contactId)!.contacted = true
@@ -187,8 +191,16 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         return this.contactIds.map((nodeId) => this.contactsById.get(nodeId)!.contact)
     }
 
-    public getSize(): number {
-        return this.contactIds.length
+    public getSize(excludedNodeIds?: Set<DhtAddress>): number {
+        let excludedCount = 0
+        if (excludedNodeIds !== undefined) {
+            for (const nodeId of excludedNodeIds) {
+                if (this.has(nodeId)) {
+                    excludedCount++
+                }
+            }
+        }
+        return this.contactIds.length - excludedCount
     }
 
     public clear(): void {

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -1,7 +1,7 @@
 import { PeerManager, getDistance } from '../../src/dht/PeerManager'
 import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { range, sampleSize, sortBy, without } from 'lodash'
+import { range, sample, sampleSize, sortBy, without } from 'lodash'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -52,5 +52,13 @@ describe('PeerManager', () => {
             (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
         ).slice(0, 5)
         expect(actual.map((n) => n.getNodeId())).toEqual(expected)
+    })
+
+    it('getContactCount', () => {
+        const nodeIds = range(10).map(() => createRandomDhtAddress())
+        const manager = createPeerManager(nodeIds)
+        expect(manager.getContactCount()).toBe(10)
+        expect(manager.getContactCount(new Set(sampleSize(nodeIds, 2)))).toBe(8)
+        expect(manager.getContactCount(new Set([sample(nodeIds)!, createRandomDhtAddress()]))).toBe(9)
     })
 })


### PR DESCRIPTION
Simplify the algorithm used in `PeerManager#getContactCount`.

## Benchmark

- before: ~19000 ms
- after: ~32 ms

Setup
- 200 contacts
- 10 random nodes excluded
- do 100000 queries