### PR TITLE
fix(network): Change NetworkStack#start info logs

### DIFF
--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -105,8 +105,9 @@ export class NetworkStack {
     }
 
     async start(doJoin = true): Promise<void> {
+        logger.info('Starting a Streamr Network Node')
         await this.layer0Node!.start()
-        logger.info(`Starting node with id ${getNodeIdFromPeerDescriptor(this.layer0Node!.getLocalPeerDescriptor())}`)
+        logger.info(`Node id is ${getNodeIdFromPeerDescriptor(this.layer0Node!.getLocalPeerDescriptor())}`)
         const connectionManager = this.layer0Node!.getTransport() as ConnectionManager
         if ((this.options.layer0?.entryPoints !== undefined) && (this.options.layer0.entryPoints.some((entryPoint) => 
             areEqualPeerDescriptors(entryPoint, this.layer0Node!.getLocalPeerDescriptor())


### PR DESCRIPTION
## Summary

Changed the start logging sequence to be as follows:

```
INFO [2024-03-28T12:31:13.274] (NetworkStack             ): Starting a Streamr Network Node
INFO [2024-03-28T12:31:13.305] (NetworkStack             ): Node id is 0822cfa25a09cb3fd4159e8a1aecd2af2a1eb129
```

The first line is logged immediately when start() is called. The second line is logged after the node has created a valid PeerDescriptor.