### PR TITLE
refactor(dht): `PeerDiscovery` gets `AbortSignal` from `DhtNode`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -268,7 +268,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             serviceId: this.config.serviceId,
             parallelism: this.config.joinParallelism,
             connectionLocker: this.connectionLocker,
-            peerManager: this.peerManager!
+            peerManager: this.peerManager!,
+            abortSignal: this.abortController.signal
         })
         this.router = new Router({
             rpcCommunicator: this.rpcCommunicator,
@@ -635,7 +636,6 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.rpcCommunicator!.stop()
         this.router!.stop()
         this.recursiveOperationManager!.stop()
-        this.peerDiscovery!.stop()
         if (this.config.transport === undefined) {
             // if the transport was not given in config, the instance was created in start() and
             // this component is responsible for stopping it

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -120,7 +120,8 @@ export class PeerDiscovery {
             parallelism: this.config.parallelism,
             noProgressLimit: this.config.joinNoProgressLimit,
             peerManager: this.config.peerManager,
-            contactedPeers
+            contactedPeers,
+            abortSignal: this.abortController.signal
         }
         return new RingDiscoverySession(sessionOptions)
     }
@@ -235,8 +236,5 @@ export class PeerDiscovery {
 
     public stop(): void {
         this.abortController.abort()
-        this.ongoingRingDiscoverySessions.forEach((session) => {
-            session.stop()
-        })
     }
 }

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -24,6 +24,7 @@ interface PeerDiscoveryConfig {
     joinTimeout: number
     connectionLocker?: ConnectionLocker
     peerManager: PeerManager
+    abortSignal: AbortSignal
 }
 
 export const createDistantDhtAddress = (address: DhtAddress): DhtAddress => {
@@ -41,13 +42,11 @@ export class PeerDiscovery {
     
     private rejoinOngoing = false
     private joinCalled = false
-    private readonly abortController: AbortController
     private recoveryIntervalStarted = false
     private readonly config: PeerDiscoveryConfig
 
     constructor(config: PeerDiscoveryConfig) {
         this.config = config
-        this.abortController = new AbortController()
     }
 
     async joinDht(
@@ -109,7 +108,7 @@ export class PeerDiscovery {
             noProgressLimit: this.config.joinNoProgressLimit,
             peerManager: this.config.peerManager,
             contactedPeers,
-            abortSignal: this.abortController.signal
+            abortSignal: this.config.abortSignal
         }
         return new DiscoverySession(sessionOptions)
     }
@@ -121,7 +120,7 @@ export class PeerDiscovery {
             noProgressLimit: this.config.joinNoProgressLimit,
             peerManager: this.config.peerManager,
             contactedPeers,
-            abortSignal: this.abortController.signal
+            abortSignal: this.config.abortSignal
         }
         return new RingDiscoverySession(sessionOptions)
     }
@@ -140,7 +139,7 @@ export class PeerDiscovery {
                     if (retry) {
                         // TODO should we catch possible promise rejection?
                         // TODO use config option or named constant?
-                        setAbortableTimeout(() => this.rejoinDht(entryPointDescriptor), 1000, this.abortController.signal)
+                        setAbortableTimeout(() => this.rejoinDht(entryPointDescriptor), 1000, this.config.abortSignal)
                     }
                 } else {
                     await this.ensureRecoveryIntervalIsRunning()
@@ -181,7 +180,7 @@ export class PeerDiscovery {
             if (!this.isStopped()) {
                 // TODO should we catch possible promise rejection?
                 // TODO use config option or named constant?
-                setAbortableTimeout(() => this.rejoinDht(entryPoint), 5000, this.abortController.signal)
+                setAbortableTimeout(() => this.rejoinDht(entryPoint), 5000, this.config.abortSignal)
             }
         } finally {
             this.rejoinOngoing = false
@@ -192,7 +191,7 @@ export class PeerDiscovery {
         if (!this.recoveryIntervalStarted) {
             this.recoveryIntervalStarted = true
             // TODO use config option or named constant?
-            await scheduleAtInterval(() => this.fetchClosestAndRandomNeighbors(), 60000, true, this.abortController.signal)
+            await scheduleAtInterval(() => this.fetchClosestAndRandomNeighbors(), 60000, true, this.config.abortSignal)
         }
     }
 
@@ -231,10 +230,6 @@ export class PeerDiscovery {
     }
 
     private isStopped() {
-        return this.abortController.signal.aborted
-    }
-
-    public stop(): void {
-        this.abortController.abort()
+        return this.config.abortSignal.aborted
     }
 }


### PR DESCRIPTION
Simplify `PeerDiscovery` state by getting the `AbortSignal` from the config object. The signal must always be in sync with `DhtNode`'s `AbortSignal`, so `DhtNode` can just pass the signal as a constructor parameter.