### PR TITLE
refactor(dht): Use `getClosestNodes` for neighbors

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -315,7 +315,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
         const pruneTargets = []
         if (this.config.periodicallyPingNeighbors === true) {
-            pruneTargets.push(() => this.peerManager!.getNeighbors().map((node) => this.createDhtNodeRpcRemote(node)))
+            pruneTargets.push(() => this.peerManager!.getNeighbors().map((node) => this.createDhtNodeRpcRemote(node.getPeerDescriptor())))
         }
         if (this.config.periodicallyPingRingContacts === true) {
             pruneTargets.push(() => this.peerManager!.getRingContacts().getAllContacts())
@@ -590,7 +590,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getNeighbors(): PeerDescriptor[] {
-        return this.started ? this.peerManager!.getNeighbors() : []
+        return this.started ? this.peerManager!.getNeighbors().map((remote: DhtNodeRpcRemote) => remote.getPeerDescriptor()) : []
     }
 
     getConnectionsView(): ConnectionsView {

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -1,5 +1,6 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Logger } from '@streamr/utils'
+import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../identifiers'
 import { Empty } from '../proto/google/protobuf/empty'
 import {
     ClosestPeersRequest,
@@ -12,13 +13,13 @@ import {
 } from '../proto/packages/dht/protos/DhtRpc'
 import { IDhtNodeRpc } from '../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../identifiers'
-import { RingIdRaw } from './contact/ringIdentifiers'
 import { RingContacts } from './contact/RingContactList'
+import { getClosestNodes } from './contact/getClosestNodes'
+import { RingIdRaw } from './contact/ringIdentifiers'
 
 interface DhtNodeRpcLocalConfig {
     peerDiscoveryQueryBatchSize: number
-    getClosestNeighborsTo: (nodeId: DhtAddress, limit: number) => PeerDescriptor[]
+    getNeighbors: () => ReadonlyArray<PeerDescriptor>
     getClosestRingContactsTo: (id: RingIdRaw, limit: number) => RingContacts
     addContact: (contact: PeerDescriptor) => void
     removeContact: (nodeId: DhtAddress) => void
@@ -37,8 +38,13 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     // TODO rename to getClosestNeighbors (breaking change)
     async getClosestPeers(request: ClosestPeersRequest, context: ServerCallContext): Promise<ClosestPeersResponse> {
         this.config.addContact((context as DhtCallContext).incomingSourceDescriptor!)
+        const peers = getClosestNodes(
+            getDhtAddressFromRaw(request.nodeId), 
+            this.config.getNeighbors(),
+            { maxCount: this.config.peerDiscoveryQueryBatchSize }
+        )
         const response = {
-            peers: this.config.getClosestNeighborsTo(getDhtAddressFromRaw(request.nodeId), this.config.peerDiscoveryQueryBatchSize),
+            peers,
             requestId: request.requestId
         }
         return response

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -1,19 +1,19 @@
 import {
-    Logger  
+    Logger
 } from '@streamr/utils'
+import EventEmitter from 'eventemitter3'
 import KBucket from 'k-bucket'
+import { LockID } from '../connection/ConnectionLockStates'
+import { ConnectionLocker } from '../connection/ConnectionManager'
+import { DhtAddress, DhtAddressRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../identifiers'
 import {
     PeerDescriptor
 } from '../proto/packages/dht/protos/DhtRpc'
 import { DhtNodeRpcRemote } from './DhtNodeRpcRemote'
 import { RandomContactList } from './contact/RandomContactList'
-import { ReadonlySortedContactList, SortedContactList } from './contact/SortedContactList'
-import { ConnectionLocker } from '../connection/ConnectionManager'
-import EventEmitter from 'eventemitter3'
-import { DhtAddress, DhtAddressRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../identifiers'
 import { RingContactList } from './contact/RingContactList'
+import { ReadonlySortedContactList, SortedContactList } from './contact/SortedContactList'
 import { RingIdRaw, getRingIdRawFromPeerDescriptor } from './contact/ringIdentifiers'
-import { LockID } from '../connection/ConnectionLockStates'
 
 const logger = new Logger(module)
 
@@ -233,17 +233,6 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         })
         this.nearbyContacts.stop()
         this.randomContacts.stop()
-    }
-
-    getClosestNeighborsTo(referenceId: DhtAddress, limit?: number, excludedNodeIds?: Set<DhtAddress>): DhtNodeRpcRemote[] {
-        const closest = new SortedContactList<DhtNodeRpcRemote>({
-            referenceId,
-            allowToContainReferenceId: true,
-            excludedNodeIds,
-            maxSize: limit
-        })
-        this.neighbors.toArray().forEach((contact) => closest.addContact(contact))
-        return closest.getClosestContacts()
     }
 
     getNearbyContacts(): ReadonlySortedContactList<DhtNodeRpcRemote> {

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -277,8 +277,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         return this.neighbors.count()
     }
 
-    getNeighbors(): PeerDescriptor[] {
-        return this.neighbors.toArray().map((rpcRemote: DhtNodeRpcRemote) => rpcRemote.getPeerDescriptor())
+    getNeighbors(): ReadonlyArray<DhtNodeRpcRemote> {
+        return this.neighbors.toArray()
     }
 
     setContactActive(nodeId: DhtAddress): void {

--- a/packages/dht/src/dht/contact/getClosestNodes.ts
+++ b/packages/dht/src/dht/contact/getClosestNodes.ts
@@ -1,23 +1,24 @@
+import { PeerDescriptor } from '../../exports'
 import { DhtAddress } from '../../identifiers'
+import { Contact } from './Contact'
 import { SortedContactList } from './SortedContactList'
 
-// TODO remove this function and use getClosestNodes instead, and rename the file
-export const getClosestContacts = <C extends { getNodeId: () => DhtAddress }>(
+export const getClosestNodes = (
     referenceId: DhtAddress,
-    contacts: Iterable<C>,
+    contacts: Iterable<PeerDescriptor>,
     opts?: {
         maxCount?: number
         excludedNodeIds?: Set<DhtAddress>
     }
-): C[] => {
-    const list = new SortedContactList<C>({
+): PeerDescriptor[] => {
+    const list = new SortedContactList<Contact>({
         referenceId,
         allowToContainReferenceId: true,
         excludedNodeIds: opts?.excludedNodeIds,
         maxSize: opts?.maxCount
     })
     for (const contact of contacts) {
-        list.addContact(contact)
+        list.addContact(new Contact(contact))
     }
-    return list.getClosestContacts()
+    return list.getClosestContacts().map((n) => n.getPeerDescriptor())
 }

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -56,10 +56,10 @@ export class DiscoverySession {
         }
         this.ongoingRequests.delete(nodeId)
         const targetId = getRawFromDhtAddress(this.config.targetId)
-        const oldClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(this.config.targetId, 1)[0]
+        const oldClosestNeighbor = getClosestContacts(this.config.targetId, this.config.peerManager.getNeighbors(), { maxCount: 1 })[0]
         const oldClosestDistance = getDistance(targetId, getRawFromDhtAddress(oldClosestNeighbor.getNodeId()))
         this.addContacts(contacts)
-        const newClosestNeighbor = this.config.peerManager.getClosestNeighborsTo(this.config.targetId, 1)[0]
+        const newClosestNeighbor = getClosestContacts(this.config.targetId, this.config.peerManager.getNeighbors(), { maxCount: 1 })[0]
         const newClosestDistance = getDistance(targetId, getRawFromDhtAddress(newClosestNeighbor.getNodeId()))
         if (newClosestDistance >= oldClosestDistance) {
             this.noProgressCounter++

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -1,30 +1,13 @@
 import { waitForCondition } from '@streamr/utils'
 import { range, without } from 'lodash'
 import { DhtNodeRpcLocal } from '../../src/dht/DhtNodeRpcLocal'
-import { Contact } from '../../src/dht/contact/Contact'
-import { SortedContactList } from '../../src/dht/contact/SortedContactList'
-import { DhtAddress, DhtNode, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '../../src/exports'
+import { DhtNode, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '../../src/exports'
 import { ClosestPeersRequest, ClosestPeersResponse, PeerDescriptor, PingRequest, PingResponse } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { FakeEnvironment } from '../utils/FakeTransport'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 const OTHER_NODE_COUNT = 3
 const SERVICE_ID_LAYER0 = 'layer0'
-
-const getClosestNodes = (
-    referenceId: DhtAddress,
-    nodes: PeerDescriptor[],
-    maxCount: number,
-    allowToContainReferenceId: boolean
-): PeerDescriptor[] => {
-    const list = new SortedContactList<Contact>({
-        referenceId,
-        allowToContainReferenceId,
-        maxSize: maxCount
-    })
-    list.addContacts(nodes.map((n) => new Contact(n)))
-    return list.getClosestContacts().map((c) => c.getPeerDescriptor())
-}
 
 describe('DhtNode', () => {
 
@@ -36,7 +19,7 @@ describe('DhtNode', () => {
         const epRpcCommunicator = new ListeningRpcCommunicator(SERVICE_ID_LAYER0, environment.createTransport(peerDescriptor))
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
             peerDiscoveryQueryBatchSize: undefined as any,
-            getClosestNeighborsTo: (nodeId: DhtAddress, maxCount: number) => getClosestNodes(nodeId, getAllPeerDescriptors(), maxCount, true),
+            getNeighbors: () => without(getAllPeerDescriptors(), peerDescriptor),
             getClosestRingContactsTo: undefined as any,
             addContact: () => {},
             removeContact: undefined as any,

--- a/packages/dht/test/unit/DiscoverySession.test.ts
+++ b/packages/dht/test/unit/DiscoverySession.test.ts
@@ -6,6 +6,7 @@ import { DiscoverySession } from '../../src/dht/discovery/DiscoverySession'
 import { DhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createTestTopology } from '../utils/topology'
+import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
 
 const NODE_COUNT = 40
 const MIN_NEIGHBOR_COUNT = 2  // nodes can get more neighbors when we merge network partitions
@@ -53,7 +54,7 @@ describe('DiscoverySession', () => {
                 queriedNodes.push(nodeId)
                 await wait(10)
                 const peerManager = createPeerManager(nodeId)
-                return peerManager.getClosestNeighborsTo(referenceId, QUERY_BATCH_SIZE).map((remote) => remote.getPeerDescriptor())
+                return getClosestNodes(referenceId, peerManager.getNeighbors().map((n) => n.getPeerDescriptor()), { maxCount: QUERY_BATCH_SIZE })
             },
             ping: async () => true
         }

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -69,7 +69,7 @@ describe('PeerManager', () => {
         const actual = manager.getClosestNeighborsTo(referenceId, 5, excluded)
 
         const expected = sortBy(
-            without(manager.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n)), ...Array.from(excluded.values())),
+            without(manager.getNeighbors().map((n) => n.getNodeId()), ...Array.from(excluded.values())),
             (n: DhtAddress) => getDistance(getRawFromDhtAddress(n), getRawFromDhtAddress(referenceId))
         ).slice(0, 5)
         expect(actual.map((n) => n.getNodeId())).toEqual(expected)
@@ -97,7 +97,7 @@ describe('PeerManager', () => {
         manager.addContact(failureContact)
         const closesSuccessContact = getClosestContact(successContacts, getNodeIdFromPeerDescriptor(localPeerDescriptor))!
         await waitForCondition(() => {
-            const neighborNodeIds = manager.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+            const neighborNodeIds = manager.getNeighbors().map((n) => n.getNodeId())
             return neighborNodeIds.includes(getNodeIdFromPeerDescriptor(closesSuccessContact))
         })
         expect(manager.getNeighbors()).toEqual([closesSuccessContact])
@@ -115,7 +115,9 @@ describe('PeerManager', () => {
         manager.addContact(failureContact)
         expect(manager.getNeighborCount()).toBe(6)
         failureSet.add(getNodeIdFromPeerDescriptor(failureContact))
-        await manager.pruneOfflineNodes(manager.getNeighbors().map((node) => createDhtNodeRpcRemote(node, localPeerDescriptor, failureSet)))
+        await manager.pruneOfflineNodes(
+            manager.getNeighbors().map((node) => createDhtNodeRpcRemote(node.getPeerDescriptor(), localPeerDescriptor, failureSet))
+        )
         expect(manager.getNeighborCount()).toBe(5)
     })
 

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -19,26 +19,27 @@ const NODES_CLOSEST_TO_DATA = sortBy(
     (id: DhtAddress) => getDistance(getRawFromDhtAddress(id), DATA_ENTRY.key)
 )
 
+const createPeerDescriptor = (nodeId: DhtAddress) => {
+    return { nodeId: getRawFromDhtAddress(nodeId), type: NodeType.NODEJS }
+}
+
 describe('StoreManager', () => {
 
     describe('new contact', () => {
 
         const createStoreManager = (
             localNodeId: DhtAddress,
-            closestNeighbors: DhtAddress[],
+            neighbors: DhtAddress[],
             replicateData: (request: ReplicateDataRequest) => unknown,
             setAllEntriesAsStale: (key: DhtAddress) => unknown
         ): StoreManager => {
-            const getClosestNeighborsTo = () => {
-                return closestNeighbors.map((nodeId) => ({ nodeId: getRawFromDhtAddress(nodeId), type: NodeType.NODEJS }))
-            }
             return new StoreManager({
                 rpcCommunicator: {
                     registerRpcMethod: () => {},
                     registerRpcNotification: () => {}
                 } as any,
                 recursiveOperationManager: undefined as any,
-                localPeerDescriptor: { nodeId: getRawFromDhtAddress(localNodeId), type: NodeType.NODEJS },
+                localPeerDescriptor: createPeerDescriptor(localNodeId),
                 localDataStore: { 
                     keys: () => [getDhtAddressFromRaw(DATA_ENTRY.key)],
                     values: () => [DATA_ENTRY],
@@ -47,7 +48,7 @@ describe('StoreManager', () => {
                 serviceId: undefined as any,
                 highestTtl: undefined as any,
                 redundancyFactor: 3,
-                getClosestNeighborsTo,
+                getNeighbors: () => neighbors.map((nodeId) => createPeerDescriptor(nodeId)),
                 createRpcRemote: () => ({ replicateData } as any)
             })
         }


### PR DESCRIPTION
Use `getClosestNodes` helper function to analyze closest nodes instead of querying the sorted data from `PeerManager`. This is a follow-up refactoring to a PR #2481.

## Changes

- Removed `PeerManager#getClosestNeighborsTo`
- Changed `PeerManager#getNeighbors` return type
  - it is now similar to two other node accessors (`getNearbyContacts`, `getRandomContacts`) which also return a list of `DhtNodeRpcRemote` instances
- Refactored `getClosestContacts` utility function to operate on `PeerDescriptor` instances, and renamed it to `getClosestNodes`

## Open questions

Is there any need to create a new `DhtNodeRpcRemote` in `DhtNode:316,` or could the pruning use the instance returned by `peerManager.getNeighbors()`? How about other places where `createDhtNodeRpcRemote` is called: would it be ok to do a lookup from `PeerManager` instead?

## Future improvements

- Migrate all uses of `getClosestContacts` to use `getClosestNodes` instead
- Maybe could simplify/optimize the analysis of `StoreManager`'s `selfIsPrimaryStorer` (currently it resorts the node list)