### PR TITLE
refactor(dht): Remove contact list event parameter

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -435,6 +435,19 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             .map((peer) => peer.getPeerDescriptor())
     }
 
+    // TODO remove defaultContactQueryLimit parameter from RandomContactList#getContacts and use explicit value here?
+    getRandomContacts(): PeerDescriptor[] {
+        return this.peerManager!.getRandomContacts().getContacts().map((c) => c.getPeerDescriptor())
+    }
+
+    getRingContacts(): RingContacts {
+        const contacts = this.peerManager!.getRingContacts().getClosestContacts()
+        return {
+            left: contacts.left.map((c) => c.getPeerDescriptor()),
+            right: contacts.right.map((c) => c.getPeerDescriptor())
+        }
+    }
+
     public getClosestRingContactsTo(ringIdRaw: RingIdRaw, limit?: number): RingContacts {
         const closest = this.peerManager!.getClosestRingContactsTo(ringIdRaw, limit)
         return {

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -53,12 +53,12 @@ import { getLocalRegion } from '@streamr/cdn-location'
 import { RingContacts } from './contact/RingContactList'
 
 export interface DhtNodeEvents {
-    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    randomContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    ringContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
-    ringContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
+    closestContactAdded: (peerDescriptor: PeerDescriptor) => void
+    closestContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor) => void
+    randomContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    ringContactAdded: (peerDescriptor: PeerDescriptor) => void
+    ringContactRemoved: (peerDescriptor: PeerDescriptor) => void
 }
 
 export interface DhtNodeOptions {
@@ -295,7 +295,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 )
             }
         })
-        this.on('contactAdded', (peerDescriptor: PeerDescriptor) => {
+        this.on('closestContactAdded', (peerDescriptor: PeerDescriptor) => {
             this.storeManager!.onContactAdded(peerDescriptor)
         })
         this.bindRpcLocalMethods()
@@ -312,23 +312,23 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
             lockId: this.config.serviceId
         })
-        this.peerManager.on('contactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) => {
-            this.emit('contactRemoved', peerDescriptor, activeContacts)
+        this.peerManager.on('closestContactRemoved', (peerDescriptor: PeerDescriptor) => {
+            this.emit('closestContactRemoved', peerDescriptor)
         })
-        this.peerManager.on('contactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
-            this.emit('contactAdded', peerDescriptor, activeContacts)
+        this.peerManager.on('closestContactAdded', (peerDescriptor: PeerDescriptor) =>
+            this.emit('closestContactAdded', peerDescriptor)
         )
-        this.peerManager.on('randomContactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
-            this.emit('randomContactRemoved', peerDescriptor, activeContacts)
+        this.peerManager.on('randomContactRemoved', (peerDescriptor: PeerDescriptor) =>
+            this.emit('randomContactRemoved', peerDescriptor)
         )
-        this.peerManager.on('randomContactAdded', (peerDescriptor: PeerDescriptor, activeContacts: PeerDescriptor[]) =>
-            this.emit('randomContactAdded', peerDescriptor, activeContacts)
+        this.peerManager.on('randomContactAdded', (peerDescriptor: PeerDescriptor) =>
+            this.emit('randomContactAdded', peerDescriptor)
         )
-        this.peerManager.on('ringContactRemoved', (peerDescriptor: PeerDescriptor, activeContacts: RingContacts) => {
-            this.emit('ringContactRemoved', peerDescriptor, activeContacts)
+        this.peerManager.on('ringContactRemoved', (peerDescriptor: PeerDescriptor) => {
+            this.emit('ringContactRemoved', peerDescriptor)
         })
-        this.peerManager.on('ringContactAdded', (peerDescriptor: PeerDescriptor, activeContacts: RingContacts) => {
-            this.emit('ringContactAdded', peerDescriptor, activeContacts)
+        this.peerManager.on('ringContactAdded', (peerDescriptor: PeerDescriptor) => {
+            this.emit('ringContactAdded', peerDescriptor)
         })
         this.peerManager.on('kBucketEmpty', () => {
             if (!this.peerDiscovery!.isJoinOngoing()

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -267,7 +267,16 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         this.ringContacts.getAllContacts().map((contact) => closest.addContact(contact))
         return closest.getClosestContacts(limit ?? 8)
     }
+    
+    getRandomContacts(): RandomContactList<DhtNodeRpcRemote> {
+        return this.randomContacts
+    }
+    
+    getRingContacts(): RingContactList<DhtNodeRpcRemote> {
+        return this.ringContacts
+    }
 
+    // TODO rename getNearbyContactsCount
     getContactCount(excludedNodeIds?: Set<DhtAddress>): number {
         return this.closestContacts.getSize(excludedNodeIds)
     }

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -11,7 +11,7 @@ import { ReadonlySortedContactList, SortedContactList } from './contact/SortedCo
 import { ConnectionLocker } from '../connection/ConnectionManager'
 import EventEmitter from 'eventemitter3'
 import { DhtAddress, DhtAddressRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../identifiers'
-import { RingContactList, RingContacts } from './contact/RingContactList'
+import { RingContactList } from './contact/RingContactList'
 import { RingIdRaw, getRingIdRawFromPeerDescriptor } from './contact/ringIdentifiers'
 import { LockID } from '../connection/ConnectionLockStates'
 
@@ -29,12 +29,12 @@ interface PeerManagerConfig {
 }
 
 export interface PeerManagerEvents {
-    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    randomContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    randomContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    ringContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
-    ringContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
+    closestContactAdded: (peerDescriptor: PeerDescriptor) => void
+    closestContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor) => void
+    randomContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    ringContactAdded: (peerDescriptor: PeerDescriptor) => void
+    ringContactRemoved: (peerDescriptor: PeerDescriptor) => void
     kBucketEmpty: () => void
 }
 
@@ -69,11 +69,11 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             numberOfNodesToPing: this.config.numberOfNodesPerKBucket
         })
         this.ringContacts = new RingContactList<DhtNodeRpcRemote>(getRingIdRawFromPeerDescriptor(this.config.localPeerDescriptor))
-        this.ringContacts.on('ringContactAdded', (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => {
-            this.emit('ringContactAdded', peerDescriptor, closestPeers)
+        this.ringContacts.on('contactAdded', (contact: DhtNodeRpcRemote) => {
+            this.emit('ringContactAdded', contact.getPeerDescriptor())
         })
-        this.ringContacts.on('ringContactRemoved', (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => {
-            this.emit('ringContactRemoved', peerDescriptor, closestPeers)
+        this.ringContacts.on('contactRemoved', (contact: DhtNodeRpcRemote) => {
+            this.emit('ringContactRemoved', contact.getPeerDescriptor())
         })
         this.neighbors.on('ping', (oldContacts: DhtNodeRpcRemote[], newContact: DhtNodeRpcRemote) => this.onKBucketPing(oldContacts, newContact))
         this.neighbors.on('removed', (contact: DhtNodeRpcRemote) => this.onKBucketRemoved(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
@@ -86,23 +86,23 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             maxSize: this.config.maxContactListSize,
             allowToContainReferenceId: false
         })
-        this.closestContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) => {
+        this.closestContacts.on('contactRemoved', (contact: DhtNodeRpcRemote) => {
             if (this.stopped) {
                 return
             }
-            this.emit('contactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
-            this.randomContacts.addContact(this.config.createDhtNodeRpcRemote(removedContact.getPeerDescriptor()))
+            this.emit('closestContactRemoved', contact.getPeerDescriptor())
+            this.randomContacts.addContact(this.config.createDhtNodeRpcRemote(contact.getPeerDescriptor()))
         })
-        this.closestContacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('contactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.closestContacts.on('contactAdded', (contact: DhtNodeRpcRemote) =>
+            this.emit('closestContactAdded', contact.getPeerDescriptor())
         )
         this.activeContacts = new Set()
         this.randomContacts = new RandomContactList(this.config.localNodeId, this.config.maxContactListSize)
-        this.randomContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('randomContactRemoved', removedContact.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.randomContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote) =>
+            this.emit('randomContactRemoved', removedContact.getPeerDescriptor())
         )
-        this.randomContacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote, activeContacts: DhtNodeRpcRemote[]) =>
-            this.emit('randomContactAdded', contactAdded.getPeerDescriptor(), activeContacts.map((c) => c.getPeerDescriptor()))
+        this.randomContacts.on('contactAdded', (contactAdded: DhtNodeRpcRemote) =>
+            this.emit('randomContactAdded', contactAdded.getPeerDescriptor())
         )
     }
 

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -2,8 +2,8 @@ import EventEmitter from 'eventemitter3'
 import { DhtAddress } from '../../identifiers'
 
 export interface Events<C> {
-    contactRemoved: (removedContact: C, closestContacts: C[]) => void
-    contactAdded: (contactAdded: C, closestContacts: C[]) => void
+    contactRemoved: (removedContact: C) => void
+    contactAdded: (contactAdded: C) => void
 }
 
 export class ContactList<C extends { getNodeId: () => DhtAddress }> extends EventEmitter<Events<C>> {

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -30,8 +30,7 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
                 this.contactsById.set(contact.getNodeId(), contact)
                 this.emit(
                     'contactAdded',
-                    contact,
-                    this.getContacts()
+                    contact
                 )
             }
         }
@@ -43,7 +42,7 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
             const index = this.contactIds.findIndex((nodeId) => (nodeId === id))
             this.contactIds.splice(index, 1)
             this.contactsById.delete(id)
-            this.emit('contactRemoved', removed, this.getContacts())
+            this.emit('contactRemoved', removed)
             return true
         }
         return false

--- a/packages/dht/src/dht/contact/RingContactList.ts
+++ b/packages/dht/src/dht/contact/RingContactList.ts
@@ -3,16 +3,14 @@ import { OrderedMap } from '@js-sdsl/ordered-map'
 import { RingDistance, RingId, RingIdRaw, getLeftDistance, getRightDistance, getRingIdFromPeerDescriptor, getRingIdFromRaw } from './ringIdentifiers'
 import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
 import EventEmitter from 'eventemitter3'
+import { Events } from './ContactList'
 
 export interface RingContacts { 
     left: PeerDescriptor[]
     right: PeerDescriptor[]
 }
-export interface RingContactListEvents {  
-    ringContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
-    ringContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
-}
-export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> extends EventEmitter<RingContactListEvents> {
+
+export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> extends EventEmitter<Events<C>> {
 
     private readonly numNeighborsPerSide = 5
     private readonly referenceId: RingId
@@ -59,16 +57,11 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
         }
 
         if (this.hasEventListeners() && (elementAdded || elementRemoved)) {
-            const closestContacts = this.getClosestContacts()
-            const closestDescriptors = { 
-                left: closestContacts.left.map((c) => c.getPeerDescriptor()), 
-                right: closestContacts.right.map((c) => c.getPeerDescriptor())
-            }
             if (elementAdded) {
-                this.emit('ringContactAdded', contact.getPeerDescriptor(), closestDescriptors)
+                this.emit('contactAdded', contact)
             }
             if (elementRemoved) {
-                this.emit('ringContactRemoved', contact.getPeerDescriptor(), closestDescriptors)
+                this.emit('contactRemoved', contact)
             }
         }
     }
@@ -91,10 +84,7 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
         }
 
         if (this.hasEventListeners() && elementRemoved) {
-            const closestContacts = this.getClosestContacts()
-            const closestDescriptors = { left: closestContacts.left.map((c) => c.getPeerDescriptor()), 
-                right: closestContacts.right.map((c) => c.getPeerDescriptor()) }
-            this.emit('ringContactRemoved', contact.getPeerDescriptor(), closestDescriptors)
+            this.emit('contactRemoved', contact)
         }
     }
 

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -57,8 +57,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 if (this.hasEventListeners()) {
                     this.emit(
                         'contactAdded',
-                        contact,
-                        this.getClosestContacts()
+                        contact
                     )
                 }
             } else if (this.compareIds(this.contactIds[this.config.maxSize - 1], contactId) > 0) {
@@ -69,16 +68,13 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
                 const index = sortedIndexBy(this.contactIds, contactId, (id: DhtAddress) => { return this.distanceToReferenceId(id) })
                 this.contactIds.splice(index, 0, contactId)
                 if (this.hasEventListeners()) {
-                    const closestContacts = this.getClosestContacts()
                     this.emit(
                         'contactRemoved',
-                        removedContact,
-                        closestContacts
+                        removedContact
                     )
                     this.emit(
                         'contactAdded',
-                        contact,
-                        closestContacts
+                        contact
                     )
                 }
             }
@@ -137,8 +133,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
             if (this.hasEventListeners()) {
                 this.emit(
                     'contactRemoved',
-                    removed,
-                    this.getClosestContacts()
+                    removed
                 )
             }
             return true

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -38,7 +38,7 @@ describe('SortedContactList', () => {
         expect(list.getSize()).toEqual(3)
         expect(list.getClosestContacts()).toEqual([item1, item2, item3])
         expect(list.getContactIds()).toEqual([item1.getNodeId(), item2.getNodeId(), item3.getNodeId()])
-        expect(onContactRemoved).toBeCalledWith(item4, [item1, item2, item3])
+        expect(onContactRemoved).toBeCalledWith(item4)
         expect(list.getContact(item4.getNodeId())).toBeFalsy()
     })
 
@@ -63,9 +63,9 @@ describe('SortedContactList', () => {
         list.removeContact(item3.getNodeId())
         list.removeContact(createRandomDhtAddress())
         expect(list.getClosestContacts()).toEqual([item1, item4])
-        expect(onContactRemoved).toHaveBeenNthCalledWith(1, item3, [])
-        expect(onContactRemoved).toHaveBeenNthCalledWith(2, item2, [item1, item3, item4])
-        expect(onContactRemoved).toHaveBeenNthCalledWith(3, item3, [item1, item4])
+        expect(onContactRemoved).toHaveBeenNthCalledWith(1, item3)
+        expect(onContactRemoved).toHaveBeenNthCalledWith(2, item2)
+        expect(onContactRemoved).toHaveBeenNthCalledWith(3, item3)
     })
 
     it('get closest contacts', () => {

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -5,8 +5,7 @@ import {
     ITransport,
     ConnectionLocker,
     DhtAddress,
-    getNodeIdFromPeerDescriptor,
-    RingContacts
+    getNodeIdFromPeerDescriptor
 } from '@streamr/dht'
 import {
     StreamMessage,
@@ -119,42 +118,38 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         this.registerDefaultServerMethods()
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
-            'contactAdded',
-            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.onContactAdded(closestPeers),
+            'closestContactAdded',
+            () => this.onNearbyContactAdded(this.config.layer1Node.getClosestContacts()),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
-            'contactRemoved',
-            (_peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => this.onContactRemoved(closestPeers),
+            'closestContactRemoved',
+            () => this.onNearbyContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'randomContactAdded',
-            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.onRandomContactAdded(randomPeers),
+            (_peerDescriptor: PeerDescriptor) => this.onRandomContactAdded(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'randomContactRemoved',
-            (_peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => this.onRandomContactRemoved(randomPeers),
+            (_peerDescriptor: PeerDescriptor) => this.onRandomContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'ringContactAdded',
-            (_: PeerDescriptor, peers: RingContacts) => {
-                this.onRingContactEvent(peers)
-            },
+            () => this.onRingContactsUpdated(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
             this.config.layer1Node as any,
             'ringContactRemoved',
-            (_: PeerDescriptor, peers: RingContacts) => {
-                this.onRingContactEvent(peers)
-            },
+            () => this.onRingContactsUpdated(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
@@ -195,9 +190,10 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                 this.abortController.signal
             )
         }
+        // TODO remove this block, not required in practice
         const candidates = this.getNeighborCandidatesFromLayer1()
         if (candidates.length > 0) {
-            this.onContactAdded(candidates)
+            this.onNearbyContactAdded(candidates)
         }
         this.config.neighborFinder.start()
         await this.config.neighborUpdateManager.start()
@@ -214,12 +210,13 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.closeConnection(req, context))
     }
 
-    private onRingContactEvent(ringContacts: RingContacts): void {
-        logger.trace(`onRingContactAdded`)
+    private onRingContactsUpdated(): void {
+        logger.trace('onRingContactsUpdated')
         if (this.isStopped()) {
             return
         }
-        this.config.leftNodeView.replaceAll(ringContacts.left.map((peer) => 
+        const contacts = this.config.layer1Node.getRingContacts()
+        this.config.leftNodeView.replaceAll(contacts.left.map((peer) => 
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,
@@ -228,7 +225,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                 this.config.rpcRequestTimeout
             )
         ))
-        this.config.rightNodeView.replaceAll(ringContacts.right.map((peer) =>
+        this.config.rightNodeView.replaceAll(contacts.right.map((peer) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 peer,
@@ -239,23 +236,25 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         ))
     }
 
-    private onContactAdded(closestNodes: PeerDescriptor[]): void {
+    // TODO refactor so that we don't need to give the parameter? (i.e. would be similar to onNearbyContactRemoved and other event handlers)
+    private onNearbyContactAdded(closestContacts: PeerDescriptor[]): void {
         logger.trace(`New nearby contact found`)
         if (this.isStopped()) {
             return
         }
-        this.updateNearbyNodeView(closestNodes)
+        this.updateNearbyNodeView(closestContacts)
         if (this.config.neighbors.size() < this.config.neighborTargetCount) {
             this.config.neighborFinder.start()
         }
     }
 
-    private onContactRemoved(closestNodes: PeerDescriptor[]): void {
+    private onNearbyContactRemoved(): void {
         logger.trace(`Nearby contact removed`)
         if (this.isStopped()) {
             return
         }
-        this.updateNearbyNodeView(closestNodes)
+        const closestContacts = this.config.layer1Node.getClosestContacts()
+        this.updateNearbyNodeView(closestContacts)
     }
 
     private updateNearbyNodeView(nodes: PeerDescriptor[]) {
@@ -284,11 +283,12 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         }
     }
 
-    private onRandomContactAdded(randomNodes: PeerDescriptor[]): void {
+    private onRandomContactAdded(): void {
         if (this.isStopped()) {
             return
         }
-        this.config.randomNodeView.replaceAll(randomNodes.map((descriptor) =>
+        const randomContacts = this.config.layer1Node.getRandomContacts()
+        this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 descriptor,
@@ -302,12 +302,13 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         }
     }
 
-    private onRandomContactRemoved(randomNodes: PeerDescriptor[]): void {
-        logger.trace(`New nearby contact found`)
+    private onRandomContactRemoved(): void {
+        logger.trace(`New random contact removed`)
         if (this.isStopped()) {
             return
         }
-        this.config.randomNodeView.replaceAll(randomNodes.map((descriptor) =>
+        const randomContacts = this.config.layer1Node.getRandomContacts()
+        this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
                 descriptor,

--- a/packages/trackerless-network/src/logic/Layer1Node.ts
+++ b/packages/trackerless-network/src/logic/Layer1Node.ts
@@ -1,32 +1,22 @@
 import { DhtAddress, PeerDescriptor, RingContacts } from '@streamr/dht'
 
 export interface Layer1NodeEvents {
-    contactAdded: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    contactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: PeerDescriptor[]) => void
-    randomContactAdded: (peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => void
-    randomContactRemoved: (peerDescriptor: PeerDescriptor, randomPeers: PeerDescriptor[]) => void
-    ringContactAdded: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
-    ringContactRemoved: (peerDescriptor: PeerDescriptor, closestPeers: RingContacts) => void
+    closestContactAdded: (peerDescriptor: PeerDescriptor) => void
+    closestContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    randomContactAdded: (peerDescriptor: PeerDescriptor) => void
+    randomContactRemoved: (peerDescriptor: PeerDescriptor) => void
+    ringContactAdded: (peerDescriptor: PeerDescriptor) => void
+    ringContactRemoved: (peerDescriptor: PeerDescriptor) => void
 }
 
 export interface Layer1Node {
-    on<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor, peers: PeerDescriptor[]) => void): void
-    once<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor, peers: PeerDescriptor[]) => void): void
-    off<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor, peers: PeerDescriptor[]) => void): void
-    on<T extends keyof Layer1NodeEvents>(
-        eventName: T,
-        listener: (peerDescriptor: PeerDescriptor, peers: RingContacts) => void
-    ): void
-    once<T extends keyof Layer1NodeEvents>(
-        eventName: T, 
-        listener: (peerDescriptor: PeerDescriptor, peers: RingContacts) => void
-    ): void
-    off<T extends keyof Layer1NodeEvents>(
-        eventName: T,
-        listener: (peerDescriptor: PeerDescriptor, peers: RingContacts
-    ) => void): void
+    on<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
+    once<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
+    off<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
     removeContact: (nodeId: DhtAddress) => void
     getClosestContacts: (maxCount?: number) => PeerDescriptor[]
+    getRandomContacts: () => PeerDescriptor[]
+    getRingContacts: () => RingContacts
     getNeighbors: () => PeerDescriptor[]
     getNeighborCount(): number
     joinDht: (entryPoints: PeerDescriptor[], doRandomJoin?: boolean, retry?: boolean) => Promise<void>

--- a/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
@@ -43,7 +43,6 @@ describe('ContentDeliveryLayerNode', () => {
             neighborFinder: new MockNeighborFinder() as any,
             streamPartId: StreamPartIDUtils.parse('stream#0'),
             isLocalNodeEntryPoint: () => false
-
         })
         await contentDeliveryLayerNode.start()
     })
@@ -69,7 +68,8 @@ describe('ContentDeliveryLayerNode', () => {
     it('Adds Closest Nodes from layer1 contactAdded event to nearbyNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.emit('contactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.setClosestContacts([peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('closestContactAdded', peerDescriptor1)
         await waitForCondition(() => nearbyNodeView.size() === 2)
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
@@ -78,7 +78,8 @@ describe('ContentDeliveryLayerNode', () => {
     it('Adds Random Nodes from layer1 randomContactAdded event to randomNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.emit('randomContactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.setRandomContacts([peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('randomContactAdded', peerDescriptor1)
         await waitForCondition(() => randomNodeView.size() === 2)
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
@@ -88,7 +89,8 @@ describe('ContentDeliveryLayerNode', () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
         layer1Node.addNewRandomPeerToKBucket()
-        layer1Node.emit('contactAdded', peerDescriptor1, [peerDescriptor1, peerDescriptor2])
+        layer1Node.setClosestContacts([peerDescriptor1, peerDescriptor2])
+        layer1Node.emit('closestContactAdded', peerDescriptor1)
         await waitForCondition(() => {
             return nearbyNodeView.size() === 3
         }, 20000)

--- a/packages/trackerless-network/test/utils/mock/MockLayer1Node.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer1Node.ts
@@ -1,10 +1,10 @@
-import { PeerDescriptor } from '@streamr/dht'
+import { PeerDescriptor, RingContacts } from '@streamr/dht'
 import { EventEmitter } from 'eventemitter3'
 import { Layer1Node } from '../../../src/logic/Layer1Node'
 import { createMockPeerDescriptor } from '../utils'
 
 export class MockLayer1Node extends EventEmitter implements Layer1Node {
-    
+
     private readonly kbucketPeers: PeerDescriptor[] = []
 
     // eslint-disable-next-line class-methods-use-this
@@ -14,6 +14,16 @@ export class MockLayer1Node extends EventEmitter implements Layer1Node {
     // eslint-disable-next-line class-methods-use-this
     getClosestContacts(): PeerDescriptor[] {
         return []
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getRandomContacts(): PeerDescriptor[] {
+        return []
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getRingContacts(): RingContacts {
+        return { left: [], right: [] }
     }
 
     getNeighbors(): PeerDescriptor[] {

--- a/packages/trackerless-network/test/utils/mock/MockLayer1Node.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer1Node.ts
@@ -6,21 +6,29 @@ import { createMockPeerDescriptor } from '../utils'
 export class MockLayer1Node extends EventEmitter implements Layer1Node {
 
     private readonly kbucketPeers: PeerDescriptor[] = []
+    private closestContacts: PeerDescriptor[] = []
+    private randomContacts: PeerDescriptor[] = []
 
     // eslint-disable-next-line class-methods-use-this
     removeContact(): void {
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getClosestContacts(): PeerDescriptor[] {
-        return []
+        return this.closestContacts 
     }
 
-    // eslint-disable-next-line class-methods-use-this
+    setClosestContacts(contacts: PeerDescriptor[]): void {
+        this.closestContacts = contacts
+    }
+
     getRandomContacts(): PeerDescriptor[] {
-        return []
+        return this.randomContacts 
     }
 
+    setRandomContacts(contacts: PeerDescriptor[]): void {
+        this.randomContacts = contacts
+    }
+    
     // eslint-disable-next-line class-methods-use-this
     getRingContacts(): RingContacts {
         return { left: [], right: [] }


### PR DESCRIPTION
Removed 2nd event argument from `SortedContactList`, `RandomContactList` and `RingContactList`. Also removed related event argument from `DhtNode` events.

Renamed `DhtNode` events:
- `contactAdded` -> `closestContactAdded`
- `contactRemoved` -> `closestContactRemoved`

Unified `RingContactList` event names.

Added `getRandomContacts` and `getRingContacts` methods to `DhtNode` so that `ContentDeliveryLayerNode` can fetch the contacts which we no longer pass in the event argument.

## Future improvements

- Some `TODO` comments added in this PR