### PR TITLE
chore: Enable `no-useless-return` eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,8 @@ module.exports = {
         //'@typescript-eslint/no-empty-function': 'error',
         'no-multi-spaces': ["error", { ignoreEOLComments: true }],
         'default-case': ['error'],
+        'no-useless-return': 'error',
+        'promise/always-return': ['error', { ignoreLastCallback: true }],
         // TODO: in follow up PRs, select which rules we should enable and fix the code. When all recommended rules
         //  have been enabled, consider enabling the "strict" preset.
         '@typescript-eslint/require-await': 'off',

--- a/packages/autocertifier-server/src/RestServer.ts
+++ b/packages/autocertifier-server/src/RestServer.ts
@@ -120,7 +120,7 @@ export class RestServer {
             sendResponse(res, session)
         } catch (err) {
             sendError(res, err)
-            return
+            
         }
     }
 
@@ -147,7 +147,7 @@ export class RestServer {
             sendResponse(res, certifiedSubdomain)
         } catch (err) {
             sendError(res, err)
-            return
+            
         }
     }
 
@@ -181,7 +181,7 @@ export class RestServer {
             sendResponse(res, certifiedSubdomain)
         } catch (err) {
             sendError(res, err)
-            return
+            
         }
     }
 

--- a/packages/autocertifier-server/src/StreamrChallenger.ts
+++ b/packages/autocertifier-server/src/StreamrChallenger.ts
@@ -67,7 +67,6 @@ export const runStreamrChallenge = (
             // eslint-disable-next-line promise/catch-or-return
             rpcClient.hasSession({ sessionId }).then(() => {
                 resolve()
-                return
             }).catch((e) => {
                 reject(e)
             }).finally(() => {

--- a/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/broker/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -177,7 +177,7 @@ describe(OperatorFleetState, () => {
 
         beforeEach(() => {
             ready = false
-            // eslint-disable-next-line promise/always-return,promise/catch-or-return
+            // eslint-disable-next-line promise/catch-or-return
             state.waitUntilReady().then(() => {
                 ready = true
             })

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -509,7 +509,6 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             // eslint-disable-next-line promise/catch-or-return
             waitForEvent3<ManagedConnectionEvents>(connection, 'disconnected', 2000).then(() => {
                 logger.trace('disconnected event received in gracefullyDisconnectAsync()')
-                return
             })
                 .catch((e) => {
                     logger.trace('force-closing connection after timeout ' + e)

--- a/packages/dht/src/connection/connectivityChecker.ts
+++ b/packages/dht/src/connection/connectivityChecker.ts
@@ -87,8 +87,6 @@ export const sendConnectivityRequest = async (
                         } else {
                             reject(`Unsupported version: ${remoteVersion}`)
                         }
-                    } else {
-                        return
                     }
                 } catch (err) {
                     logger.trace('Could not parse message', { err })

--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -119,7 +119,6 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
     public addRemoteCandidate(candidate: string, mid: string): void {
         this.peerConnection?.addIceCandidate({ candidate: candidate, sdpMid: mid })
-            .then(() => { return })
             .catch((err) => {
                 logger.warn('Failed to add ICE candidate', { err })
             })

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -275,7 +275,6 @@ export class WebsocketConnector {
             )
             remoteConnector.requestConnection().then(() => {
                 logger.trace('Sent WebsocketConnectionRequest notification to peer', { targetPeerDescriptor })
-                return
             }, (err) => {
                 logger.debug('Failed to send WebsocketConnectionRequest notification to peer ', {
                     error: err, targetPeerDescriptor

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -156,7 +156,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
                         this.removeContact(nodeId)
                         this.addClosestContactToBucket()
                     }
-                    return
                 }).catch((_e) => {
                     this.config.connectionLocker?.weakUnlockConnection(nodeId, this.config.lockId)
                     this.removeContact(nodeId)

--- a/packages/dht/test/utils/mock/Router.ts
+++ b/packages/dht/test/utils/mock/Router.ts
@@ -6,17 +6,14 @@ export class MockRouter implements Methods<Router> {
 
     // eslint-disable-next-line class-methods-use-this
     addRoutingSession(): void {
-        return
     }
 
     // eslint-disable-next-line class-methods-use-this
     removeRoutingSession(): void {
-        return
     }
 
     // eslint-disable-next-line class-methods-use-this
     addToDuplicateDetector(): void {
-        return
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/proto-rpc/src/RpcCommunicator.ts
+++ b/packages/proto-rpc/src/RpcCommunicator.ts
@@ -225,7 +225,6 @@ export class RpcCommunicator<T extends ProtoCallContext> extends EventEmitter<Rp
                             ongoingRequest.resolveNotification()
                         }
                     }
-                    return
                 })
         } else {
             if (deferredPromises) {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -110,7 +110,6 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
                 if (response.accepted) {
                     this.config.neighbors.remove(getNodeIdFromPeerDescriptor(lastPeerDescriptor!))
                 }
-                return
             }).catch(() => {
                 // no-op: InterleaveRequest cannot reject
             }).finally(() => {

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -148,7 +148,7 @@ const run = async () => {
     await shutdownNetwork()
 } 
 
-// eslint-disable-next-line promise/catch-or-return, promise/always-return
+// eslint-disable-next-line promise/catch-or-return
 run().then(() => {
     console.log('done')
 }).catch((err) => {

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -38,7 +38,6 @@ describe('Propagation', () => {
             )
             await layer1.start()
             await randomGraphNode.start()
-            // eslint-disable-next-line promise/always-return
             await layer1.joinDht([entryPointDescriptor]).then(() => {
                 randomGraphNode.on('message', () => { totalReceived += 1 })
                 layer1Nodes.push(layer1)

--- a/packages/trackerless-network/test/utils/mock/MockLayer0Node.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer0Node.ts
@@ -41,7 +41,6 @@ export class MockLayer0Node extends EventEmitter implements Layer0Node {
 
     // eslint-disable-next-line class-methods-use-this
     async send(): Promise<void> {
-        return
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Enable `no-useless-return` rule:
- https://eslint.org/docs/latest/rules/no-useless-return

Also enabled change config options for `promise/always-return` rule to allow omitting the unnecessary `return` in the last item of a callback chain:
- https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/always-return.md#ignorelastcallback

Autofixed  `no-useless-return` errors and disabled the unnecessary ignores of `promise/always-return`.
