### PR TITLE
refactor(dht): Move `ManagedWebrtcConnection` class

### DIFF
--- a/packages/dht/src/connection/webrtc/ManagedWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/ManagedWebrtcConnection.ts
@@ -1,7 +1,7 @@
-import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
-import { ConnectionType } from './IConnection'
-import { ManagedConnection } from './ManagedConnection'
-import { NodeWebrtcConnection } from './webrtc/NodeWebrtcConnection'
+import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
+import { ConnectionType } from '../IConnection'
+import { ManagedConnection } from '../ManagedConnection'
+import { NodeWebrtcConnection } from './NodeWebrtcConnection'
 
 export class ManagedWebrtcConnection extends ManagedConnection {
 

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -9,7 +9,7 @@ import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicat
 import { NodeWebrtcConnection } from './NodeWebrtcConnection'
 import { WebrtcConnectorRpcRemote } from './WebrtcConnectorRpcRemote'
 import { WebrtcConnectorRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
-import { ManagedWebrtcConnection } from '../ManagedWebrtcConnection'
+import { ManagedWebrtcConnection } from './ManagedWebrtcConnection'
 import { Logger } from '@streamr/utils'
 import * as Err from '../../helpers/errors'
 import { ManagedConnection } from '../ManagedConnection'

--- a/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
@@ -14,7 +14,7 @@ import { IWebrtcConnectorRpc } from '../../proto/packages/dht/protos/DhtRpc.serv
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
 import { ManagedConnection } from '../ManagedConnection'
-import { ManagedWebrtcConnection } from '../ManagedWebrtcConnection'
+import { ManagedWebrtcConnection } from './ManagedWebrtcConnection'
 import { NodeWebrtcConnection } from './NodeWebrtcConnection'
 import { WebrtcConnectorRpcRemote } from './WebrtcConnectorRpcRemote'
 import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'


### PR DESCRIPTION
Moved into `webrtc` directory as the class is WebRTC-specific.