### PR TITLE
refactor(dht): Extract `ConnectionsView`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -24,6 +24,7 @@ import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { ConnectionLockRpcLocal } from './ConnectionLockRpcLocal'
 import { DhtAddress, areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../identifiers'
 import { getOfferer } from '../helpers/offering'
+import { ConnectionsView } from './ConnectionsView'
 
 export interface ConnectionManagerConfig {
     maxConnections?: number
@@ -93,7 +94,7 @@ export const getNodeIdOrUnknownFromPeerDescriptor = (peerDescriptor: PeerDescrip
     }
 }
 
-export class ConnectionManager extends EventEmitter<TransportEvents> implements ITransport, ConnectionLocker {
+export class ConnectionManager extends EventEmitter<TransportEvents> implements ITransport, ConnectionsView, ConnectionLocker {
 
     private config: ConnectionManagerConfig
     private readonly metricsContext: MetricsContext

--- a/packages/dht/src/connection/ConnectionsView.ts
+++ b/packages/dht/src/connection/ConnectionsView.ts
@@ -1,0 +1,8 @@
+import { DhtAddress } from '../identifiers'
+import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
+
+export interface ConnectionsView {
+    getConnections: () => PeerDescriptor[]
+    getConnectionCount: () => number
+    hasConnection: (nodeId: DhtAddress) => boolean
+}

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -52,6 +52,7 @@ import { createPeerDescriptor } from '../helpers/createPeerDescriptor'
 import { RingIdRaw } from './contact/ringIdentifiers'
 import { getLocalRegion } from '@streamr/cdn-location'
 import { RingContacts } from './contact/RingContactList'
+import { ConnectionsView } from '../connection/ConnectionsView'
 
 export interface DhtNodeEvents {
     closestContactAdded: (peerDescriptor: PeerDescriptor) => void
@@ -81,6 +82,7 @@ export interface DhtNodeOptions {
     periodicallyPingRingContacts?: boolean
 
     transport?: ITransport
+    connectionsView?: ConnectionsView
     connectionLocker?: ConnectionLocker
     peerDescriptor?: PeerDescriptor
     entryPoints?: PeerDescriptor[]
@@ -135,10 +137,12 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private recursiveOperationManager?: RecursiveOperationManager
     private peerDiscovery?: PeerDiscovery
     private peerManager?: PeerManager
+    private connectionsView?: ConnectionsView
     public connectionLocker?: ConnectionLocker
     private region?: number
     private started = false
     private abortController = new AbortController()
+
     constructor(conf: DhtNodeOptions) {
         super()
         this.config = merge({
@@ -200,6 +204,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             
         if (this.config.transport) {
             this.transport = this.config.transport
+            this.connectionsView = this.config.connectionsView
             this.connectionLocker = this.config.connectionLocker
             this.localPeerDescriptor = this.transport.getLocalPeerDescriptor()
         } else {
@@ -239,6 +244,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 metricsContext: this.config.metricsContext
             })
             await connectionManager.start()
+            this.connectionsView = connectionManager
             this.connectionLocker = connectionManager
             this.transport = connectionManager
         }
@@ -266,12 +272,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             localPeerDescriptor: this.localPeerDescriptor!,
             handleMessage: (message: Message) => this.handleMessageFromRouter(message),
-            getConnections: () => this.getConnections()
+            getConnections: () => this.connectionsView!.getConnections()
         })
         this.recursiveOperationManager = new RecursiveOperationManager({
             rpcCommunicator: this.rpcCommunicator,
             router: this.router,
             sessionTransport: this,
+            connectionsView: this.connectionsView!,
             localPeerDescriptor: this.localPeerDescriptor!,
             serviceId: this.config.serviceId,
             localDataStore: this.localDataStore,
@@ -321,7 +328,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             connectionLocker: this.connectionLocker,
             lockId: this.config.serviceId,
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
-            hasConnection: (nodeId: DhtAddress) => this.transport!.hasConnection(nodeId)
+            hasConnection: (nodeId: DhtAddress) => this.connectionsView!.hasConnection(nodeId)
         })
         this.peerManager.on('closestContactRemoved', (peerDescriptor: PeerDescriptor) => {
             this.emit('closestContactRemoved', peerDescriptor)
@@ -497,7 +504,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     private getConnectedEntryPoints(): PeerDescriptor[] {
         return this.config.entryPoints !== undefined ? this.config.entryPoints.filter((entryPoint) =>
-            this.transport!.hasConnection(getNodeIdFromPeerDescriptor(entryPoint))
+            this.connectionsView!.hasConnection(getNodeIdFromPeerDescriptor(entryPoint))
         ) : []
     }
 
@@ -575,16 +582,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.started ? this.peerManager!.getNeighbors() : []
     }
 
-    public getConnections(): PeerDescriptor[] {
-        return this.transport!.getConnections()
-    }
-
-    public getConnectionCount(): number {
-        return this.transport!.getConnectionCount()
-    }
-
-    public hasConnection(nodeId: DhtAddress): boolean {
-        return this.transport!.hasConnection(nodeId)
+    getConnectionsView(): ConnectionsView {
+        return this.connectionsView!
     }
 
     public getLocalLockedConnectionCount(): number {
@@ -604,7 +603,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             if (!this.peerManager) {
                 return false
             } else {
-                return (this.getConnectionCount() > 0)
+                return (this.connectionsView!.getConnectionCount() > 0)
             }
         }, this.config.networkConnectivityTimeout, 100, this.abortController.signal)
     }

--- a/packages/dht/src/exports.ts
+++ b/packages/dht/src/exports.ts
@@ -7,6 +7,7 @@ export { getRandomRegion, getRegionDelayMatrix } from './connection/simulator/pi
 export { PeerDescriptor, Message, NodeType, DataEntry } from './proto/packages/dht/protos/DhtRpc'
 export { ITransport, TransportEvents } from './transport/ITransport'
 export { ConnectionManager, ConnectionLocker, PortRange, TlsCertificate } from './connection/ConnectionManager'
+export { ConnectionsView } from './connection/ConnectionsView'
 export { LockID } from './connection/ConnectionLockStates'
 export { DefaultConnectorFacade } from './connection/ConnectorFacade'
 export { DhtRpcOptions } from './rpc-protocol/DhtRpcOptions'

--- a/packages/dht/src/transport/ITransport.ts
+++ b/packages/dht/src/transport/ITransport.ts
@@ -1,4 +1,3 @@
-import { DhtAddress } from '../identifiers'
 import { Message, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 
 export interface TransportEvents {
@@ -33,8 +32,5 @@ export interface ITransport {
 
     send(msg: Message, opts?: SendOptions): Promise<void>
     getLocalPeerDescriptor(): PeerDescriptor
-    getConnections(): PeerDescriptor[]
-    getConnectionCount(): number
-    hasConnection(nodeId: DhtAddress): boolean
     stop(): void | Promise<void>
 }

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -56,7 +56,7 @@ describe('Find correctness', () => {
         logger.info('waiting over')
 
         nodes.forEach((node) => logger.info(getNodeIdFromPeerDescriptor(node.getLocalPeerDescriptor()) + ': connections:' +
-            node.getConnectionCount() + ', kbucket: ' + node.getNeighborCount()
+            node.getConnectionsView().getConnectionCount() + ', kbucket: ' + node.getNeighborCount()
             + ', localLocked: ' + node.getLocalLockedConnectionCount()
             + ', remoteLocked: ' + node.getRemoteLockedConnectionCount()
             + ', weakLocked: ' + node.getWeakLockedConnectionCount()))

--- a/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0-Layer1.test.ts
@@ -39,11 +39,11 @@ describe('Layer0-Layer1', () => {
         await node1.start()
         await node2.start()
 
-        stream1Node1 = new DhtNode({ transport: epDhtNode, serviceId: STREAM_ID1 })
-        stream1Node2 = new DhtNode({ transport: node1, serviceId: STREAM_ID1 })
+        stream1Node1 = new DhtNode({ transport: epDhtNode, connectionsView: epDhtNode.getConnectionsView(), serviceId: STREAM_ID1 })
+        stream1Node2 = new DhtNode({ transport: node1, connectionsView: node1.getConnectionsView(), serviceId: STREAM_ID1 })
 
-        stream2Node1 = new DhtNode({ transport: epDhtNode, serviceId: STREAM_ID2 })
-        stream2Node2 = new DhtNode({ transport: node2, serviceId: STREAM_ID2 })
+        stream2Node1 = new DhtNode({ transport: epDhtNode, connectionsView: epDhtNode.getConnectionsView(), serviceId: STREAM_ID2 })
+        stream2Node2 = new DhtNode({ transport: node2, connectionsView: node2.getConnectionsView(), serviceId: STREAM_ID2 })
 
         await Promise.all([
             stream1Node1.start(),

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -50,41 +50,47 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
             entryPoints: [entrypointDescriptor]
         })
 
+        await layer0EntryPoint.start()
+        await layer0Node1.start()
+        await layer0Node2.start()
+        await layer0Node3.start()
+        await layer0Node4.start()
+
         layer1EntryPoint = new DhtNode({
             nodeId: getNodeIdFromPeerDescriptor(entrypointDescriptor),
             transport: layer0EntryPoint,
+            connectionsView: layer0EntryPoint.getConnectionsView(),
             serviceId: 'layer1'
         })
 
         layer1Node1 = new DhtNode({
             nodeId: layer0Node1Id,
             transport: layer0Node1,
+            connectionsView: layer0Node1.getConnectionsView(),
             serviceId: 'layer1'
         })
 
         layer1Node2 = new DhtNode({
             nodeId: layer0Node2Id,
             transport: layer0Node2,
+            connectionsView: layer0Node2.getConnectionsView(),
             serviceId: 'layer1'
         })
 
         layer1Node3 = new DhtNode({
             nodeId: layer0Node3Id,
             transport: layer0Node3,
+            connectionsView: layer0Node3.getConnectionsView(),
             serviceId: 'layer1'
         })
 
         layer1Node4 = new DhtNode({
             nodeId: layer0Node4Id,
             transport: layer0Node4,
+            connectionsView: layer0Node4.getConnectionsView(),
             serviceId: 'layer1'
         })
 
-        await layer0EntryPoint.start()
-        await layer0Node1.start()
-        await layer0Node2.start()
-        await layer0Node3.start()
-        await layer0Node4.start()
         await layer1EntryPoint.start()
         await layer1Node1.start()
         await layer1Node2.start()

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -24,7 +24,12 @@ describe('Layer1 Scale', () => {
         await epLayer0Node.start()
         await epLayer0Node.joinDht([epPeerDescriptor])
 
-        epLayer1Node = new DhtNode({ transport: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
+        epLayer1Node = new DhtNode({ 
+            transport: epLayer0Node,
+            connectionsView: epLayer0Node.getConnectionsView(),
+            peerDescriptor: epPeerDescriptor,
+            serviceId: STREAM_ID
+        })
         await epLayer1Node.start()
         await epLayer1Node.joinDht([epPeerDescriptor])
 
@@ -42,6 +47,7 @@ describe('Layer1 Scale', () => {
             layer0Nodes.push(node)
             const layer1 = new DhtNode({
                 transport: node,
+                connectionsView: node.getConnectionsView(),
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getLocalPeerDescriptor(),
                 serviceId: STREAM_ID,

--- a/packages/dht/test/end-to-end/Layer1-Scale-Webrtc.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-Webrtc.test.ts
@@ -16,11 +16,19 @@ describe('Layer1 Scale', () => {
     let epLayer1Node: DhtNode
 
     beforeEach(async () => {
-        epLayer0Node = new DhtNode({ peerDescriptor: epPeerDescriptor, websocketServerEnableTls: false })
+        epLayer0Node = new DhtNode({
+            peerDescriptor: epPeerDescriptor,
+            websocketServerEnableTls: false
+        })
         await epLayer0Node.start()
         await epLayer0Node.joinDht([epPeerDescriptor])
 
-        epLayer1Node = new DhtNode({ transport: epLayer0Node, peerDescriptor: epPeerDescriptor, serviceId: STREAM_ID })
+        epLayer1Node = new DhtNode({
+            transport: epLayer0Node,
+            connectionsView: epLayer0Node.getConnectionsView(),
+            peerDescriptor: epPeerDescriptor,
+            serviceId: STREAM_ID
+        })
         await epLayer1Node.start()
         await epLayer1Node.joinDht([epPeerDescriptor])
 
@@ -36,6 +44,7 @@ describe('Layer1 Scale', () => {
             layer0Nodes.push(node)
             const layer1 = new DhtNode({
                 transport: node,
+                connectionsView: node.getConnectionsView(),
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getLocalPeerDescriptor(),
                 serviceId: STREAM_ID,

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -64,9 +64,11 @@ describe('DhtNode', () => {
             startRemoteNode(other, environment)
         }
 
+        const transport = environment.createTransport(localPeerDescriptor)
         const localNode = new DhtNode({
             peerDescriptor: localPeerDescriptor,
-            transport: environment.createTransport(localPeerDescriptor),
+            transport,
+            connectionsView: transport,
             entryPoints: [entryPointPeerDescriptor]
         })
         await localNode.start()

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -63,9 +63,9 @@ describe('Layer1', () => {
             const layer0Node = nodes[i]
             const layer1Node = layer1Nodes[i]
             expect(layer1Node.getNodeId()).toEqual(layer0Node.getNodeId())
-            expect(layer1Node.getConnectionCount()).toEqual(layer0Node.getConnectionCount())
+            expect(layer1Node.getConnectionsView().getConnectionCount()).toEqual(layer0Node.getConnectionsView().getConnectionCount())
             expect(layer1Node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
-            expect(layer1Node.getConnections()).toEqual(layer0Node.getConnections())
+            expect(layer1Node.getConnectionsView().getConnections()).toEqual(layer0Node.getConnectionsView().getConnections())
         }
     }, 120000)
 
@@ -119,10 +119,10 @@ describe('Layer1', () => {
             const stream3Node = stream3[i]
             const stream4Node = stream4[i]
 
-            expect(layer0Node.getConnectionCount()).toEqual(stream1Node.getConnectionCount())
-            expect(layer0Node.getConnectionCount()).toEqual(stream2Node.getConnectionCount())
-            expect(layer0Node.getConnectionCount()).toEqual(stream3Node.getConnectionCount())
-            expect(layer0Node.getConnectionCount()).toEqual(stream4Node.getConnectionCount())
+            expect(layer0Node.getConnectionsView().getConnectionCount()).toEqual(stream1Node.getConnectionsView().getConnectionCount())
+            expect(layer0Node.getConnectionsView().getConnectionCount()).toEqual(stream2Node.getConnectionsView().getConnectionCount())
+            expect(layer0Node.getConnectionsView().getConnectionCount()).toEqual(stream3Node.getConnectionsView().getConnectionCount())
+            expect(layer0Node.getConnectionsView().getConnectionCount()).toEqual(stream4Node.getConnectionsView().getConnectionCount())
 
         }
     }, 120000)

--- a/packages/dht/test/integration/ScaleDownDht.test.ts
+++ b/packages/dht/test/integration/ScaleDownDht.test.ts
@@ -57,7 +57,7 @@ describe('Scaling down a Dht network', () => {
             stoppedNodes.add(getNodeIdFromPeerDescriptor(stoppingPeerDescriptor))
             await nodeToStop.stop()
             const nodeIsCleaned = nodes.filter((node) => !stoppedNodes.has(node.getNodeId())).every((node) =>
-                node.getConnections().every((peer) => {
+                node.getConnectionsView().getConnections().every((peer) => {
                     if (areEqualPeerDescriptors(peer, stoppingPeerDescriptor)) {
                         logger.error(getNodeIdFromPeerDescriptor(node.getLocalPeerDescriptor()) + ', ' 
                             + getNodeIdFromPeerDescriptor(stoppingPeerDescriptor) + ' cleaning up failed')

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -19,6 +19,7 @@ import { FakeRpcCommunicator } from '../utils/FakeRpcCommunicator'
 import { Router } from '../../src/dht/routing/Router'
 import { ITransport } from '../../src/transport/ITransport'
 import { areEqualPeerDescriptors, createRandomDhtAddress } from '../../src/identifiers'
+import { MockConnectionsView } from '../utils/mock/MockConnectionsView'
 
 const createMockRouter = (error?: RouteMessageError): Partial<Router> => {
     return {
@@ -77,6 +78,7 @@ describe('RecursiveOperationManager', () => {
             serviceId: 'RecursiveOperationManager',
             localDataStore: new LocalDataStore(30 * 100),
             sessionTransport: transport,
+            connectionsView: new MockConnectionsView(),
             addContact: () => {},
             rpcCommunicator: rpcCommunicator as any,
             createDhtNodeRpcRemote: () => undefined as any

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -2,8 +2,10 @@ import { EventEmitter } from 'eventemitter3'
 import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { DEFAULT_SEND_OPTIONS, ITransport, SendOptions, TransportEvents } from '../../src/transport/ITransport'
+import { ConnectionsView } from '../../src/exports'
 
-class FakeTransport extends EventEmitter<TransportEvents> implements ITransport {
+// TODO extract ConnectionsView functionality to FakeConnectionsView
+class FakeTransport extends EventEmitter<TransportEvents> implements ITransport, ConnectionsView {
 
     private onSend: (msg: Message) => void
     private readonly localPeerDescriptor: PeerDescriptor
@@ -60,7 +62,7 @@ export class FakeEnvironment {
 
     private transports: FakeTransport[] = []
 
-    createTransport(peerDescriptor: PeerDescriptor): ITransport {
+    createTransport(peerDescriptor: PeerDescriptor): FakeTransport {
         const transport = new FakeTransport(peerDescriptor, (msg) => {
             const targetNode = getDhtAddressFromRaw(msg.targetDescriptor!.nodeId)
             const targetTransport = this.transports.find((t) => getNodeIdFromPeerDescriptor(t.getLocalPeerDescriptor()) === targetNode)

--- a/packages/dht/test/utils/mock/MockConnectionsView.ts
+++ b/packages/dht/test/utils/mock/MockConnectionsView.ts
@@ -1,0 +1,18 @@
+import { PeerDescriptor } from '../../../src/proto/packages/dht/protos/DhtRpc'
+
+export class MockConnectionsView {
+    // eslint-disable-next-line class-methods-use-this
+    getConnections(): PeerDescriptor[] {
+        return []
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getConnectionCount(): number {
+        return 0
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    hasConnection(): boolean {
+        return false
+    }
+}

--- a/packages/dht/test/utils/mock/MockTransport.ts
+++ b/packages/dht/test/utils/mock/MockTransport.ts
@@ -15,21 +15,6 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getConnections(): PeerDescriptor[] {
-        return []
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    getConnectionCount(): number {
-        return 0
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    hasConnection(): boolean {
-        return false
-    }
-
-    // eslint-disable-next-line class-methods-use-this
     stop(): void {
 
     }

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -89,6 +89,7 @@ export const createMockConnectionDhtNode = async (
     const opts = {
         peerDescriptor: peerDescriptor,
         transport: mockConnectionManager,
+        connectionsView: mockConnectionManager,
         connectionLocker: mockConnectionManager,
         numberOfNodesPerKBucket,
         maxConnections: maxConnections,
@@ -115,7 +116,9 @@ export const createMockConnectionLayer1Node = async (
         type: NodeType.NODEJS,
     }
     const node = new DhtNode({
-        peerDescriptor: descriptor, transport: layer0Node,
+        peerDescriptor: descriptor,
+        transport: layer0Node,
+        connectionsView: layer0Node.getConnectionsView(),
         serviceId: serviceId ? serviceId : 'layer1', numberOfNodesPerKBucket,
         rpcRequestTimeout: 10000
     })

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -168,7 +168,7 @@ export class NetworkStack {
         return {
             peerDescriptor: this.getLayer0Node().getLocalPeerDescriptor(),
             controlLayer: {
-                connections: this.getLayer0Node().getConnections(),
+                connections: this.getLayer0Node().getConnectionsView().getConnections(),
                 neighbors: this.getLayer0Node().getNeighbors()
             },
             streamPartitions: this.getContentDeliveryManager().getNodeInfo(),

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -214,6 +214,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
     private createLayer1Node(streamPartId: StreamPartID, entryPoints: PeerDescriptor[]): Layer1Node {
         return new DhtNode({
             transport: this.layer0Node!,
+            connectionsView: this.layer0Node!.getConnectionsView(),
             serviceId: 'layer1::' + streamPartId,
             peerDescriptor: this.layer0Node!.getLocalPeerDescriptor(),
             entryPoints,

--- a/packages/trackerless-network/src/logic/Layer0Node.ts
+++ b/packages/trackerless-network/src/logic/Layer0Node.ts
@@ -1,4 +1,4 @@
-import { DataEntry, DhtAddress, ITransport, PeerDescriptor } from '@streamr/dht'
+import { ConnectionsView, DataEntry, DhtAddress, ITransport, PeerDescriptor } from '@streamr/dht'
 import { Any } from '../proto/google/protobuf/any'
 
 export interface Layer0Node extends ITransport {
@@ -11,7 +11,7 @@ export interface Layer0Node extends ITransport {
     waitForNetworkConnectivity(): Promise<void>
     getTransport(): ITransport
     getNeighbors(): PeerDescriptor[]
-    getConnections(): PeerDescriptor[]
+    getConnectionsView(): ConnectionsView
     start(): Promise<void>
     stop(): Promise<void>
 }

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -159,7 +159,7 @@ run().then(() => {
     console.log(foundData)
     const layer0Node = currentNode.stack.getLayer0Node() as DhtNode
     console.log(layer0Node.getNeighbors().length)
-    console.log(layer0Node.getConnectionCount())
+    console.log(layer0Node.getConnectionsView().getConnectionCount())
     const streamPartDelivery = contentDeliveryManager
         .getStreamPartDelivery(streamParts[0])! as { layer1Node: Layer1Node, node: ContentDeliveryLayerNode }
     console.log(streamPartDelivery.layer1Node.getNeighbors())

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -29,11 +29,13 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
 
         entryPointLayer1Node = new DhtNode({
             transport: entrypointCm,
+            connectionsView: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
         otherLayer1Nodes = range(otherNodeCount).map((i) => new DhtNode({
             transport: cms[i],
+            connectionsView: cms[i],
             peerDescriptor: peerDescriptors[i],
             serviceId: streamPartId
         }))

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -44,12 +44,14 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
 
         entryPointLayer1Node = new DhtNode({
             transport: entrypointCm,
+            connectionsView: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
 
         otherLayer1Nodes = range(otherNodeCount).map((i) => new DhtNode({
             transport: cms[i],
+            connectionsView: cms[i],
             peerDescriptor: peerDescriptors[i],
             serviceId: streamPartId
         }))

--- a/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
@@ -44,11 +44,13 @@ describe('ContentDeliveryManager', () => {
         await transport2.start()
         layer0Node1 = new DhtNode({
             transport: transport1,
+            connectionsView: transport1,
             peerDescriptor: peerDescriptor1,
             entryPoints: [peerDescriptor1]
         })
         layer0Node2 = new DhtNode({
             transport: transport2,
+            connectionsView: transport2,
             peerDescriptor: peerDescriptor2,
             entryPoints: [peerDescriptor1]
         })

--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -30,7 +30,8 @@ describe('inspect', () => {
             layer0: {
                 entryPoints: [publisherDescriptor],
                 peerDescriptor,
-                transport
+                transport,
+                connectionsView: transport
             }
         })
         await node.start()

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -37,14 +37,16 @@ describe('NetworkNode', () => {
             layer0: {
                 entryPoints: [pd1],
                 peerDescriptor: pd1,
-                transport: transport1
+                transport: transport1,
+                connectionsView: transport1
             }
         })
         node2 = createNetworkNode({
             layer0: {
                 entryPoints: [pd1],
                 peerDescriptor: pd2,
-                transport: transport2
+                transport: transport2,
+                connectionsView: transport2
             }
         })
 

--- a/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NodeInfoRpc.test.ts
@@ -40,6 +40,7 @@ describe('NetworkStack NodeInfoRpc', () => {
         requesteStack = new NetworkStack({
             layer0: {
                 transport: requesteeTransport1,
+                connectionsView: requesteeTransport1,
                 peerDescriptor: requesteePeerDescriptor,
                 entryPoints: [requesteePeerDescriptor]
             }
@@ -47,6 +48,7 @@ describe('NetworkStack NodeInfoRpc', () => {
         otherStack = new NetworkStack({
             layer0: {
                 transport: otherTransport,
+                connectionsView: otherTransport,
                 peerDescriptor: otherPeerDescriptor,
                 entryPoints: [requesteePeerDescriptor]
             }

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -28,6 +28,7 @@ describe('Joining stream parts on offline nodes', () => {
         entryPoint = new NetworkStack({
             layer0: {
                 transport: entryPointTransport,
+                connectionsView: entryPointTransport,
                 peerDescriptor: entryPointPeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -36,6 +37,7 @@ describe('Joining stream parts on offline nodes', () => {
         node1 = new NetworkStack({
             layer0: {
                 transport: node1Transport,
+                connectionsView: node1Transport,
                 peerDescriptor: node1PeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -44,6 +46,7 @@ describe('Joining stream parts on offline nodes', () => {
         node2 = new NetworkStack({
             layer0: {
                 transport: node2Transport,
+                connectionsView: node2Transport,
                 peerDescriptor: node2PeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -53,6 +53,7 @@ describe('stream without default entrypoints', () => {
         entrypoint = createNetworkNode({
             layer0: {
                 transport: entryPointTransport,
+                connectionsView: entryPointTransport,
                 peerDescriptor: entryPointPeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -66,6 +67,7 @@ describe('stream without default entrypoints', () => {
                 layer0: {
                     peerDescriptor,
                     transport,
+                    connectionsView: transport,
                     entryPoints: [entryPointPeerDescriptor]
                 }
             })

--- a/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
+++ b/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
@@ -27,6 +27,7 @@ describe('Stream Entry Points are replaced when known entry points leave streams
         const node = new NetworkStack({
             layer0: {
                 transport,
+                connectionsView: transport,
                 peerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }
@@ -41,6 +42,7 @@ describe('Stream Entry Points are replaced when known entry points leave streams
         layer0EntryPoint = new NetworkStack({
             layer0: {
                 transport: entryPointTransport,
+                connectionsView: entryPointTransport,
                 peerDescriptor: entryPointPeerDescriptor,
                 entryPoints: [entryPointPeerDescriptor]
             }

--- a/packages/trackerless-network/test/utils/mock/MockConnectionsView.ts
+++ b/packages/trackerless-network/test/utils/mock/MockConnectionsView.ts
@@ -1,0 +1,18 @@
+import { PeerDescriptor } from '@streamr/dht'
+
+export class MockConnectionsView {
+    // eslint-disable-next-line class-methods-use-this
+    getConnections(): PeerDescriptor[] {
+        return []
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getConnectionCount(): number {
+        return 0
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    hasConnection(): boolean {
+        return false
+    }
+}

--- a/packages/trackerless-network/test/utils/mock/MockLayer0Node.ts
+++ b/packages/trackerless-network/test/utils/mock/MockLayer0Node.ts
@@ -1,6 +1,7 @@
-import { PeerDescriptor, DataEntry, ITransport, TransportEvents } from '@streamr/dht'
+import { PeerDescriptor, DataEntry, ITransport, TransportEvents, ConnectionsView } from '@streamr/dht'
 import { Layer0Node } from '../../../src/logic/Layer0Node'
 import { EventEmitter } from 'eventemitter3'
+import { MockConnectionsView } from './MockConnectionsView'
 
 export class MockLayer0Node extends EventEmitter<TransportEvents> implements Layer0Node {
 
@@ -44,18 +45,8 @@ export class MockLayer0Node extends EventEmitter<TransportEvents> implements Lay
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getConnections(): PeerDescriptor[] {
-        return []
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    getConnectionCount(): number {
-        return 0
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    hasConnection(): boolean {
-        return false
+    getConnectionsView(): ConnectionsView {
+        return new MockConnectionsView()
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/trackerless-network/test/utils/mock/MockTransport.ts
+++ b/packages/trackerless-network/test/utils/mock/MockTransport.ts
@@ -15,21 +15,6 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     }
 
     // eslint-disable-next-line class-methods-use-this
-    getConnections(): PeerDescriptor[] {
-        return []
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    getConnectionCount(): number {
-        return 0
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    hasConnection(): boolean {
-        return false
-    }
-
-    // eslint-disable-next-line class-methods-use-this
     stop(): void {
     }
 }

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -47,6 +47,7 @@ export const createMockContentDeliveryLayerNodeAndDhtNode = async (
     await mockCm.start()
     const layer1Node = new DhtNode({
         transport: mockCm,
+        connectionsView: mockCm,
         peerDescriptor: localPeerDescriptor,
         numberOfNodesPerKBucket: 4,
         entryPoints: [entryPointDescriptor],


### PR DESCRIPTION
Extracted `ConnectionsView` interface from `ITransport`. Now `ITransport` handles just the transport logic. Connection management and queries are in separate classes: in `ConnectionLocker` and in the new `ConnectionsView`.

## Future improvements

- The `transport` and `connectionLocker` instances are dependencies of a `DhtNode` object. Therefore we should pass those instances in `DhtNode`'s config instead of creating a `ConnectionManager` instance internally. This would enhance module boundaries and make testing siginificantly easier. There is currently a circular dependency between `DhtNode` and `ConnectionManager`, which makes this implementation non-trivial.
- Extract `ConnectionsView` functionality from `FakeTransport` (and maybe also `SimulatorTransport` if possible).