### PR TITLE
refactor(dht): Manage active states in `PeerManager`

### DIFF
--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -1,9 +1,8 @@
 import EventEmitter from 'eventemitter3'
 import { DhtAddress } from '../../identifiers'
 
-export class ContactState<C> {
+export class ContactState<C> {  // TODO remove this wrapper
 
-    public active = false
     public contact: C
 
     constructor(contact: C) {

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -96,32 +96,11 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         return this.contactsById.has(id)
     }
 
-    public setActive(contactId: DhtAddress): void {
-        if (this.contactsById.has(contactId)) {
-            this.contactsById.get(contactId)!.active = true
-        }
-    }
-
     public getClosestContacts(limit?: number): C[] {
         const ret = this.getAllContacts()
         return (limit === undefined) 
             ? ret 
             : ret.slice(0, limit)
-    }
-
-    public getActiveContacts(limit?: number): C[] {
-        const ret: C[] = []
-        this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId)!
-            if (contact.active) {
-                ret.push(contact.contact)
-            }
-        })
-        if (limit !== undefined) {
-            return ret.slice(0, limit)
-        } else {
-            return ret
-        }
     }
 
     public compareIds(id1: DhtAddress, id2: DhtAddress): number {
@@ -153,10 +132,6 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
             return true
         }
         return false
-    }
-
-    public isActive(id: DhtAddress): boolean {
-        return this.contactsById.has(id) ? this.contactsById.get(id)!.active : false
     }
 
     public getAllContacts(): C[] {

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -1,18 +1,31 @@
-import { PeerManager, getDistance } from '../../src/dht/PeerManager'
-import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
-import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { waitForCondition } from '@streamr/utils'
 import { range, sample, sampleSize, sortBy, without } from 'lodash'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
+import { PeerManager, getDistance } from '../../src/dht/PeerManager'
+import { Contact } from '../../src/dht/contact/Contact'
+import { SortedContactList } from '../../src/dht/contact/SortedContactList'
+import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 import { createMockPeerDescriptor } from '../utils/utils'
 
-const createPeerManager = (nodeIds: DhtAddress[]) => {
-    const peerDescriptor = createMockPeerDescriptor()
+const createPeerManager = (
+    nodeIds: DhtAddress[], 
+    localPeerDescriptor = createMockPeerDescriptor(),
+    pingFailures: Set<DhtAddress> = new Set()
+) => {
     const manager = new PeerManager({
-        localNodeId: getNodeIdFromPeerDescriptor(peerDescriptor),
-        localPeerDescriptor: peerDescriptor,
+        localNodeId: getNodeIdFromPeerDescriptor(localPeerDescriptor),
+        localPeerDescriptor: localPeerDescriptor,
+        isLayer0: true,
         createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => {
-            return new DhtNodeRpcRemote(undefined as any, peerDescriptor, undefined as any, new MockRpcCommunicator())
+            const remote = new class extends DhtNodeRpcRemote {
+                // eslint-disable-next-line class-methods-use-this
+                async ping(): Promise<boolean> {
+                    return !pingFailures.has(getNodeIdFromPeerDescriptor(peerDescriptor))
+                }
+            }(localPeerDescriptor, peerDescriptor, undefined as any, new MockRpcCommunicator())
+            return remote
         }
     } as any)
     const contacts = nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS }))
@@ -20,6 +33,23 @@ const createPeerManager = (nodeIds: DhtAddress[]) => {
         manager.addContact(contact)
     }
     return manager
+}
+
+const getClosestContact = (contacts: PeerDescriptor[], referenceId: DhtAddress): PeerDescriptor | undefined => {
+    const list = new SortedContactList({
+        referenceId,
+        allowToContainReferenceId: false,
+        emitEvents: false
+    })
+    for (const contact of contacts) {
+        list.addContact(new Contact(contact))
+    }
+    const id = list.getClosestContactId()
+    if (id !== undefined) {
+        return contacts.find((c) => getNodeIdFromPeerDescriptor(c) === id)
+    } else {
+        return undefined
+    }
 }
 
 describe('PeerManager', () => {
@@ -60,5 +90,25 @@ describe('PeerManager', () => {
         expect(manager.getContactCount()).toBe(10)
         expect(manager.getContactCount(new Set(sampleSize(nodeIds, 2)))).toBe(8)
         expect(manager.getContactCount(new Set([sample(nodeIds)!, createRandomDhtAddress()]))).toBe(9)
+    })
+
+    it('addContact: ping fails', async () => {
+        const localPeerDescriptor = createMockPeerDescriptor()
+        const successContacts = range(5).map(() => createMockPeerDescriptor())
+        const failureContact = createMockPeerDescriptor()
+        const manager = createPeerManager([], localPeerDescriptor, new Set([getNodeIdFromPeerDescriptor(failureContact)]))
+        for (const successContact of successContacts) {
+            manager.addContact(successContact)
+            manager.setContactActive(getNodeIdFromPeerDescriptor(successContact))
+            manager.onContactDisconnected(getNodeIdFromPeerDescriptor(successContact), false)
+        }
+        expect(manager.getNeighborCount()).toBe(0)
+        manager.addContact(failureContact)
+        const closesSuccessContact = getClosestContact(successContacts, getNodeIdFromPeerDescriptor(localPeerDescriptor))!
+        await waitForCondition(() => {
+            const neighborNodeIds = manager.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+            return neighborNodeIds.includes(getNodeIdFromPeerDescriptor(closesSuccessContact))
+        })
+        expect(manager.getNeighbors()).toEqual([closesSuccessContact])
     })
 })

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -83,18 +83,6 @@ describe('SortedContactList', () => {
         expect(list.getClosestContacts()).toEqual([item1, item2, item3, item4])
     })
 
-    it('get active contacts', () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: false })
-        list.addContact(item1)
-        list.addContact(item3)
-        list.addContact(item4)
-        list.addContact(item2)
-        list.setActive(item2.getNodeId())
-        list.setActive(item3.getNodeId())
-        list.setActive(item4.getNodeId())
-        expect(list.getActiveContacts()).toEqual([item2, item3, item4])
-    })
-
     it('does not emit contactAdded if contact did not fit the structure', () => {
         const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 2, allowToContainReferenceId: false, emitEvents: true })
         const onContactAdded = jest.fn()


### PR DESCRIPTION
Moved the state management of active contacts from `SortedContactList` to `PeerManager`.  The state is not relevant in other use cases of `SortedContactList`. This change allows us to remove the `ContactState` wrapper and therefore optimize some `SortedContactList` methods significantly.

## Future improvements

- Remove `ContactState` wrapper
- Rename `PeerManagerEvents` arguments