### PR TITLE
test(dht): `DhtNode` integration test

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -241,7 +241,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
         this.rpcCommunicator = new RoutingRpcCommunicator(
             this.config.serviceId,
-            this.transport.send,
+            (msg, opts) => this.transport!.send(msg, opts),
             { rpcRequestTimeout: this.config.rpcRequestTimeout }
         )
 

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -1,0 +1,81 @@
+import { waitForCondition } from '@streamr/utils'
+import { range, without } from 'lodash'
+import { DhtNodeRpcLocal } from '../../src/dht/DhtNodeRpcLocal'
+import { Contact } from '../../src/dht/contact/Contact'
+import { SortedContactList } from '../../src/dht/contact/SortedContactList'
+import { DhtAddress, DhtNode, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '../../src/exports'
+import { ClosestPeersRequest, ClosestPeersResponse, PeerDescriptor, PingRequest, PingResponse } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { FakeEnvironment } from '../utils/FakeTransport'
+import { createMockPeerDescriptor } from '../utils/utils'
+
+const OTHER_NODE_COUNT = 3
+const SERVICE_ID_LAYER0 = 'layer0'
+
+const getClosestNodes = (
+    referenceId: DhtAddress,
+    nodes: PeerDescriptor[],
+    maxCount: number,
+    allowToContainReferenceId: boolean
+): PeerDescriptor[] => {
+    const list = new SortedContactList<Contact>({
+        referenceId,
+        allowToContainReferenceId,
+        maxSize: maxCount
+    })
+    list.addContacts(nodes.map((n) => new Contact(n)))
+    return list.getClosestContacts().map((c) => c.getPeerDescriptor())
+}
+
+describe('DhtNode', () => {
+
+    let localPeerDescriptor: PeerDescriptor
+    let entryPointPeerDescriptor: PeerDescriptor
+    let otherPeerDescriptors: PeerDescriptor[]
+
+    const startRemoteNode = (peerDescriptor: PeerDescriptor, environment: FakeEnvironment) => {
+        const epRpcCommunicator = new ListeningRpcCommunicator(SERVICE_ID_LAYER0, environment.createTransport(peerDescriptor))
+        const dhtNodeRpcLocal = new DhtNodeRpcLocal({
+            peerDiscoveryQueryBatchSize: undefined as any,
+            getClosestPeersTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
+            getClosestRingPeersTo: undefined as any,
+            addContact: () => {},
+            removeContact: undefined as any,
+        })
+        epRpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping',
+            (req: PingRequest, context) => dhtNodeRpcLocal.ping(req, context))
+        epRpcCommunicator.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers',
+            (req: ClosestPeersRequest, context) => dhtNodeRpcLocal.getClosestPeers(req, context))
+    }
+
+    const getAllPeerDescriptors = () => {
+        return [localPeerDescriptor, entryPointPeerDescriptor, ...otherPeerDescriptors]
+    }
+
+    beforeAll(() => {
+        localPeerDescriptor = createMockPeerDescriptor()
+        entryPointPeerDescriptor = createMockPeerDescriptor()
+        otherPeerDescriptors = range(OTHER_NODE_COUNT).map(() => createMockPeerDescriptor())
+    })
+      
+    it('start node and join DHT', async () => {
+        const environment = new FakeEnvironment()
+        startRemoteNode(entryPointPeerDescriptor, environment)
+        for (const other of otherPeerDescriptors) {
+            startRemoteNode(other, environment)
+        }
+
+        const localNode = new DhtNode({
+            peerDescriptor: localPeerDescriptor,
+            transport: environment.createTransport(localPeerDescriptor),
+            entryPoints: [entryPointPeerDescriptor]
+        })
+        await localNode.start()
+        await localNode.joinDht([entryPointPeerDescriptor])
+        await localNode.waitForNetworkConnectivity()
+
+        await waitForCondition(() => localNode.getNeighborCount() === otherPeerDescriptors.length + 1)
+        const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => getNodeIdFromPeerDescriptor(n))
+        const actualNodeIds = localNode.getClosestContacts().map((n) => getNodeIdFromPeerDescriptor(n))
+        expect(actualNodeIds).toIncludeSameMembers(expectedNodeIds)
+    }, 20 * 1000)
+})

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -77,5 +77,5 @@ describe('DhtNode', () => {
         const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => getNodeIdFromPeerDescriptor(n))
         const actualNodeIds = localNode.getClosestContacts().map((n) => getNodeIdFromPeerDescriptor(n))
         expect(actualNodeIds).toIncludeSameMembers(expectedNodeIds)
-    }, 20 * 1000)
+    })
 })

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -1,11 +1,16 @@
 import { EventEmitter } from 'eventemitter3'
-import { ITransport, TransportEvents } from '../../src/transport/ITransport'
+import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { DEFAULT_SEND_OPTIONS, ITransport, SendOptions, TransportEvents } from '../../src/transport/ITransport'
 
 class FakeTransport extends EventEmitter<TransportEvents> implements ITransport {
 
     private onSend: (msg: Message) => void
     private readonly localPeerDescriptor: PeerDescriptor
+    // currently adds a peerDescription to the connections array when a "connect" option is seen in
+    // in send() call and never disconnects (TODO could add some disconnection logic? and maybe
+    // the connection should be seen by another FakeTransport instance, too?)
+    private connections: PeerDescriptor[] = []
 
     constructor(peerDescriptor: PeerDescriptor, onSend: (msg: Message) => void) {
         super()
@@ -13,19 +18,27 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport 
         this.localPeerDescriptor = peerDescriptor
     }
 
-    async send(msg: Message): Promise<void> {
+    async send(msg: Message, opts?: SendOptions): Promise<void> {
+        const connect = opts?.connect ?? DEFAULT_SEND_OPTIONS.connect
+        const targetNodeId = getNodeIdFromPeerDescriptor(msg.targetDescriptor!)
+        if (connect && !this.connections.some((c) => getNodeIdFromPeerDescriptor(c) === targetNodeId)) {
+            this.connect(msg.targetDescriptor!)
+        }
         msg.sourceDescriptor = this.localPeerDescriptor
         this.onSend(msg)
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getLocalPeerDescriptor(): PeerDescriptor {
-        throw new Error('not implemented')
+        return this.localPeerDescriptor
     }
 
-    // eslint-disable-next-line class-methods-use-this
+    private connect(peerDescriptor: PeerDescriptor) {
+        this.connections.push(peerDescriptor)
+        this.emit('connected', peerDescriptor)
+    }
+
     getConnections(): PeerDescriptor[] {
-        throw new Error('not implemented')
+        return this.connections
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -39,7 +52,11 @@ export class FakeEnvironment {
 
     createTransport(peerDescriptor: PeerDescriptor): ITransport {
         const transport = new FakeTransport(peerDescriptor, (msg) => {
-            this.transports.forEach((t) => t.emit('message', msg))
+            const targetNode = getDhtAddressFromRaw(msg.targetDescriptor!.nodeId)
+            const targetTransport = this.transports.find((t) => getNodeIdFromPeerDescriptor(t.getLocalPeerDescriptor()) === targetNode)
+            if (targetTransport !== undefined) {
+                targetTransport.emit('message', msg)
+            }
         })
         this.transports.push(transport)
         return transport


### PR DESCRIPTION
Added a simple integration test for `DhtNode`. In the test there is an entry point, and 3 other nodes using the same _fake environment_, i.e. transports which propagate messages between instances just by calling `transport.send()` methods. The entry point and other nodes are minimalistic `DhtNodeRpcLocal` instances.

In the test the local joins a DHT. Soon after the join it should have 4 neighbors in the network (the entry point and the 3 other nodes).

Fixed also a `this` binding issue in `DhtNode`.

## Future improvements

- The connection management in `FakeTransport` is currently very straighforward. Maybe the connections could be bidirectional: i.e. if there is a connection from `A` to `B`, there should also be a connection from `B` to `A`. Maybe it could also have some disconnection logic or max connection count?