### PR TITLE
refactor(dht): Add `DhtNodeOptions#connectionLocker`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -77,6 +77,7 @@ export interface DhtNodeOptions {
     region?: number
 
     transport?: ITransport
+    connectionLocker?: ConnectionLocker
     peerDescriptor?: PeerDescriptor
     entryPoints?: PeerDescriptor[]
     websocketHost?: string
@@ -193,13 +194,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.region = await getLocalRegion()
         }
             
-        // If transport is given, do not create a ConnectionManager
         if (this.config.transport) {
             this.transport = this.config.transport
+            this.connectionLocker = this.config.connectionLocker
             this.localPeerDescriptor = this.transport.getLocalPeerDescriptor()
-            if (this.config.transport instanceof ConnectionManager) {
-                this.connectionLocker = this.config.transport
-            }
         } else {
             const connectorFacadeConfig: DefaultConnectorFacadeConfig = {
                 transport: this,
@@ -310,7 +308,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             maxContactListSize: this.config.maxNeighborListSize,
             localNodeId: this.getNodeId(),
             localPeerDescriptor: this.localPeerDescriptor!,
-            connectionLocker: this.connectionLocker!,
+            connectionLocker: this.connectionLocker,
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
             isLayer0: (this.connectionLocker !== undefined),
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -56,6 +56,7 @@ export const createMockRingNode = async (
     const opts = {
         peerDescriptor: peerDescriptor,
         transport: mockConnectionManager,
+        connectionLocker: mockConnectionManager,
         numberOfNodesPerKBucket: 8,
         maxConnections: maxConnections,
         dhtJoinTimeout,
@@ -88,6 +89,7 @@ export const createMockConnectionDhtNode = async (
     const opts = {
         peerDescriptor: peerDescriptor,
         transport: mockConnectionManager,
+        connectionLocker: mockConnectionManager,
         numberOfNodesPerKBucket,
         maxConnections: maxConnections,
         dhtJoinTimeout,


### PR DESCRIPTION
The `connectionLocker` is provided in an explicit option instead of reading it from `config.transport `conditionally. This way we can configure both options separately e.g in tests. There is also less coupling between transport and connection locker features. 

Fixed also a type assertion.

## Future improvements

- We could always create  `transport` and `connectionLocker` outside of `DhtNode`