### PR TITLE
refactor(DHT): remove duplicate connectingConnections check

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -89,7 +89,6 @@ export class WebsocketConnector {
             connect: (targetPeerDescriptor: PeerDescriptor) => this.connect(targetPeerDescriptor),
             hasConnection: (nodeId: DhtAddress): boolean => {
                 if (this.connectingConnections.has(nodeId)
-                    || this.connectingConnections.has(nodeId)
                     || this.ongoingConnectRequests.has(nodeId)
                     || config.hasConnection(nodeId)
                 ) {

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -87,16 +87,10 @@ export class WebsocketConnector {
     private registerLocalRpcMethods(config: WebsocketConnectorConfig) {
         const rpcLocal = new WebsocketConnectorRpcLocal({
             connect: (targetPeerDescriptor: PeerDescriptor) => this.connect(targetPeerDescriptor),
-            hasConnection: (nodeId: DhtAddress): boolean => {
-                if (this.connectingConnections.has(nodeId)
-                    || this.ongoingConnectRequests.has(nodeId)
-                    || config.hasConnection(nodeId)
-                ) {
-                    return true
-                } else {
-                    return false
-                }
-            },
+            hasConnection: (nodeId: DhtAddress): boolean => (this.connectingConnections.has(nodeId)
+                || this.ongoingConnectRequests.has(nodeId)
+                || config.hasConnection(nodeId))
+            ,
             onNewConnection: (connection: ManagedConnection) => config.onNewConnection(connection),
             abortSignal: this.abortController.signal
         })


### PR DESCRIPTION
## Summary

Remove duplicate connectingConnections check from `hasConnection` passed passed to `WebsocketConnectorRpcLocal`

Also removed redundant if else blocks