### PR TITLE
refactor(dht): Fix closest peer naming

### DIFF
--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 import "packages/proto-rpc/protos/ProtoRpc.proto";
 
 service DhtNodeRpc {
+  // TODO rename to getClosestNeighbors (breaking change)
   rpc getClosestPeers (ClosestPeersRequest) returns (ClosestPeersResponse);
   // TODO rename to getClosestRingContacts (breaking change)
   rpc getClosestRingPeers (ClosestRingPeersRequest) returns (ClosestRingPeersResponse);
@@ -93,11 +94,13 @@ message DataEntry {
   bool deleted = 8;
 }
 
+// TODO rename to ClosestNeighborsRequest
 message ClosestPeersRequest {
   bytes nodeId = 1;
   string requestId = 2;
 }
 
+// TODO rename to ClosestNeighborsResponse
 message ClosestPeersResponse {
   repeated PeerDescriptor peers = 1;
   string requestId = 2;
@@ -128,7 +131,7 @@ enum RecursiveOperation {
 }
 
 message RecursiveOperationResponse {
-  repeated PeerDescriptor closestConnectedPeers = 1;
+  repeated PeerDescriptor closestConnectedNodes = 1;
   repeated DataEntry dataEntries = 2;
   bool noCloserNodesFound = 3;
   repeated PeerDescriptor routingPath = 4;

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -366,7 +366,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
             peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
-            getClosestPeersTo: (nodeId: DhtAddress, limit: number) => {
+            getClosestNeighborsTo: (nodeId: DhtAddress, limit: number) => {
                 return this.peerManager!.getClosestNeighborsTo(nodeId, limit)
                     .map((dhtPeer: DhtNodeRpcRemote) => dhtPeer.getPeerDescriptor())
             },

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -18,7 +18,7 @@ import { RingContacts } from './contact/RingContactList'
 
 interface DhtNodeRpcLocalConfig {
     peerDiscoveryQueryBatchSize: number
-    getClosestPeersTo: (nodeId: DhtAddress, limit: number) => PeerDescriptor[]
+    getClosestNeighborsTo: (nodeId: DhtAddress, limit: number) => PeerDescriptor[]
     getClosestRingContactsTo: (id: RingIdRaw, limit: number) => RingContacts
     addContact: (contact: PeerDescriptor) => void
     removeContact: (nodeId: DhtAddress) => void
@@ -37,7 +37,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     async getClosestPeers(request: ClosestPeersRequest, context: ServerCallContext): Promise<ClosestPeersResponse> {
         this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
         const response = {
-            peers: this.config.getClosestPeersTo(getDhtAddressFromRaw(request.nodeId), this.config.peerDiscoveryQueryBatchSize),
+            peers: this.config.getClosestNeighborsTo(getDhtAddressFromRaw(request.nodeId), this.config.peerDiscoveryQueryBatchSize),
             requestId: request.requestId
         }
         return response
@@ -46,10 +46,10 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     // TODO rename to getClosestRingContacts
     async getClosestRingPeers(request: ClosestRingPeersRequest, context: ServerCallContext): Promise<ClosestRingPeersResponse> {
         this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
-        const closestPeers = this.config.getClosestRingContactsTo(request.ringId as RingIdRaw, this.config.peerDiscoveryQueryBatchSize)
+        const closestContacts = this.config.getClosestRingContactsTo(request.ringId as RingIdRaw, this.config.peerDiscoveryQueryBatchSize)
         const response = {
-            leftPeers: closestPeers.left,
-            rightPeers: closestPeers.right,
+            leftPeers: closestContacts.left,
+            rightPeers: closestContacts.right,
             requestId: request.requestId
         }
         return response

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -28,7 +28,7 @@ export class DiscoverySession {
     private stopped = false
     private emitter = new EventEmitter<DiscoverySessionEvents>()
     private noProgressCounter = 0
-    private ongoingClosestPeersRequests: Set<DhtAddress> = new Set()
+    private ongoingRequests: Set<DhtAddress> = new Set()
     private readonly config: DiscoverySessionConfig
 
     constructor(config: DiscoverySessionConfig) {
@@ -44,22 +44,22 @@ export class DiscoverySession {
         }
     }
 
-    private async getClosestPeersFromContact(contact: DhtNodeRpcRemote): Promise<PeerDescriptor[]> {
+    private async fetchClosestNeighborsFromRemote(contact: DhtNodeRpcRemote): Promise<PeerDescriptor[]> {
         if (this.stopped) {
             return []
         }
-        logger.trace(`Getting closest peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+        logger.trace(`Getting closest neighbors from remote: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
         this.config.contactedPeers.add(contact.getNodeId())
         const returnedContacts = await contact.getClosestPeers(this.config.targetId)
         this.config.peerManager.setContactActive(contact.getNodeId())
         return returnedContacts
     }
 
-    private onClosestPeersRequestSucceeded(nodeId: DhtAddress, contacts: PeerDescriptor[]) {
-        if (!this.ongoingClosestPeersRequests.has(nodeId)) {
+    private onRequestSucceeded(nodeId: DhtAddress, contacts: PeerDescriptor[]) {
+        if (!this.ongoingRequests.has(nodeId)) {
             return
         }
-        this.ongoingClosestPeersRequests.delete(nodeId)
+        this.ongoingRequests.delete(nodeId)
         const targetId = getRawFromDhtAddress(this.config.targetId)
         const oldClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(this.config.targetId, 1)[0]
         const oldClosestDistance = getDistance(targetId, getRawFromDhtAddress(oldClosestNeighbor.getNodeId()))
@@ -71,11 +71,11 @@ export class DiscoverySession {
         }
     }
 
-    private onClosestPeersRequestFailed(peer: DhtNodeRpcRemote) {
-        if (!this.ongoingClosestPeersRequests.has(peer.getNodeId())) {
+    private onRequestFailed(peer: DhtNodeRpcRemote) {
+        if (!this.ongoingRequests.has(peer.getNodeId())) {
             return
         }
-        this.ongoingClosestPeersRequests.delete(peer.getNodeId())
+        this.ongoingRequests.delete(peer.getNodeId())
         this.config.peerManager.removeContact(peer.getNodeId())
     }
 
@@ -97,14 +97,14 @@ export class DiscoverySession {
             return
         }
         for (const nextPeer of uncontacted) {
-            if (this.ongoingClosestPeersRequests.size >= this.config.parallelism) {
+            if (this.ongoingRequests.size >= this.config.parallelism) {
                 break
             }
-            this.ongoingClosestPeersRequests.add(nextPeer.getNodeId())
+            this.ongoingRequests.add(nextPeer.getNodeId())
             // eslint-disable-next-line promise/catch-or-return
-            this.getClosestPeersFromContact(nextPeer)
-                .then((contacts) => this.onClosestPeersRequestSucceeded(nextPeer.getNodeId(), contacts))
-                .catch(() => this.onClosestPeersRequestFailed(nextPeer))
+            this.fetchClosestNeighborsFromRemote(nextPeer)
+                .then((contacts) => this.onRequestSucceeded(nextPeer.getNodeId(), contacts))
+                .catch(() => this.onRequestFailed(nextPeer))
                 .finally(() => {
                     this.findMoreContacts()
                 })

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -183,11 +183,12 @@ export class PeerDiscovery {
         if (!this.recoveryIntervalStarted) {
             this.recoveryIntervalStarted = true
             // TODO use config option or named constant?
-            await scheduleAtInterval(() => this.fetchClosestPeersFromBucket(), 60000, true, this.abortController.signal)
+            await scheduleAtInterval(() => this.fetchClosestNeighborsFromBucket(), 60000, true, this.abortController.signal)
         }
     }
 
-    private async fetchClosestPeersFromBucket(): Promise<void> {
+    // TODO rename the method (the bucket is not relevant abstraction for this class)
+    private async fetchClosestNeighborsFromBucket(): Promise<void> {
         if (this.isStopped()) {
             return
         }
@@ -197,8 +198,8 @@ export class PeerDiscovery {
             this.config.parallelism
         )
         await Promise.allSettled(
-            nodes.map(async (peer: DhtNodeRpcRemote) => {
-                const contacts = await peer.getClosestPeers(localNodeId)
+            nodes.map(async (node: DhtNodeRpcRemote) => {
+                const contacts = await node.getClosestPeers(localNodeId)
                 for (const contact of contacts) {
                     this.config.peerManager.addContact(contact)
                 }

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -183,12 +183,11 @@ export class PeerDiscovery {
         if (!this.recoveryIntervalStarted) {
             this.recoveryIntervalStarted = true
             // TODO use config option or named constant?
-            await scheduleAtInterval(() => this.fetchClosestNeighborsFromBucket(), 60000, true, this.abortController.signal)
+            await scheduleAtInterval(() => this.fetchClosestNeighbors(), 60000, true, this.abortController.signal)
         }
     }
 
-    // TODO rename the method (the bucket is not relevant abstraction for this class)
-    private async fetchClosestNeighborsFromBucket(): Promise<void> {
+    private async fetchClosestNeighbors(): Promise<void> {
         if (this.isStopped()) {
             return
         }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -140,7 +140,7 @@ export class RecursiveOperationManager {
         routingPath: PeerDescriptor[],
         targetPeerDescriptor: PeerDescriptor,
         serviceId: ServiceID,
-        closestNodes: PeerDescriptor[],
+        closestConnectedNodes: PeerDescriptor[],
         dataEntries: DataEntry[],
         noCloserNodesFound: boolean = false
     ): void {
@@ -150,7 +150,7 @@ export class RecursiveOperationManager {
                 .onResponseReceived(
                     getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor),
                     routingPath,
-                    closestNodes,
+                    closestConnectedNodes,
                     dataEntries,
                     noCloserNodesFound
                 )
@@ -165,7 +165,7 @@ export class RecursiveOperationManager {
                 // TODO use config option or named constant?
                 10000
             )
-            rpcRemote.sendResponse(routingPath, closestNodes, dataEntries, noCloserNodesFound)
+            rpcRemote.sendResponse(routingPath, closestConnectedNodes, dataEntries, noCloserNodesFound)
             remoteCommunicator.destroy()
         }
     }
@@ -177,7 +177,7 @@ export class RecursiveOperationManager {
         const targetId = getDhtAddressFromRaw(routedMessage.target)
         const request = (routedMessage.message!.body as { recursiveOperationRequest: RecursiveOperationRequest }).recursiveOperationRequest
         // TODO use config option or named constant?
-        const closestPeersToDestination = this.getClosestConnections(targetId, 5)
+        const closestConnectedNodes = this.getClosestConnectedNodes(targetId, 5)
         const dataEntries = (request.operation === RecursiveOperation.FETCH_DATA) 
             ? Array.from(this.config.localDataStore.values(targetId))
             : []
@@ -190,7 +190,7 @@ export class RecursiveOperationManager {
                 routedMessage.routingPath,
                 routedMessage.sourcePeer!,
                 request.sessionId,
-                closestPeersToDestination,
+                closestConnectedNodes,
                 dataEntries,
                 true
             )
@@ -200,15 +200,15 @@ export class RecursiveOperationManager {
             if ((ack.error === undefined) || (ack.error === RouteMessageError.NO_TARGETS)) {
                 const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
                     (
-                        closestPeersToDestination.length > 0 
+                        closestConnectedNodes.length > 0 
                         && getPreviousPeer(routedMessage) 
-                        && !this.isPeerCloserToIdThanSelf(closestPeersToDestination[0], targetId)
+                        && !this.isPeerCloserToIdThanSelf(closestConnectedNodes[0], targetId)
                     )
                 this.sendResponse(
                     routedMessage.routingPath,
                     routedMessage.sourcePeer!,
                     request.sessionId,
-                    closestPeersToDestination,
+                    closestConnectedNodes,
                     dataEntries,
                     noCloserContactsFound
                 )
@@ -217,15 +217,15 @@ export class RecursiveOperationManager {
         }    
     }
 
-    private getClosestConnections(referenceId: DhtAddress, limit: number): PeerDescriptor[] {
-        const connectedPeers = Array.from(this.config.connections.values())
-        const closestPeers = new SortedContactList<DhtNodeRpcRemote>({
+    private getClosestConnectedNodes(referenceId: DhtAddress, limit: number): PeerDescriptor[] {
+        const connectedNodes = Array.from(this.config.connections.values())
+        const sorted = new SortedContactList<DhtNodeRpcRemote>({
             referenceId,
             maxSize: limit,
             allowToContainReferenceId: true
         })
-        closestPeers.addContacts(connectedPeers)
-        return closestPeers.getClosestContacts(limit).map((peer) => peer.getPeerDescriptor())
+        sorted.addContacts(connectedNodes)
+        return sorted.getClosestContacts(limit).map((peer) => peer.getPeerDescriptor())
     }
 
     private isPeerCloserToIdThanSelf(peer: PeerDescriptor, nodeIdOrDataKey: DhtAddress): boolean {

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -66,11 +66,11 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
             onResponseReceived: (
                 sourceId: DhtAddress,
                 routingPath: PeerDescriptor[],
-                nodes: PeerDescriptor[],
+                closestConnectedNodes: PeerDescriptor[],
                 dataEntries: DataEntry[],
                 noCloserNodesFound: boolean
             ) => {
-                this.onResponseReceived(sourceId, routingPath, nodes, dataEntries, noCloserNodesFound)
+                this.onResponseReceived(sourceId, routingPath, closestConnectedNodes, dataEntries, noCloserNodesFound)
             }
         })
         this.rpcCommunicator.registerRpcNotification(RecursiveOperationResponse, 'sendResponse',
@@ -131,7 +131,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
     public onResponseReceived(
         sourceId: DhtAddress,
         routingPath: PeerDescriptor[],
-        nodes: PeerDescriptor[],
+        closestConnectedNodes: PeerDescriptor[],
         dataEntries: DataEntry[],
         noCloserNodesFound: boolean
     ): void {
@@ -139,7 +139,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         if (routingPath.length >= 1) {
             this.setHopAsReported(routingPath[routingPath.length - 1])
         }
-        nodes.forEach((descriptor: PeerDescriptor) => {
+        closestConnectedNodes.forEach((descriptor: PeerDescriptor) => {
             this.results.addContact(new Contact(descriptor))
         })
         this.processFoundData(dataEntries)

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
@@ -29,7 +29,7 @@ export class RecursiveOperationSessionRpcLocal implements IRecursiveOperationSes
     async sendResponse(report: RecursiveOperationResponse, context: ServerCallContext): Promise<Empty> {
         const sourceId = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
         logger.trace('RecursiveOperationResponse arrived: ' + JSON.stringify(report))
-        this.config.onResponseReceived(sourceId, report.routingPath, report.closestConnectedPeers, report.dataEntries, report.noCloserNodesFound)
+        this.config.onResponseReceived(sourceId, report.routingPath, report.closestConnectedNodes, report.dataEntries, report.noCloserNodesFound)
         return {}
     }
 }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcRemote.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcRemote.ts
@@ -13,13 +13,13 @@ export class RecursiveOperationSessionRpcRemote extends RpcRemote<RecursiveOpera
 
     sendResponse(
         routingPath: PeerDescriptor[],
-        closestNodes: PeerDescriptor[],
+        closestConnectedNodes: PeerDescriptor[],
         dataEntries: DataEntry[],
         noCloserNodesFound: boolean
     ): void {
         const report: RecursiveOperationResponse = {
             routingPath,
-            closestConnectedPeers: closestNodes,
+            closestConnectedNodes,
             dataEntries,
             noCloserNodesFound
         }

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -32,7 +32,7 @@ export class StoreRpcLocal implements IStoreRpc {
     async storeData(request: StoreDataRequest): Promise<StoreDataResponse> {
         logger.trace('storeData()')
         const key = getDhtAddressFromRaw(request.key)
-        const selfIsOneOfClosestPeers = this.config.selfIsWithinRedundancyFactor(key)
+        const selfIsWithinRedundancyFactor = this.config.selfIsWithinRedundancyFactor(key)
         this.config.localDataStore.storeEntry({ 
             key: request.key,
             data: request.data,
@@ -40,10 +40,10 @@ export class StoreRpcLocal implements IStoreRpc {
             createdAt: request.createdAt,
             storedAt: Timestamp.now(),
             ttl: request.ttl,
-            stale: !selfIsOneOfClosestPeers,
+            stale: !selfIsWithinRedundancyFactor,
             deleted: false
         })
-        if (!selfIsOneOfClosestPeers) {
+        if (!selfIsWithinRedundancyFactor) {
             this.config.localDataStore.setAllEntriesAsStale(key)
         }
         return {}

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -47,10 +47,14 @@ import type { RpcOptions } from "@protobuf-ts/runtime-rpc";
  */
 export interface IDhtNodeRpcClient {
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(input: ClosestPeersRequest, options?: RpcOptions): UnaryCall<ClosestPeersRequest, ClosestPeersResponse>;
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse>;
@@ -73,6 +77,8 @@ export class DhtNodeRpcClient implements IDhtNodeRpcClient, ServiceInfo {
     constructor(private readonly _transport: RpcTransport) {
     }
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(input: ClosestPeersRequest, options?: RpcOptions): UnaryCall<ClosestPeersRequest, ClosestPeersResponse> {
@@ -80,6 +86,8 @@ export class DhtNodeRpcClient implements IDhtNodeRpcClient, ServiceInfo {
         return stackIntercept<ClosestPeersRequest, ClosestPeersResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse> {

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -34,10 +34,14 @@ import { ServerCallContext } from "@protobuf-ts/runtime-rpc";
  */
 export interface IDhtNodeRpc<T = ServerCallContext> {
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(request: ClosestPeersRequest, context: T): Promise<ClosestPeersResponse>;
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(request: ClosestRingPeersRequest, context: T): Promise<ClosestRingPeersResponse>;

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -108,6 +108,8 @@ export interface DataEntry {
     deleted: boolean;
 }
 /**
+ * TODO rename to ClosestNeighborsRequest
+ *
  * @generated from protobuf message dht.ClosestPeersRequest
  */
 export interface ClosestPeersRequest {
@@ -121,6 +123,8 @@ export interface ClosestPeersRequest {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestPeersResponse
+ *
  * @generated from protobuf message dht.ClosestPeersResponse
  */
 export interface ClosestPeersResponse {
@@ -134,6 +138,8 @@ export interface ClosestPeersResponse {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestRingContactsRequest
+ *
  * @generated from protobuf message dht.ClosestRingPeersRequest
  */
 export interface ClosestRingPeersRequest {
@@ -147,6 +153,8 @@ export interface ClosestRingPeersRequest {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestRingContactsResponse
+ *
  * @generated from protobuf message dht.ClosestRingPeersResponse
  */
 export interface ClosestRingPeersResponse {
@@ -181,9 +189,9 @@ export interface RecursiveOperationRequest {
  */
 export interface RecursiveOperationResponse {
     /**
-     * @generated from protobuf field: repeated dht.PeerDescriptor closestConnectedPeers = 1;
+     * @generated from protobuf field: repeated dht.PeerDescriptor closestConnectedNodes = 1;
      */
-    closestConnectedPeers: PeerDescriptor[];
+    closestConnectedNodes: PeerDescriptor[];
     /**
      * @generated from protobuf field: repeated dht.DataEntry dataEntries = 2;
      */
@@ -837,7 +845,7 @@ export const RecursiveOperationRequest = new RecursiveOperationRequest$Type();
 class RecursiveOperationResponse$Type extends MessageType<RecursiveOperationResponse> {
     constructor() {
         super("dht.RecursiveOperationResponse", [
-            { no: 1, name: "closestConnectedPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
+            { no: 1, name: "closestConnectedNodes", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
             { no: 2, name: "dataEntries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry },
             { no: 3, name: "noCloserNodesFound", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 4, name: "routingPath", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -36,7 +36,7 @@ describe('DhtNode', () => {
         const epRpcCommunicator = new ListeningRpcCommunicator(SERVICE_ID_LAYER0, environment.createTransport(peerDescriptor))
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
             peerDiscoveryQueryBatchSize: undefined as any,
-            getClosestPeersTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
+            getClosestNeighborsTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
             getClosestRingContactsTo: undefined as any,
             addContact: () => {},
             removeContact: undefined as any,

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -47,10 +47,14 @@ import type { RpcOptions } from "@protobuf-ts/runtime-rpc";
  */
 export interface IDhtNodeRpcClient {
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(input: ClosestPeersRequest, options?: RpcOptions): UnaryCall<ClosestPeersRequest, ClosestPeersResponse>;
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse>;
@@ -73,6 +77,8 @@ export class DhtNodeRpcClient implements IDhtNodeRpcClient, ServiceInfo {
     constructor(private readonly _transport: RpcTransport) {
     }
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(input: ClosestPeersRequest, options?: RpcOptions): UnaryCall<ClosestPeersRequest, ClosestPeersResponse> {
@@ -80,6 +86,8 @@ export class DhtNodeRpcClient implements IDhtNodeRpcClient, ServiceInfo {
         return stackIntercept<ClosestPeersRequest, ClosestPeersResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(input: ClosestRingPeersRequest, options?: RpcOptions): UnaryCall<ClosestRingPeersRequest, ClosestRingPeersResponse> {

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -34,10 +34,14 @@ import { ServerCallContext } from "@protobuf-ts/runtime-rpc";
  */
 export interface IDhtNodeRpc<T = ServerCallContext> {
     /**
+     * TODO rename to getClosestNeighbors (breaking change)
+     *
      * @generated from protobuf rpc: getClosestPeers(dht.ClosestPeersRequest) returns (dht.ClosestPeersResponse);
      */
     getClosestPeers(request: ClosestPeersRequest, context: T): Promise<ClosestPeersResponse>;
     /**
+     * TODO rename to getClosestRingContacts (breaking change)
+     *
      * @generated from protobuf rpc: getClosestRingPeers(dht.ClosestRingPeersRequest) returns (dht.ClosestRingPeersResponse);
      */
     getClosestRingPeers(request: ClosestRingPeersRequest, context: T): Promise<ClosestRingPeersResponse>;

--- a/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/dht/protos/DhtRpc.ts
@@ -108,6 +108,8 @@ export interface DataEntry {
     deleted: boolean;
 }
 /**
+ * TODO rename to ClosestNeighborsRequest
+ *
  * @generated from protobuf message dht.ClosestPeersRequest
  */
 export interface ClosestPeersRequest {
@@ -121,6 +123,8 @@ export interface ClosestPeersRequest {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestPeersResponse
+ *
  * @generated from protobuf message dht.ClosestPeersResponse
  */
 export interface ClosestPeersResponse {
@@ -134,6 +138,8 @@ export interface ClosestPeersResponse {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestRingContactsRequest
+ *
  * @generated from protobuf message dht.ClosestRingPeersRequest
  */
 export interface ClosestRingPeersRequest {
@@ -147,6 +153,8 @@ export interface ClosestRingPeersRequest {
     requestId: string;
 }
 /**
+ * TODO rename to ClosestRingContactsResponse
+ *
  * @generated from protobuf message dht.ClosestRingPeersResponse
  */
 export interface ClosestRingPeersResponse {
@@ -181,9 +189,9 @@ export interface RecursiveOperationRequest {
  */
 export interface RecursiveOperationResponse {
     /**
-     * @generated from protobuf field: repeated dht.PeerDescriptor closestConnectedPeers = 1;
+     * @generated from protobuf field: repeated dht.PeerDescriptor closestConnectedNodes = 1;
      */
-    closestConnectedPeers: PeerDescriptor[];
+    closestConnectedNodes: PeerDescriptor[];
     /**
      * @generated from protobuf field: repeated dht.DataEntry dataEntries = 2;
      */
@@ -837,7 +845,7 @@ export const RecursiveOperationRequest = new RecursiveOperationRequest$Type();
 class RecursiveOperationResponse$Type extends MessageType<RecursiveOperationResponse> {
     constructor() {
         super("dht.RecursiveOperationResponse", [
-            { no: 1, name: "closestConnectedPeers", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
+            { no: 1, name: "closestConnectedNodes", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
             { no: 2, name: "dataEntries", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => DataEntry },
             { no: 3, name: "noCloserNodesFound", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
             { no: 4, name: "routingPath", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor }


### PR DESCRIPTION
We should avoid using `peer` term, as it is used to refer both `neighbor` and `contact`.

In this PR fixed the term in use cases where closest peers are handled.

There is one field renaming in proto file: that should be a backwards compatible change.

## Future improvements

- Rename `closestContacts` -> `nearbyContacts`