### PR TITLE
refactor(DHT): Use incoming handshaker in attach handshaker

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -117,6 +117,7 @@ export class WebsocketConnector {
             if (this.ongoingConnectRequests.has(nodeId)) {
                 managedConnection.destroy()
                 const ongoingConnectRequest = this.ongoingConnectRequests.get(nodeId)!
+                ongoingConnectRequest.setRemotePeerDescriptor(remotePeerDescriptor)
                 if (!isMaybeSupportedVersion(remoteVersion)) {
                     rejectHandshake(ongoingConnectRequest, connection, handshaker, HandshakeError.UNSUPPORTED_VERSION)  
                 } else if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {
@@ -125,6 +126,7 @@ export class WebsocketConnector {
                     acceptHandshake(ongoingConnectRequest, connection, handshaker, remotePeerDescriptor)
                 }
                 this.ongoingConnectRequests.delete(nodeId)
+                handshaker.stop()
             } else if (!isMaybeSupportedVersion(remoteVersion)) {
                 rejectHandshake(managedConnection, connection, handshaker, HandshakeError.UNSUPPORTED_VERSION)  
             } else if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {

--- a/packages/dht/src/connection/websocket/WebsocketConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketConnector.ts
@@ -135,7 +135,6 @@ export class WebsocketConnector {
                 rejectHandshake(managedConnection, connection, handshaker, HandshakeError.DUPLICATE_CONNECTION)
             }    
         })
-        
     }
 
     public async autoCertify(): Promise<void> {


### PR DESCRIPTION
## Summary

No longer create a new Handshaker in attachHandshaker. Instead use the createIncomingHandshaker function.

The precreated ManagedConnection has to be destroyed if an ongoingConnectionRequest exists. The handshake is accepted and rejected with a ref to the connectionRequests ManagedConnection.


