### PR TITLE
refactor(dht): Optimize storer analysis

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -159,7 +159,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             storeHighestTtl: 60000,
             storeMaxTtl: 60000,
             networkConnectivityTimeout: 10000,
-            storageRedundancyFactor: 5,
+            storageRedundancyFactor: 5, // TODO validate that this is > 1 (as each node should replicate the data to other node)
             metricsContext: new MetricsContext()
         }, conf)
         this.validateConfig()

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -1,6 +1,12 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Logger, executeSafePromise } from '@streamr/utils'
-import { DhtAddress, areEqualPeerDescriptors, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../identifiers'
+import {
+    DhtAddress,
+    areEqualPeerDescriptors,
+    getDhtAddressFromRaw,
+    getNodeIdFromPeerDescriptor,
+    getRawFromDhtAddress
+} from '../../identifiers'
 import { Any } from '../../proto/google/protobuf/any'
 import { Timestamp } from '../../proto/google/protobuf/timestamp'
 import {
@@ -12,9 +18,6 @@ import {
 } from '../../proto/packages/dht/protos/DhtRpc'
 import { RoutingRpcCommunicator } from '../../transport/RoutingRpcCommunicator'
 import { ServiceID } from '../../types/ServiceID'
-import { getDistance } from '../PeerManager'
-import { Contact } from '../contact/Contact'
-import { SortedContactList } from '../contact/SortedContactList'
 import { getClosestNodes } from '../contact/getClosestNodes'
 import { RecursiveOperationManager } from '../recursive-operation/RecursiveOperationManager'
 import { LocalDataStore } from './LocalDataStore'
@@ -48,7 +51,9 @@ export class StoreManager {
         const rpcLocal = new StoreRpcLocal({
             localDataStore: this.config.localDataStore,
             replicateDataToNeighbors: (incomingPeer: PeerDescriptor, dataEntry: DataEntry) => this.replicateDataToNeighbors(incomingPeer, dataEntry),
-            selfIsWithinRedundancyFactor: (key: DhtAddress): boolean => this.selfIsWithinRedundancyFactor(key)
+            isLocalNodeStorer: (dataKey: DhtAddress) => {
+                return this.getStorers(dataKey).some((p) => areEqualPeerDescriptors(p, this.config.localPeerDescriptor))
+            }
         })
         this.config.rpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData',
             (request: StoreDataRequest) => rpcLocal.storeData(request))
@@ -62,32 +67,19 @@ export class StoreManager {
         }
     }
 
-    private replicateAndUpdateStaleState(key: DhtAddress, newNode: PeerDescriptor): void {
-        const newNodeId = getNodeIdFromPeerDescriptor(newNode)
-        const closestToData = getClosestNodes(key, this.config.getNeighbors(), { maxCount: this.config.redundancyFactor })
-        // TODO maybe we could analyze the selfIsPrimaryStorer without creating a separate sorted list?
-        const sortedList = new SortedContactList<Contact>({
-            referenceId: key, 
-            maxSize: this.config.redundancyFactor,
-            allowToContainReferenceId: true
-        })
-        sortedList.addContact(new Contact(this.config.localPeerDescriptor))
-        closestToData.forEach((neighbor) => {
-            if (newNodeId !== getNodeIdFromPeerDescriptor(neighbor)) {
-                sortedList.addContact(new Contact(neighbor))
-            }
-        })
-        const selfIsPrimaryStorer = (sortedList.getClosestContactId() === getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor))
-        if (selfIsPrimaryStorer) {
-            sortedList.addContact(new Contact(newNode))
-            if (sortedList.getContact(newNodeId) !== undefined) {
+    private replicateAndUpdateStaleState(dataKey: DhtAddress, newNode: PeerDescriptor): void {
+        const storers = this.getStorers(dataKey)
+        const storersBeforeContactAdded = storers.filter((p) => !areEqualPeerDescriptors(p, newNode))
+        const selfWasPrimaryStorer = areEqualPeerDescriptors(storersBeforeContactAdded[0], this.config.localPeerDescriptor)
+        if (selfWasPrimaryStorer) {
+            if (storers.some((p) => areEqualPeerDescriptors(p, newNode))) {
                 setImmediate(async () => {
-                    const dataEntries = Array.from(this.config.localDataStore.values(key))
+                    const dataEntries = Array.from(this.config.localDataStore.values(dataKey))
                     await Promise.all(dataEntries.map(async (dataEntry) => this.replicateDataToContact(dataEntry, newNode)))
                 })
             }
-        } else if (!this.selfIsWithinRedundancyFactor(key)) {
-            this.config.localDataStore.setAllEntriesAsStale(key)
+        } else if (!storers.some((p) => areEqualPeerDescriptors(p, this.config.localPeerDescriptor))) {
+            this.config.localDataStore.setAllEntriesAsStale(dataKey)
         }
     }
 
@@ -142,21 +134,6 @@ export class StoreManager {
         return successfulNodes
     }
 
-    private selfIsWithinRedundancyFactor(dataKey: DhtAddress): boolean {
-        const closestNeighbors = getClosestNodes(
-            dataKey,
-            this.config.getNeighbors(),
-            { maxCount: this.config.redundancyFactor }
-        )
-        if (closestNeighbors.length < this.config.redundancyFactor) {
-            return true
-        } else {
-            const furthestCloseNeighbor = closestNeighbors[closestNeighbors.length - 1]
-            const dataKeyRaw = getRawFromDhtAddress(dataKey)
-            return getDistance(dataKeyRaw, this.config.localPeerDescriptor.nodeId) < getDistance(dataKeyRaw, furthestCloseNeighbor.nodeId)
-        }
-    }
-
     private async replicateDataToClosestNodes(): Promise<void> {
         const dataEntries = Array.from(this.config.localDataStore.values())
         await Promise.all(dataEntries.map(async (dataEntry) => {
@@ -177,44 +154,32 @@ export class StoreManager {
         }))
     }
 
-    private replicateDataToNeighbors(incomingPeer: PeerDescriptor, dataEntry: DataEntry): void {
-        // sort own contact list according to data id
-        const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
-        const incomingNodeId = getNodeIdFromPeerDescriptor(incomingPeer)
-        const key = getDhtAddressFromRaw(dataEntry.key)
-        // TODO use config option or named constant?
-        const closestToData = getClosestNodes(key, this.config.getNeighbors(), { maxCount: 10 })
-        // TODO maybe we could analyze the selfIsPrimaryStorer without creating a separate sorted list?
-        const sortedList = new SortedContactList<Contact>({
-            referenceId: key, 
-            maxSize: this.config.redundancyFactor,
-            allowToContainReferenceId: true
+    private replicateDataToNeighbors(requestor: PeerDescriptor, dataEntry: DataEntry): void {
+        const dataKey = getDhtAddressFromRaw(dataEntry.key)
+        const storers = this.getStorers(dataKey)
+        const selfIsPrimaryStorer = areEqualPeerDescriptors(storers[0], this.config.localPeerDescriptor)
+        // If we are the closest to the data, get storageRedundancyFactor - 1 nearest node to the data, and
+        // replicate to all those node. Otherwise replicate only to the one closest one. And never replicate 
+        // to the requestor nor to itself.
+        const targets = (selfIsPrimaryStorer ? storers : [storers[0]]).filter(
+            (p) => !areEqualPeerDescriptors(p, requestor) && !areEqualPeerDescriptors(p, this.config.localPeerDescriptor)
+        )
+        targets.forEach((target) => {
+            setImmediate(() => {
+                executeSafePromise(() => this.replicateDataToContact(dataEntry, target))
+            })
         })
-        sortedList.addContact(new Contact(this.config.localPeerDescriptor))
-        closestToData.forEach((neighbor) => {
-            sortedList.addContact(new Contact(neighbor))
-        })
-        const selfIsPrimaryStorer = (sortedList.getClosestContactId() === localNodeId)
-        const targetLimit = selfIsPrimaryStorer
-            // if we are the closest to the data, replicate to all storageRedundancyFactor nearest
-            ? undefined
-            // if we are not the closest node to the data, replicate only to the closest one to the data
-            : 1
-        const targets = sortedList.getClosestContacts(targetLimit)
-        targets.forEach((contact) => {
-            const contactNodeId = contact.getNodeId()
-            if ((incomingNodeId !== contactNodeId) && (localNodeId !== contactNodeId)) {
-                setImmediate(() => {
-                    executeSafePromise(async () => {
-                        await this.replicateDataToContact(dataEntry, contact.getPeerDescriptor())
-                        logger.trace('replicateDataToContact() returned', { 
-                            node: contactNodeId,
-                            replicateOnlyToClosest: !selfIsPrimaryStorer
-                        })
-                    })
-                })
+    }
+
+    private getStorers(dataKey: DhtAddress, excludedNode?: PeerDescriptor): PeerDescriptor[] {
+        return getClosestNodes(
+            dataKey,
+            [...this.config.getNeighbors(), this.config.localPeerDescriptor],
+            { 
+                maxCount: this.config.redundancyFactor,
+                excludedNodeIds: excludedNode !== undefined ? new Set([getNodeIdFromPeerDescriptor(excludedNode)]) : undefined
             }
-        })
+        )
     }
 
     async destroy(): Promise<void> {

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -1,26 +1,27 @@
 import { wait, waitForCondition } from '@streamr/utils'
-import { range, sortBy } from 'lodash'
-import { getDistance } from '../../src/dht/PeerManager'
+import { range, without } from 'lodash'
+import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
 import { StoreManager } from '../../src/dht/store/StoreManager'
 import {
     DhtAddress,
     createRandomDhtAddress,
     getDhtAddressFromRaw,
-    getRawFromDhtAddress,
+    getRawFromDhtAddress
 } from '../../src/identifiers'
-import { NodeType, ReplicateDataRequest } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { PeerDescriptor, ReplicateDataRequest } from '../../src/proto/packages/dht/protos/DhtRpc'
+import { createMockPeerDescriptor } from '../utils/utils'
+
+const NODE_COUNT = 10
 
 const DATA_ENTRY = {
     key: getRawFromDhtAddress(createRandomDhtAddress()),
     creator: getRawFromDhtAddress(createRandomDhtAddress())
 }
-const NODES_CLOSEST_TO_DATA = sortBy(
-    range(5).map(() => createRandomDhtAddress()),
-    (id: DhtAddress) => getDistance(getRawFromDhtAddress(id), DATA_ENTRY.key)
-)
+const ALL_NODES = range(NODE_COUNT).map(() => createMockPeerDescriptor())
 
-const createPeerDescriptor = (nodeId: DhtAddress) => {
-    return { nodeId: getRawFromDhtAddress(nodeId), type: NodeType.NODEJS }
+const getNodeCloseToData = (distanceIndex: number) => {
+    const dataKey = getDhtAddressFromRaw(DATA_ENTRY.key)
+    return getClosestNodes(dataKey, ALL_NODES)[distanceIndex]
 }
 
 describe('StoreManager', () => {
@@ -28,8 +29,8 @@ describe('StoreManager', () => {
     describe('new contact', () => {
 
         const createStoreManager = (
-            localNodeId: DhtAddress,
-            neighbors: DhtAddress[],
+            localPeerDescriptor: PeerDescriptor,
+            redundancyFactor: number,
             replicateData: (request: ReplicateDataRequest) => unknown,
             setAllEntriesAsStale: (key: DhtAddress) => unknown
         ): StoreManager => {
@@ -39,7 +40,7 @@ describe('StoreManager', () => {
                     registerRpcNotification: () => {}
                 } as any,
                 recursiveOperationManager: undefined as any,
-                localPeerDescriptor: createPeerDescriptor(localNodeId),
+                localPeerDescriptor,
                 localDataStore: { 
                     keys: () => [getDhtAddressFromRaw(DATA_ENTRY.key)],
                     values: () => [DATA_ENTRY],
@@ -47,24 +48,25 @@ describe('StoreManager', () => {
                 } as any,
                 serviceId: undefined as any,
                 highestTtl: undefined as any,
-                redundancyFactor: 3,
-                getNeighbors: () => neighbors.map((nodeId) => createPeerDescriptor(nodeId)),
+                redundancyFactor,
+                getNeighbors: () => without(ALL_NODES, localPeerDescriptor),
                 createRpcRemote: () => ({ replicateData } as any)
             })
         }
 
-        describe('this node is primary storer', () => {
+        describe('this node was primary storer', () => {
 
             it('new node is within redundancy factor', async () => {
                 const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setAllEntriesAsStale = jest.fn<undefined, [DhtAddress]>()
+                const localNode = getNodeCloseToData(0)
                 const manager = createStoreManager(
-                    NODES_CLOSEST_TO_DATA[0],
-                    [NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[3], NODES_CLOSEST_TO_DATA[4]],
+                    localNode,
+                    3,
                     replicateData,
                     setAllEntriesAsStale
                 )
-                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[2]), type: NodeType.NODEJS })
+                manager.onContactAdded(getNodeCloseToData(2))
                 await waitForCondition(() => replicateData.mock.calls.length === 1)
                 expect(replicateData).toHaveBeenCalledWith({
                     entry: DATA_ENTRY
@@ -75,61 +77,66 @@ describe('StoreManager', () => {
             it('new node is not within redundancy factor', async () => {
                 const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setAllEntriesAsStale = jest.fn<undefined, [DhtAddress]>()
+                const localNode = getNodeCloseToData(0)
                 const manager = createStoreManager(
-                    NODES_CLOSEST_TO_DATA[0],
-                    [NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[2], NODES_CLOSEST_TO_DATA[3]],
+                    localNode,
+                    3,
                     replicateData,
                     setAllEntriesAsStale
                 )
-                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded(getNodeCloseToData(4))
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setAllEntriesAsStale).not.toHaveBeenCalled()
             })
         })
 
-        describe('this node is not primary storer', () => {
+        describe('this node was not primary storer', () => {
 
             it('this node is within redundancy factor', async () => {
                 const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setAllEntriesAsStale = jest.fn<undefined, [DhtAddress]>()
+                const localNode = getNodeCloseToData(1)
                 const manager = createStoreManager(
-                    NODES_CLOSEST_TO_DATA[1],
-                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[2], NODES_CLOSEST_TO_DATA[3]],
+                    localNode,
+                    3,
                     replicateData,
                     setAllEntriesAsStale
                 )
-                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded(getNodeCloseToData(4))
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
+                expect(setAllEntriesAsStale).toHaveBeenCalledTimes(0)
             })
 
             it('this node is not within redundancy factor', async () => {
                 const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setAllEntriesAsStale = jest.fn<undefined, [DhtAddress]>()
+                const localNode = getNodeCloseToData(3)
                 const manager = createStoreManager(
-                    NODES_CLOSEST_TO_DATA[3],
-                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[1], NODES_CLOSEST_TO_DATA[2]],
+                    localNode,
+                    3,
                     replicateData,
                     setAllEntriesAsStale
                 )
-                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded(getNodeCloseToData(4))
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setAllEntriesAsStale).toHaveBeenCalledTimes(1)
                 expect(setAllEntriesAsStale).toHaveBeenCalledWith(getDhtAddressFromRaw(DATA_ENTRY.key))
             })
 
-            it('this node has less than redundancyFactor neighbors', async () => {
+            it('this node is within redundancy factor, the node has less than redundancyFactor neighbors', async () => {
                 const replicateData = jest.fn<undefined, [ReplicateDataRequest]>()
                 const setAllEntriesAsStale = jest.fn<undefined, [DhtAddress]>()
+                const localNode = getNodeCloseToData(3)
                 const manager = createStoreManager(
-                    NODES_CLOSEST_TO_DATA[3],
-                    [NODES_CLOSEST_TO_DATA[0], NODES_CLOSEST_TO_DATA[1]],
+                    localNode,
+                    100,
                     replicateData,
                     setAllEntriesAsStale
                 )
-                manager.onContactAdded({ nodeId: getRawFromDhtAddress(NODES_CLOSEST_TO_DATA[4]), type: NodeType.NODEJS })
+                manager.onContactAdded(getNodeCloseToData(4))
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setAllEntriesAsStale).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
Optimized storer analysis in `StoreManager`. Before this PR we sorted the candidates twice: first by querying `getClosestNodes(key, this.config.getNeighbors(), ...),` and then by adding those contacts to a new `SortedContactList`. Now we sort the list only once.

Also refactored the class. And made test cases more realistic by including the added contact in the neighbors list (as it would be in this kind of small network).

## Benchmark 1
- 50 neighbors
- do 1000 `onContactAdded` calls, i.e. benchmark the `replicateAndUpdateStaleState` method
- before: ~1200 ms
- after: ~1000 ms

## Benchmark 2
- 50 neighbors
- do 1000 `replicateDataToNeighbors` calls
- before: ~520 ms
- after: ~370 ms

## Future improvements

- Improve test coverage by adding a test in which the new contact is not a neighbor (i.e. it is some other nearby contact). 