### PR TITLE
refactor(dht): Rename `PeerManager` fields

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -51,21 +51,19 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     // * 'connections' are the nodes that are connected to this node on Layer0
     // * 'contacts' are all non-unresponsive nodes that we know about
 
-    // The kademlia k-bucket
-    private bucket: KBucket<DhtNodeRpcRemote>
+    private neighbors: KBucket<DhtNodeRpcRemote>
     // Nodes that are connected to this node on Layer0
     public readonly connections: Map<DhtAddress, DhtNodeRpcRemote> = new Map()
-    // All nodes that we know about
-    private contacts: SortedContactList<DhtNodeRpcRemote>
-    private randomPeers: RandomContactList<DhtNodeRpcRemote>
+    private closestContacts: SortedContactList<DhtNodeRpcRemote>
     private ringContacts: RingContactList<DhtNodeRpcRemote>
+    private randomContacts: RandomContactList<DhtNodeRpcRemote>
     private stopped: boolean = false
     private readonly config: PeerManagerConfig
 
     constructor(config: PeerManagerConfig) {
         super()
         this.config = config
-        this.bucket = new KBucket<DhtNodeRpcRemote>({
+        this.neighbors = new KBucket<DhtNodeRpcRemote>({
             localNodeId: getRawFromDhtAddress(this.config.localNodeId),
             numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
             numberOfNodesToPing: this.config.numberOfNodesPerKBucket
@@ -77,33 +75,33 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.ringContacts.on('ringContactRemoved', (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => {
             this.emit('ringContactRemoved', peerDescriptor, closestPeers)
         })
-        this.bucket.on('ping', (oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote) => this.onKBucketPing(oldContacts, newContact))
-        this.bucket.on('removed', (contact: DhtNodeRpcRemote) => this.onKBucketRemoved(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
-        this.bucket.on('added', (contact: DhtNodeRpcRemote) => this.onKBucketAdded(contact))
-        this.bucket.on('updated', () => {
+        this.neighbors.on('ping', (oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote) => this.onKBucketPing(oldContacts, newContact))
+        this.neighbors.on('removed', (contact: DhtNodeRpcRemote) => this.onKBucketRemoved(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
+        this.neighbors.on('added', (contact: DhtNodeRpcRemote) => this.onKBucketAdded(contact))
+        this.neighbors.on('updated', () => {
             // TODO: Update contact info to the connection manager and reconnect
         })
-        this.contacts = new SortedContactList({
+        this.closestContacts = new SortedContactList({
             referenceId: this.config.localNodeId,
             maxSize: this.config.maxContactListSize,
             allowToContainReferenceId: false,
             emitEvents: true
         })
-        this.contacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
+        this.closestContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
             if (this.stopped) {
                 return
             }
             this.emit('contactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
-            this.randomPeers.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
+            this.randomContacts.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
         })
-        this.contacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+        this.closestContacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('contactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
-        this.randomPeers = new RandomContactList(this.config.localNodeId, this.config.maxContactListSize)
-        this.randomPeers.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+        this.randomContacts = new RandomContactList(this.config.localNodeId, this.config.maxContactListSize)
+        this.randomContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
-        this.randomPeers.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
+        this.randomContacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
             this.emit('randomContactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
         )
     }
@@ -122,8 +120,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         const sortedContacts = sortingList.getAllContacts()
         const removableNodeId = sortedContacts[sortedContacts.length - 1].getNodeId()
         this.config.connectionLocker?.weakUnlockConnection(removableNodeId, this.config.lockId)
-        this.bucket.remove(getRawFromDhtAddress(removableNodeId))
-        this.bucket.add(newContact)
+        this.neighbors.remove(getRawFromDhtAddress(removableNodeId))
+        this.neighbors.add(newContact)
     }
 
     private onKBucketRemoved(nodeId: DhtAddress): void {
@@ -132,7 +130,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
         this.config.connectionLocker?.weakUnlockConnection(nodeId, this.config.lockId)
         logger.trace(`Removed contact ${nodeId}`)
-        if (this.bucket.count() === 0) {
+        if (this.neighbors.count() === 0) {
             this.emit('kBucketEmpty')
         }
     }
@@ -180,9 +178,9 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     }
 
     private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
-        for (const contactId of this.contacts.getContactIds()) {
-            if (!this.bucket.get(getRawFromDhtAddress(contactId)) && this.contacts.isActive(contactId)) {
-                return this.contacts.getContact(contactId)!.contact
+        for (const contactId of this.closestContacts.getContactIds()) {
+            if (!this.neighbors.get(getRawFromDhtAddress(contactId)) && this.closestContacts.isActive(contactId)) {
+                return this.closestContacts.getContact(contactId)!.contact
             }
         }
         return undefined
@@ -207,7 +205,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         logger.trace('disconnected: ' + nodeId)
         this.connections.delete(nodeId)
         if (this.config.isLayer0) {
-            this.bucket.remove(getRawFromDhtAddress(nodeId))
+            this.neighbors.remove(getRawFromDhtAddress(nodeId))
             if (gracefulLeave === true) {
                 logger.trace(nodeId + ' ' + 'onTransportDisconnected with gracefulLeave ' + gracefulLeave)
                 this.removeContact(nodeId)
@@ -222,25 +220,25 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         logger.trace(`Removing contact ${nodeId}`)
-        this.ringContacts.removeContact(this.contacts.getContact(nodeId)?.contact)
-        this.bucket.remove(getRawFromDhtAddress(nodeId))
-        this.contacts.removeContact(nodeId)
-        this.randomPeers.removeContact(nodeId)
+        this.ringContacts.removeContact(this.closestContacts.getContact(nodeId)?.contact)
+        this.neighbors.remove(getRawFromDhtAddress(nodeId))
+        this.closestContacts.removeContact(nodeId)
+        this.randomContacts.removeContact(nodeId)
     }
 
     stop(): void {
         this.stopped = true
-        this.bucket.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => {
+        this.neighbors.toArray().forEach((rpcRemote: DhtNodeRpcRemote) => {
             rpcRemote.leaveNotice()
-            this.bucket.remove(rpcRemote.id)
+            this.neighbors.remove(rpcRemote.id)
         })
-        this.bucket.removeAllListeners()
+        this.neighbors.removeAllListeners()
         this.ringContacts.getAllContacts().forEach((rpcRemote) => {
             rpcRemote.leaveNotice()
             this.ringContacts.removeContact(rpcRemote)
         })
-        this.contacts.stop()
-        this.randomPeers.stop()
+        this.closestContacts.stop()
+        this.randomContacts.stop()
         this.connections.clear()
     }
 
@@ -252,7 +250,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             excludedNodeIds,
             maxSize: limit
         })
-        this.bucket.toArray().forEach((contact) => closest.addContact(contact))
+        this.neighbors.toArray().forEach((contact) => closest.addContact(contact))
         return closest.getAllContacts()
     }
 
@@ -265,7 +263,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             excludedNodeIds,
             maxSize: limit
         })
-        this.contacts.getAllContacts().map((contact) => closest.addContact(contact))
+        this.closestContacts.getAllContacts().map((contact) => closest.addContact(contact))
         return closest.getAllContacts()
     }
 
@@ -275,13 +273,13 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         excludedIds?: Set<DhtAddress>
     ): { left: DhtNodeRpcRemote[], right: DhtNodeRpcRemote[] } {
         const closest = new RingContactList<DhtNodeRpcRemote>(ringIdRaw, false, excludedIds)
-        this.contacts.getAllContacts().map((contact) => closest.addContact(contact))
+        this.closestContacts.getAllContacts().map((contact) => closest.addContact(contact))
         this.ringContacts.getAllContacts().map((contact) => closest.addContact(contact))
         return closest.getClosestContacts(limit ?? 8)
     }
 
     getContactCount(excludedNodeIds?: Set<DhtAddress>): number {
-        return this.contacts.getSize(excludedNodeIds)
+        return this.closestContacts.getSize(excludedNodeIds)
     }
 
     getConnectionCount(): number {
@@ -289,15 +287,15 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     }
 
     getNeighborCount(): number {
-        return this.bucket.count()
+        return this.neighbors.count()
     }
 
     getNeighbors(): PeerDescriptor[] {
-        return this.bucket.toArray().map((rpcRemote: DhtNodeRpcRemote) => rpcRemote.getPeerDescriptor())
+        return this.neighbors.toArray().map((rpcRemote: DhtNodeRpcRemote) => rpcRemote.getPeerDescriptor())
     }
 
     setContactActive(nodeId: DhtAddress): void {
-        this.contacts.setActive(nodeId)
+        this.closestContacts.setActive(nodeId)
     }
 
     addContact(peerDescriptor: PeerDescriptor): void {
@@ -308,18 +306,18 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         if (nodeId !== this.config.localNodeId) {
             logger.trace(`Adding new contact ${nodeId}`)
             const remote = this.config.createDhtNodeRpcRemote(peerDescriptor)
-            const isInBucket = (this.bucket.get(peerDescriptor.nodeId) !== null)
-            const isInContacts = (this.contacts.getContact(nodeId) !== undefined)
+            const isInNeighbors = (this.neighbors.get(peerDescriptor.nodeId) !== null)
+            const isInClosestContacts = (this.closestContacts.getContact(nodeId) !== undefined)
             const isInRingContacts = this.ringContacts.getContact(peerDescriptor) !== undefined
 
-            if (isInBucket || isInContacts) {
-                this.randomPeers.addContact(remote)
+            if (isInNeighbors || isInClosestContacts) {
+                this.randomContacts.addContact(remote)
             }
-            if (!isInBucket) {
-                this.bucket.add(remote)
+            if (!isInNeighbors) {
+                this.neighbors.add(remote)
             }
-            if (!isInContacts) {
-                this.contacts.addContact(remote)
+            if (!isInClosestContacts) {
+                this.closestContacts.addContact(remote)
             }
             if (!isInRingContacts) {
                 this.ringContacts.addContact(remote)


### PR DESCRIPTION
Renamed: 
- `bucket` -> `neighbors`
- `contacts` -> `closestContacts`
- `randomPeers` -> `randomContacts`

## Future improvements

- Maybe update some `PeerManager` method names