### PR TITLE
refactor(dht): Use `SortedContactList#getClosestContacts`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -172,10 +172,9 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 disconnectionCandidates.addContact(connection)
             }
         })
-        const sortedCandidates = disconnectionCandidates.getAllContacts()
-        const targetNum = this.connections.size - maxConnections
-        for (let i = 0; i < sortedCandidates.length && i < targetNum; i++) {
-            const peerDescriptor = sortedCandidates[sortedCandidates.length - 1 - i].getPeerDescriptor()!
+        const disconnectables = disconnectionCandidates.getFurthestContacts(this.connections.size - maxConnections)
+        for (const disconnectable of disconnectables) {
+            const peerDescriptor = disconnectable.getPeerDescriptor()!
             logger.trace('garbageCollecting ' + getNodeIdFromPeerDescriptor(peerDescriptor))
             this.gracefullyDisconnectAsync(peerDescriptor, DisconnectMode.NORMAL).catch((_e) => { })
         }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -119,8 +119,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             emitEvents: false
         })
         sortingList.addContacts(oldContacts)
-        const sortedContacts = sortingList.getAllContacts()
-        const removableNodeId = sortedContacts[sortedContacts.length - 1].getNodeId()
+        const removableNodeId = sortingList.getFurthestContacts(1)[0].getNodeId()
         this.config.connectionLocker?.weakUnlockConnection(removableNodeId, this.config.lockId)
         this.bucket.remove(getRawFromDhtAddress(removableNodeId))
         this.bucket.add(newContact)

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -116,7 +116,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
      * Furthest first then others in descending distance order
      */
     getFurthestContacts(limit?: number): C[] {
-        const ret = this.getClosestContacts().reverse()
+        const ret = this.getClosestContacts().toReversed()
         return (limit === undefined) 
             ? ret 
             : ret.slice(0, Math.max(limit, 0))

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -109,7 +109,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         const ret = this.getAllContacts()
         return (limit === undefined) 
             ? ret 
-            : ret.slice(0, limit)
+            : ret.slice(0, Math.max(limit, 0))
     }
 
     /*
@@ -119,7 +119,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         const ret = this.getClosestContacts().reverse()
         return (limit === undefined) 
             ? ret 
-            : ret.slice(0, limit)
+            : ret.slice(0, Math.max(limit, 0))
     }
 
     public getActiveContacts(limit?: number): C[] {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -102,8 +102,21 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         }
     }
 
+    /*
+     * Closest first then others in ascending distance order
+     */
     public getClosestContacts(limit?: number): C[] {
         const ret = this.getAllContacts()
+        return (limit === undefined) 
+            ? ret 
+            : ret.slice(0, limit)
+    }
+
+    /*
+     * Furthest first then others in descending distance order
+     */
+    getFurthestContacts(limit?: number): C[] {
+        const ret = this.getClosestContacts().reverse()
         return (limit === undefined) 
             ? ret 
             : ret.slice(0, limit)

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -212,7 +212,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
 
     public getResults(): RecursiveOperationResult {
         return {
-            closestNodes: this.results.getAllContacts().map((contact) => contact.getPeerDescriptor()),
+            closestNodes: this.results.getClosestContacts().map((contact) => contact.getPeerDescriptor()),
             dataEntries: Array.from(this.foundData.values())
         }
     }

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -184,7 +184,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             routingTable.addContacts(contacts)
             this.config.routingTablesCache.set(targetId, routingTable, previousId)
         }
-        return routingTable.getAllContacts()
+        return routingTable.getClosestContacts()
             .filter((contact) => !this.contactedPeers.has(contact.getNodeId()) && !this.config.excludedNodeIds.has(contact.getNodeId()))
     }
 

--- a/packages/dht/src/dht/routing/RoutingTablesCache.ts
+++ b/packages/dht/src/dht/routing/RoutingTablesCache.ts
@@ -4,7 +4,9 @@ import { RoutingRemoteContact } from './RoutingSession'
 import { LRUCache } from 'lru-cache'
 
 type RoutingTableID = string
-export type RoutingTable = Pick<SortedContactList<RoutingRemoteContact>, 'getAllContacts' | 'addContacts' | 'addContact' | 'removeContact' | 'stop'>
+export type RoutingTable = Pick<
+    SortedContactList<RoutingRemoteContact>,
+    'getClosestContacts' | 'addContacts' | 'addContact' | 'removeContact' | 'stop'>
 
 const createRoutingTableId = (targetId: DhtAddress, previousId?: DhtAddress): RoutingTableID => {
     return targetId + (previousId ? previousId : '')

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -182,11 +182,12 @@ export class StoreManager {
             sortedList.addContact(new Contact(neighbor))
         })
         const selfIsPrimaryStorer = (sortedList.getClosestContactId() === localNodeId)
-        const targets = selfIsPrimaryStorer
+        const targetLimit = selfIsPrimaryStorer
             // if we are the closest to the data, replicate to all storageRedundancyFactor nearest
-            ? sortedList.getAllContacts()
+            ? undefined
             // if we are not the closest node to the data, replicate only to the closest one to the data
-            : [sortedList.getAllContacts()[0]]
+            : 1
+        const targets = sortedList.getClosestContacts(targetLimit)
         targets.forEach((contact) => {
             const contactNodeId = contact.getNodeId()
             if ((incomingNodeId !== contactNodeId) && (localNodeId !== contactNodeId)) {

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -80,7 +80,24 @@ describe('SortedContactList', () => {
         list.addContact(item4)
         list.addContact(item2)
         expect(list.getClosestContacts(2)).toEqual([item1, item2])
+        expect(list.getClosestContacts(10)).toEqual([item1, item2, item3, item4])
         expect(list.getClosestContacts()).toEqual([item1, item2, item3, item4])
+    })
+
+    it('get furthest contacts', () => {
+        const list = new SortedContactList({
+            referenceId: item0.getNodeId(), 
+            maxSize: 8, 
+            allowToContainReferenceId: false, 
+            emitEvents: false 
+        })
+        list.addContact(item1)
+        list.addContact(item3)
+        list.addContact(item4)
+        list.addContact(item2)
+        expect(list.getFurthestContacts(2)).toEqual([item4, item3])
+        expect(list.getFurthestContacts(10)).toEqual([item4, item3, item2, item1])
+        expect(list.getFurthestContacts()).toEqual([item4, item3, item2, item1])
     })
 
     it('get active contacts', () => {

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -82,6 +82,7 @@ describe('SortedContactList', () => {
         expect(list.getClosestContacts(2)).toEqual([item1, item2])
         expect(list.getClosestContacts(10)).toEqual([item1, item2, item3, item4])
         expect(list.getClosestContacts()).toEqual([item1, item2, item3, item4])
+        expect(list.getClosestContacts(-2)).toEqual([])
     })
 
     it('get furthest contacts', () => {
@@ -98,6 +99,7 @@ describe('SortedContactList', () => {
         expect(list.getFurthestContacts(2)).toEqual([item4, item3])
         expect(list.getFurthestContacts(10)).toEqual([item4, item3, item2, item1])
         expect(list.getFurthestContacts()).toEqual([item4, item3, item2, item1])
+        expect(list.getFurthestContacts(-2)).toEqual([])
     })
 
     it('get active contacts', () => {


### PR DESCRIPTION
Use the `getClosestContacts` and `getFurthestContacts` methods instead of the `getAllContacts` method when querying the closes/furthest contacts from a contact list.

The `getFurthestContacts` is a new method and it is just a reverse of `getClosestContacts`.

Added also a check for the `limit` parameter: if it is negative, no items are returned.
