### PR TITLE
refactor(dht): Remove `ContactState` wrapper

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -181,7 +181,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     private getClosestActiveContactNotInBucket(): DhtNodeRpcRemote | undefined {
         for (const contactId of this.contacts.getContactIds()) {
             if (!this.bucket.get(getRawFromDhtAddress(contactId)) && this.activeContacts.has(contactId)) {
-                return this.contacts.getContact(contactId)!.contact
+                return this.contacts.getContact(contactId)!
             }
         }
         return undefined
@@ -221,7 +221,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         logger.trace(`Removing contact ${nodeId}`)
-        this.ringContacts.removeContact(this.contacts.getContact(nodeId)?.contact)
+        this.ringContacts.removeContact(this.contacts.getContact(nodeId))
         this.bucket.remove(getRawFromDhtAddress(nodeId))
         this.contacts.removeContact(nodeId)
         this.activeContacts.delete(nodeId)

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -1,15 +1,6 @@
 import EventEmitter from 'eventemitter3'
 import { DhtAddress } from '../../identifiers'
 
-export class ContactState<C> {  // TODO remove this wrapper
-
-    public contact: C
-
-    constructor(contact: C) {
-        this.contact = contact
-    }
-}
-
 export interface Events<C> {
     contactRemoved: (removedContact: C, closestContacts: C[]) => void
     contactAdded: (contactAdded: C, closestContacts: C[]) => void
@@ -17,7 +8,7 @@ export interface Events<C> {
 
 export class ContactList<C extends { getNodeId: () => DhtAddress }> extends EventEmitter<Events<C>> {
 
-    protected contactsById: Map<DhtAddress, ContactState<C>> = new Map()
+    protected contactsById: Map<DhtAddress, C> = new Map()
     // TODO move this to SortedContactList
     protected contactIds: DhtAddress[] = []
     protected localNodeId: DhtAddress
@@ -35,7 +26,7 @@ export class ContactList<C extends { getNodeId: () => DhtAddress }> extends Even
         this.defaultContactQueryLimit = defaultContactQueryLimit
     }
 
-    public getContact(id: DhtAddress): ContactState<C> | undefined {
+    public getContact(id: DhtAddress): C | undefined {
         return this.contactsById.get(id)
     }
 

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -1,5 +1,5 @@
 import { DhtAddress } from '../../identifiers'
-import { ContactList, ContactState } from './ContactList'
+import { ContactList } from './ContactList'
 
 export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extends ContactList<C> {
 
@@ -27,7 +27,7 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
                     this.removeContact(toRemove)
                 }
                 this.contactIds.push(contact.getNodeId())
-                this.contactsById.set(contact.getNodeId(), new ContactState(contact))
+                this.contactsById.set(contact.getNodeId(), contact)
                 this.emit(
                     'contactAdded',
                     contact,
@@ -39,7 +39,7 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
 
     removeContact(id: DhtAddress): boolean {
         if (this.contactsById.has(id)) {
-            const removed = this.contactsById.get(id)!.contact
+            const removed = this.contactsById.get(id)!
             const index = this.contactIds.findIndex((nodeId) => (nodeId === id))
             this.contactIds.splice(index, 1)
             this.contactsById.delete(id)
@@ -50,13 +50,6 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
     }
 
     public getContacts(limit = this.defaultContactQueryLimit): C[] {
-        const ret: C[] = []
-        this.contactIds.forEach((contactId) => {
-            const contact = this.contactsById.get(contactId)
-            if (contact) {
-                ret.push(contact.contact)
-            }
-        })
-        return ret.slice(0, limit)
+        return this.contactIds.map((contactId) => this.contactsById.get(contactId)!).slice(0, limit)
     }
 }

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -50,6 +50,6 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
     }
 
     public getContacts(limit = this.defaultContactQueryLimit): C[] {
-        return this.contactIds.map((contactId) => this.contactsById.get(contactId)!).slice(0, limit)
+        return this.contactIds.slice(0, limit).map((contactId) => this.contactsById.get(contactId)!)
     }
 }


### PR DESCRIPTION
The state management was moved to PeerManager in https://github.com/streamr-dev/network/pull/2456. Therefore the `ContactState` wrapper is no longer needed.