### PR TITLE
fix(dht): Node 18 compatibility in `SortedContactList#getFurthestContacts`

### DIFF
--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -105,7 +105,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
      * Furthest first then others in descending distance order
      */
     getFurthestContacts(limit?: number): C[] {
-        const ret = this.getClosestContacts().toReversed()
+        const ret = this.getClosestContacts().reverse()
         return (limit === undefined) 
             ? ret 
             : ret.slice(0, Math.max(limit, 0))

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -105,7 +105,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
      * Furthest first then others in descending distance order
      */
     getFurthestContacts(limit?: number): C[] {
-        const ret = this.getClosestContacts().reverse()
+        const ret = [...this.getClosestContacts()].reverse()
         return (limit === undefined) 
             ? ret 
             : ret.slice(0, Math.max(limit, 0))


### PR DESCRIPTION
Use `reverse()` instead of `toReversed()`  to keep Node 18 compatibility.

Copying the array before reversing it is not strictly required, but it is safer to do so as the `getClosestContacts` implementation may change in the future.