### PR TITLE
refactor(dht): Change `DhtNode` field visibility

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -129,16 +129,17 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     private rpcCommunicator?: RoutingRpcCommunicator
     private transport?: ITransport
     private localPeerDescriptor?: PeerDescriptor
-    public router?: Router
+    private router?: Router
     private storeManager?: StoreManager
     private localDataStore: LocalDataStore
     private recursiveOperationManager?: RecursiveOperationManager
     private peerDiscovery?: PeerDiscovery
     private peerManager?: PeerManager
-    public connectionLocker?: ConnectionLocker
+    private connectionLocker?: ConnectionLocker
     private region?: number
     private started = false
     private abortController = new AbortController()
+
     constructor(conf: DhtNodeOptions) {
         super()
         this.config = merge({

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -73,6 +73,7 @@ describe('Route Message With Mock Connections', () => {
         }
 
         await runAndWaitForEvents3<DhtNodeEvents>([() => {
+            // @ts-expect-error private
             sourceNode.router!.doRouteMessage({
                 message,
                 target: destinationNode.getLocalPeerDescriptor().nodeId,
@@ -104,6 +105,7 @@ describe('Route Message With Mock Connections', () => {
                 sourceDescriptor: sourceNode.getLocalPeerDescriptor(),
                 targetDescriptor: destinationNode.getLocalPeerDescriptor()
             }
+            // @ts-expect-error private
             sourceNode.router!.doRouteMessage({
                 message,
                 target: destinationNode.getLocalPeerDescriptor().nodeId,
@@ -141,6 +143,7 @@ describe('Route Message With Mock Connections', () => {
                             sourceDescriptor: node.getLocalPeerDescriptor(),
                             targetDescriptor: destinationNode.getLocalPeerDescriptor()
                         }
+                        // @ts-expect-error private
                         node.router!.doRouteMessage({
                             message,
                             target: receiver.getLocalPeerDescriptor().nodeId,
@@ -217,6 +220,7 @@ describe('Route Message With Mock Connections', () => {
         }
 
         await runAndWaitForEvents3<DhtNodeEvents>([() => {
+            // @ts-expect-error private
             sourceNode.router!.doRouteMessage(forwardedMessage, RoutingMode.FORWARD)
         }], [[destinationNode, 'message']])
 


### PR DESCRIPTION
`DhtNode`'s  `router` and `connectionLocker` fields changed to `private`.

## Future improvements

- Refactor `RouteMessage` test so that it doesn't use `DhtNode`'s internal field