### PR TITLE
feat(dht): Optimize `DhtNode#getClosestContacts`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -241,7 +241,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
         this.rpcCommunicator = new RoutingRpcCommunicator(
             this.config.serviceId,
-            this.transport.send,
+            (msg, opts) => this.transport!.send(msg, opts),
             { rpcRequestTimeout: this.config.rpcRequestTimeout }
         )
 

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -432,9 +432,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getClosestContacts(limit?: number): PeerDescriptor[] {
-        return this.peerManager!.getClosestContactsTo(
-            this.getNodeId(),
-            limit).map((peer) => peer.getPeerDescriptor())
+        return this.peerManager!.getClosestContacts()
+            .getClosestContacts(limit)
+            .map((peer) => peer.getPeerDescriptor())
     }
 
     public getClosestRingContactsTo(ringIdRaw: RingIdRaw, limit?: number): RingContacts {

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -7,7 +7,7 @@ import {
 } from '../proto/packages/dht/protos/DhtRpc'
 import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
 import { RandomContactList } from './contact/RandomContactList'
-import { SortedContactList } from './contact/SortedContactList'
+import { ReadonlySortedContactList, SortedContactList } from './contact/SortedContactList'
 import { ConnectionLocker } from '../connection/ConnectionManager'
 import EventEmitter from 'eventemitter3'
 import { DhtAddress, DhtAddressRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../identifiers'
@@ -252,18 +252,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         return closest.getClosestContacts()
     }
 
-    // TODO reduce copy-paste?
-    getClosestContactsTo(referenceId: DhtAddress, limit?: number, excludedNodeIds?: Set<DhtAddress>): DhtNodeRpcRemote[] {
-        const closest = new SortedContactList<DhtNodeRpcRemote>({
-            referenceId,
-            allowToContainReferenceId: true,
-            excludedNodeIds,
-            maxSize: limit
-        })
-        for (const contact of this.closestContacts.getAllContactsInUndefinedOrder()) {
-            closest.addContact(contact)
-        }
-        return closest.getClosestContacts()
+    getClosestContacts(): ReadonlySortedContactList<DhtNodeRpcRemote> {
+        return this.closestContacts
     }
 
     getClosestRingContactsTo(

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -4,6 +4,10 @@ import EventEmitter from 'eventemitter3'
 import { getDistance } from '../PeerManager'
 import { DhtAddress, getRawFromDhtAddress } from '../../identifiers'
 
+// add other getters in the future if needed
+export type ReadonlySortedContactList<C extends { getNodeId: () => DhtAddress }> =
+    Pick<SortedContactList<C>, 'getClosestContacts' | 'getAllContactsInUndefinedOrder'>
+
 export interface SortedContactListConfig {
     referenceId: DhtAddress  // all contacts in this list are in sorted by the distance to this ID
     allowToContainReferenceId: boolean
@@ -142,7 +146,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
         return false
     }
 
-    public getAllContactsInUndefinedOrder(): IterableIterator<C> {
+    public getAllContactsInUndefinedOrder(): Iterable<C> {
         return this.contactsById.values()
     }
 

--- a/packages/dht/src/dht/contact/getClosestContacts.ts
+++ b/packages/dht/src/dht/contact/getClosestContacts.ts
@@ -1,0 +1,22 @@
+import { DhtAddress } from '../../identifiers'
+import { SortedContactList } from './SortedContactList'
+
+export const getClosestContacts = <C extends { getNodeId: () => DhtAddress }>(
+    referenceId: DhtAddress,
+    contacts: Iterable<C>,
+    opts?: {
+        maxCount?: number
+        excludedNodeIds?: Set<DhtAddress>
+    }
+): C[] => {
+    const list = new SortedContactList<C>({
+        referenceId,
+        allowToContainReferenceId: true,
+        excludedNodeIds: opts?.excludedNodeIds,
+        maxSize: opts?.maxCount
+    })
+    for (const contact of contacts) {
+        list.addContact(contact)
+    }
+    return list.getClosestContacts()
+}

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -5,6 +5,7 @@ import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { PeerManager, getDistance } from '../PeerManager'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { DhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../identifiers'
+import { getClosestContacts } from '../contact/getClosestContacts'
 
 const logger = new Logger(module)
 
@@ -82,10 +83,13 @@ export class DiscoverySession {
         if (this.stopped) {
             return
         }
-        const uncontacted = this.config.peerManager.getClosestContactsTo(
+        const uncontacted = getClosestContacts(
             this.config.targetId,
-            this.config.parallelism,
-            this.config.contactedPeers
+            this.config.peerManager.getClosestContacts().getAllContactsInUndefinedOrder(),
+            {
+                maxCount: this.config.parallelism,
+                excludedNodeIds: this.config.contactedPeers
+            }
         )
         if (uncontacted.length === 0 || this.noProgressCounter >= this.config.noProgressLimit) {
             this.emitter.emit('discoveryCompleted')

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -1,0 +1,81 @@
+import { waitForCondition } from '@streamr/utils'
+import { range, without } from 'lodash'
+import { DhtNodeRpcLocal } from '../../src/dht/DhtNodeRpcLocal'
+import { Contact } from '../../src/dht/contact/Contact'
+import { SortedContactList } from '../../src/dht/contact/SortedContactList'
+import { DhtAddress, DhtNode, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '../../src/exports'
+import { ClosestPeersRequest, ClosestPeersResponse, PeerDescriptor, PingRequest, PingResponse } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { FakeEnvironment } from '../utils/FakeTransport'
+import { createMockPeerDescriptor } from '../utils/utils'
+
+const OTHER_NODE_COUNT = 3
+const SERVICE_ID_LAYER0 = 'layer0'
+
+const getClosestNodes = (
+    referenceId: DhtAddress,
+    nodes: PeerDescriptor[],
+    maxCount: number,
+    allowToContainReferenceId: boolean
+): PeerDescriptor[] => {
+    const list = new SortedContactList<Contact>({
+        referenceId,
+        allowToContainReferenceId,
+        maxSize: maxCount
+    })
+    list.addContacts(nodes.map((n) => new Contact(n)))
+    return list.getClosestContacts().map((c) => c.getPeerDescriptor())
+}
+
+describe('DhtNode', () => {
+
+    let localPeerDescriptor: PeerDescriptor
+    let entryPointPeerDescriptor: PeerDescriptor
+    let otherPeerDescriptors: PeerDescriptor[]
+
+    const startRemoteNode = (peerDescriptor: PeerDescriptor, environment: FakeEnvironment) => {
+        const epRpcCommunicator = new ListeningRpcCommunicator(SERVICE_ID_LAYER0, environment.createTransport(peerDescriptor))
+        const dhtNodeRpcLocal = new DhtNodeRpcLocal({
+            peerDiscoveryQueryBatchSize: undefined as any,
+            getClosestPeersTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
+            getClosestRingPeersTo: undefined as any,
+            addContact: () => {},
+            removeContact: undefined as any,
+        })
+        epRpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping',
+            (req: PingRequest, context) => dhtNodeRpcLocal.ping(req, context))
+        epRpcCommunicator.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers',
+            (req: ClosestPeersRequest, context) => dhtNodeRpcLocal.getClosestPeers(req, context))
+    }
+
+    const getAllPeerDescriptors = () => {
+        return [localPeerDescriptor, entryPointPeerDescriptor, ...otherPeerDescriptors]
+    }
+
+    beforeAll(() => {
+        localPeerDescriptor = createMockPeerDescriptor()
+        entryPointPeerDescriptor = createMockPeerDescriptor()
+        otherPeerDescriptors = range(OTHER_NODE_COUNT).map(() => createMockPeerDescriptor())
+    })
+      
+    it('start node and join DHT', async () => {
+        const environment = new FakeEnvironment()
+        startRemoteNode(entryPointPeerDescriptor, environment)
+        for (const other of otherPeerDescriptors) {
+            startRemoteNode(other, environment)
+        }
+
+        const localNode = new DhtNode({
+            peerDescriptor: localPeerDescriptor,
+            transport: environment.createTransport(localPeerDescriptor),
+            entryPoints: [entryPointPeerDescriptor]
+        })
+        await localNode.start()
+        await localNode.joinDht([entryPointPeerDescriptor])
+        await localNode.waitForNetworkConnectivity()
+
+        await waitForCondition(() => localNode.getNeighborCount() === otherPeerDescriptors.length + 1)
+        const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => getNodeIdFromPeerDescriptor(n))
+        const actualNodeIds = localNode.getClosestContacts().map((n) => getNodeIdFromPeerDescriptor(n))
+        expect(actualNodeIds).toIncludeSameMembers(expectedNodeIds)
+    }, 20 * 1000)
+})

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -77,5 +77,5 @@ describe('DhtNode', () => {
         const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => getNodeIdFromPeerDescriptor(n))
         const actualNodeIds = localNode.getClosestContacts().map((n) => getNodeIdFromPeerDescriptor(n))
         expect(actualNodeIds).toIncludeSameMembers(expectedNodeIds)
-    }, 20 * 1000)
+    })
 })

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -53,21 +53,6 @@ const getClosestContact = (contacts: PeerDescriptor[], referenceId: DhtAddress):
 
 describe('PeerManager', () => {
 
-    it('getClosestContactsTo', () => {
-        const nodeIds = range(10).map(() => createRandomDhtAddress())
-        const manager = createPeerManager(nodeIds)
-        const referenceId = createRandomDhtAddress()
-        const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))
-
-        const actual = manager.getClosestContactsTo(referenceId, 5, excluded)
-
-        const expected = sortBy(
-            without(nodeIds, ...Array.from(excluded.values())),
-            (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
-        ).slice(0, 5)
-        expect(actual.map((n) => n.getNodeId())).toEqual(expected)
-    })
-
     it('getClosestNeighborsTo', () => {
         const nodeIds = range(10).map(() => createRandomDhtAddress())
         const manager = createPeerManager(nodeIds)

--- a/packages/dht/test/unit/getClosestContacts.test.ts
+++ b/packages/dht/test/unit/getClosestContacts.test.ts
@@ -1,0 +1,28 @@
+import { range, sampleSize, sortBy, without } from 'lodash'
+import { getDistance } from '../../src/dht/PeerManager'
+import { getClosestContacts } from '../../src/dht/contact/getClosestContacts'
+import { DhtAddress, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+
+describe('getClosestContacts', () => {
+
+    it('happy path', () => {
+        const nodeIds = range(10).map(() => createRandomDhtAddress())
+        const referenceId = createRandomDhtAddress()
+        const excluded = new Set<DhtAddress>(sampleSize(nodeIds, 2))
+
+        const actual = getClosestContacts(
+            referenceId,
+            nodeIds.map((nodeId) => ({ getNodeId: () => nodeId })),
+            {
+                maxCount: 5,
+                excludedNodeIds: excluded
+            }
+        )
+
+        const expected = sortBy(
+            without(nodeIds, ...Array.from(excluded.values())),
+            (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
+        ).slice(0, 5)
+        expect(actual.map((n) => n.getNodeId())).toEqual(expected)
+    })
+})

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -1,11 +1,16 @@
 import { EventEmitter } from 'eventemitter3'
-import { ITransport, TransportEvents } from '../../src/transport/ITransport'
+import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { DEFAULT_SEND_OPTIONS, ITransport, SendOptions, TransportEvents } from '../../src/transport/ITransport'
 
 class FakeTransport extends EventEmitter<TransportEvents> implements ITransport {
 
     private onSend: (msg: Message) => void
     private readonly localPeerDescriptor: PeerDescriptor
+    // currently adds a peerDescription to the connections array when a "connect" option is seen in
+    // in send() call and never disconnects (TODO could add some disconnection logic? and maybe
+    // the connection should be seen by another FakeTransport instance, too?)
+    private connections: PeerDescriptor[] = []
 
     constructor(peerDescriptor: PeerDescriptor, onSend: (msg: Message) => void) {
         super()
@@ -13,19 +18,27 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport 
         this.localPeerDescriptor = peerDescriptor
     }
 
-    async send(msg: Message): Promise<void> {
+    async send(msg: Message, opts?: SendOptions): Promise<void> {
+        const connect = opts?.connect ?? DEFAULT_SEND_OPTIONS.connect
+        const targetNodeId = getNodeIdFromPeerDescriptor(msg.targetDescriptor!)
+        if (connect && !this.connections.some((c) => getNodeIdFromPeerDescriptor(c) === targetNodeId)) {
+            this.connect(msg.targetDescriptor!)
+        }
         msg.sourceDescriptor = this.localPeerDescriptor
         this.onSend(msg)
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getLocalPeerDescriptor(): PeerDescriptor {
-        throw new Error('not implemented')
+        return this.localPeerDescriptor
     }
 
-    // eslint-disable-next-line class-methods-use-this
+    private connect(peerDescriptor: PeerDescriptor) {
+        this.connections.push(peerDescriptor)
+        this.emit('connected', peerDescriptor)
+    }
+
     getConnections(): PeerDescriptor[] {
-        throw new Error('not implemented')
+        return this.connections
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -39,7 +52,11 @@ export class FakeEnvironment {
 
     createTransport(peerDescriptor: PeerDescriptor): ITransport {
         const transport = new FakeTransport(peerDescriptor, (msg) => {
-            this.transports.forEach((t) => t.emit('message', msg))
+            const targetNode = getDhtAddressFromRaw(msg.targetDescriptor!.nodeId)
+            const targetTransport = this.transports.find((t) => getNodeIdFromPeerDescriptor(t.getLocalPeerDescriptor()) === targetNode)
+            if (targetTransport !== undefined) {
+                targetTransport.emit('message', msg)
+            }
         })
         this.transports.push(transport)
         return transport


### PR DESCRIPTION
Before this PR `DhtNode#getClosestContacts` did unnecessary sorting. The `PeerManager#closestContacts `is always sorted in reference to the node's ID, and therefore we can just return the nodes in that order from `DhtNode#getClosestContacts`.

Moved the `getClosestContactsTo` functionality from `PeerManager` to a separate helper function. The only place that functionality is currently needed is the `DiscoverySession#findContacts`. There we query the `PeerManager`'s contacts and pass those to the `getClosestContacts` helper function. The helper function receives the contact list as an `Iterable`, and therefore it can take inputs also from other sources in the future.

As `PeerManager#getClosestContacts` now returns a `PeerManager`'s data without copying it, the return type has changed to `ReadonlySortedContactList<DhtNodeRpcRemote>`. That way we can ensure that other components can't corrupt `PeerManager`'s internal state by modifying the object. 

## Benchmark

- 200 contacts in the `PeerManager`
- do 1000 queries

`DhtNode#getClosestContacts`:

- before: ~3400 ms
- after: ~10 ms

## Future improvements

- Other `PeerManager` methods (e.g. `getClosestNeighborsTo`) could use this same pattern
- Maybe we could use `getClosestContacts` helper method in some places where we now create a temporary `SortedContactList`  instance just to order the contacts (maybe bit more readable, doesn't affect performance)