### PR TITLE
refactor(dht): Fix ring peer naming

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -10,6 +10,7 @@ import "packages/proto-rpc/protos/ProtoRpc.proto";
 
 service DhtNodeRpc {
   rpc getClosestPeers (ClosestPeersRequest) returns (ClosestPeersResponse);
+  // TODO rename to getClosestRingContacts (breaking change)
   rpc getClosestRingPeers (ClosestRingPeersRequest) returns (ClosestRingPeersResponse);
   rpc ping (PingRequest) returns (PingResponse);
   rpc leaveNotice (LeaveNotice) returns (google.protobuf.Empty);
@@ -102,11 +103,13 @@ message ClosestPeersResponse {
   string requestId = 2;
 }
 
+// TODO rename to ClosestRingContactsRequest
 message ClosestRingPeersRequest {
   bytes ringId = 1;
   string requestId = 2;
 }
 
+// TODO rename to ClosestRingContactsResponse
 message ClosestRingPeersResponse {
   repeated PeerDescriptor leftPeers = 1;
   repeated PeerDescriptor rightPeers = 2;

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -370,7 +370,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 return this.peerManager!.getClosestNeighborsTo(nodeId, limit)
                     .map((dhtPeer: DhtNodeRpcRemote) => dhtPeer.getPeerDescriptor())
             },
-            getClosestRingPeersTo: (ringIdRaw: RingIdRaw, limit: number) => {
+            getClosestRingContactsTo: (ringIdRaw: RingIdRaw, limit: number) => {
                 return this.getClosestRingContactsTo(ringIdRaw, limit)
             },
             addContact: (contact: PeerDescriptor) => this.peerManager!.addContact(contact),

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -19,7 +19,7 @@ import { RingContacts } from './contact/RingContactList'
 interface DhtNodeRpcLocalConfig {
     peerDiscoveryQueryBatchSize: number
     getClosestPeersTo: (nodeId: DhtAddress, limit: number) => PeerDescriptor[]
-    getClosestRingPeersTo: (id: RingIdRaw, limit: number) => RingContacts
+    getClosestRingContactsTo: (id: RingIdRaw, limit: number) => RingContacts
     addContact: (contact: PeerDescriptor) => void
     removeContact: (nodeId: DhtAddress) => void
 }
@@ -43,9 +43,10 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
         return response
     }
 
+    // TODO rename to getClosestRingContacts
     async getClosestRingPeers(request: ClosestRingPeersRequest, context: ServerCallContext): Promise<ClosestRingPeersResponse> {
         this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
-        const closestPeers = this.config.getClosestRingPeersTo(request.ringId as RingIdRaw, this.config.peerDiscoveryQueryBatchSize)
+        const closestPeers = this.config.getClosestRingContactsTo(request.ringId as RingIdRaw, this.config.peerDiscoveryQueryBatchSize)
         const response = {
             leftPeers: closestPeers.left,
             rightPeers: closestPeers.right,

--- a/packages/dht/src/dht/DhtNodeRpcRemote.ts
+++ b/packages/dht/src/dht/DhtNodeRpcRemote.ts
@@ -58,6 +58,7 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
         }
     }
 
+    // TODO rename to getClosestRingContacts (breaking change)
     async getClosestRingPeers(ringIdRaw: RingIdRaw): Promise<RingContacts> {
         logger.trace(`Requesting getClosestRingPeers on ${this.serviceId} from ${this.getNodeId()}`)
         const request: ClosestRingPeersRequest = {

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -37,7 +37,7 @@ describe('DhtNode', () => {
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
             peerDiscoveryQueryBatchSize: undefined as any,
             getClosestPeersTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
-            getClosestRingPeersTo: undefined as any,
+            getClosestRingContactsTo: undefined as any,
             addContact: () => {},
             removeContact: undefined as any,
         })

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -214,12 +214,12 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.closeConnection(req, context))
     }
 
-    private onRingContactEvent(ringPeers: RingContacts): void {
+    private onRingContactEvent(ringContacts: RingContacts): void {
         logger.trace(`onRingContactAdded`)
         if (this.isStopped()) {
             return
         }
-        this.config.leftNodeView.replaceAll(ringPeers.left.map((peer) => 
+        this.config.leftNodeView.replaceAll(ringContacts.left.map((peer) => 
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,
@@ -228,7 +228,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                 this.config.rpcRequestTimeout
             )
         ))
-        this.config.rightNodeView.replaceAll(ringPeers.right.map((peer) =>
+        this.config.rightNodeView.replaceAll(ringContacts.right.map((peer) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,


### PR DESCRIPTION
We should avoid using `peer` term, as it is used to refer both `neighbor` and `contact`.

In this PR fixed term `ringPeer` -> `ringContact` as the `neighbor` term refers to Kademlia neighbors, and therefore the ring contacts are always `contacts`, not `neighbors`.