### PR TITLE
deps(browser-test-runner): Remove `node-module-polyfill`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21824,31 +21824,6 @@
             "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
             "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
         },
-        "node_modules/node-module-polyfill": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/node-module-polyfill/-/node-module-polyfill-1.0.1.tgz",
-            "integrity": "sha512-ScK3fK8UAlhG9Dm9egLZrjCDy0VPtBVwGta4pi1UrQE1JqfMFzDfltg8ERTZLKOnW6Se46PSgpSTgW5hEtvYww==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^12.7.8",
-                "semver": "^6.3.0"
-            }
-        },
-        "node_modules/node-module-polyfill/node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-            "dev": true
-        },
-        "node_modules/node-module-polyfill/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/node-polyfill-webpack-plugin": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-2.0.1.tgz",
@@ -30294,7 +30269,6 @@
                 "karma-sourcemap-loader": "^0.4.0",
                 "karma-spec-reporter": "^0.0.36",
                 "karma-webpack": "^5.0.1",
-                "node-module-polyfill": "^1.0.1",
                 "node-polyfill-webpack-plugin": "^2.0.1",
                 "timers-browserify": "^2.0.12",
                 "webpack": "^5.90.3",

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -30,7 +30,6 @@
     "karma-sourcemap-loader": "^0.4.0",
     "karma-spec-reporter": "^0.0.36",
     "karma-webpack": "^5.0.1",
-    "node-module-polyfill": "^1.0.1",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "timers-browserify": "^2.0.12",
     "webpack": "^5.90.3",


### PR DESCRIPTION
The module implements polyfill for Node versions < 12.2.0. Therefore we shouldn't need it anymore.