### PR TITLE
feat: LoggingStaticJsonRpcProvider

### DIFF
--- a/packages/client/src/Ethereum.ts
+++ b/packages/client/src/Ethereum.ts
@@ -2,12 +2,12 @@
  * Config and utilities for interating with identity & Ethereum chain.
  */
 import { Wallet } from '@ethersproject/wallet'
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import type { Provider } from '@ethersproject/providers'
 import type { ConnectionInfo } from '@ethersproject/web'
 import type { Overrides } from '@ethersproject/contracts'
 import type { BigNumber } from '@ethersproject/bignumber'
 import { ChainConnectionInfo, StrictStreamrClientConfig } from './Config'
+import { LoggingStaticJsonRpcProvider } from './utils/LoggingStaticJsonRpcProvider'
 
 export const generateEthereumAccount = (): { address: string, privateKey: string } => {
     const wallet = Wallet.createRandom()
@@ -23,7 +23,7 @@ export const getStreamRegistryChainProviders = (config: Pick<StrictStreamrClient
 
 const getRpcProviders = (connectionInfo: ChainConnectionInfo, pollInterval?: number): Provider[] => {
     return connectionInfo.rpcs.map((c: ConnectionInfo) => {
-        const provider = new StaticJsonRpcProvider(c)
+        const provider = new LoggingStaticJsonRpcProvider(c)
         if (pollInterval !== undefined) {
             provider.pollingInterval = pollInterval
         }

--- a/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
+++ b/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
@@ -11,7 +11,10 @@ export class LoggingStaticJsonRpcProvider extends StaticJsonRpcProvider {
             traceId,
             method,
             params,
-            connection: this.connection
+            connection: {
+                url: this.connection.url,
+                timeout: this.connection.timeout
+            }
         }
         this.logger.debug('Send request', logContext)
         let result

--- a/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
+++ b/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
@@ -1,0 +1,34 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
+import { Logger, randomString } from '@streamr/utils'
+
+export class LoggingStaticJsonRpcProvider extends StaticJsonRpcProvider {
+    private readonly logger = new Logger(module)
+
+    override async send(method: string, params: any[]): Promise<any> {
+        const traceId = randomString(5)
+        const startTime = Date.now()
+        const logContext = {
+            traceId,
+            method,
+            params,
+            connection: this.connection
+        }
+        this.logger.debug('Sending request', logContext)
+        let result
+        try {
+            result = await super.send(method, params)
+        } catch (err) {
+            this.logger.warn('Encountered error while requesting', {
+                ...logContext,
+                reason: err?.reason,
+                elapsedTime: Date.now() - startTime
+            })
+            throw err
+        }
+        this.logger.debug('Received response', {
+            ...logContext,
+            elapsedTime: Date.now() - startTime
+        })
+        return result
+    }
+}

--- a/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
+++ b/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
@@ -20,7 +20,7 @@ export class LoggingStaticJsonRpcProvider extends StaticJsonRpcProvider {
         } catch (err) {
             this.logger.debug('Encountered error while requesting', {
                 ...logContext,
-                reason: err?.reason,
+                err,
                 elapsedTime: Date.now() - startTime
             })
             throw err

--- a/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
+++ b/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
@@ -13,7 +13,7 @@ export class LoggingStaticJsonRpcProvider extends StaticJsonRpcProvider {
             params,
             connection: this.connection
         }
-        this.logger.debug('Sending request', logContext)
+        this.logger.debug('Send request', logContext)
         let result
         try {
             result = await super.send(method, params)

--- a/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
+++ b/packages/client/src/utils/LoggingStaticJsonRpcProvider.ts
@@ -18,7 +18,7 @@ export class LoggingStaticJsonRpcProvider extends StaticJsonRpcProvider {
         try {
             result = await super.send(method, params)
         } catch (err) {
-            this.logger.warn('Encountered error while requesting', {
+            this.logger.debug('Encountered error while requesting', {
                 ...logContext,
                 reason: err?.reason,
                 elapsedTime: Date.now() - startTime


### PR DESCRIPTION
## Summary

Create a logging variant of `StaticJsonRpcProvider` so that we get decent logging of requests and possible errors as well as elapsed time.

## Limitations and future improvements

- Reduce timeout
- Avoid creating multiple providers per contract

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [ ] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.
