### PR TITLE
ci: extra-log-prefix

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: boolean
         default: false
+      extra-log-prefix:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -52,4 +55,4 @@ jobs:
         if: success() || failure()
         uses: ./.github/workflows/reusable/collect-and-upload-logs
         with:
-          artifact_prefix: ${{ inputs.package }}
+          artifact_prefix: "${{ inputs.package }}${{inputs.extra-log-prefix }}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -142,6 +142,7 @@ jobs:
     uses: ./.github/workflows/test-setup.yml
     with:
       package: client
+      extra-log-prefix: '-browser'
       docker-services: init-keyspace dev-chain-fast deploy-network-subgraphs-fastchain
       run-entry-point: true
       run-brokers: true


### PR DESCRIPTION
## Summary

Fix issue in which two log artifacts (client-e2e and client-browser-e2e) were assigned the same name.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
