### PR TITLE
fix(broker): address memory leak in Subscriber plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Fix memory leak in SubscriberPlugin (https://github.com/streamr-dev/network/pull/2578)
+
 #### Security
 
 

--- a/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
+++ b/packages/broker/src/plugins/subscriber/SubscriberPlugin.ts
@@ -19,7 +19,7 @@ export class SubscriberPlugin extends Plugin<SubscriberPluginConfig> {
 
     private async subscribeToStreamParts(streamrClient: StreamrClient): Promise<void> {
         this.subscriptions = await pTransaction(this.pluginConfig.streams.map(({ streamId, streamPartition }) => (
-            streamrClient.subscribe({ id: streamId, partition: streamPartition, raw: true })
+            streamrClient.subscribe({ id: streamId, partition: streamPartition, raw: true }, () => {})
         )), (sub) => sub.unsubscribe())
     }
 


### PR DESCRIPTION
## Summary

Fix memory leak in Subscriber plugin by providing empty callback function
