### PR TITLE
feat(client) [NET-1281]: Include nodeId in metrics payload

### DIFF
--- a/docs/docs/usage/streamr-js-client/configuration/metrics-publishing.md
+++ b/docs/docs/usage/streamr-js-client/configuration/metrics-publishing.md
@@ -8,6 +8,7 @@ By default, the Streamr SDK is configured to publish metrics to the Streamr Netw
 ```ts
 {
     node: {
+        id: string
         broadcastMessagesPerSecond: number
         broadcastBytesPerSecond: number
         sendMessagesPerSecond: number

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -87,8 +87,15 @@ export class MetricsPublisher {
 
     private async publish(report: MetricsReport, streamId: string, partitionKey: string): Promise<void> {
         await wait(Math.random() * this.config.maxPublishDelay)
+        const message = {
+            ...report,
+            node: { 
+                ...report.node,
+                id: await this.node.getNodeId()
+            }
+        }
         try {
-            await this.publisher.publish(streamId, report, {
+            await this.publisher.publish(streamId, message, {
                 timestamp: report.period.end,
                 partitionKey
             })

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -65,6 +65,7 @@ describe('NodeMetrics', () => {
         await waitForCondition(() => report !== undefined, 10000)
         expect(report!).toMatchObject({
             node: {
+                id: await generatorClient.getNodeId(),
                 broadcastMessagesPerSecond: expect.any(Number),
                 broadcastBytesPerSecond: expect.any(Number),
                 sendMessagesPerSecond: expect.any(Number),

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -1,12 +1,13 @@
 import 'reflect-metadata'
 
+import { DhtAddress } from '@streamr/dht'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { LevelMetric, MetricsContext, wait } from '@streamr/utils'
 import { StreamrClientConfig } from '../../src/Config'
 import { DestroySignal } from '../../src/DestroySignal'
-import { StreamrClientEventEmitter } from '../../src/events'
-import { MetricsPublisher, DEFAULTS } from '../../src/MetricsPublisher'
+import { DEFAULTS, MetricsPublisher } from '../../src/MetricsPublisher'
 import { NetworkNodeFacade } from '../../src/NetworkNodeFacade'
+import { StreamrClientEventEmitter } from '../../src/events'
 import { Publisher } from '../../src/publish/Publisher'
 import { waitForCalls } from '../test-utils/utils'
 
@@ -23,11 +24,11 @@ describe('MetricsPublisher', () => {
         const publisher: Pick<Publisher, 'publish'> = {
             publish: publishReportMessage
         }
-        const node: Pick<NetworkNodeFacade, 'getNode'> = {
+        const node: Pick<NetworkNodeFacade, 'getNode' | 'getNodeId'> = {
             getNode: async () => ({
                 getMetricsContext: () => metricsContext,
-                getNodeId: () => nodeAddress + '#mock-session-id'
-            }) as any
+            }) as any,
+            getNodeId: async () => '12345678' as DhtAddress
         }
         const authentication = {
             getAddress: async () => nodeAddress


### PR DESCRIPTION
In Brubeck era we used the `publisherId` of the message to identify the publisher node. Now it makes sense to add a separate field as there is no trivial mapping between `publisherId` and `nodeId`.