### PR TITLE
Remove `SortedContactList#emitEvents` config option

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -156,8 +156,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         const disconnectionCandidates = new SortedContactList<ManagedConnection>({
             referenceId: getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor()), 
             maxSize: 100000,  // TODO use config option or named constant?
-            allowToContainReferenceId: false,
-            emitEvents: false
+            allowToContainReferenceId: false
         })
         this.connections.forEach((connection, key) => {
             // TODO: Investigate why multiple invalid WS client connections to the same

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -70,7 +70,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
             numberOfNodesToPing: this.config.numberOfNodesPerKBucket
         })
-        this.ringContacts = new RingContactList<DhtNodeRpcRemote>(getRingIdRawFromPeerDescriptor(this.config.localPeerDescriptor), true)
+        this.ringContacts = new RingContactList<DhtNodeRpcRemote>(getRingIdRawFromPeerDescriptor(this.config.localPeerDescriptor))
         this.ringContacts.on('ringContactAdded', (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => {
             this.emit('ringContactAdded', peerDescriptor, closestPeers)
         })
@@ -86,8 +86,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.contacts = new SortedContactList({
             referenceId: this.config.localNodeId,
             maxSize: this.config.maxContactListSize,
-            allowToContainReferenceId: false,
-            emitEvents: true
+            allowToContainReferenceId: false
         })
         this.contacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
             if (this.stopped) {
@@ -115,8 +114,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList({
             referenceId: this.config.localNodeId,
             maxSize: 100,  // TODO use config option or named constant?
-            allowToContainReferenceId: false,
-            emitEvents: false
+            allowToContainReferenceId: false
         })
         sortingList.addContacts(oldContacts)
         const sortedContacts = sortingList.getAllContacts()
@@ -248,7 +246,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         const closest = new SortedContactList<DhtNodeRpcRemote>({
             referenceId,
             allowToContainReferenceId: true,
-            emitEvents: false,
             excludedNodeIds,
             maxSize: limit
         })
@@ -261,7 +258,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         const closest = new SortedContactList<DhtNodeRpcRemote>({
             referenceId,
             allowToContainReferenceId: true,
-            emitEvents: false,
             excludedNodeIds,
             maxSize: limit
         })
@@ -274,7 +270,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         limit?: number,
         excludedIds?: Set<DhtAddress>
     ): { left: DhtNodeRpcRemote[], right: DhtNodeRpcRemote[] } {
-        const closest = new RingContactList<DhtNodeRpcRemote>(ringIdRaw, false, excludedIds)
+        const closest = new RingContactList<DhtNodeRpcRemote>(ringIdRaw, excludedIds)
         this.contacts.getAllContacts().map((contact) => closest.addContact(contact))
         this.ringContacts.getAllContacts().map((contact) => closest.addContact(contact))
         return closest.getClosestContacts(limit ?? 8)

--- a/packages/dht/src/dht/contact/RingContactList.ts
+++ b/packages/dht/src/dht/contact/RingContactList.ts
@@ -19,12 +19,10 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
     private readonly excludedIds: Set<DhtAddress>
     private readonly leftNeighbors: OrderedMap<RingDistance, C>
     private readonly rightNeighbors: OrderedMap<RingDistance, C>
-    private readonly emitEvents: boolean
 
-    constructor(rawReferenceId: RingIdRaw, emitEvents: boolean, excludedIds?: Set<DhtAddress>) {
+    constructor(rawReferenceId: RingIdRaw, excludedIds?: Set<DhtAddress>) {
         super()
         this.referenceId = getRingIdFromRaw(rawReferenceId)
-        this.emitEvents = emitEvents
         this.excludedIds = excludedIds ?? new Set()
         this.leftNeighbors = new OrderedMap<RingDistance, C>()
         this.rightNeighbors = new OrderedMap<RingDistance, C>()
@@ -60,7 +58,7 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
             }
         }
 
-        if (this.emitEvents && (elementAdded || elementRemoved)) {
+        if (this.hasEventListeners() && (elementAdded || elementRemoved)) {
             const closestContacts = this.getClosestContacts()
             const closestDescriptors = { 
                 left: closestContacts.left.map((c) => c.getPeerDescriptor()), 
@@ -92,7 +90,7 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
             elementRemoved = true
         }
 
-        if (this.emitEvents && elementRemoved) {
+        if (this.hasEventListeners() && elementRemoved) {
             const closestContacts = this.getClosestContacts()
             const closestDescriptors = { left: closestContacts.left.map((c) => c.getPeerDescriptor()), 
                 right: closestContacts.right.map((c) => c.getPeerDescriptor()) }
@@ -147,5 +145,9 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
             ret.push(item[1])
         }
         return ret
+    }
+
+    private hasEventListeners(): boolean {
+        return this.eventNames().length > 0
     }
 }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -222,8 +222,7 @@ export class RecursiveOperationManager {
         const closestPeers = new SortedContactList<DhtNodeRpcRemote>({
             referenceId,
             maxSize: limit,
-            allowToContainReferenceId: true,
-            emitEvents: false
+            allowToContainReferenceId: true
         })
         closestPeers.addContacts(connectedPeers)
         return closestPeers.getClosestContacts(limit).map((peer) => peer.getPeerDescriptor())

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -53,8 +53,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         this.results = new SortedContactList({
             referenceId: config.targetId, 
             maxSize: 10,  // TODO use config option or named constant?
-            allowToContainReferenceId: true,
-            emitEvents: false
+            allowToContainReferenceId: true
         })
         this.rpcCommunicator = new ListeningRpcCommunicator(this.id, config.transport, {
             rpcRequestTimeout: 15000  // TODO use config option or named constant?

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -172,8 +172,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
                 referenceId: getDhtAddressFromRaw(this.config.routedMessage.target),
                 maxSize: ROUTING_TABLE_MAX_SIZE,
                 allowToContainReferenceId: true,
-                nodeIdDistanceLimit: previousId,
-                emitEvents: false
+                nodeIdDistanceLimit: previousId
             })
             const contacts = Array.from(this.config.connections.values())
                 .map((peer) => new RoutingRemoteContact(

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -64,8 +64,7 @@ export class StoreManager {
         const sortedList = new SortedContactList<Contact>({
             referenceId: key, 
             maxSize: this.config.redundancyFactor,
-            allowToContainReferenceId: true,
-            emitEvents: false
+            allowToContainReferenceId: true
         })
         sortedList.addContact(new Contact(this.config.localPeerDescriptor))
         closestToData.forEach((neighbor) => {
@@ -173,9 +172,8 @@ export class StoreManager {
         const closestToData = this.config.getClosestNeighborsTo(key, 10)
         const sortedList = new SortedContactList<Contact>({
             referenceId: key, 
-            maxSize: this.config.redundancyFactor, 
-            allowToContainReferenceId: true, 
-            emitEvents: false
+            maxSize: this.config.redundancyFactor,
+            allowToContainReferenceId: true
         })
         sortedList.addContact(new Contact(this.config.localPeerDescriptor))
         closestToData.forEach((neighbor) => {

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -39,27 +39,14 @@ describe('SortedContactListBenchmark', () => {
         }
         const list = new SortedContactList({
             referenceId: createRandomDhtAddress(),
-            allowToContainReferenceId: true,
-            emitEvents: true
+            allowToContainReferenceId: true
         })
 
-        console.time('SortedContactList.addContact() with emitEvents=true')
+        console.time('SortedContactList.addContact()')
         for (let i = 0; i < NUM_ADDS; i++) {
             list.addContact(randomIds[i])
         }
-        console.timeEnd('SortedContactList.addContact() with emitEvents=true')
-
-        const list2 = new SortedContactList({
-            referenceId: createRandomDhtAddress(),
-            allowToContainReferenceId: true,
-            emitEvents: false
-        })
-
-        console.time('SortedContactList.addContact() with emitEvents=false')
-        for (let i = 0; i < NUM_ADDS; i++) {
-            list2.addContact(randomIds[i])
-        }
-        console.timeEnd('SortedContactList.addContact() with emitEvents=false')
+        console.timeEnd('SortedContactList.addContact()')
 
         const kBucket = new KBucket<Item>({ localNodeId: getRawFromDhtAddress(createRandomDhtAddress()) })
         console.time('KBucket.add()')
@@ -81,61 +68,44 @@ describe('SortedContactListBenchmark', () => {
         }
         console.timeEnd('kBucket closest()')
 
-        console.time('SortedContactList.getClosestContacts() with emitEvents=true')
+        console.time('SortedContactList.getClosestContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
                 referenceId: createRandomDhtAddress(),
-                allowToContainReferenceId: true,
-                emitEvents: true
+                allowToContainReferenceId: true
             })
 
             const arrayFromBucket = kBucket.toArray()
             arrayFromBucket.forEach((contact) => closest.addContact(contact))
             closest.getClosestContacts(20)
         }
-        console.timeEnd('SortedContactList.getClosestContacts() with emitEvents=true')
+        console.timeEnd('SortedContactList.getClosestContacts()')
 
-        console.time('SortedContactList.getClosestContacts() with emitEvents=false')
+        console.time('SortedContactList.getClosestContacts() and lodash')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
                 referenceId: createRandomDhtAddress(),
-                allowToContainReferenceId: true,
-                emitEvents: false
+                allowToContainReferenceId: true
             })
 
             const arrayFromBucket = kBucket.toArray()
             arrayFromBucket.forEach((contact) => closest.addContact(contact))
             closest.getClosestContacts(20)
         }
-        console.timeEnd('SortedContactList.getClosestContacts() with emitEvents=false')
+        console.timeEnd('SortedContactList.getClosestContacts() and lodash')
 
-        console.time('SortedContactList.getClosestContacts() with emitEvents=false and lodash')
+        console.time('SortedContactList.getClosestContacts() and addContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
                 referenceId: createRandomDhtAddress(),
-                allowToContainReferenceId: true,
-                emitEvents: false
-            })
-
-            const arrayFromBucket = kBucket.toArray()
-            arrayFromBucket.forEach((contact) => closest.addContact(contact))
-            closest.getClosestContacts(20)
-        }
-        console.timeEnd('SortedContactList.getClosestContacts() with emitEvents=false and lodash')
-
-        console.time('SortedContactList.getClosestContacts() with emitEvents=false and addContacts()')
-        for (let i = 0; i < NUM_ADDS; i++) {
-            const closest = new SortedContactList<Item>({
-                referenceId: createRandomDhtAddress(),
-                allowToContainReferenceId: true,
-                emitEvents: false
+                allowToContainReferenceId: true
             })
 
             const arrayFromBucket = kBucket.toArray()
             closest.addContacts(arrayFromBucket)
             closest.getClosestContacts(20)
         }
-        console.timeEnd('SortedContactList.getClosestContacts() with emitEvents=false and addContacts()')
+        console.timeEnd('SortedContactList.getClosestContacts() and addContacts()')
 
         const shuffled = shuffleArray(kBucket.toArray())
         console.time('kbucket add and closest')

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -81,19 +81,6 @@ describe('SortedContactListBenchmark', () => {
         }
         console.timeEnd('SortedContactList.getClosestContacts()')
 
-        console.time('SortedContactList.getClosestContacts() and lodash')
-        for (let i = 0; i < NUM_ADDS; i++) {
-            const closest = new SortedContactList<Item>({
-                referenceId: createRandomDhtAddress(),
-                allowToContainReferenceId: true
-            })
-
-            const arrayFromBucket = kBucket.toArray()
-            arrayFromBucket.forEach((contact) => closest.addContact(contact))
-            closest.getClosestContacts(20)
-        }
-        console.timeEnd('SortedContactList.getClosestContacts() and lodash')
-
         console.time('SortedContactList.getClosestContacts() and addContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({

--- a/packages/dht/test/benchmark/hybrid-network-simulation/RingContactList.test.ts
+++ b/packages/dht/test/benchmark/hybrid-network-simulation/RingContactList.test.ts
@@ -61,8 +61,7 @@ const mockData: Array< [number, string] > = [
 const mockNodes: MockNode[] = mockData.map(([region, ipAddress]) => new MockNode(region, ipAddress))
 const referenceNode = mockNodes[5]
 const ringContactList: RingContactList<MockNode> = new RingContactList<MockNode>(
-    getRingIdRawFromPeerDescriptor(referenceNode.getPeerDescriptor()),
-    false
+    getRingIdRawFromPeerDescriptor(referenceNode.getPeerDescriptor())
 )
 
 mockNodes.forEach((node) => ringContactList.addContact(node))

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -56,8 +56,7 @@ describe('Replicate data from node to node in DHT', () => {
         const sortedList = new SortedContactList<DhtNode>({ 
             referenceId: getDhtAddressFromRaw(DATA.key),
             maxSize: 10000, 
-            allowToContainReferenceId: true, 
-            emitEvents: false 
+            allowToContainReferenceId: true
         })
         nodes.forEach((node) => sortedList.addContact(node))
 

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -16,7 +16,7 @@ describe('SortedContactList', () => {
     const item4 = createItem(new Uint8Array([0, 0, 0, 4]))
 
     it('compares Ids correctly', async () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 10, allowToContainReferenceId: true, emitEvents: false })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 10, allowToContainReferenceId: true })
         expect(list.compareIds(item0.getNodeId(), item0.getNodeId())).toBe(0)
         expect(list.compareIds(item1.getNodeId(), item1.getNodeId())).toBe(0)
         expect(list.compareIds(item0.getNodeId(), item1.getNodeId())).toBe(-1)
@@ -28,7 +28,7 @@ describe('SortedContactList', () => {
     })
 
     it('cannot exceed maxSize', async () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 3, allowToContainReferenceId: false, emitEvents: true })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 3, allowToContainReferenceId: false })
         const onContactRemoved = jest.fn()
         list.on('contactRemoved', onContactRemoved)
         list.addContact(item1)
@@ -43,7 +43,7 @@ describe('SortedContactList', () => {
     })
 
     it('removing contacts', async () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: true })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false })
         const onContactRemoved = jest.fn()
         list.on('contactRemoved', onContactRemoved)
         list.removeContact(createRandomDhtAddress())
@@ -72,8 +72,7 @@ describe('SortedContactList', () => {
         const list = new SortedContactList({
             referenceId: item0.getNodeId(), 
             maxSize: 8, 
-            allowToContainReferenceId: false, 
-            emitEvents: false 
+            allowToContainReferenceId: false
         })
         list.addContact(item1)
         list.addContact(item3)
@@ -84,7 +83,7 @@ describe('SortedContactList', () => {
     })
 
     it('get active contacts', () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false, emitEvents: false })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false })
         list.addContact(item1)
         list.addContact(item3)
         list.addContact(item4)
@@ -96,7 +95,7 @@ describe('SortedContactList', () => {
     })
 
     it('does not emit contactAdded if contact did not fit the structure', () => {
-        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 2, allowToContainReferenceId: false, emitEvents: true })
+        const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 2, allowToContainReferenceId: false })
         const onContactAdded = jest.fn()
         list.on('contactAdded', onContactAdded)
         list.addContact(item1)


### PR DESCRIPTION
We can check if there are any event listeners registered, and emit the events only if there are some listeners.