### PR TITLE
test(client): Fix `ProxyDirection` import

### DIFF
--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -1,6 +1,6 @@
 import { DhtAddress, PeerDescriptor, getDhtAddressFromRaw } from '@streamr/dht'
-import { ProxyDirection, StreamMessage, StreamPartID } from '@streamr/protocol'
-import { NetworkOptions } from '@streamr/trackerless-network'
+import { StreamMessage, StreamPartID } from '@streamr/protocol'
+import { NetworkOptions, ProxyDirection } from '@streamr/trackerless-network'
 import { EthereumAddress, MetricsContext } from '@streamr/utils'
 import crypto from 'crypto'
 import pull from 'lodash/pull'


### PR DESCRIPTION
The enum was incorrectly imported from `protocol` package in the `FakeNetworkNode` class. Other client classes uses the enum from `@streamr/trackerless-network` package.