### PR TITLE
chore: Update GitHub actions to Node 20

### DIFF
--- a/.github/workflows/reusable/cached-build/action.yml
+++ b/.github/workflows/reusable/cached-build/action.yml
@@ -4,7 +4,7 @@ description: "build monorepo and cache result, or restore from cache if present"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
         cache: 'npm'
@@ -12,7 +12,7 @@ runs:
         registry-url: 'https://registry.npmjs.org'
     - name: cache node_modules
       id: cache-node-modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: cache-node-modules-${{ hashFiles('package-lock.json') }}
         path: |
@@ -20,7 +20,7 @@ runs:
           packages/*/node_modules
     - name: cache build
       id: cache-build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: cache-build-${{ github.sha }}
         path: |

--- a/.github/workflows/reusable/collect-and-upload-logs/action.yml
+++ b/.github/workflows/reusable/collect-and-upload-logs/action.yml
@@ -8,11 +8,11 @@ runs:
   using: "composite"
   steps:
     - name: collect docker service logs
-      uses: jwalton/gh-docker-logs@v2.2.1
+      uses: jwalton/gh-docker-logs@v2.2.2
       with:
         dest: 'logs'
     - name: upload logs to GitHub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{ inputs.artifact_prefix }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt}}
         path: 'logs'


### PR DESCRIPTION
Resolves the warning which was shown when observing GitHub runs with `gh run watch RUN-ID` command:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3, actions/cache@v3, jwalton/gh-docker-logs@v2.2.1, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```