### PR TITLE
refactor(trackerless-network): Rename `EntryPointDiscovery`

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -133,7 +133,7 @@ message InterleaveResponse {
 
 message LeaveStreamPartNotice {
   string streamPartId = 1;
-  bool isEntryPoint = 2;
+  bool isStored = 2;
 }
 
 message NeighborUpdate {

--- a/packages/trackerless-network/src/exports.ts
+++ b/packages/trackerless-network/src/exports.ts
@@ -2,7 +2,7 @@ export { NetworkStack, NetworkOptions, NodeInfo } from './NetworkStack'
 export { NetworkNode, createNetworkNode } from './NetworkNode'
 export { ContentDeliveryManagerConfig } from './logic/ContentDeliveryManager'
 export { ProxyDirection, GroupKeyRequest, GroupKeyResponse } from './proto/packages/trackerless-network/protos/NetworkRpc'
-export { streamPartIdToDataKey } from './logic/EntryPointDiscovery'
+export { streamPartIdToDataKey } from './logic/KnownNodesManager'
 export {
     convertStreamMessageToBytes,
     convertBytesToStreamMessage,

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -36,7 +36,7 @@ import { StreamPartID } from '@streamr/protocol'
 export interface Events {
     message: (message: StreamMessage) => void
     neighborConnected: (nodeId: DhtAddress) => void
-    entryPointLeaveDetected: () => void
+    storedNodeLeaveDetected: () => void
 }
 
 export interface StrictContentDeliveryLayerNodeConfig {
@@ -107,7 +107,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                     this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)
                 }
                 if (sourceIsStreamEntryPoint) {
-                    this.emit('entryPointLeaveDetected')
+                    this.emit('storedNodeLeaveDetected')
                 }
             },
             markForInspection: (senderId: DhtAddress, messageId: MessageID) => this.config.inspector.markMessage(senderId, messageId)

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -87,26 +87,26 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             rpcCommunicator: this.config.rpcCommunicator,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: DhtAddress) => this.broadcast(message, previousNode),
-            onLeaveNotice: (sourceId: DhtAddress, sourceIsStreamEntryPoint: boolean) => {
+            onLeaveNotice: (remoteNodeId: DhtAddress, isStored: boolean) => {
                 if (this.abortController.signal.aborted) {
                     return
                 }
-                const contact = this.config.nearbyNodeView.get(sourceId)
-                || this.config.randomNodeView.get(sourceId)
-                || this.config.neighbors.get(sourceId)
-                || this.config.proxyConnectionRpcLocal?.getConnection(sourceId)?.remote
+                const contact = this.config.nearbyNodeView.get(remoteNodeId)
+                || this.config.randomNodeView.get(remoteNodeId)
+                || this.config.neighbors.get(remoteNodeId)
+                || this.config.proxyConnectionRpcLocal?.getConnection(remoteNodeId)?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {
-                    this.config.layer1Node.removeContact(sourceId)
-                    this.config.neighbors.remove(sourceId)
-                    this.config.nearbyNodeView.remove(sourceId)
-                    this.config.randomNodeView.remove(sourceId)
-                    this.config.leftNodeView.remove(sourceId)
-                    this.config.rightNodeView.remove(sourceId)
-                    this.config.neighborFinder.start([sourceId])
-                    this.config.proxyConnectionRpcLocal?.removeConnection(sourceId)
+                    this.config.layer1Node.removeContact(remoteNodeId)
+                    this.config.neighbors.remove(remoteNodeId)
+                    this.config.nearbyNodeView.remove(remoteNodeId)
+                    this.config.randomNodeView.remove(remoteNodeId)
+                    this.config.leftNodeView.remove(remoteNodeId)
+                    this.config.rightNodeView.remove(remoteNodeId)
+                    this.config.neighborFinder.start([remoteNodeId])
+                    this.config.proxyConnectionRpcLocal?.removeConnection(remoteNodeId)
                 }
-                if (sourceIsStreamEntryPoint) {
+                if (isStored) {
                     this.emit('storedNodeLeaveDetected')
                 }
             },

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -59,7 +59,7 @@ export interface StrictContentDeliveryLayerNodeConfig {
     neighborTargetCount: number
     inspector: Inspector
     temporaryConnectionRpcLocal: TemporaryConnectionRpcLocal
-    isLocalNodeEntryPoint: () => boolean
+    isLocalNodeStored: () => boolean
 
     proxyConnectionRpcLocal?: ProxyConnectionRpcLocal
     rpcRequestTimeout?: number
@@ -338,7 +338,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         this.abortController.abort()
         this.config.proxyConnectionRpcLocal?.stop()
         this.config.neighbors.getAll().map((remote) => {
-            remote.leaveStreamPartNotice(this.config.streamPartId, this.config.isLocalNodeEntryPoint())
+            remote.leaveStreamPartNotice(this.config.streamPartId, this.config.isLocalNodeStored())
             this.config.connectionLocker.weakUnlockConnection(
                 getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
                 this.config.streamPartId

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -245,7 +245,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
     private createContentDeliveryLayerNode(
         streamPartId: StreamPartID,
         layer1Node: Layer1Node,
-        isLocalNodeEntryPoint: () => boolean
+        isLocalNodeStored: () => boolean
     ) {
         return createContentDeliveryLayerNode({
             streamPartId,
@@ -257,7 +257,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             neighborTargetCount: this.config.streamPartitionNeighborTargetCount,
             acceptProxyConnections: this.config.acceptProxyConnections,
             rpcRequestTimeout: this.config.rpcRequestTimeout,
-            isLocalNodeEntryPoint
+            isLocalNodeStored
         })
     }
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -187,7 +187,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                 await streamPartReconnect.reconnect()
             }
         })
-        node.on('entryPointLeaveDetected', () => handleEntryPointLeave())
+        node.on('storedNodeLeaveDetected', () => handleEntryPointLeave())
         setImmediate(async () => {
             try {
                 await this.startLayersAndJoinDht(streamPartId, knownNodesManager)

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -19,7 +19,7 @@ import {
 import { EventEmitter } from 'eventemitter3'
 import { sampleSize } from 'lodash'
 import { ProxyDirection, StreamMessage, StreamPartitionInfo } from '../proto/packages/trackerless-network/protos/NetworkRpc'
-import { ENTRYPOINT_STORE_LIMIT, KnownNodesManager } from './KnownNodesManager'
+import { MAX_STORED_COUNT, KnownNodesManager } from './KnownNodesManager'
 import { Layer0Node } from './Layer0Node'
 import { Layer1Node } from './Layer1Node'
 import { ContentDeliveryLayerNode } from './ContentDeliveryLayerNode'
@@ -177,7 +177,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                 return
             }
             const entryPoints = await knownNodesManager.discoverNodes()
-            if (entryPoints.length < ENTRYPOINT_STORE_LIMIT) {
+            if (entryPoints.length < MAX_STORED_COUNT) {
                 await knownNodesManager.storeAndKeepLocalNodeAsEntryPoint()
             }
         }
@@ -218,7 +218,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                 streamPart.layer1Node.joinDht(sampleSize(entryPoints, NETWORK_SPLIT_AVOIDANCE_MIN_NEIGHBOR_COUNT)),
                 streamPart.layer1Node.joinRing()
             ])
-            if (entryPoints.length < ENTRYPOINT_STORE_LIMIT) {
+            if (entryPoints.length < MAX_STORED_COUNT) {
                 await knownNodesManager.storeAndKeepLocalNodeAsEntryPoint()
                 if (streamPart.layer1Node.getNeighborCount() < NETWORK_SPLIT_AVOIDANCE_MIN_NEIGHBOR_COUNT) {
                     setImmediate(() => streamPart.networkSplitAvoidance.avoidNetworkSplit())

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -41,7 +41,7 @@ export class ContentDeliveryRpcLocal implements IContentDeliveryRpc {
         if (message.streamPartId === this.config.streamPartId) {
             const sourcePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
             const sourceId = getNodeIdFromPeerDescriptor(sourcePeerDescriptor)
-            this.config.onLeaveNotice(sourceId, message.isEntryPoint)
+            this.config.onLeaveNotice(sourceId, message.isStored)
         }
         return Empty
     }

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -15,7 +15,7 @@ export interface ContentDeliveryRpcLocalConfig {
     streamPartId: StreamPartID
     markAndCheckDuplicate: (messageId: MessageID, previousMessageRef?: MessageRef) => boolean
     broadcast: (message: StreamMessage, previousNode?: DhtAddress) => void
-    onLeaveNotice(senderId: DhtAddress, isLocalNodeEntryPoint: boolean): void
+    onLeaveNotice(senderId: DhtAddress, isLocalNodeStored: boolean): void
     markForInspection(senderId: DhtAddress, messageId: MessageID): void
     rpcCommunicator: ListeningRpcCommunicator
 }

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -15,7 +15,7 @@ export interface ContentDeliveryRpcLocalConfig {
     streamPartId: StreamPartID
     markAndCheckDuplicate: (messageId: MessageID, previousMessageRef?: MessageRef) => boolean
     broadcast: (message: StreamMessage, previousNode?: DhtAddress) => void
-    onLeaveNotice(senderId: DhtAddress, isLocalNodeStored: boolean): void
+    onLeaveNotice(remoteNodeId: DhtAddress, isStored: boolean): void
     markForInspection(senderId: DhtAddress, messageId: MessageID): void
     rpcCommunicator: ListeningRpcCommunicator
 }

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
@@ -20,10 +20,10 @@ export class ContentDeliveryRpcRemote extends RpcRemote<ContentDeliveryRpcClient
         })
     }
 
-    leaveStreamPartNotice(streamPartId: StreamPartID, isLocalNodeEntryPoint: boolean): void {
+    leaveStreamPartNotice(streamPartId: StreamPartID, isLocalNodeStored: boolean): void {
         const notification: LeaveStreamPartNotice = {
             streamPartId,
-            isStored: isLocalNodeEntryPoint
+            isStored: isLocalNodeStored
         }
         const options = this.formDhtRpcOptions({
             notification: true

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
@@ -23,7 +23,7 @@ export class ContentDeliveryRpcRemote extends RpcRemote<ContentDeliveryRpcClient
     leaveStreamPartNotice(streamPartId: StreamPartID, isLocalNodeEntryPoint: boolean): void {
         const notification: LeaveStreamPartNotice = {
             streamPartId,
-            isEntryPoint: isLocalNodeEntryPoint
+            isStored: isLocalNodeEntryPoint
         }
         const options = this.formDhtRpcOptions({
             notification: true

--- a/packages/trackerless-network/src/logic/KnownNodesManager.ts
+++ b/packages/trackerless-network/src/logic/KnownNodesManager.ts
@@ -20,7 +20,7 @@ const parseEntryPointData = (dataEntries: DataEntry[]): PeerDescriptor[] => {
 
 const logger = new Logger(module)
 
-export const ENTRYPOINT_STORE_LIMIT = 8
+export const MAX_STORED_COUNT = 8
 
 interface KnownNodesManagerConfig {
     streamPartId: StreamPartID
@@ -80,7 +80,7 @@ export class KnownNodesManager {
             logger.trace(`Attempting to keep self as entrypoint for ${this.config.streamPartId}`)
             try {
                 const discovered = await this.discoverNodes()
-                if (discovered.length < ENTRYPOINT_STORE_LIMIT 
+                if (discovered.length < MAX_STORED_COUNT 
                     || discovered.some((peerDescriptor) => areEqualPeerDescriptors(peerDescriptor, this.config.localPeerDescriptor))) {
                     await this.storeLocalNodeAsEntryPoint()
                 }

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -94,8 +94,8 @@ export class ProxyClient extends EventEmitter<Events> {
             streamPartId: this.config.streamPartId,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: DhtAddress) => this.broadcast(message, previousNode),
-            onLeaveNotice: (senderId: DhtAddress) => {
-                const contact = this.neighbors.get(senderId)
+            onLeaveNotice: (remoteNodeId: DhtAddress) => {
+                const contact = this.neighbors.get(remoteNodeId)
                 if (contact) {
                     // TODO should we catch possible promise rejection?
                     setImmediate(() => this.onNodeDisconnected(contact.getPeerDescriptor()))

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -241,9 +241,9 @@ export interface LeaveStreamPartNotice {
      */
     streamPartId: string;
     /**
-     * @generated from protobuf field: bool isEntryPoint = 2;
+     * @generated from protobuf field: bool isStored = 2;
      */
-    isEntryPoint: boolean;
+    isStored: boolean;
 }
 /**
  * @generated from protobuf message NeighborUpdate
@@ -597,7 +597,7 @@ class LeaveStreamPartNotice$Type extends MessageType<LeaveStreamPartNotice> {
     constructor() {
         super("LeaveStreamPartNotice", [
             { no: 1, name: "streamPartId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "isEntryPoint", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 2, name: "isStored", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
 }

--- a/packages/trackerless-network/test/benchmark/StreamPartIdDataKeyDistribution.test.ts
+++ b/packages/trackerless-network/test/benchmark/StreamPartIdDataKeyDistribution.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { groupBy, range } from 'lodash'
-import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { streamPartIdToDataKey } from '../../src/logic/KnownNodesManager'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { DhtAddress } from '@streamr/dht'
 

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -23,7 +23,7 @@ import {
 import { hexToBinary, utf8ToBinary, waitForEvent3 } from '@streamr/utils'
 import fs from 'fs'
 import { NetworkNode } from '../../src/NetworkNode'
-import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { streamPartIdToDataKey } from '../../src/logic/KnownNodesManager'
 import { createMockPeerDescriptor, createNetworkNodeWithSimulator } from '../utils/utils'
 import { Layer1Node } from '../../src/logic/Layer1Node'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'

--- a/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
@@ -49,7 +49,7 @@ describe('content delivery layer node with real connections', () => {
                 transport: epDhtNode.getTransport(),
                 connectionLocker: epDhtNode.getTransport() as ConnectionManager,
                 localPeerDescriptor: epPeerDescriptor,
-                isLocalNodeEntryPoint: () => false
+                isLocalNodeStored: () => false
             }
         )
         contentDeliveryLayerNode2 = createContentDeliveryLayerNode({
@@ -58,7 +58,7 @@ describe('content delivery layer node with real connections', () => {
             transport: dhtNode1.getTransport(),
             connectionLocker: dhtNode1.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode1.getLocalPeerDescriptor(),
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
         contentDeliveryLayerNode3 = createContentDeliveryLayerNode({
             streamPartId,
@@ -66,7 +66,7 @@ describe('content delivery layer node with real connections', () => {
             transport: dhtNode2.getTransport(),
             connectionLocker: dhtNode2.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode2.getLocalPeerDescriptor(),
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
         contentDeliveryLayerNode4 = createContentDeliveryLayerNode({
             streamPartId,
@@ -74,7 +74,7 @@ describe('content delivery layer node with real connections', () => {
             transport: dhtNode3.getTransport(),
             connectionLocker: dhtNode3.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode3.getLocalPeerDescriptor(),
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
         contentDeliveryLayerNode5 = createContentDeliveryLayerNode({
             streamPartId,
@@ -82,7 +82,7 @@ describe('content delivery layer node with real connections', () => {
             transport: dhtNode4.getTransport(),
             connectionLocker: dhtNode4.getTransport() as ConnectionManager,
             localPeerDescriptor: dhtNode4.getLocalPeerDescriptor(),
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
         await Promise.all([
             contentDeliveryLayerNode1.start(),

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -45,7 +45,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
             transport: cms[i],
             connectionLocker: cms[i],
             localPeerDescriptor: peerDescriptors[i],
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         }))
         entryPointContentDeliveryLayerNode = createContentDeliveryLayerNode({
             streamPartId,
@@ -53,7 +53,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
             transport: entrypointCm,
             connectionLocker: entrypointCm,
             localPeerDescriptor: entrypointDescriptor,
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
 
         await entryPointDiscoveryLayerNode.start()

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -63,7 +63,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
             connectionLocker: cms[i],
             localPeerDescriptor: peerDescriptors[i],
             neighborUpdateInterval: 2000,
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         }))
 
         entryPointContentDeliveryLayerNode = createContentDeliveryLayerNode({
@@ -73,7 +73,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
             connectionLocker: entrypointCm,
             localPeerDescriptor: entrypointDescriptor,
             neighborUpdateInterval: 2000,
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
 
         await entryPointDiscoveryLayerNode.start()

--- a/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
+++ b/packages/trackerless-network/test/integration/joining-streams-on-offline-peers.test.ts
@@ -1,6 +1,6 @@
 import { PeerDescriptor, Simulator, SimulatorTransport, LatencyType } from '@streamr/dht'
 import { NetworkStack } from '../../src/NetworkStack'
-import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { streamPartIdToDataKey } from '../../src/logic/KnownNodesManager'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -12,7 +12,7 @@ import {
 import { EthereumAddress, hexToBinary, utf8ToBinary, waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
-import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { streamPartIdToDataKey } from '../../src/logic/KnownNodesManager'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('test#0')

--- a/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
+++ b/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
@@ -1,7 +1,7 @@
 import { Simulator, SimulatorTransport, LatencyType } from '@streamr/dht'
 import { NetworkStack } from '../../src/NetworkStack'
 import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
-import { ENTRYPOINT_STORE_LIMIT } from '../../src/logic/EntryPointDiscovery'
+import { ENTRYPOINT_STORE_LIMIT } from '../../src/logic/KnownNodesManager'
 import { range } from 'lodash'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { waitForCondition } from '@streamr/utils'

--- a/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
+++ b/packages/trackerless-network/test/integration/streamEntryPointReplacing.test.ts
@@ -1,7 +1,7 @@
 import { Simulator, SimulatorTransport, LatencyType } from '@streamr/dht'
 import { NetworkStack } from '../../src/NetworkStack'
 import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
-import { ENTRYPOINT_STORE_LIMIT } from '../../src/logic/KnownNodesManager'
+import { MAX_STORED_COUNT } from '../../src/logic/KnownNodesManager'
 import { range } from 'lodash'
 import { StreamPartIDUtils } from '@streamr/protocol'
 import { waitForCondition } from '@streamr/utils'
@@ -50,7 +50,7 @@ describe('Stream Entry Points are replaced when known entry points leave streams
         await entryPointTransport.start()
         await layer0EntryPoint.start()
 
-        initialNodesOnStream = await Promise.all(range(ENTRYPOINT_STORE_LIMIT).map(async () => {
+        initialNodesOnStream = await Promise.all(range(MAX_STORED_COUNT).map(async () => {
             return await startNode()
         }))
 

--- a/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
@@ -42,7 +42,7 @@ describe('ContentDeliveryLayerNode', () => {
             neighborUpdateManager: new MockNeighborUpdateManager() as any,
             neighborFinder: new MockNeighborFinder() as any,
             streamPartId: StreamPartIDUtils.parse('stream#0'),
-            isLocalNodeEntryPoint: () => false
+            isLocalNodeStored: () => false
         })
         await contentDeliveryLayerNode.start()
     })

--- a/packages/trackerless-network/test/unit/ContentDeliveryRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryRpcLocal.test.ts
@@ -51,7 +51,7 @@ describe('ContentDeliveryRpcLocal', () => {
     it('Server leaveStreamPartNotice()', async () => {
         const leaveNotice: LeaveStreamPartNotice = {
             streamPartId: StreamPartIDUtils.parse('stream#0'),
-            isEntryPoint: false
+            isStored: false
         }
         await rpcLocal.leaveStreamPartNotice(leaveNotice, { incomingSourceDescriptor: mockSender } as any)
         expect(mockOnLeaveNotice).toHaveBeenCalledTimes(1)

--- a/packages/trackerless-network/test/unit/StreamPartIDDataKey.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartIDDataKey.test.ts
@@ -1,5 +1,5 @@
 import { StreamPartIDUtils } from '@streamr/protocol'
-import { streamPartIdToDataKey } from '../../src/logic/EntryPointDiscovery'
+import { streamPartIdToDataKey } from '../../src/logic/KnownNodesManager'
 
 describe('StreamPartIDtoDataKey', () => {
 

--- a/packages/trackerless-network/test/unit/StreamPartReconnect.test.ts
+++ b/packages/trackerless-network/test/unit/StreamPartReconnect.test.ts
@@ -1,19 +1,19 @@
-import { EntryPointDiscovery } from '../../src/logic/EntryPointDiscovery'
+import { KnownNodesManager } from '../../src/logic/KnownNodesManager'
 import { StreamPartReconnect } from '../../src/logic/StreamPartReconnect'
 import { MockLayer1Node } from '../utils/mock/MockLayer1Node'
-import { createFakeEntryPointDiscovery } from '../utils/fake/FakeEntryPointDiscovery'
+import { createFakeKnownNodesManager } from '../utils/fake/FakeKnownNodesManager'
 import { waitForCondition } from '@streamr/utils'
 
 describe('StreamPartReconnect', () => {
 
-    let entryPointDiscovery: EntryPointDiscovery
+    let knownNodesManager: KnownNodesManager
     let layer1Node: MockLayer1Node
     let streamPartReconnect: StreamPartReconnect
 
     beforeEach(() => {
-        entryPointDiscovery = createFakeEntryPointDiscovery()
+        knownNodesManager = createFakeKnownNodesManager()
         layer1Node = new MockLayer1Node()
-        streamPartReconnect = new StreamPartReconnect(layer1Node, entryPointDiscovery)
+        streamPartReconnect = new StreamPartReconnect(layer1Node, knownNodesManager)
     })
 
     afterEach(() => {

--- a/packages/trackerless-network/test/utils/fake/FakeKnownNodesManager.ts
+++ b/packages/trackerless-network/test/utils/fake/FakeKnownNodesManager.ts
@@ -1,11 +1,11 @@
 import { PeerDescriptor } from '@streamr/dht'
-import { EntryPointDiscovery } from '../../../src/logic/EntryPointDiscovery'
+import { KnownNodesManager } from '../../../src/logic/KnownNodesManager'
 
-export const createFakeEntryPointDiscovery = (): EntryPointDiscovery => {
-    return new FakeEntryPointDiscovery() as unknown as EntryPointDiscovery
+export const createFakeKnownNodesManager = (): KnownNodesManager => {
+    return new FakeKnownNodesManager() as unknown as KnownNodesManager
 }
 
-class FakeEntryPointDiscovery {
+class FakeKnownNodesManager {
 
     private entryPoints: PeerDescriptor[] = []
 

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -60,7 +60,7 @@ export const createMockContentDeliveryLayerNodeAndDhtNode = async (
         connectionLocker: mockCm,
         localPeerDescriptor,
         rpcRequestTimeout: 5000,
-        isLocalNodeEntryPoint: () => false
+        isLocalNodeStored: () => false
     })
     return [layer1Node, contentDeliveryLayerNode]
 }


### PR DESCRIPTION
Rename
- `EntryPointDiscovery` -> `KnownNodesManager`

## TODO

Rename all _entryPoint_ phrases to _stored_ / _knownNodes_ in `trackerless-network` (unless it is talking about `layer0` entry point). Or _registered_ nodes?

## Future improvements

Remove `setStreamPartEntryPoints` method and add the list of known nodes as an optional parameter to join/leave methods.