### PR TITLE
test(broker): Run integration test sequentially

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -23,7 +23,7 @@
     "test": "npm run test-unit && npm run test-integration && npm run test-sequential",
     "test-unit": "jest test/unit",
     "test-sequential": "jest --bail --forceExit --maxWorkers=1 test/sequential # always run sequential tests with maxWorkers=1",
-    "test-integration": "jest --bail --forceExit test/integration && npm run test-sequential"
+    "test-integration": "jest --bail --forceExit --runInBand test/integration && npm run test-sequential"
   },
   "author": "Streamr Network AG <contact@streamr.network>",
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",


### PR DESCRIPTION
It seems that [Hardhat upgrade](https://github.com/streamr-dev/network-contracts/pull/853) affected nonce handling. We need to run the Broker tests sequentially to avoid nonce collisions.

This is a temporary change as we'll have a better solution for nonce handling in https://github.com/streamr-dev/network/pull/2506.