### PR TITLE
fix(dht): Do not limit neighbor list in `PeerManager#onKBucketPing`

### DIFF
--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -125,7 +125,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         }
         const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList({
             referenceId: this.config.localNodeId,
-            maxSize: 100,  // TODO use config option or named constant?
             allowToContainReferenceId: false
         })
         sortingList.addContacts(oldContacts)


### PR DESCRIPTION
When we sort the `oldContacts`, we should sort all contacts, not just a subset. In practice the `oldContacts` array length is already limited by the `numberOfNodesPerKBucket` (see `PeerManager.ts:82`), so there is no need to re-limit it in the `PeerManager#onKBucketPing` function.