### PR TITLE
Use Node 18 types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
             "dependencies": {
                 "@manypkg/cli": "^0.21.2",
                 "@protobuf-ts/plugin": "^2.9.3",
-                "@tsconfig/node20": "^20.1.2",
+                "@tsconfig/node18": "^18.2.4",
                 "@types/jest": "^29.5.12",
-                "@types/node": "^20.10.7",
+                "@types/node": "^18.19.31",
                 "@typescript-eslint/eslint-plugin": "^7.1.1",
                 "@typescript-eslint/parser": "^7.1.1",
                 "cli-table": "^0.3.6",
@@ -3919,6 +3919,14 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@inquirer/core/node_modules/@types/node": {
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "node_modules/@inquirer/core/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4335,6 +4343,15 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@inquirer/testing/node_modules/@types/node": {
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "node_modules/@inquirer/testing/node_modules/mute-stream": {
@@ -8249,10 +8266,10 @@
             "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
             "dev": true
         },
-        "node_modules/@tsconfig/node20": {
-            "version": "20.1.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.2.tgz",
-            "integrity": "sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ=="
+        "node_modules/@tsconfig/node18": {
+            "version": "18.2.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+            "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ=="
         },
         "node_modules/@tufjs/canonical-json": {
             "version": "1.0.0",
@@ -8620,9 +8637,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.11.25",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-            "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+            "version": "18.19.31",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+            "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -12954,6 +12971,15 @@
             "version": "1.4.628",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.628.tgz",
             "integrity": "sha512-2k7t5PHvLsufpP6Zwk0nof62yLOsCf032wZx7/q0mv8gwlXjhcxI3lz6f0jBr0GrnWKcm3burXzI3t5IrcdUxw=="
+        },
+        "node_modules/electron/node_modules/@types/node": {
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -29638,14 +29664,6 @@
             },
             "engines": {
                 "node": ">= 16.0.0"
-            }
-        },
-        "node_modules/zx/node_modules/@types/node": {
-            "version": "18.19.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.5.tgz",
-            "integrity": "sha512-22MG6T02Hos2JWfa1o5jsIByn+bc5iOt1IS4xyg6OG68Bu+wMonVZzdrgCw693++rpLE9RUT/Bx15BeDzO0j+g==",
-            "dependencies": {
-                "undici-types": "~5.26.4"
             }
         },
         "node_modules/zx/node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "dependencies": {
         "@manypkg/cli": "^0.21.2",
         "@protobuf-ts/plugin": "^2.9.3",
-        "@tsconfig/node20": "^20.1.2",
+        "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.10.7",
+        "@types/node": "^18.19.31",
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
         "cli-table": "^0.3.6",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "display": "Node 20 – Streamr",
-    "extends": "@tsconfig/node20/tsconfig.json",
+    "display": "Node 18 – Streamr",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         "allowJs": true,
         "composite": true,


### PR DESCRIPTION
Downgrade `@types/node` and `@tsconfig/node20` from Node 20 to Node 18. As our minimum Node version is currently v18, this helps us to avoid using functionality which is not supported by Node 18.