### PR TITLE
refactor(dht): Simplify `RingDiscoverySession`

### DIFF
--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -120,7 +120,8 @@ export class PeerDiscovery {
             parallelism: this.config.parallelism,
             noProgressLimit: this.config.joinNoProgressLimit,
             peerManager: this.config.peerManager,
-            contactedPeers
+            contactedPeers,
+            abortSignal: this.abortController.signal
         }
         return new RingDiscoverySession(sessionOptions)
     }
@@ -235,8 +236,5 @@ export class PeerDiscovery {
 
     public stop(): void {
         this.abortController.abort()
-        this.ongoingRingDiscoverySessions.forEach((session) => {
-            session.stop()
-        })
     }
 }


### PR DESCRIPTION
Apply same refactoring to `RingDiscoverySession` which we already applied to `DiscoverySession` in PR #2477.

## Future improvements

- Combine `DiscoverySession` and `RingDiscoverySession` to a class which can handle both session types.