### PR TITLE
refactor(trackerless-network): Explicit size for `randomNodeView`

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -469,9 +469,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             .map((peer) => peer.getPeerDescriptor())
     }
 
-    // TODO remove defaultContactQueryLimit parameter from RandomContactList#getContacts and use explicit value here?
-    getRandomContacts(): PeerDescriptor[] {
-        return this.peerManager!.getRandomContacts().getContacts().map((c) => c.getPeerDescriptor())
+    getRandomContacts(limit?: number): PeerDescriptor[] {
+        return this.peerManager!.getRandomContacts().getContacts(limit).map((c) => c.getPeerDescriptor())
     }
 
     getRingContacts(): RingContacts {

--- a/packages/dht/src/dht/contact/ContactList.ts
+++ b/packages/dht/src/dht/contact/ContactList.ts
@@ -13,17 +13,14 @@ export class ContactList<C extends { getNodeId: () => DhtAddress }> extends Even
     protected contactIds: DhtAddress[] = []
     protected localNodeId: DhtAddress
     protected maxSize: number
-    protected defaultContactQueryLimit
 
     constructor(
         localNodeId: DhtAddress,
-        maxSize: number,
-        defaultContactQueryLimit = 20
+        maxSize: number
     ) {
         super()
         this.localNodeId = localNodeId
         this.maxSize = maxSize
-        this.defaultContactQueryLimit = defaultContactQueryLimit
     }
 
     public getContact(id: DhtAddress): C | undefined {

--- a/packages/dht/src/dht/contact/RandomContactList.ts
+++ b/packages/dht/src/dht/contact/RandomContactList.ts
@@ -8,10 +8,9 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
     constructor(
         localNodeId: DhtAddress,
         maxSize: number,
-        randomness = 0.20,
-        defaultContactQueryLimit?: number
+        randomness = 0.20
     ) {
-        super(localNodeId, maxSize, defaultContactQueryLimit)
+        super(localNodeId, maxSize)
         this.randomness = randomness
     }
 
@@ -48,7 +47,10 @@ export class RandomContactList<C extends { getNodeId: () => DhtAddress }> extend
         return false
     }
 
-    public getContacts(limit = this.defaultContactQueryLimit): C[] {
-        return this.contactIds.slice(0, limit).map((contactId) => this.contactsById.get(contactId)!)
+    public getContacts(limit?: number): C[] {
+        const items = (limit === undefined)
+            ? this.contactIds
+            : this.contactIds.slice(0, Math.max(limit, 0))
+        return items.map((contactId) => this.contactsById.get(contactId)!)
     }
 }

--- a/packages/dht/test/unit/RandomContactList.test.ts
+++ b/packages/dht/test/unit/RandomContactList.test.ts
@@ -45,4 +45,14 @@ describe('RandomContactList', () => {
         expect(list.getSize()).toEqual(3)
     })
 
+    it('get contacts', () => {
+        const list = new RandomContactList(item0.getNodeId(), 5, 1)
+        list.addContact(item1)
+        list.addContact(item2)
+        list.addContact(item3)
+        list.addContact(item4)
+        expect(list.getContacts()).toHaveLength(4)
+        expect(list.getContacts(3)).toHaveLength(3)
+        expect(list.getContacts(-2)).toHaveLength(0)
+    })
 })

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -65,6 +65,8 @@ export interface StrictContentDeliveryLayerNodeConfig {
     rpcRequestTimeout?: number
 }
 
+const RANDOM_NODE_VIEW_SIZE = 20
+
 const logger = new Logger(module)
 
 export class ContentDeliveryLayerNode extends EventEmitter<Events> {
@@ -281,7 +283,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.layer1Node.getRandomContacts()
+        const randomContacts = this.config.layer1Node.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
         this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
@@ -301,7 +303,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.layer1Node.getRandomContacts()
+        const randomContacts = this.config.layer1Node.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
         this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,

--- a/packages/trackerless-network/src/logic/Layer1Node.ts
+++ b/packages/trackerless-network/src/logic/Layer1Node.ts
@@ -19,7 +19,7 @@ export interface Layer1Node {
     off<T extends keyof Layer1NodeEvents>(eventName: T, listener: () => void): void
     removeContact: (nodeId: DhtAddress) => void
     getClosestContacts: (maxCount?: number) => PeerDescriptor[]
-    getRandomContacts: () => PeerDescriptor[]
+    getRandomContacts: (maxCount?: number) => PeerDescriptor[]
     getRingContacts: () => RingContacts
     getNeighbors: () => PeerDescriptor[]
     getNeighborCount(): number


### PR DESCRIPTION
When `ContentDeliveryLayerNode` queries random nodes from `DhtNode`, it uses explicit item count limit.

Before this PR the item count limit was implicitly defined in `DhtNode`'s `RandomContactList`. The `DhtNode#getRandomContacts` method didn't have any parameters, and therefore it was not clear that the method didn't return all random contacts.

Also fixed handling of negative limit values in `RandomContactList#getContacts`.