### PR TITLE
refactor(trackerless-network): Use named layers

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -126,6 +126,9 @@ const logger = new Logger(module)
 
 const PERIODICAL_PING_INTERVAL = 60 * 1000
 
+// TODO move this to trackerless-network package and change serviceId to be a required paramater
+export const CONTROL_LAYER_NODE_SERVICE_ID = 'layer0'
+
 export type Events = TransportEvents & DhtNodeEvents
 
 export class DhtNode extends EventEmitter<Events> implements ITransport {
@@ -148,7 +151,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     constructor(conf: DhtNodeOptions) {
         super()
         this.config = merge({
-            serviceId: 'layer0',
+            serviceId: CONTROL_LAYER_NODE_SERVICE_ID,
             joinParallelism: 3,
             maxNeighborListSize: 200,
             numberOfNodesPerKBucket: 8,
@@ -378,8 +381,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             this.emit('connected', peerDescriptor)
         })
         this.transport!.on('disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => {
-            const isLayer0 = (this.connectionLocker !== undefined)
-            if (isLayer0) {
+            const isControlLayerNode = (this.connectionLocker !== undefined)
+            if (isControlLayerNode) {
                 const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
                 if (gracefulLeave) {
                     this.peerManager!.removeContact(nodeId)

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -80,7 +80,8 @@ export class PeerDiscovery {
         }
         this.joinCalled = true
         logger.debug(
-            `Joining ${this.config.serviceId === CONTROL_LAYER_NODE_SERVICE_ID ? 'The Streamr Network' : `Control Layer for ${this.config.serviceId}`}`
+            `Joining ${this.config.serviceId === CONTROL_LAYER_NODE_SERVICE_ID
+                ? 'The Streamr Network' : `Control Layer for ${this.config.serviceId}`}`
             + ` via entrypoint ${getNodeIdFromPeerDescriptor(entryPointDescriptor)}`
         )
         if (areEqualPeerDescriptors(entryPointDescriptor, this.config.localPeerDescriptor)) {

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -16,6 +16,7 @@ import { getClosestNodes } from '../contact/getClosestNodes'
 import { RingIdRaw, getRingIdRawFromPeerDescriptor } from '../contact/ringIdentifiers'
 import { DiscoverySession } from './DiscoverySession'
 import { RingDiscoverySession } from './RingDiscoverySession'
+import { CONTROL_LAYER_NODE_SERVICE_ID } from '../DhtNode'
 
 interface PeerDiscoveryConfig {
     localPeerDescriptor: PeerDescriptor
@@ -79,7 +80,7 @@ export class PeerDiscovery {
         }
         this.joinCalled = true
         logger.debug(
-            `Joining ${this.config.serviceId === 'layer0' ? 'The Streamr Network' : `Control Layer for ${this.config.serviceId}`}`
+            `Joining ${this.config.serviceId === CONTROL_LAYER_NODE_SERVICE_ID ? 'The Streamr Network' : `Control Layer for ${this.config.serviceId}`}`
             + ` via entrypoint ${getNodeIdFromPeerDescriptor(entryPointDescriptor)}`
         )
         if (areEqualPeerDescriptors(entryPointDescriptor, this.config.localPeerDescriptor)) {

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -101,7 +101,7 @@ export class NetworkNode {
     }
 
     getPeerDescriptor(): PeerDescriptor {
-        return this.stack.getLayer0Node().getLocalPeerDescriptor()
+        return this.stack.getControlLayerNode().getLocalPeerDescriptor()
     }
 
     getMetricsContext(): MetricsContext {

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -30,7 +30,7 @@ import { ProxyConnectionRpcLocal } from './proxy/ProxyConnectionRpcLocal'
 import { Inspector } from './inspect/Inspector'
 import { TemporaryConnectionRpcLocal } from './temporary-connection/TemporaryConnectionRpcLocal'
 import { markAndCheckDuplicate } from './utils'
-import { Layer1Node } from './Layer1Node'
+import { DiscoveryLayerNode } from './DiscoveryLayerNode'
 import { StreamPartID } from '@streamr/protocol'
 
 export interface Events {
@@ -41,7 +41,7 @@ export interface Events {
 
 export interface StrictContentDeliveryLayerNodeConfig {
     streamPartId: StreamPartID
-    layer1Node: Layer1Node
+    discoveryLayerNode: DiscoveryLayerNode
     transport: ITransport
     connectionLocker: ConnectionLocker
     localPeerDescriptor: PeerDescriptor
@@ -97,7 +97,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                 || this.config.proxyConnectionRpcLocal?.getConnection(sourceId)?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {
-                    this.config.layer1Node.removeContact(sourceId)
+                    this.config.discoveryLayerNode.removeContact(sourceId)
                     this.config.neighbors.remove(sourceId)
                     this.config.nearbyNodeView.remove(sourceId)
                     this.config.randomNodeView.remove(sourceId)
@@ -118,37 +118,37 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         this.started = true
         this.registerDefaultServerMethods()
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'nearbyContactAdded', 
             () => this.onNearbyContactAdded(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'nearbyContactRemoved',
             () => this.onNearbyContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'randomContactAdded',
             () => this.onRandomContactAdded(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'randomContactRemoved',
             () => this.onRandomContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'ringContactAdded',
             () => this.onRingContactsUpdated(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.layer1Node as any,
+            this.config.discoveryLayerNode as any,
             'ringContactRemoved',
             () => this.onRingContactsUpdated(),
             this.abortController.signal
@@ -211,7 +211,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const contacts = this.config.layer1Node.getRingContacts()
+        const contacts = this.config.discoveryLayerNode.getRingContacts()
         this.config.leftNodeView.replaceAll(contacts.left.map((peer) => 
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
@@ -237,7 +237,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const closestContacts = this.config.layer1Node.getClosestContacts()
+        const closestContacts = this.config.discoveryLayerNode.getClosestContacts()
         this.updateNearbyNodeView(closestContacts)
         if (this.config.neighbors.size() < this.config.neighborTargetCount) {
             this.config.neighborFinder.start()
@@ -249,7 +249,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const closestContacts = this.config.layer1Node.getClosestContacts()
+        const closestContacts = this.config.discoveryLayerNode.getClosestContacts()
         this.updateNearbyNodeView(closestContacts)
     }
 
@@ -263,7 +263,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                 this.config.rpcRequestTimeout
             )
         ))
-        for (const descriptor of this.config.layer1Node.getNeighbors()) {
+        for (const descriptor of this.config.discoveryLayerNode.getNeighbors()) {
             if (this.config.nearbyNodeView.size() >= this.config.nodeViewSize) {
                 break
             }
@@ -283,7 +283,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.layer1Node.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        const randomContacts = this.config.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
         this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,
@@ -303,7 +303,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.layer1Node.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        const randomContacts = this.config.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
         this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.config.localPeerDescriptor,

--- a/packages/trackerless-network/src/logic/ControlLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ControlLayerNode.ts
@@ -1,7 +1,7 @@
 import { ConnectionsView, DataEntry, DhtAddress, ITransport, PeerDescriptor } from '@streamr/dht'
 import { Any } from '../proto/google/protobuf/any'
 
-export interface Layer0Node extends ITransport {
+export interface ControlLayerNode extends ITransport {
     joinDht(entryPointDescriptors: PeerDescriptor[]): Promise<void>
     hasJoined(): boolean
     getLocalPeerDescriptor(): PeerDescriptor

--- a/packages/trackerless-network/src/logic/DiscoveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/DiscoveryLayerNode.ts
@@ -1,6 +1,6 @@
 import { DhtAddress, PeerDescriptor, RingContacts } from '@streamr/dht'
 
-export interface Layer1NodeEvents {
+export interface DiscoveryLayerNodeEvents {
     manualRejoinRequired: () => void
     nearbyContactAdded: (peerDescriptor: PeerDescriptor) => void
     nearbyContactRemoved: (peerDescriptor: PeerDescriptor) => void
@@ -10,13 +10,13 @@ export interface Layer1NodeEvents {
     ringContactRemoved: (peerDescriptor: PeerDescriptor) => void
 }
 
-export interface Layer1Node {
-    on<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
-    once<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
-    off<T extends keyof Layer1NodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
-    on<T extends keyof Layer1NodeEvents>(eventName: T, listener: () => void): void
-    once<T extends keyof Layer1NodeEvents>(eventName: T, listener: () => void): void
-    off<T extends keyof Layer1NodeEvents>(eventName: T, listener: () => void): void
+export interface DiscoveryLayerNode {
+    on<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
+    once<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
+    off<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: (peerDescriptor: PeerDescriptor) => void): void
+    on<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: () => void): void
+    once<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: () => void): void
+    off<T extends keyof DiscoveryLayerNodeEvents>(eventName: T, listener: () => void): void
     removeContact: (nodeId: DhtAddress) => void
     getClosestContacts: (maxCount?: number) => PeerDescriptor[]
     getRandomContacts: (maxCount?: number) => PeerDescriptor[]

--- a/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
+++ b/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
@@ -1,6 +1,6 @@
 import { areEqualPeerDescriptors, DhtAddress, getNodeIdFromPeerDescriptor, PeerDescriptor } from '@streamr/dht'
 import { Logger, wait } from '@streamr/utils'
-import { Layer1Node } from './Layer1Node'
+import { DiscoveryLayerNode } from './DiscoveryLayerNode'
 
 /*
  * Tries to find new neighbors if we currently have less than MIN_NEIGHBOR_COUNT neigbors. It does so by
@@ -41,7 +41,7 @@ const exponentialRunOff = async (
 export const MIN_NEIGHBOR_COUNT = 4
 
 export interface StreamPartNetworkSplitAvoidanceConfig {
-    layer1Node: Layer1Node
+    discoveryLayerNode: DiscoveryLayerNode
     discoverEntryPoints: (excludedNodes?: Set<DhtAddress>) => Promise<PeerDescriptor[]>
     exponentialRunOfBaseDelay?: number
 }
@@ -63,11 +63,11 @@ export class StreamPartNetworkSplitAvoidance {
         await exponentialRunOff(async () => {
             const discoveredEntrypoints = await this.config.discoverEntryPoints()
             const filteredEntryPoints = discoveredEntrypoints.filter((peer) => !this.excludedNodes.has(getNodeIdFromPeerDescriptor(peer)))
-            await this.config.layer1Node.joinDht(filteredEntryPoints, false, false)
-            if (this.config.layer1Node.getNeighborCount() < MIN_NEIGHBOR_COUNT) {
+            await this.config.discoveryLayerNode.joinDht(filteredEntryPoints, false, false)
+            if (this.config.discoveryLayerNode.getNeighborCount() < MIN_NEIGHBOR_COUNT) {
                 // Filter out nodes that are not neighbors as those nodes are assumed to be offline
                 const newExcludes = filteredEntryPoints
-                    .filter((peer) => !this.config.layer1Node.getNeighbors()
+                    .filter((peer) => !this.config.discoveryLayerNode.getNeighbors()
                         .some((neighbor) => areEqualPeerDescriptors(neighbor, peer)))
                     .map((peer) => getNodeIdFromPeerDescriptor(peer))
                 newExcludes.forEach((node) => this.excludedNodes.add(node))

--- a/packages/trackerless-network/src/logic/StreamPartReconnect.ts
+++ b/packages/trackerless-network/src/logic/StreamPartReconnect.ts
@@ -1,15 +1,15 @@
 import { scheduleAtInterval } from '@streamr/utils'
 import { EntryPointDiscovery } from './EntryPointDiscovery'
-import { Layer1Node } from './Layer1Node'
+import { DiscoveryLayerNode } from './DiscoveryLayerNode'
 
 const DEFAULT_RECONNECT_INTERVAL = 30 * 1000
 export class StreamPartReconnect {
     private abortController?: AbortController
-    private readonly layer1Node: Layer1Node
+    private readonly discoveryLayerNode: DiscoveryLayerNode
     private readonly entryPointDiscovery: EntryPointDiscovery
 
-    constructor(layer1Node: Layer1Node, entryPointDiscovery: EntryPointDiscovery) {
-        this.layer1Node = layer1Node
+    constructor(discoveryLayerNode: DiscoveryLayerNode, entryPointDiscovery: EntryPointDiscovery) {
+        this.discoveryLayerNode = discoveryLayerNode
         this.entryPointDiscovery = entryPointDiscovery
     }
 
@@ -17,11 +17,11 @@ export class StreamPartReconnect {
         this.abortController = new AbortController()
         await scheduleAtInterval(async () => {
             const entryPoints = await this.entryPointDiscovery.discoverEntryPoints()
-            await this.layer1Node.joinDht(entryPoints)
+            await this.discoveryLayerNode.joinDht(entryPoints)
             if (this.entryPointDiscovery.isLocalNodeEntryPoint()) {
                 await this.entryPointDiscovery.storeAndKeepLocalNodeAsEntryPoint()
             }
-            if (this.layer1Node.getNeighborCount() > 0) {
+            if (this.discoveryLayerNode.getNeighborCount() > 0) {
                 this.abortController!.abort()
             }
         }, timeout, true, this.abortController.signal)

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -25,7 +25,7 @@ import fs from 'fs'
 import { NetworkNode } from '../../src/NetworkNode'
 import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
 import { createMockPeerDescriptor, createNetworkNodeWithSimulator } from '../utils/utils'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
 
 const numNodes = 10000
@@ -161,8 +161,8 @@ run().then(() => {
     console.log(controlLayerNode.getNeighbors().length)
     console.log(controlLayerNode.getConnectionsView().getConnectionCount())
     const streamPartDelivery = contentDeliveryManager
-        .getStreamPartDelivery(streamParts[0])! as { layer1Node: Layer1Node, node: ContentDeliveryLayerNode }
-    console.log(streamPartDelivery.layer1Node.getNeighbors())
+        .getStreamPartDelivery(streamParts[0])! as { discoveryLayerNode: DiscoveryLayerNode, node: ContentDeliveryLayerNode }
+    console.log(streamPartDelivery.discoveryLayerNode.getNeighbors())
     console.log(streamPartDelivery.node.getNeighbors())
     console.log(nodes[nodes.length - 1])
     if (publishInterval) {

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -112,7 +112,7 @@ const measureJoiningTime = async () => {
     const streamSubscriber = await createNetworkNodeWithSimulator(
         peerDescriptor,
         simulator,
-        [randomNode.stack.getLayer0Node().getLocalPeerDescriptor()]
+        [randomNode.stack.getControlLayerNode().getLocalPeerDescriptor()]
     )
     currentNode = streamSubscriber
     const start = performance.now()
@@ -155,11 +155,11 @@ run().then(() => {
     console.error(err)
     const contentDeliveryManager = currentNode.stack.getContentDeliveryManager()
     const streamParts = contentDeliveryManager.getStreamParts()
-    const foundData = nodes[0].stack.getLayer0Node().fetchDataFromDht(streamPartIdToDataKey(streamParts[0]))
+    const foundData = nodes[0].stack.getControlLayerNode().fetchDataFromDht(streamPartIdToDataKey(streamParts[0]))
     console.log(foundData)
-    const layer0Node = currentNode.stack.getLayer0Node() as DhtNode
-    console.log(layer0Node.getNeighbors().length)
-    console.log(layer0Node.getConnectionsView().getConnectionCount())
+    const controlLayerNode = currentNode.stack.getControlLayerNode() as DhtNode
+    console.log(controlLayerNode.getNeighbors().length)
+    console.log(controlLayerNode.getConnectionsView().getConnectionCount())
     const streamPartDelivery = contentDeliveryManager
         .getStreamPartDelivery(streamParts[0])! as { layer1Node: Layer1Node, node: ContentDeliveryLayerNode }
     console.log(streamPartDelivery.layer1Node.getNeighbors())

--- a/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
@@ -5,7 +5,7 @@ import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { createContentDeliveryLayerNode } from '../../src/logic/createContentDeliveryLayerNode'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
-import { Layer0Node } from '../../src/logic/Layer0Node'
+import { ControlLayerNode } from '../../src/logic/ControlLayerNode'
 import { Layer1Node } from '../../src/logic/Layer1Node'
 
 describe('content delivery layer node with real connections', () => {
@@ -18,11 +18,11 @@ describe('content delivery layer node with real connections', () => {
     // Currently the nodes here are practically layer0 nodes acting as layer1 nodes, for the purpose of this test
     // they are layer1 nodes as the DHT is per stream
     // TODO refactor the test to use normal layering style (i.e. have separate objects for layer0 and layer1 nodes)
-    let epDhtNode: Layer0Node & Layer1Node
-    let dhtNode1: Layer0Node & Layer1Node
-    let dhtNode2: Layer0Node & Layer1Node
-    let dhtNode3: Layer0Node & Layer1Node
-    let dhtNode4: Layer0Node & Layer1Node
+    let epDhtNode: ControlLayerNode & Layer1Node
+    let dhtNode1: ControlLayerNode & Layer1Node
+    let dhtNode2: ControlLayerNode & Layer1Node
+    let dhtNode3: ControlLayerNode & Layer1Node
+    let dhtNode4: ControlLayerNode & Layer1Node
     let contentDeliveryLayerNode1: ContentDeliveryLayerNode
     let contentDeliveryLayerNode2: ContentDeliveryLayerNode
     let contentDeliveryLayerNode3: ContentDeliveryLayerNode

--- a/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
@@ -6,7 +6,7 @@ import { createContentDeliveryLayerNode } from '../../src/logic/createContentDel
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { ControlLayerNode } from '../../src/logic/ControlLayerNode'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 
 describe('content delivery layer node with real connections', () => {
 
@@ -18,11 +18,11 @@ describe('content delivery layer node with real connections', () => {
     // Currently the nodes here are practically layer0 nodes acting as layer1 nodes, for the purpose of this test
     // they are layer1 nodes as the DHT is per stream
     // TODO refactor the test to use normal layering style (i.e. have separate objects for layer0 and layer1 nodes)
-    let epDhtNode: ControlLayerNode & Layer1Node
-    let dhtNode1: ControlLayerNode & Layer1Node
-    let dhtNode2: ControlLayerNode & Layer1Node
-    let dhtNode3: ControlLayerNode & Layer1Node
-    let dhtNode4: ControlLayerNode & Layer1Node
+    let epDhtNode: ControlLayerNode & DiscoveryLayerNode
+    let dhtNode1: ControlLayerNode & DiscoveryLayerNode
+    let dhtNode2: ControlLayerNode & DiscoveryLayerNode
+    let dhtNode3: ControlLayerNode & DiscoveryLayerNode
+    let dhtNode4: ControlLayerNode & DiscoveryLayerNode
     let contentDeliveryLayerNode1: ContentDeliveryLayerNode
     let contentDeliveryLayerNode2: ContentDeliveryLayerNode
     let contentDeliveryLayerNode3: ContentDeliveryLayerNode
@@ -45,7 +45,7 @@ describe('content delivery layer node with real connections', () => {
         contentDeliveryLayerNode1 = createContentDeliveryLayerNode(
             {
                 streamPartId,
-                layer1Node: epDhtNode,
+                discoveryLayerNode: epDhtNode,
                 transport: epDhtNode.getTransport(),
                 connectionLocker: epDhtNode.getTransport() as ConnectionManager,
                 localPeerDescriptor: epPeerDescriptor,
@@ -54,7 +54,7 @@ describe('content delivery layer node with real connections', () => {
         )
         contentDeliveryLayerNode2 = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: dhtNode1,
+            discoveryLayerNode: dhtNode1,
             transport: dhtNode1.getTransport(),
             connectionLocker: dhtNode1.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode1.getLocalPeerDescriptor(),
@@ -62,7 +62,7 @@ describe('content delivery layer node with real connections', () => {
         })
         contentDeliveryLayerNode3 = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: dhtNode2,
+            discoveryLayerNode: dhtNode2,
             transport: dhtNode2.getTransport(),
             connectionLocker: dhtNode2.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode2.getLocalPeerDescriptor(),
@@ -70,7 +70,7 @@ describe('content delivery layer node with real connections', () => {
         })
         contentDeliveryLayerNode4 = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: dhtNode3,
+            discoveryLayerNode: dhtNode3,
             transport: dhtNode3.getTransport(),
             connectionLocker: dhtNode3.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode3.getLocalPeerDescriptor(),
@@ -78,7 +78,7 @@ describe('content delivery layer node with real connections', () => {
         })
         contentDeliveryLayerNode5 = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: dhtNode4,
+            discoveryLayerNode: dhtNode4,
             transport: dhtNode4.getTransport(),
             connectionLocker: dhtNode4.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode4.getLocalPeerDescriptor(),

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -87,14 +87,14 @@ describe('proxy and full node', () => {
 
     it('proxied node can act as full node on another stream part', async () => {
         await proxiedNode.setProxies(proxiedStreamPart, [proxyNodeDescriptor], ProxyDirection.PUBLISH, PROXIED_NODE_USER_ID, 1)
-        expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(false)
+        expect(proxiedNode.stack.getControlLayerNode().hasJoined()).toBe(false)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getContentDeliveryManager() as any, 'newMessage'),
             proxiedNode.broadcast(createMessage(regularStreamPart1))
         ])
 
-        expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(true)
+        expect(proxiedNode.stack.getControlLayerNode().hasJoined()).toBe(true)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getContentDeliveryManager() as any, 'newMessage'),
@@ -107,7 +107,7 @@ describe('proxy and full node', () => {
 
     it('proxied node can act as full node on multiple stream parts', async () => {
         await proxiedNode.setProxies(proxiedStreamPart, [proxyNodeDescriptor], ProxyDirection.PUBLISH, PROXIED_NODE_USER_ID, 1)
-        expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(false)
+        expect(proxiedNode.stack.getControlLayerNode().hasJoined()).toBe(false)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getContentDeliveryManager() as any, 'newMessage', 5000, 
@@ -124,7 +124,7 @@ describe('proxy and full node', () => {
             proxiedNode.broadcast(createMessage(regularStreamPart4))
         ])
 
-        expect(proxiedNode.stack.getLayer0Node().hasJoined()).toBe(true)
+        expect(proxiedNode.stack.getControlLayerNode().hasJoined()).toBe(true)
 
         await Promise.all([
             waitForEvent3(proxyNode.stack.getContentDeliveryManager() as any, 'newMessage'),

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -5,12 +5,12 @@ import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNo
 import { createContentDeliveryLayerNode } from '../../src/logic/createContentDeliveryLayerNode'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 
 describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
     const otherNodeCount = 64
-    let otherLayer1Nodes: Layer1Node[]
-    let entryPointLayer1Node: Layer1Node
+    let otherDiscoveryLayerNodes: DiscoveryLayerNode[]
+    let entryPointDiscoveryLayerNode: DiscoveryLayerNode
     let entryPointContentDeliveryLayerNode: ContentDeliveryLayerNode
     let otherContentDeliveryLayerNodes: ContentDeliveryLayerNode[]
 
@@ -27,13 +27,13 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
         await entrypointCm.start()
         await Promise.all(cms.map((cm) => cm.start()))
 
-        entryPointLayer1Node = new DhtNode({
+        entryPointDiscoveryLayerNode = new DhtNode({
             transport: entrypointCm,
             connectionsView: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
-        otherLayer1Nodes = range(otherNodeCount).map((i) => new DhtNode({
+        otherDiscoveryLayerNodes = range(otherNodeCount).map((i) => new DhtNode({
             transport: cms[i],
             connectionsView: cms[i],
             peerDescriptor: peerDescriptors[i],
@@ -41,7 +41,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
         }))
         otherContentDeliveryLayerNodes = range(otherNodeCount).map((i) => createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: otherLayer1Nodes[i],
+            discoveryLayerNode: otherDiscoveryLayerNodes[i],
             transport: cms[i],
             connectionLocker: cms[i],
             localPeerDescriptor: peerDescriptors[i],
@@ -49,29 +49,29 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
         }))
         entryPointContentDeliveryLayerNode = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: entryPointLayer1Node,
+            discoveryLayerNode: entryPointDiscoveryLayerNode,
             transport: entrypointCm,
             connectionLocker: entrypointCm,
             localPeerDescriptor: entrypointDescriptor,
             isLocalNodeEntryPoint: () => false
         })
 
-        await entryPointLayer1Node.start()
+        await entryPointDiscoveryLayerNode.start()
         entryPointContentDeliveryLayerNode.start()
-        await entryPointLayer1Node.joinDht([entrypointDescriptor])
-        await Promise.all(otherLayer1Nodes.map((node) => node.start()))
+        await entryPointDiscoveryLayerNode.joinDht([entrypointDescriptor])
+        await Promise.all(otherDiscoveryLayerNodes.map((node) => node.start()))
     })
 
     afterEach(async () => {
-        entryPointLayer1Node.stop()
+        entryPointDiscoveryLayerNode.stop()
         entryPointContentDeliveryLayerNode.stop()
-        await Promise.all(otherLayer1Nodes.map((node) => node.stop()))
+        await Promise.all(otherDiscoveryLayerNodes.map((node) => node.stop()))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) => node.stop()))
     })
 
     it('happy path single node', async () => {
         await otherContentDeliveryLayerNodes[0].start()
-        await otherLayer1Nodes[0].joinDht([entrypointDescriptor])
+        await otherDiscoveryLayerNodes[0].joinDht([entrypointDescriptor])
         await Promise.all([
             waitForCondition(() => otherContentDeliveryLayerNodes[0].getNearbyNodeView().getIds().length === 1),
             waitForCondition(() => otherContentDeliveryLayerNodes[0].getNeighbors().length === 1)
@@ -83,7 +83,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
     it('happy path 5 nodes', async () => {
         range(4).forEach((i) => otherContentDeliveryLayerNodes[i].start())
         await Promise.all(range(4).map(async (i) => {
-            await otherLayer1Nodes[i].joinDht([entrypointDescriptor])
+            await otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
         await waitForCondition(() => range(4).every((i) => otherContentDeliveryLayerNodes[i].getNeighbors().length >= 4), 15000, 1000)
         range(4).forEach((i) => {
@@ -108,7 +108,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
     it('happy path 64 nodes', async () => {
         await Promise.all(range(otherNodeCount).map((i) => otherContentDeliveryLayerNodes[i].start()))
         await Promise.all(range(otherNodeCount).map((i) => {
-            otherLayer1Nodes[i].joinDht([entrypointDescriptor])
+            otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) =>
             waitForCondition(() => node.getNeighbors().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -5,14 +5,14 @@ import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNo
 import { createContentDeliveryLayerNode } from '../../src/logic/createContentDeliveryLayerNode'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 
 const logger = new Logger(module)
 
 describe('ContentDeliveryLayerNode-DhtNode', () => {
     const otherNodeCount = 64
-    let entryPointLayer1Node: Layer1Node
-    let otherLayer1Nodes: Layer1Node[]
+    let entryPointDiscoveryLayerNode: DiscoveryLayerNode
+    let otherDiscoveryLayerNodes: DiscoveryLayerNode[]
     let entryPointContentDeliveryLayerNode: ContentDeliveryLayerNode
     let otherContentDeliveryLayerNodes: ContentDeliveryLayerNode[]
 
@@ -42,14 +42,14 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
         )
         await Promise.all(cms.map((cm) => cm.start()))
 
-        entryPointLayer1Node = new DhtNode({
+        entryPointDiscoveryLayerNode = new DhtNode({
             transport: entrypointCm,
             connectionsView: entrypointCm,
             peerDescriptor: entrypointDescriptor,
             serviceId: streamPartId
         })
 
-        otherLayer1Nodes = range(otherNodeCount).map((i) => new DhtNode({
+        otherDiscoveryLayerNodes = range(otherNodeCount).map((i) => new DhtNode({
             transport: cms[i],
             connectionsView: cms[i],
             peerDescriptor: peerDescriptors[i],
@@ -58,7 +58,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
 
         otherContentDeliveryLayerNodes = range(otherNodeCount).map((i) => createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: otherLayer1Nodes[i],
+            discoveryLayerNode: otherDiscoveryLayerNodes[i],
             transport: cms[i],
             connectionLocker: cms[i],
             localPeerDescriptor: peerDescriptors[i],
@@ -68,7 +68,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
 
         entryPointContentDeliveryLayerNode = createContentDeliveryLayerNode({
             streamPartId,
-            layer1Node: entryPointLayer1Node,
+            discoveryLayerNode: entryPointDiscoveryLayerNode,
             transport: entrypointCm,
             connectionLocker: entrypointCm,
             localPeerDescriptor: entrypointDescriptor,
@@ -76,22 +76,22 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
             isLocalNodeEntryPoint: () => false
         })
 
-        await entryPointLayer1Node.start()
+        await entryPointDiscoveryLayerNode.start()
         await entryPointContentDeliveryLayerNode.start()
-        await entryPointLayer1Node.joinDht([entrypointDescriptor])
-        await Promise.all(otherLayer1Nodes.map((node) => node.start()))
+        await entryPointDiscoveryLayerNode.joinDht([entrypointDescriptor])
+        await Promise.all(otherDiscoveryLayerNodes.map((node) => node.start()))
     })
 
     afterEach(async () => {
-        await entryPointLayer1Node.stop()
+        await entryPointDiscoveryLayerNode.stop()
         entryPointContentDeliveryLayerNode.stop()
-        await Promise.all(otherLayer1Nodes.map((node) => node.stop()))
+        await Promise.all(otherDiscoveryLayerNodes.map((node) => node.stop()))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) => node.stop()))
     })
 
     it('happy path single node ', async () => {
         await otherContentDeliveryLayerNodes[0].start()
-        await otherLayer1Nodes[0].joinDht([entrypointDescriptor])
+        await otherDiscoveryLayerNodes[0].joinDht([entrypointDescriptor])
 
         await waitForCondition(() => otherContentDeliveryLayerNodes[0].getNeighbors().length === 1)
         expect(otherContentDeliveryLayerNodes[0].getNearbyNodeView().getIds().length).toEqual(1)
@@ -101,7 +101,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
     it('happy path 4 nodes', async () => {
         range(4).forEach((i) => otherContentDeliveryLayerNodes[i].start())
         await Promise.all(range(4).map(async (i) => {
-            await otherLayer1Nodes[i].joinDht([entrypointDescriptor])
+            await otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
 
         await waitForCondition(() => range(4).every((i) => otherContentDeliveryLayerNodes[i].getNeighbors().length === 4))
@@ -127,7 +127,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
     it('happy path 64 nodes', async () => {
         await Promise.all(range(otherNodeCount).map((i) => otherContentDeliveryLayerNodes[i].start()))
         await Promise.all(range(otherNodeCount).map((i) => {
-            otherLayer1Nodes[i].joinDht([entrypointDescriptor])
+            otherDiscoveryLayerNodes[i].joinDht([entrypointDescriptor])
         }))
         await Promise.all(otherContentDeliveryLayerNodes.map((node) =>
             waitForCondition(() => node.getNeighbors().length >= 4, 10000)

--- a/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
@@ -8,12 +8,12 @@ import { waitForEvent3, waitForCondition } from '@streamr/utils'
 import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
-import { Layer0Node } from '../../src/logic/Layer0Node'
+import { ControlLayerNode } from '../../src/logic/ControlLayerNode'
 
 describe('ContentDeliveryManager', () => {
 
-    let layer0Node1: Layer0Node
-    let layer0Node2: Layer0Node
+    let controlLayerNode1: ControlLayerNode
+    let controlLayerNode2: ControlLayerNode
     let transport1: SimulatorTransport
     let transport2: SimulatorTransport
     let manager1: ContentDeliveryManager
@@ -42,32 +42,32 @@ describe('ContentDeliveryManager', () => {
         await transport1.start()
         transport2 = new SimulatorTransport(peerDescriptor2, simulator)
         await transport2.start()
-        layer0Node1 = new DhtNode({
+        controlLayerNode1 = new DhtNode({
             transport: transport1,
             connectionsView: transport1,
             peerDescriptor: peerDescriptor1,
             entryPoints: [peerDescriptor1]
         })
-        layer0Node2 = new DhtNode({
+        controlLayerNode2 = new DhtNode({
             transport: transport2,
             connectionsView: transport2,
             peerDescriptor: peerDescriptor2,
             entryPoints: [peerDescriptor1]
         })
         await Promise.all([
-            layer0Node1.start(),
-            layer0Node2.start()
+            controlLayerNode1.start(),
+            controlLayerNode2.start()
         ])
         await Promise.all([
-            layer0Node1.joinDht([peerDescriptor1]),
-            layer0Node2.joinDht([peerDescriptor1])
+            controlLayerNode1.joinDht([peerDescriptor1]),
+            controlLayerNode2.joinDht([peerDescriptor1])
         ])
 
         manager1 = new ContentDeliveryManager({})
         manager2 = new ContentDeliveryManager({})
-        await manager1.start(layer0Node1, transport1, transport1)
+        await manager1.start(controlLayerNode1, transport1, transport1)
         manager1.setStreamPartEntryPoints(STREAM_PART_ID, [peerDescriptor1])
-        await manager2.start(layer0Node2, transport2, transport2)
+        await manager2.start(controlLayerNode2, transport2, transport2)
         manager2.setStreamPartEntryPoints(STREAM_PART_ID, [peerDescriptor1])
     })
 

--- a/packages/trackerless-network/test/integration/Inspect.test.ts
+++ b/packages/trackerless-network/test/integration/Inspect.test.ts
@@ -81,7 +81,7 @@ describe('inspect', () => {
         }, 200)
 
         for (const node of inspectedNodes) {
-            const result = await inspectorNode.getContentDeliveryManager().inspect(node.getLayer0Node().getLocalPeerDescriptor(), streamPartId)
+            const result = await inspectorNode.getContentDeliveryManager().inspect(node.getControlLayerNode().getLocalPeerDescriptor(), streamPartId)
             expect(result).toEqual(true)
         }
     }, 25000)

--- a/packages/trackerless-network/test/integration/Propagation.test.ts
+++ b/packages/trackerless-network/test/integration/Propagation.test.ts
@@ -5,11 +5,11 @@ import { waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
 import { createMockPeerDescriptor, createMockContentDeliveryLayerNodeAndDhtNode, createStreamMessage } from '../utils/utils'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 
 describe('Propagation', () => {
     const entryPointDescriptor = createMockPeerDescriptor()
-    let layer1Nodes: Layer1Node[]
+    let discoveryLayerNodes: DiscoveryLayerNode[]
     let contentDeliveryLayerNodes: ContentDeliveryLayerNode[]
     const STREAM_PART_ID = StreamPartIDUtils.parse('testingtesting#0')
     let totalReceived: number
@@ -18,7 +18,7 @@ describe('Propagation', () => {
     beforeEach(async () => {
         const simulator = new Simulator()
         totalReceived = 0
-        layer1Nodes = []
+        discoveryLayerNodes = []
         contentDeliveryLayerNodes = []
         const [entryPoint, node1] = await createMockContentDeliveryLayerNodeAndDhtNode(
             entryPointDescriptor,
@@ -30,7 +30,7 @@ describe('Propagation', () => {
         await entryPoint.joinDht([entryPointDescriptor])
         await node1.start()
         node1.on('message', () => {totalReceived += 1})
-        layer1Nodes.push(entryPoint)
+        discoveryLayerNodes.push(entryPoint)
         contentDeliveryLayerNodes.push(node1)
 
         await Promise.all(range(NUM_OF_NODES).map(async (_i) => {
@@ -45,7 +45,7 @@ describe('Propagation', () => {
             await contentDeliveryLayerNode.start()
             await layer1.joinDht([entryPointDescriptor]).then(() => {
                 contentDeliveryLayerNode.on('message', () => { totalReceived += 1 })
-                layer1Nodes.push(layer1)
+                discoveryLayerNodes.push(layer1)
                 contentDeliveryLayerNodes.push(contentDeliveryLayerNode)
             })
         }))
@@ -53,7 +53,7 @@ describe('Propagation', () => {
 
     afterEach(async () => {
         await Promise.all(contentDeliveryLayerNodes.map((node) => node.stop()))
-        await Promise.all(layer1Nodes.map((node) => node.stop()))
+        await Promise.all(discoveryLayerNodes.map((node) => node.stop()))
     })
 
     it('All nodes receive messages', async () => {

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -70,8 +70,8 @@ describe('Joining stream parts on offline nodes', () => {
         let messageReceived = false
 
         // store offline peer descriptors to DHT
-        await entryPoint.getLayer0Node().storeDataToDht(streamPartIdToDataKey(STREAM_PART_ID), Any.pack(offlineDescriptor1, PeerDescriptor))
-        await entryPoint.getLayer0Node().storeDataToDht(streamPartIdToDataKey(STREAM_PART_ID), Any.pack(offlineDescriptor2, PeerDescriptor))
+        await entryPoint.getControlLayerNode().storeDataToDht(streamPartIdToDataKey(STREAM_PART_ID), Any.pack(offlineDescriptor1, PeerDescriptor))
+        await entryPoint.getControlLayerNode().storeDataToDht(streamPartIdToDataKey(STREAM_PART_ID), Any.pack(offlineDescriptor2, PeerDescriptor))
         
         node1.getContentDeliveryManager().joinStreamPart(STREAM_PART_ID)
         node1.getContentDeliveryManager().on('newMessage', () => { messageReceived = true })

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -121,7 +121,7 @@ describe('stream without default entrypoints', () => {
             await nodes[i].join(STREAM_PART_ID, { minCount: (i > 0) ? 1 : 0, timeout: 15000 })
         }
         await waitForCondition(async () => {
-            const entryPointData = await nodes[15].stack.getLayer0Node().fetchDataFromDht(streamPartIdToDataKey(STREAM_PART_ID))
+            const entryPointData = await nodes[15].stack.getControlLayerNode().fetchDataFromDht(streamPartIdToDataKey(STREAM_PART_ID))
             return entryPointData.length >= 7
         }, 15000)
         

--- a/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
@@ -3,7 +3,7 @@ import { NodeList } from '../../src/logic/NodeList'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
 import { createContentDeliveryLayerNode } from '../../src/logic/createContentDeliveryLayerNode'
 import { MockHandshaker } from '../utils/mock/MockHandshaker'
-import { MockLayer1Node } from '../utils/mock/MockLayer1Node'
+import { MockDiscoveryLayerNode } from '../utils/mock/MockDiscoveryLayerNode'
 import { MockNeighborFinder } from '../utils/mock/MockNeighborFinder'
 import { MockNeighborUpdateManager } from '../utils/mock/MockNeighborUpdateManager'
 import { MockTransport } from '../utils/mock/MockTransport'
@@ -20,7 +20,7 @@ describe('ContentDeliveryLayerNode', () => {
     let nearbyNodeView: NodeList
     let randomNodeView: NodeList
 
-    let layer1Node: MockLayer1Node
+    let discoveryLayerNode: MockDiscoveryLayerNode
 
     beforeEach(async () => {
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
@@ -28,7 +28,7 @@ describe('ContentDeliveryLayerNode', () => {
         neighbors = new NodeList(nodeId, 10)
         randomNodeView = new NodeList(nodeId, 10)
         nearbyNodeView = new NodeList(nodeId, 10)
-        layer1Node = new MockLayer1Node()
+        discoveryLayerNode = new MockDiscoveryLayerNode()
 
         contentDeliveryLayerNode = createContentDeliveryLayerNode({
             neighbors,
@@ -36,7 +36,7 @@ describe('ContentDeliveryLayerNode', () => {
             nearbyNodeView,
             transport: new MockTransport(),
             localPeerDescriptor: peerDescriptor,
-            layer1Node,
+            discoveryLayerNode,
             connectionLocker: mockConnectionLocker,
             handshaker: new MockHandshaker() as any,
             neighborUpdateManager: new MockNeighborUpdateManager() as any,
@@ -68,8 +68,8 @@ describe('ContentDeliveryLayerNode', () => {
     it('Adds Closest Nodes from layer1 nearbyContactAdded event to nearbyNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.setClosestContacts([peerDescriptor1, peerDescriptor2])
-        layer1Node.emit('nearbyContactAdded', peerDescriptor1)
+        discoveryLayerNode.setClosestContacts([peerDescriptor1, peerDescriptor2])
+        discoveryLayerNode.emit('nearbyContactAdded', peerDescriptor1)
         await waitForCondition(() => nearbyNodeView.size() === 2)
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
@@ -78,8 +78,8 @@ describe('ContentDeliveryLayerNode', () => {
     it('Adds Random Nodes from layer1 randomContactAdded event to randomNodeView', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.setRandomContacts([peerDescriptor1, peerDescriptor2])
-        layer1Node.emit('randomContactAdded', peerDescriptor1)
+        discoveryLayerNode.setRandomContacts([peerDescriptor1, peerDescriptor2])
+        discoveryLayerNode.emit('randomContactAdded', peerDescriptor1)
         await waitForCondition(() => randomNodeView.size() === 2)
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
         expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
@@ -88,9 +88,9 @@ describe('ContentDeliveryLayerNode', () => {
     it('Adds Nodes from layer1 neighbors to nearbyNodeView if its size is below nodeViewSize', async () => {
         const peerDescriptor1 = createMockPeerDescriptor()
         const peerDescriptor2 = createMockPeerDescriptor()
-        layer1Node.addNewRandomPeerToKBucket()
-        layer1Node.setClosestContacts([peerDescriptor1, peerDescriptor2])
-        layer1Node.emit('nearbyContactAdded', peerDescriptor1)
+        discoveryLayerNode.addNewRandomPeerToKBucket()
+        discoveryLayerNode.setClosestContacts([peerDescriptor1, peerDescriptor2])
+        discoveryLayerNode.emit('nearbyContactAdded', peerDescriptor1)
         await waitForCondition(() => {
             return nearbyNodeView.size() === 3
         }, 20000)

--- a/packages/trackerless-network/test/unit/ContentDeliveryManager.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryManager.test.ts
@@ -3,7 +3,7 @@ import { StreamPartIDUtils } from '@streamr/protocol'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { waitForCondition } from '@streamr/utils'
 import { ContentDeliveryManager } from '../../src/logic/ContentDeliveryManager'
-import { MockLayer0Node } from '../utils/mock/MockLayer0Node'
+import { MockControlLayerNode } from '../utils/mock/MockControlLayerNode'
 import { MockTransport } from '../utils/mock/MockTransport'
 import { createMockPeerDescriptor, createStreamMessage, mockConnectionLocker } from '../utils/utils'
 import { ProxyDirection } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
@@ -15,7 +15,7 @@ describe('ContentDeliveryManager', () => {
 
     beforeEach(async () => {
         manager = new ContentDeliveryManager({})
-        const mockLayer0 = new MockLayer0Node(peerDescriptor)
+        const mockLayer0 = new MockControlLayerNode(peerDescriptor)
         await manager.start(mockLayer0, new MockTransport(), mockConnectionLocker)
     })
 

--- a/packages/trackerless-network/test/unit/StreamPartNetworkSplitAvoidance.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartNetworkSplitAvoidance.test.ts
@@ -1,32 +1,32 @@
 import { MIN_NEIGHBOR_COUNT } from '../../src/logic/StreamPartNetworkSplitAvoidance'
 import { StreamPartNetworkSplitAvoidance } from '../../src/logic/StreamPartNetworkSplitAvoidance'
-import { MockLayer1Node } from '../utils/mock/MockLayer1Node'
+import { MockDiscoveryLayerNode } from '../utils/mock/MockDiscoveryLayerNode'
 
 describe('StreamPartNetworkSplitAvoidance', () => {
 
     let avoidance: StreamPartNetworkSplitAvoidance
-    let layer1Node: MockLayer1Node
+    let discoveryLayerNode: MockDiscoveryLayerNode
     
     beforeEach(() => {
-        layer1Node = new MockLayer1Node()
+        discoveryLayerNode = new MockDiscoveryLayerNode()
         avoidance = new StreamPartNetworkSplitAvoidance({
-            layer1Node,
+            discoveryLayerNode,
             discoverEntryPoints: async () => { 
-                layer1Node.addNewRandomPeerToKBucket() 
-                return layer1Node.getNeighbors()
+                discoveryLayerNode.addNewRandomPeerToKBucket() 
+                return discoveryLayerNode.getNeighbors()
             },
             exponentialRunOfBaseDelay: 1
         })
     })
 
     afterEach(() => {
-        layer1Node.stop()
+        discoveryLayerNode.stop()
         avoidance.destroy()
     })
 
     it('runs avoidance until number of neighbors is above MIN_NEIGHBOR_COUNT', async () => {
         await avoidance.avoidNetworkSplit()
-        expect(layer1Node.getNeighborCount()).toBeGreaterThan(MIN_NEIGHBOR_COUNT)
+        expect(discoveryLayerNode.getNeighborCount()).toBeGreaterThan(MIN_NEIGHBOR_COUNT)
     })
 
 })

--- a/packages/trackerless-network/test/unit/StreamPartReconnect.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartReconnect.test.ts
@@ -1,19 +1,19 @@
 import { EntryPointDiscovery } from '../../src/logic/EntryPointDiscovery'
 import { StreamPartReconnect } from '../../src/logic/StreamPartReconnect'
-import { MockLayer1Node } from '../utils/mock/MockLayer1Node'
+import { MockDiscoveryLayerNode } from '../utils/mock/MockDiscoveryLayerNode'
 import { createFakeEntryPointDiscovery } from '../utils/fake/FakeEntryPointDiscovery'
 import { waitForCondition } from '@streamr/utils'
 
 describe('StreamPartReconnect', () => {
 
     let entryPointDiscovery: EntryPointDiscovery
-    let layer1Node: MockLayer1Node
+    let discoveryLayerNode: MockDiscoveryLayerNode
     let streamPartReconnect: StreamPartReconnect
 
     beforeEach(() => {
         entryPointDiscovery = createFakeEntryPointDiscovery()
-        layer1Node = new MockLayer1Node()
-        streamPartReconnect = new StreamPartReconnect(layer1Node, entryPointDiscovery)
+        discoveryLayerNode = new MockDiscoveryLayerNode()
+        streamPartReconnect = new StreamPartReconnect(discoveryLayerNode, entryPointDiscovery)
     })
 
     afterEach(() => {
@@ -23,7 +23,7 @@ describe('StreamPartReconnect', () => {
     it('Happy path', async () => {
         await streamPartReconnect.reconnect(1000)
         expect(streamPartReconnect.isRunning()).toEqual(true)
-        layer1Node.addNewRandomPeerToKBucket()
+        discoveryLayerNode.addNewRandomPeerToKBucket()
         await waitForCondition(() => streamPartReconnect.isRunning() === false)
     })
 

--- a/packages/trackerless-network/test/utils/mock/MockControlLayerNode.ts
+++ b/packages/trackerless-network/test/utils/mock/MockControlLayerNode.ts
@@ -1,9 +1,9 @@
 import { PeerDescriptor, DataEntry, ITransport, TransportEvents, ConnectionsView } from '@streamr/dht'
-import { Layer0Node } from '../../../src/logic/Layer0Node'
+import { ControlLayerNode } from '../../../src/logic/ControlLayerNode'
 import { EventEmitter } from 'eventemitter3'
 import { MockConnectionsView } from './MockConnectionsView'
 
-export class MockLayer0Node extends EventEmitter<TransportEvents> implements Layer0Node {
+export class MockControlLayerNode extends EventEmitter<TransportEvents> implements ControlLayerNode {
 
     private readonly peerDescriptor: PeerDescriptor
 

--- a/packages/trackerless-network/test/utils/mock/MockDiscoveryLayerNode.ts
+++ b/packages/trackerless-network/test/utils/mock/MockDiscoveryLayerNode.ts
@@ -1,9 +1,9 @@
 import { PeerDescriptor, RingContacts } from '@streamr/dht'
 import { EventEmitter } from 'eventemitter3'
-import { Layer1Node, Layer1NodeEvents } from '../../../src/logic/Layer1Node'
+import { DiscoveryLayerNode, DiscoveryLayerNodeEvents } from '../../../src/logic/DiscoveryLayerNode'
 import { createMockPeerDescriptor } from '../utils'
 
-export class MockLayer1Node extends EventEmitter<Layer1NodeEvents> implements Layer1Node {
+export class MockDiscoveryLayerNode extends EventEmitter<DiscoveryLayerNodeEvents> implements DiscoveryLayerNode {
 
     private readonly kbucketPeers: PeerDescriptor[] = []
     private closestContacts: PeerDescriptor[] = []

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -23,7 +23,7 @@ import { HandshakeRpcRemote } from '../../src/logic/neighbor-discovery/Handshake
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { EthereumAddress, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import { StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
-import { Layer1Node } from '../../src/logic/Layer1Node'
+import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
 import { ContentDeliveryRpcClient, HandshakeRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { RpcCommunicator } from '@streamr/proto-rpc'
 
@@ -42,10 +42,10 @@ export const createMockContentDeliveryLayerNodeAndDhtNode = async (
     entryPointDescriptor: PeerDescriptor,
     streamPartId: StreamPartID,
     simulator: Simulator
-): Promise<[ Layer1Node, ContentDeliveryLayerNode ]> => {
+): Promise<[ DiscoveryLayerNode, ContentDeliveryLayerNode ]> => {
     const mockCm = new SimulatorTransport(localPeerDescriptor, simulator)
     await mockCm.start()
-    const layer1Node = new DhtNode({
+    const discoveryLayerNode = new DhtNode({
         transport: mockCm,
         connectionsView: mockCm,
         peerDescriptor: localPeerDescriptor,
@@ -56,13 +56,13 @@ export const createMockContentDeliveryLayerNodeAndDhtNode = async (
     const contentDeliveryLayerNode = createContentDeliveryLayerNode({
         streamPartId,
         transport: mockCm,
-        layer1Node,
+        discoveryLayerNode,
         connectionLocker: mockCm,
         localPeerDescriptor,
         rpcRequestTimeout: 5000,
         isLocalNodeEntryPoint: () => false
     })
-    return [layer1Node, contentDeliveryLayerNode]
+    return [discoveryLayerNode, contentDeliveryLayerNode]
 }
 
 export const createStreamMessage = (


### PR DESCRIPTION
Use names instead of numbers:
- `Layer0Node` -> `ControlLayerNode`
- `Layer1Node` -> `DiscoveryLayerNode`

## Future improvements

Change also all text references (e.g. in comments and test names) to use names instead of numbers.