### PR TITLE
feat(sdk): subscribe on behalf of an ERC-1271 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
+- Add support for subscribing to a stream on behalf of an [ERC-1271 contract](https://eips.ethereum.org/EIPS/eip-1271) (https://github.com/streamr-dev/network/pull/2454)
+
 #### Changed
 
 #### Deprecated

--- a/packages/client/src/Stream.ts
+++ b/packages/client/src/Stream.ts
@@ -236,7 +236,13 @@ export class Stream {
         let assignmentSubscription
         try {
             const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(normalizedNodeAddress), DEFAULT_PARTITION)
-            assignmentSubscription = new Subscription(streamPartId, false, new EventEmitter<SubscriptionEvents>(), this._loggerFactory)
+            assignmentSubscription = new Subscription(
+                streamPartId,
+                false,
+                undefined,
+                new EventEmitter<SubscriptionEvents>(),
+                this._loggerFactory
+            )
             await this._subscriber.add(assignmentSubscription)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
                 id: this.id,

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -64,6 +64,12 @@ export interface ExtraSubscribeOptions {
      * and decryption _disabled_.
      */
     raw?: boolean
+
+    /**
+     * Subscribe on behalf of a contract implementing the [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271) standard.
+     * The streamr client wallet address must be an authorized signer for the contract.
+     */
+    erc1271Contract?: string
 }
 
 /**
@@ -205,7 +211,13 @@ export class StreamrClient {
         }
         const streamPartId = await this.streamIdBuilder.toStreamPartID(options)
         const eventEmitter = new EventEmitter<SubscriptionEvents>()
-        const sub = new Subscription(streamPartId, options.raw ?? false, eventEmitter, this.loggerFactory)
+        const sub = new Subscription(
+            streamPartId,
+            options.raw ?? false,
+            options.erc1271Contract !== undefined ? toEthereumAddress(options.erc1271Contract) : undefined,
+            eventEmitter,
+            this.loggerFactory
+        )
         if (options.resend !== undefined) {
             initResendSubscription(
                 sub,

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -1,21 +1,18 @@
 import {
     ContentType,
     EncryptionType,
-    MessageID,
     GroupKeyRequest as OldGroupKeyRequest,
     GroupKeyResponse as OldGroupKeyResponse,
+    MessageID,
     SignatureType,
     StreamMessage,
     StreamMessageType,
     StreamPartID,
     StreamPartIDUtils
 } from '@streamr/protocol'
-import {
-    convertBytesToGroupKeyResponse,
-    convertGroupKeyRequestToBytes
-} from '@streamr/trackerless-network'
+import { convertBytesToGroupKeyResponse, convertGroupKeyRequestToBytes } from '@streamr/trackerless-network'
 import { EthereumAddress, Logger } from '@streamr/utils'
-import { Lifecycle, inject, scoped } from 'tsyringe'
+import { inject, Lifecycle, scoped } from 'tsyringe'
 import { v4 as uuidv4 } from 'uuid'
 import { Authentication, AuthenticationInjectionToken } from '../Authentication'
 import { ConfigInjectionToken, StrictStreamrClientConfig } from '../Config'
@@ -31,6 +28,7 @@ import { GroupKey } from './GroupKey'
 import { LocalGroupKeyStore } from './LocalGroupKeyStore'
 import { RSAKeyPair } from './RSAKeyPair'
 import { ERC1271ContractFacade } from '../contracts/ERC1271ContractFacade'
+import { Subscriber } from '../subscribe/Subscriber'
 
 const MAX_PENDING_REQUEST_COUNT = 50000 // just some limit, we can tweak the number if needed
 
@@ -47,6 +45,7 @@ export class SubscriberKeyExchange {
     private readonly streamRegistry: StreamRegistry
     private readonly erc1271ContractFacade: ERC1271ContractFacade
     private readonly store: LocalGroupKeyStore
+    private readonly subscriber: Subscriber
     private readonly authentication: Authentication
     private readonly logger: Logger
     private readonly ensureStarted: () => Promise<void>
@@ -57,6 +56,7 @@ export class SubscriberKeyExchange {
         streamRegistry: StreamRegistry,
         @inject(ERC1271ContractFacade) erc1271ContractFacade: ERC1271ContractFacade,
         store: LocalGroupKeyStore,
+        subscriber: Subscriber,
         @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'encryption'>,
         @inject(AuthenticationInjectionToken) authentication: Authentication,
         loggerFactory: LoggerFactory
@@ -65,6 +65,7 @@ export class SubscriberKeyExchange {
         this.streamRegistry = streamRegistry
         this.erc1271ContractFacade = erc1271ContractFacade
         this.store = store
+        this.subscriber = subscriber
         this.authentication = authentication
         this.logger = loggerFactory.createLogger(module)
         this.ensureStarted = pOnce(async () => {
@@ -111,13 +112,14 @@ export class SubscriberKeyExchange {
             rsaPublicKey,
             groupKeyIds: [groupKeyId],
         })
+        const erc1271contract = this.subscriber.getERC1271ContractAddress(streamPartId)
         return createSignedMessage({
             messageId: new MessageID(
                 StreamPartIDUtils.getStreamID(streamPartId),
                 StreamPartIDUtils.getStreamPartition(streamPartId),
                 Date.now(),
                 0,
-                await this.authentication.getAddress(),
+                erc1271contract === undefined ? await this.authentication.getAddress() : erc1271contract,
                 createRandomMsgChainId()
             ),
             content: convertGroupKeyRequestToBytes(requestContent),
@@ -125,16 +127,15 @@ export class SubscriberKeyExchange {
             messageType: StreamMessageType.GROUP_KEY_REQUEST,
             encryptionType: EncryptionType.NONE,
             authentication: this.authentication,
-            signatureType: SignatureType.SECP256K1
+            signatureType: erc1271contract === undefined ? SignatureType.SECP256K1 : SignatureType.ERC_1271
         })
     }
 
     private async onMessage(msg: StreamMessage): Promise<void> {
         if (OldGroupKeyResponse.is(msg)) {
             try {
-                const authenticatedUser = await this.authentication.getAddress()
                 const { requestId, recipient, encryptedGroupKeys } = convertBytesToGroupKeyResponse(msg.content)
-                if ((recipient === authenticatedUser) && (this.pendingRequests.has(requestId))) {
+                if (await this.isAssignedToMe(msg.getStreamPartID(), recipient, requestId)) {
                     this.logger.debug('Handle group key response', { requestId })
                     this.pendingRequests.delete(requestId)
                     await validateStreamMessage(msg, this.streamRegistry, this.erc1271ContractFacade)
@@ -147,5 +148,14 @@ export class SubscriberKeyExchange {
                 this.logger.debug('Failed to handle group key response', { err })
             }
         }
+    }
+
+    private async isAssignedToMe(streamPartId: StreamPartID, recipient: EthereumAddress, requestId: string): Promise<boolean> {
+        if (this.pendingRequests.has(requestId)) {
+            const erc1271Contract = this.subscriber.getERC1271ContractAddress(streamPartId)
+            const authenticatedUser = await this.authentication.getAddress()
+            return recipient === authenticatedUser || (recipient === erc1271Contract && erc1271Contract !== undefined)
+        }
+        return false
     }
 }

--- a/packages/client/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/client/src/encryption/SubscriberKeyExchange.ts
@@ -152,9 +152,9 @@ export class SubscriberKeyExchange {
 
     private async isAssignedToMe(streamPartId: StreamPartID, recipient: EthereumAddress, requestId: string): Promise<boolean> {
         if (this.pendingRequests.has(requestId)) {
-            const erc1271Contract = this.subscriber.getERC1271ContractAddress(streamPartId)
             const authenticatedUser = await this.authentication.getAddress()
-            return recipient === authenticatedUser || (recipient === erc1271Contract && erc1271Contract !== undefined)
+            const erc1271Contract = this.subscriber.getERC1271ContractAddress(streamPartId)
+            return (recipient === authenticatedUser) || (recipient === erc1271Contract)
         }
         return false
     }

--- a/packages/client/src/subscribe/Subscriber.ts
+++ b/packages/client/src/subscribe/Subscriber.ts
@@ -1,5 +1,5 @@
 import { StreamPartID } from '@streamr/protocol'
-import { Logger } from '@streamr/utils'
+import { EthereumAddress, Logger } from '@streamr/utils'
 import { Lifecycle, scoped } from 'tsyringe'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { LoggerFactory } from '../utils/LoggerFactory'
@@ -71,6 +71,10 @@ export class Subscriber {
             o.push(...s.subscriptions)
             return o
         }, [])
+    }
+
+    getERC1271ContractAddress(streamPartId: StreamPartID): EthereumAddress | undefined {
+        return this.subSessions.get(streamPartId)?.getERC1271ContractAddress()
     }
 
     /**

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -1,7 +1,7 @@
 import { StreamPartID } from '@streamr/protocol'
 import { MessageStream } from './MessageStream'
 import { LoggerFactory } from '../utils/LoggerFactory'
-import { Logger } from '@streamr/utils'
+import { EthereumAddress, Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 
 /**
@@ -29,14 +29,22 @@ export class Subscription extends MessageStream {
     readonly streamPartId: StreamPartID
     /** @internal */
     readonly isRaw: boolean
+    readonly erc1271ContractAddress: EthereumAddress | undefined
     private readonly eventEmitter: EventEmitter<SubscriptionEvents>
     private readonly logger: Logger
 
     /** @internal */
-    constructor(streamPartId: StreamPartID, isRaw: boolean, eventEmitter: EventEmitter<SubscriptionEvents>, loggerFactory: LoggerFactory) {
+    constructor(
+        streamPartId: StreamPartID,
+        isRaw: boolean,
+        erc1271ContractAddress: EthereumAddress | undefined,
+        eventEmitter: EventEmitter<SubscriptionEvents>,
+        loggerFactory: LoggerFactory
+    ) {
         super()
         this.streamPartId = streamPartId
         this.isRaw = isRaw
+        this.erc1271ContractAddress = erc1271ContractAddress
         this.eventEmitter = eventEmitter
         this.logger = loggerFactory.createLogger(module)
         this.onError.listen((err) => {

--- a/packages/client/test/end-to-end/erc1271-publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/erc1271-publish-subscribe.test.ts
@@ -104,37 +104,97 @@ describe('ERC-1271: subscribe', () => {
         return stream.id
     }
 
-    describe('private stream', () => {
-        let publisher: StreamrClient
-        let subscriber: StreamrClient
-        let streamId: StreamID
+    let publisher: StreamrClient
+    let subscriber: StreamrClient
+    let streamId: StreamID
 
-        beforeEach(async () => {
-            subscriber = createTestClient(subscriberWallet.privateKey)
-            publisher = createTestClient(publisherWallet.privateKey)
-            streamId = await createStream()
-        }, TIMEOUT)
+    beforeEach(async () => {
+        subscriber = createTestClient(subscriberWallet.privateKey)
+        publisher = createTestClient(publisherWallet.privateKey)
+        streamId = await createStream()
+    }, TIMEOUT)
 
-        afterEach(async () => {
-            await subscriber.destroy()
-            await publisher.destroy()
-        })
-
-        it('subscriber configured with ERC-1271 contract can receive messages', async () => {
-            const messages: unknown[] = []
-            const metadatas: MessageMetadata[] = []
-            await subscriber.subscribe({
-                streamId,
-                erc1271Contract: erc1271ContractAddress
-            }, (msg: any, metadata) => {
-                messages.push(msg)
-                metadatas.push(metadata)
-            })
-            await publisher.publish(streamId, PAYLOAD)
-            await waitForCondition(() => messages.length > 0, TIMEOUT)
-            expect(metadatas[0].signatureType).toEqual('SECP256K1')
-            expect(metadatas[0].groupKeyId).toBeString()
-            expect(areEqualBinaries(messages[0] as Uint8Array, PAYLOAD)).toBe(true)
-        }, TIMEOUT)
+    afterEach(async () => {
+        await subscriber.destroy()
+        await publisher.destroy()
     })
+
+    it('subscriber configured with ERC-1271 contract can receive messages', async () => {
+        const messages: unknown[] = []
+        const metadatas: MessageMetadata[] = []
+        await subscriber.subscribe({
+            streamId,
+            erc1271Contract: erc1271ContractAddress
+        }, (msg: any, metadata) => {
+            messages.push(msg)
+            metadatas.push(metadata)
+        })
+        await publisher.publish(streamId, PAYLOAD)
+        await waitForCondition(() => messages.length > 0, TIMEOUT)
+        expect(metadatas[0].signatureType).toEqual('SECP256K1')
+        expect(metadatas[0].groupKeyId).toBeString()
+        expect(areEqualBinaries(messages[0] as Uint8Array, PAYLOAD)).toBe(true)
+    }, TIMEOUT)
+})
+
+describe('ERC-1271: publish and subscribe', () => {
+    let publisherWallet: Wallet
+    let subscriberWallet: Wallet
+    let erc1271SubscriberContractAddress: EthereumAddress
+    let erc1271PublisherContractAddress: EthereumAddress
+
+    beforeAll(async () => {
+        subscriberWallet = fastWallet()
+        publisherWallet = new Wallet(await fetchPrivateKeyWithGas())
+        erc1271SubscriberContractAddress = await deployTestERC1271Contract([toEthereumAddress(subscriberWallet.address)])
+        erc1271PublisherContractAddress = await deployTestERC1271Contract([toEthereumAddress(publisherWallet.address)])
+    }, TIMEOUT)
+
+    async function createStream(): Promise<StreamID> {
+        const creator = createTestClient(await fetchPrivateKeyWithGas())
+        const stream = await createTestStream(creator, module)
+        await stream.grantPermissions({
+            permissions: [StreamPermission.PUBLISH],
+            user: erc1271PublisherContractAddress
+        })
+        await stream.grantPermissions({
+            permissions: [StreamPermission.SUBSCRIBE],
+            user: erc1271SubscriberContractAddress
+
+        })
+        await creator.destroy()
+        return stream.id
+    }
+
+    let publisher: StreamrClient
+    let subscriber: StreamrClient
+    let streamId: StreamID
+
+    beforeEach(async () => {
+        subscriber = createTestClient(subscriberWallet.privateKey)
+        publisher = createTestClient(publisherWallet.privateKey)
+        streamId = await createStream()
+    }, TIMEOUT)
+
+    afterEach(async () => {
+        await subscriber.destroy()
+        await publisher.destroy()
+    })
+
+    it('subscriber configured with ERC-1271 contract can receive ERC-1271 signed messages', async () => {
+        const messages: unknown[] = []
+        const metadatas: MessageMetadata[] = []
+        await subscriber.subscribe({
+            streamId,
+            erc1271Contract: erc1271SubscriberContractAddress
+        }, (msg: any, metadata) => {
+            messages.push(msg)
+            metadatas.push(metadata)
+        })
+        await publisher.publish(streamId, PAYLOAD, { erc1271Contract: erc1271PublisherContractAddress })
+        await waitForCondition(() => messages.length > 0, TIMEOUT)
+        expect(metadatas[0].signatureType).toEqual('ERC_1271')
+        expect(metadatas[0].groupKeyId).toBeString()
+        expect(areEqualBinaries(messages[0] as Uint8Array, PAYLOAD)).toBe(true)
+    }, TIMEOUT)
 })

--- a/packages/client/test/end-to-end/erc1271-publish-subscribe.test.ts
+++ b/packages/client/test/end-to-end/erc1271-publish-subscribe.test.ts
@@ -11,7 +11,7 @@ import { MessageMetadata } from '../../src'
 const PAYLOAD = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 const TIMEOUT = 30 * 1000
 
-describe('ERC-1271: publish and subscribe', () => {
+describe('ERC-1271: publish', () => {
     let publisherWallet: Wallet
     let subscriberWallet: Wallet
     let erc1271ContractAddress: EthereumAddress
@@ -72,6 +72,68 @@ describe('ERC-1271: publish and subscribe', () => {
             } else {
                 expect(metadatas[0].groupKeyId).toBeString()
             }
+            expect(areEqualBinaries(messages[0] as Uint8Array, PAYLOAD)).toBe(true)
+        }, TIMEOUT)
+    })
+})
+
+describe('ERC-1271: subscribe', () => {
+    let publisherWallet: Wallet
+    let subscriberWallet: Wallet
+    let erc1271ContractAddress: EthereumAddress
+
+    beforeAll(async () => {
+        subscriberWallet = fastWallet()
+        publisherWallet = new Wallet(await fetchPrivateKeyWithGas())
+        erc1271ContractAddress = await deployTestERC1271Contract([toEthereumAddress(subscriberWallet.address)])
+    }, TIMEOUT)
+
+    async function createStream(): Promise<StreamID> {
+        const creator = createTestClient(await fetchPrivateKeyWithGas())
+        const stream = await createTestStream(creator, module)
+        await stream.grantPermissions({
+            permissions: [StreamPermission.PUBLISH],
+            user: publisherWallet.address
+        })
+        await stream.grantPermissions({
+            permissions: [StreamPermission.SUBSCRIBE],
+            user: erc1271ContractAddress
+
+        })
+        await creator.destroy()
+        return stream.id
+    }
+
+    describe('private stream', () => {
+        let publisher: StreamrClient
+        let subscriber: StreamrClient
+        let streamId: StreamID
+
+        beforeEach(async () => {
+            subscriber = createTestClient(subscriberWallet.privateKey)
+            publisher = createTestClient(publisherWallet.privateKey)
+            streamId = await createStream()
+        }, TIMEOUT)
+
+        afterEach(async () => {
+            await subscriber.destroy()
+            await publisher.destroy()
+        })
+
+        it('subscriber configured with ERC-1271 contract can receive messages', async () => {
+            const messages: unknown[] = []
+            const metadatas: MessageMetadata[] = []
+            await subscriber.subscribe({
+                streamId,
+                erc1271Contract: erc1271ContractAddress
+            }, (msg: any, metadata) => {
+                messages.push(msg)
+                metadatas.push(metadata)
+            })
+            await publisher.publish(streamId, PAYLOAD)
+            await waitForCondition(() => messages.length > 0, TIMEOUT)
+            expect(metadatas[0].signatureType).toEqual('SECP256K1')
+            expect(metadatas[0].groupKeyId).toBeString()
             expect(areEqualBinaries(messages[0] as Uint8Array, PAYLOAD)).toBe(true)
         }, TIMEOUT)
     })

--- a/packages/client/test/unit/SubscriptionSession.test.ts
+++ b/packages/client/test/unit/SubscriptionSession.test.ts
@@ -1,0 +1,78 @@
+import { SubscriptionSession } from '../../src/subscribe/SubscriptionSession'
+import { StreamMessage, toStreamID, toStreamPartID } from '@streamr/protocol'
+import { MessagePipelineFactory } from '../../src/subscribe/MessagePipelineFactory'
+import { mock } from 'jest-mock-extended'
+import { NetworkNodeFacade, NetworkNodeStub } from '../../src/NetworkNodeFacade'
+import { Subscription } from '../../src'
+import { randomEthereumAddress } from '@streamr/test-utils'
+import { PushPipeline } from '../../src/utils/PushPipeline'
+import { ErrorSignal, Signal } from '../../src/utils/Signal'
+import { EthereumAddress } from '@streamr/utils'
+
+const STREAM_PART_ID = toStreamPartID(toStreamID('foobar.eth'), 0)
+const ADDRESS_ONE = randomEthereumAddress()
+const ADDRESS_TWO = randomEthereumAddress()
+
+function createSubscription(erc1271contractAddress?: EthereumAddress): Subscription {
+    return new Subscription(STREAM_PART_ID, false, erc1271contractAddress, mock(), mock())
+}
+
+describe('SubscriptionSession', () => {
+    let session: SubscriptionSession
+
+    beforeEach(() => {
+        const pipelineFactory = mock<MessagePipelineFactory>()
+        const pushPipeline = mock<PushPipeline<StreamMessage, StreamMessage>>()
+        pushPipeline.onError = ErrorSignal.once()
+        pushPipeline.onBeforeFinally = Signal.once()
+        pushPipeline.pipe.mockReturnValue(pushPipeline as any)
+        pipelineFactory.createMessagePipeline.mockReturnValue(pushPipeline)
+
+        const networkNodeFacade = mock<NetworkNodeFacade>()
+        networkNodeFacade.getNode.mockResolvedValue(mock<NetworkNodeStub>())
+
+        session = new SubscriptionSession(STREAM_PART_ID, pipelineFactory, networkNodeFacade)
+    })
+
+    describe('getERC1271ContractAddress', () => {
+        it('returns undefined if no subscriptions', () => {
+            expect(session.getERC1271ContractAddress()).toBeUndefined()
+        })
+
+        it('returns undefined if does not exist on subscription', async () => {
+            await session.add(createSubscription())
+            expect(session.getERC1271ContractAddress()).toBeUndefined()
+        })
+
+        it('returns erc1271contractAddress if exists on subscription', async () => {
+            await session.add(createSubscription(ADDRESS_ONE))
+            expect(session.getERC1271ContractAddress()).toEqual(ADDRESS_ONE)
+        })
+
+    })
+
+    it('can add multiple subscriptions without erc1271contractAddress', async () => {
+        await session.add(createSubscription())
+        await session.add(createSubscription())
+    })
+
+    it('can add multiple subscriptions with same erc1271contractAddress', async () => {
+        await session.add(createSubscription(ADDRESS_ONE))
+        await session.add(createSubscription(ADDRESS_ONE))
+    })
+
+    it('cannot subscribe with erc1271contractAddress if existing has none', async () => {
+        await session.add(createSubscription())
+        await expect(session.add(createSubscription(ADDRESS_ONE))).rejects.toEqual(new Error('Subscription ERC-1271 mismatch'))
+    })
+
+    it('cannot subscribe without erc1271contractAddress if existing has one', async () => {
+        await session.add(createSubscription(ADDRESS_ONE))
+        await expect(session.add(createSubscription())).rejects.toEqual(new Error('Subscription ERC-1271 mismatch'))
+    })
+
+    it('cannot subscribe with different erc1271contractAddress if existing has one', async () => {
+        await session.add(createSubscription(ADDRESS_ONE))
+        await expect(session.add(createSubscription(ADDRESS_TWO))).rejects.toEqual(new Error('Subscription ERC-1271 mismatch'))
+    })
+})

--- a/packages/client/test/unit/resendSubscription.test.ts
+++ b/packages/client/test/unit/resendSubscription.test.ts
@@ -99,7 +99,7 @@ describe('resend subscription', () => {
         gapFill = true
     ) => {
         const eventEmitter = new EventEmitter<SubscriptionEvents>()
-        sub = new Subscription(STREAM_PART_ID, false, eventEmitter, mockLoggerFactory())
+        sub = new Subscription(STREAM_PART_ID, false, undefined, eventEmitter, mockLoggerFactory())
         initResendSubscription(
             sub,
             undefined as any,


### PR DESCRIPTION
## Summary
Subscribe on behalf of an ERC-1271 contract. Follow up to #2423 where we implemented publishing on behalf of an ERC-1271 contract.

### Usage
```ts
const client = new StreamrClient({
    auth: {
        privateKey: '<REDACTED>'
    }
})

await client.subscribe({
    streamId,
    erc1271Contract: '0xc0ffee254729296a45a3885639AC7E10F9d54979'
}, (msg) => {
    console.log(msg)
})
```

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
