### PR TITLE
feat(client): Use node ID as partition key in metrics publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Changed
 
-- The partition of the metrics streams is calculated from the node ID
+- Change the way in which the partition of the metrics stream is calculated (based on node ID)
 
 #### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
+- Metrics stream messages contain the node ID
+
 #### Changed
+
+- The partition of the metrics streams is calculated from the node ID
 
 #### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
-- Metrics stream messages contain the node ID
+- Add node ID to metrics messages
 
 #### Changed
 

--- a/packages/client/test/end-to-end/Metrics.test.ts
+++ b/packages/client/test/end-to-end/Metrics.test.ts
@@ -48,9 +48,7 @@ describe('NodeMetrics', () => {
     it('should retrieve a metrics report', async () => {
         let report: MetricsReport | undefined
 
-        const nodeAddress = await generatorClient.getAddress()
-        const partition = keyToArrayIndex(NUM_OF_PARTITIONS, nodeAddress)
-
+        const partition = keyToArrayIndex(NUM_OF_PARTITIONS, await generatorClient.getNodeId())
         await subscriberClient.subscribe({ id: stream.id, partition }, (content: any) => {
             const isReady = content.node.connectionAverageCount > 0
             if (isReady && (report === undefined)) {

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata'
 
 import { DhtAddress } from '@streamr/dht'
-import { randomEthereumAddress } from '@streamr/test-utils'
 import { LevelMetric, MetricsContext, wait } from '@streamr/utils'
 import { StreamrClientConfig } from '../../src/Config'
 import { DestroySignal } from '../../src/DestroySignal'
@@ -11,7 +10,7 @@ import { StreamrClientEventEmitter } from '../../src/events'
 import { Publisher } from '../../src/publish/Publisher'
 import { waitForCalls } from '../test-utils/utils'
 
-const nodeAddress = randomEthereumAddress()
+const NODE_ID = '12345678' as DhtAddress
 const DEFAULT_DURATIONS = DEFAULTS.periods.map((p) => p.duration)
 
 describe('MetricsPublisher', () => {
@@ -20,24 +19,20 @@ describe('MetricsPublisher', () => {
     let metricsContext: MetricsContext
     let destroySignal: DestroySignal
 
-    const startMetricsPublisher = (config: Pick<StreamrClientConfig, 'metrics' | 'auth'>) => {
+    const startMetricsPublisher = (config: Pick<StreamrClientConfig, 'metrics'>) => {
         const publisher: Pick<Publisher, 'publish'> = {
             publish: publishReportMessage
         }
-        const node: Pick<NetworkNodeFacade, 'getNode' | 'getNodeId'> = {
+        const node: Pick<NetworkNodeFacade, 'getNode'> = {
             getNode: async () => ({
                 getMetricsContext: () => metricsContext,
+                getNodeId: () => NODE_ID
             }) as any,
-            getNodeId: async () => '12345678' as DhtAddress
-        }
-        const authentication = {
-            getAddress: async () => nodeAddress
         }
         const eventEmitter = new StreamrClientEventEmitter()
         new MetricsPublisher(
             publisher as any,
             node as any,
-            authentication as any,
             config,
             eventEmitter,
             destroySignal
@@ -48,7 +43,7 @@ describe('MetricsPublisher', () => {
     }
 
     const assertPublisherEnabled = async (
-        config: Pick<StreamrClientConfig, 'metrics' | 'auth'>,
+        config: Pick<StreamrClientConfig, 'metrics'>,
         expectedDurations: number[]
     ) => {
         startMetricsPublisher(config)
@@ -107,7 +102,7 @@ describe('MetricsPublisher', () => {
             }
         })
         expect(publishMetadata).toMatchObject({
-            partitionKey: nodeAddress,
+            partitionKey: NODE_ID,
             timestamp: expect.toBeNumber()
         })
     })


### PR DESCRIPTION
The partition is now determined by `nodeId` instead of the `userId`. This way e.g. the Network Explorer can calculate a partition number in order to receive some node-specific metrics messages.