### PR TITLE
fix(DHT): fix hanging connection issue with connectivity requests

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -159,14 +159,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             allowToContainReferenceId: false
         })
         this.connections.forEach((connection, key) => {
-            // TODO: Investigate why multiple invalid WS client connections to the same
-            // server with a different nodeId can remain in the this.connections map.
-            // Seems to only happen if the ConnectionManager acting as client is not running a WS server itself.
-            if (connection.getPeerDescriptor() !== undefined && !this.hasConnection(getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!))) {
-                logger.trace(`Attempting to disconnect a hanging connection to ${getNodeIdFromPeerDescriptor(connection.getPeerDescriptor()!)}`)
-                connection.close(false).catch(() => {})
-                this.connections.delete(key)
-            } else if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsedTimestamp() > maxIdleTime) {
+            if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsedTimestamp() > maxIdleTime) {
                 logger.trace('disconnecting in timeout interval: ' + getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()))
                 disconnectionCandidates.addContact(connection)
             }

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -158,7 +158,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             maxSize: 100000,  // TODO use config option or named constant?
             allowToContainReferenceId: false
         })
-        this.connections.forEach((connection, key) => {
+        this.connections.forEach((connection) => {
             if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsedTimestamp() > maxIdleTime) {
                 logger.trace('disconnecting in timeout interval: ' + getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()))
                 disconnectionCandidates.addContact(connection)

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -307,6 +307,8 @@ export class WebsocketConnector {
             const ongoingConnectRequest = this.ongoingConnectRequests.get(nodeId)!
             if (!isMaybeSupportedVersion(remoteVersion)) {
                 ongoingConnectRequest.rejectHandshake(HandshakeError.UNSUPPORTED_VERSION)
+            } else if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {
+                ongoingConnectRequest.rejectHandshake(HandshakeError.INVALID_TARGET_PEER_DESCRIPTOR)
             } else {
                 ongoingConnectRequest.attachImplementation(websocketServerConnection)
                 ongoingConnectRequest.acceptHandshake()


### PR DESCRIPTION
## Summary

When ws connections are opened using connection requests, the server checks if the requested connection's presumed peer descriptor is correct. This fixes a problem with hanging connections detected in nodes that do run a WS server.

## Future improvements

This problem went undetected due to the case not being tested. The connection layer needs thorough refactoring to make testing possible. 
