### PR TITLE
refactor: rename dependency configs to `Options`

### DIFF
--- a/packages/dht/src/connection/ConnectionLockRpcRemote.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcRemote.ts
@@ -45,7 +45,7 @@ export class ConnectionLockRpcRemote extends RpcRemote<ConnectionLockRpcClient> 
         const options = this.formDhtRpcOptions({
             connect: false,
             sendIfStopped: true,
-            timeout: 2000  // TODO use config option or named constant?
+            timeout: 2000  // TODO use options option or named constant?
         })
         await this.getClient().gracefulDisconnect(request, options)
     }

--- a/packages/dht/src/connection/connectivityChecker.ts
+++ b/packages/dht/src/connection/connectivityChecker.ts
@@ -12,7 +12,7 @@ import { isMaybeSupportedVersion } from '../helpers/version'
 
 const logger = new Logger(module)
 
-// TODO use config option or named constant?
+// TODO use options option or named constant?
 export const connectAsync = async ({ url, allowSelfSignedCertificate, timeoutMs = 1000 }:
     { url: string, allowSelfSignedCertificate: boolean, timeoutMs?: number }
 ): Promise<IConnection> => {

--- a/packages/dht/src/connection/websocket/AutoCertifierClientFacade.ts
+++ b/packages/dht/src/connection/websocket/AutoCertifierClientFacade.ts
@@ -37,7 +37,7 @@ export interface IAutoCertifierClient {
     on(eventName: string, cb: (subdomain: CertifiedSubdomain) => void): void
 }
 
-interface AutoCertifierClientFacadeConfig {
+interface AutoCertifierClientFacadeOptions {
     url: string
     configFile: string
     transport: ITransport
@@ -55,24 +55,24 @@ export class AutoCertifierClientFacade {
 
     private autoCertifierClient: IAutoCertifierClient
     private readonly rpcCommunicator: ListeningRpcCommunicator
-    private readonly config: AutoCertifierClientFacadeConfig
+    private readonly options: AutoCertifierClientFacadeOptions
 
-    constructor(config: AutoCertifierClientFacadeConfig) {
-        this.config = config
-        this.rpcCommunicator = new ListeningRpcCommunicator(AUTO_CERTIFIER_SERVICE_ID, config.transport)
-        this.autoCertifierClient = config.createClientFactory ? config.createClientFactory() 
+    constructor(options: AutoCertifierClientFacadeOptions) {
+        this.options = options
+        this.rpcCommunicator = new ListeningRpcCommunicator(AUTO_CERTIFIER_SERVICE_ID, options.transport)
+        this.autoCertifierClient = options.createClientFactory ? options.createClientFactory() 
             : defaultAutoCertifierClientFactory(
-                config.configFile,
-                config.url,
+                options.configFile,
+                options.url,
                 this.rpcCommunicator,
-                config.wsServerPort
+                options.wsServerPort
             )
     }
 
     async start(): Promise<void> {
         this.autoCertifierClient.on('updatedCertificate', (subdomain: CertifiedSubdomain) => {
-            this.config.setHost(subdomain.fqdn)
-            this.config.updateCertificate(subdomain.certificate, subdomain.privateKey)
+            this.options.setHost(subdomain.fqdn)
+            this.options.updateCertificate(subdomain.certificate, subdomain.privateKey)
             logger.trace(`Updated certificate`)
         })
         await Promise.all([

--- a/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcLocal.ts
@@ -10,7 +10,7 @@ import { getNodeIdFromPeerDescriptor } from '../../identifiers'
 import { DhtAddress } from '../../identifiers'
 import { PendingConnection } from '../PendingConnection'
 
-interface WebsocketClientConnectorRpcLocalConfig {
+interface WebsocketClientConnectorRpcLocalOptions {
     connect: (targetPeerDescriptor: PeerDescriptor) => PendingConnection
     hasConnection: (nodeId: DhtAddress) => boolean
     onNewConnection: (connection: PendingConnection) => boolean
@@ -19,20 +19,20 @@ interface WebsocketClientConnectorRpcLocalConfig {
 
 export class WebsocketClientConnectorRpcLocal implements IWebsocketClientConnectorRpc {
 
-    private readonly config: WebsocketClientConnectorRpcLocalConfig
+    private readonly options: WebsocketClientConnectorRpcLocalOptions
 
-    constructor(config: WebsocketClientConnectorRpcLocalConfig) {
-        this.config = config
+    constructor(options: WebsocketClientConnectorRpcLocalOptions) {
+        this.options = options
     }
 
     public async requestConnection(_request: WebsocketConnectionRequest, context: ServerCallContext): Promise<Empty> {
-        if (this.config.abortSignal.aborted) {
+        if (this.options.abortSignal.aborted) {
             return {}
         }
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        if (!this.config.hasConnection(getNodeIdFromPeerDescriptor(senderPeerDescriptor))) {
-            const connection = this.config.connect(senderPeerDescriptor)
-            this.config.onNewConnection(connection)
+        if (!this.options.hasConnection(getNodeIdFromPeerDescriptor(senderPeerDescriptor))) {
+            const connection = this.options.connect(senderPeerDescriptor)
+            this.options.onNewConnection(connection)
         }
         return {}
     }

--- a/packages/dht/src/connection/websocket/WebsocketServer.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServer.ts
@@ -15,7 +15,7 @@ import { IConnection } from '../IConnection'
 
 const logger = new Logger(module)
 
-interface WebsocketServerConfig {
+interface WebsocketServerOptions {
     portRange: PortRange
     enableTls: boolean
     tlsCertificate?: TlsCertificate
@@ -31,18 +31,18 @@ export class WebsocketServer extends EventEmitter<Events> {
     private httpServer?: HttpServer | HttpsServer
     private wsServer?: WebSocket.Server
     private readonly abortController = new AbortController()
-    private readonly config: WebsocketServerConfig
+    private readonly options: WebsocketServerOptions
 
-    constructor(config: WebsocketServerConfig) {
+    constructor(options: WebsocketServerOptions) {
         super()
-        this.config = config
+        this.options = options
     }
 
     public async start(): Promise<number> {
-        const ports = range(this.config.portRange.min, this.config.portRange.max + 1)
+        const ports = range(this.options.portRange.min, this.options.portRange.max + 1)
         for (const port of ports) {
             try {
-                await asAbortable(this.startServer(port, this.config.enableTls), this.abortController.signal)
+                await asAbortable(this.startServer(port, this.options.enableTls), this.abortController.signal)
                 return port
             } catch (err) {
                 if (err.originalError?.code === 'EADDRINUSE') {
@@ -53,7 +53,7 @@ export class WebsocketServer extends EventEmitter<Events> {
             }
         }
         throw new WebsocketServerStartError(
-            `Failed to start WebSocket server on any port in range: ${this.config.portRange.min}-${this.config.portRange.min}`
+            `Failed to start WebSocket server on any port in range: ${this.options.portRange.min}-${this.options.portRange.min}`
         )
     }
 
@@ -66,15 +66,15 @@ export class WebsocketServer extends EventEmitter<Events> {
             response.end()
         }
         return new Promise((resolve, reject) => {
-            if (this.config.tlsCertificate) {
+            if (this.options.tlsCertificate) {
                 this.httpServer = createHttpsServer({
-                    key: fs.readFileSync(this.config.tlsCertificate.privateKeyFileName),
-                    cert: fs.readFileSync(this.config.tlsCertificate.certFileName)
+                    key: fs.readFileSync(this.options.tlsCertificate.privateKeyFileName),
+                    cert: fs.readFileSync(this.options.tlsCertificate.certFileName)
                 }, requestListener)
             } else if (!tls) {
                 this.httpServer = createHttpServer(requestListener)
             } else {
-                // TODO use config option or named constant?
+                // TODO use options option or named constant?
                 const certificate = createSelfSignedCertificate('streamr-self-signed-' + uuid(), 1000)
                 this.httpServer = createHttpsServer({
                     key: certificate.serverKey,
@@ -155,7 +155,7 @@ export class WebsocketServer extends EventEmitter<Events> {
     }
 
     private createWsServer(): WebSocket.Server {
-        const maxPayload = this.config.maxMessageSize ?? 1048576
+        const maxPayload = this.options.maxMessageSize ?? 1048576
         return this.wsServer = new WebSocket.Server({
             noServer: true,
             maxPayload

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -11,7 +11,7 @@ import { sample } from 'lodash'
 import { MarkRequired } from 'ts-essentials'
 import { ConnectionLocker, ConnectionManager, PortRange, TlsCertificate } from '../connection/ConnectionManager'
 import { ConnectionsView } from '../connection/ConnectionsView'
-import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../connection/ConnectorFacade'
+import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../connection/ConnectorFacade'
 import { IceServer } from '../connection/webrtc/WebrtcConnector'
 import { isBrowserEnvironment } from '../helpers/browser/isBrowserEnvironment'
 import { createPeerDescriptor } from '../helpers/createPeerDescriptor'
@@ -132,7 +132,7 @@ export type Events = TransportEvents & DhtNodeEvents
 
 export class DhtNode extends EventEmitter<Events> implements ITransport {
 
-    private readonly config: StrictDhtNodeOptions
+    private readonly options: StrictDhtNodeOptions
     private rpcCommunicator?: RoutingRpcCommunicator
     private transport?: ITransport
     private localPeerDescriptor?: PeerDescriptor
@@ -149,7 +149,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     constructor(conf: DhtNodeOptions) {
         super()
-        this.config = merge({
+        this.options = merge({
             serviceId: CONTROL_LAYER_NODE_SERVICE_ID,
             joinParallelism: 3,
             maxContactCount: 200,
@@ -164,26 +164,26 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             storageRedundancyFactor: 5, // TODO validate that this is > 1 (as each node should replicate the data to other node)
             metricsContext: new MetricsContext()
         }, conf)
-        this.validateConfig()
-        this.localDataStore = new LocalDataStore(this.config.storeMaxTtl)
+        this.validateOptions()
+        this.localDataStore = new LocalDataStore(this.options.storeMaxTtl)
         this.send = this.send.bind(this)
     }
 
-    private validateConfig(): void {
+    private validateOptions(): void {
         const expectedNodeIdLength = KADEMLIA_ID_LENGTH_IN_BYTES * 2
-        if (this.config.nodeId !== undefined) {
-            if (!/^[0-9a-fA-F]+$/.test(this.config.nodeId)) {
+        if (this.options.nodeId !== undefined) {
+            if (!/^[0-9a-fA-F]+$/.test(this.options.nodeId)) {
                 throw new Error('Invalid nodeId, the nodeId should be a hex string')
-            } else if (this.config.nodeId.length !== expectedNodeIdLength) {
+            } else if (this.options.nodeId.length !== expectedNodeIdLength) {
                 throw new Error(`Invalid nodeId, the length of the nodeId should be ${expectedNodeIdLength}`)
             }
         }
-        if (this.config.peerDescriptor !== undefined) {
-            if (this.config.peerDescriptor.nodeId.length !== KADEMLIA_ID_LENGTH_IN_BYTES) {
+        if (this.options.peerDescriptor !== undefined) {
+            if (this.options.peerDescriptor.nodeId.length !== KADEMLIA_ID_LENGTH_IN_BYTES) {
                 throw new Error(`Invalid peerDescriptor, the length of the nodeId should be ${KADEMLIA_ID_LENGTH_IN_BYTES} bytes`)
             }
         }
-        if (this.config.transport !== undefined && this.config.connectionsView === undefined) {
+        if (this.options.transport !== undefined && this.options.connectionsView === undefined) {
             throw new Error('connectionsView is required when transport is given')
         }
     }
@@ -192,57 +192,57 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         if (this.started || this.abortController.signal.aborted) {
             return
         }
-        logger.trace(`Starting new Streamr Network DHT Node with serviceId ${this.config.serviceId}`)
+        logger.trace(`Starting new Streamr Network DHT Node with serviceId ${this.options.serviceId}`)
         this.started = true
 
         if (isBrowserEnvironment()) {
-            this.config.websocketPortRange = undefined
-            if (this.config.peerDescriptor) {
-                this.config.peerDescriptor.websocket = undefined
+            this.options.websocketPortRange = undefined
+            if (this.options.peerDescriptor) {
+                this.options.peerDescriptor.websocket = undefined
             }
         } 
           
         // If transport is given, do not create a ConnectionManager
-        if (this.config.transport) {
-            this.transport = this.config.transport
-            this.connectionsView = this.config.connectionsView
-            this.connectionLocker = this.config.connectionLocker
+        if (this.options.transport) {
+            this.transport = this.options.transport
+            this.connectionsView = this.options.connectionsView
+            this.connectionLocker = this.options.connectionLocker
             this.localPeerDescriptor = this.transport.getLocalPeerDescriptor()
         } else {
-            const connectorFacadeConfig: DefaultConnectorFacadeConfig = {
+            const connectorFacadeOptions: DefaultConnectorFacadeOptions = {
                 transport: this,
-                entryPoints: this.config.entryPoints,
-                iceServers: this.config.iceServers,
-                webrtcAllowPrivateAddresses: this.config.webrtcAllowPrivateAddresses,
-                webrtcDatachannelBufferThresholdLow: this.config.webrtcDatachannelBufferThresholdLow,
-                webrtcDatachannelBufferThresholdHigh: this.config.webrtcDatachannelBufferThresholdHigh,
-                webrtcPortRange: this.config.webrtcPortRange,
-                maxMessageSize: this.config.maxMessageSize,
-                websocketServerEnableTls: this.config.websocketServerEnableTls,
-                tlsCertificate: this.config.tlsCertificate,
-                externalIp: this.config.externalIp,
-                autoCertifierUrl: this.config.autoCertifierUrl,
-                autoCertifierConfigFile: this.config.autoCertifierConfigFile,
-                geoIpDatabaseFolder: this.config.geoIpDatabaseFolder,
+                entryPoints: this.options.entryPoints,
+                iceServers: this.options.iceServers,
+                webrtcAllowPrivateAddresses: this.options.webrtcAllowPrivateAddresses,
+                webrtcDatachannelBufferThresholdLow: this.options.webrtcDatachannelBufferThresholdLow,
+                webrtcDatachannelBufferThresholdHigh: this.options.webrtcDatachannelBufferThresholdHigh,
+                webrtcPortRange: this.options.webrtcPortRange,
+                maxMessageSize: this.options.maxMessageSize,
+                websocketServerEnableTls: this.options.websocketServerEnableTls,
+                tlsCertificate: this.options.tlsCertificate,
+                externalIp: this.options.externalIp,
+                autoCertifierUrl: this.options.autoCertifierUrl,
+                autoCertifierConfigFile: this.options.autoCertifierConfigFile,
+                geoIpDatabaseFolder: this.options.geoIpDatabaseFolder,
                 createLocalPeerDescriptor: (connectivityResponse: ConnectivityResponse) => this.generatePeerDescriptorCallBack(connectivityResponse)
             }
-            // If own PeerDescriptor is given in config, create a ConnectionManager with ws server
-            if (this.config.peerDescriptor?.websocket) {
-                connectorFacadeConfig.websocketHost = this.config.peerDescriptor.websocket.host
-                connectorFacadeConfig.websocketPortRange = {
-                    min: this.config.peerDescriptor.websocket.port,
-                    max: this.config.peerDescriptor.websocket.port
+            // If own PeerDescriptor is given in options, create a ConnectionManager with ws server
+            if (this.options.peerDescriptor?.websocket) {
+                connectorFacadeOptions.websocketHost = this.options.peerDescriptor.websocket.host
+                connectorFacadeOptions.websocketPortRange = {
+                    min: this.options.peerDescriptor.websocket.port,
+                    max: this.options.peerDescriptor.websocket.port
                 }
                 // If websocketPortRange is given, create ws server using it, websocketHost can be undefined
-            } else if (this.config.websocketPortRange) {
-                connectorFacadeConfig.websocketHost = this.config.websocketHost
-                connectorFacadeConfig.websocketPortRange = this.config.websocketPortRange
+            } else if (this.options.websocketPortRange) {
+                connectorFacadeOptions.websocketHost = this.options.websocketHost
+                connectorFacadeOptions.websocketPortRange = this.options.websocketPortRange
             }
 
             const connectionManager = new ConnectionManager({
-                createConnectorFacade: () => new DefaultConnectorFacade(connectorFacadeConfig),
-                maxConnections: this.config.maxConnections,
-                metricsContext: this.config.metricsContext
+                createConnectorFacade: () => new DefaultConnectorFacade(connectorFacadeOptions),
+                maxConnections: this.options.maxConnections,
+                metricsContext: this.options.metricsContext
             })
             await connectionManager.start()
             this.connectionsView = connectionManager
@@ -251,9 +251,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         }
 
         this.rpcCommunicator = new RoutingRpcCommunicator(
-            this.config.serviceId,
+            this.options.serviceId,
             (msg, opts) => this.transport!.send(msg, opts),
-            { rpcRequestTimeout: this.config.rpcRequestTimeout }
+            { rpcRequestTimeout: this.options.rpcRequestTimeout }
         )
 
         this.transport.on('message', (message: Message) => this.handleMessageFromTransport(message))
@@ -262,10 +262,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
         this.peerDiscovery = new PeerDiscovery({
             localPeerDescriptor: this.localPeerDescriptor!,
-            joinNoProgressLimit: this.config.joinNoProgressLimit,
-            joinTimeout: this.config.dhtJoinTimeout,
-            serviceId: this.config.serviceId,
-            parallelism: this.config.joinParallelism,
+            joinNoProgressLimit: this.options.joinNoProgressLimit,
+            joinTimeout: this.options.dhtJoinTimeout,
+            serviceId: this.options.serviceId,
+            parallelism: this.options.joinParallelism,
             connectionLocker: this.connectionLocker,
             peerManager: this.peerManager!,
             abortSignal: this.abortController.signal,
@@ -283,7 +283,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             sessionTransport: this,
             connectionsView: this.connectionsView!,
             localPeerDescriptor: this.localPeerDescriptor!,
-            serviceId: this.config.serviceId,
+            serviceId: this.options.serviceId,
             localDataStore: this.localDataStore,
             addContact: (contact: PeerDescriptor) => this.peerManager!.addContact(contact),
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
@@ -292,9 +292,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             rpcCommunicator: this.rpcCommunicator,
             recursiveOperationManager: this.recursiveOperationManager,
             localPeerDescriptor: this.localPeerDescriptor!,
-            serviceId: this.config.serviceId,
-            highestTtl: this.config.storeHighestTtl,
-            redundancyFactor: this.config.storageRedundancyFactor,
+            serviceId: this.options.serviceId,
+            highestTtl: this.options.storeHighestTtl,
+            redundancyFactor: this.options.storageRedundancyFactor,
             localDataStore: this.localDataStore,
             getNeighbors: () => this.peerManager!.getNeighbors().map((n) => n.getPeerDescriptor()),
             createRpcRemote: (contact: PeerDescriptor) => {
@@ -303,7 +303,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                     contact,
                     this.rpcCommunicator!,
                     StoreRpcClient,
-                    this.config.rpcRequestTimeout
+                    this.options.rpcRequestTimeout
                 )
             }
         })
@@ -313,10 +313,10 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.bindRpcLocalMethods()
 
         const pruneTargets = []
-        if (this.config.periodicallyPingNeighbors === true) {
+        if (this.options.periodicallyPingNeighbors === true) {
             pruneTargets.push(() => this.peerManager!.getNeighbors().map((node) => this.createDhtNodeRpcRemote(node.getPeerDescriptor())))
         }
-        if (this.config.periodicallyPingRingContacts === true) {
+        if (this.options.periodicallyPingRingContacts === true) {
             pruneTargets.push(() => this.peerManager!.getRingContacts().getAllContacts())
         }
         for (const pruneTarget of pruneTargets) {
@@ -331,12 +331,12 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     private initPeerManager() {
         this.peerManager = new PeerManager({
-            numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
-            maxContactCount: this.config.maxContactCount,
+            numberOfNodesPerKBucket: this.options.numberOfNodesPerKBucket,
+            maxContactCount: this.options.maxContactCount,
             localNodeId: this.getNodeId(),
             localPeerDescriptor: this.localPeerDescriptor!,
             connectionLocker: this.connectionLocker,
-            lockId: this.config.serviceId,
+            lockId: this.options.serviceId,
             createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => this.createDhtNodeRpcRemote(peerDescriptor),
             hasConnection: (nodeId: DhtAddress) => this.connectionsView!.hasConnection(nodeId)
         })
@@ -360,12 +360,12 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         })
         this.peerManager.on('kBucketEmpty', () => {
             if (!this.peerDiscovery!.isJoinOngoing()) {
-                if (this.config.entryPoints && this.config.entryPoints.length > 0) {
+                if (this.options.entryPoints && this.options.entryPoints.length > 0) {
                     setImmediate(async () => {
                         const contactedPeers = new Set<DhtAddress>()
                         const distantJoinContactPeers = new Set<DhtAddress>()
                         // TODO should we catch possible promise rejection?
-                        await Promise.all(this.config.entryPoints!.map((entryPoint) =>
+                        await Promise.all(this.options.entryPoints!.map((entryPoint) =>
                             this.peerDiscovery!.rejoinDht(entryPoint, contactedPeers, distantJoinContactPeers)
                         ))
                     })
@@ -398,7 +398,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             return
         }
         const dhtNodeRpcLocal = new DhtNodeRpcLocal({
-            peerDiscoveryQueryBatchSize: this.config.peerDiscoveryQueryBatchSize,
+            peerDiscoveryQueryBatchSize: this.options.peerDiscoveryQueryBatchSize,
             getNeighbors: () => this.peerManager!.getNeighbors().map((n) => n.getPeerDescriptor()),
             getClosestRingContactsTo: (ringIdRaw: RingIdRaw, limit: number) => {
                 return this.getClosestRingContactsTo(ringIdRaw, limit)
@@ -425,25 +425,25 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             ExternalFetchDataResponse,
             'externalFetchData',
             (req: ExternalFetchDataRequest, context: ServerCallContext) => externalApiRpcLocal.externalFetchData(req, context),
-            { timeout: 10000 }  // TODO use config option or named constant?
+            { timeout: 10000 }  // TODO use options option or named constant?
         )
         this.rpcCommunicator!.registerRpcMethod(
             ExternalStoreDataRequest,
             ExternalStoreDataResponse,
             'externalStoreData',
             (req: ExternalStoreDataRequest, context: ServerCallContext) => externalApiRpcLocal.externalStoreData(req, context),
-            { timeout: 10000 }  // TODO use config option or named constant?
+            { timeout: 10000 }  // TODO use options option or named constant?
         )
     }
 
     private handleMessageFromTransport(message: Message): void {
-        if (message.serviceId === this.config.serviceId) {
+        if (message.serviceId === this.options.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } 
     }
     
     private handleMessageFromRouter(message: Message): void {
-        if (message.serviceId === this.config.serviceId) {
+        if (message.serviceId === this.options.serviceId) {
             this.rpcCommunicator?.handleMessageFromPeer(message)
         } else {
             this.emit('message', message)
@@ -451,13 +451,13 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     private async generatePeerDescriptorCallBack(connectivityResponse: ConnectivityResponse) {
-        if (this.config.peerDescriptor !== undefined) {
-            this.localPeerDescriptor = this.config.peerDescriptor
+        if (this.options.peerDescriptor !== undefined) {
+            this.localPeerDescriptor = this.options.peerDescriptor
         } else {
             let region: number | undefined = undefined
-            if (this.config.region !== undefined) {
-                region = this.config.region
-                logger.debug(`Using region ${region} from config when generating local PeerDescriptor`)
+            if (this.options.region !== undefined) {
+                region = this.options.region
+                logger.debug(`Using region ${region} from options when generating local PeerDescriptor`)
             } else if (connectivityResponse.latitude !== undefined && connectivityResponse.longitude !== undefined) {
                 region = getLocalRegionByCoordinates(connectivityResponse.latitude, connectivityResponse.longitude)
                 logger.debug(`Using region ${region} from GeoIP when generating local PeerDescriptor`)
@@ -468,7 +468,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 logger.debug(`Using region ${region} from CDN when generating local PeerDescriptor`)
             }
             
-            this.localPeerDescriptor = createPeerDescriptor(connectivityResponse, region, this.config.nodeId)
+            this.localPeerDescriptor = createPeerDescriptor(connectivityResponse, region, this.options.nodeId)
         }
         return this.localPeerDescriptor
     }
@@ -523,7 +523,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     private getConnectedEntryPoints(): PeerDescriptor[] {
-        return this.config.entryPoints !== undefined ? this.config.entryPoints.filter((entryPoint) =>
+        return this.options.entryPoints !== undefined ? this.options.entryPoints.filter((entryPoint) =>
             this.connectionsView!.hasConnection(getNodeIdFromPeerDescriptor(entryPoint))
         ) : []
     }
@@ -621,7 +621,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     public async waitForNetworkConnectivity(): Promise<void> {
         await waitForCondition(
             () => this.connectionsView!.getConnectionCount() > 0,
-            this.config.networkConnectivityTimeout,
+            this.options.networkConnectivityTimeout,
             100,
             this.abortController.signal
         )
@@ -643,8 +643,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.rpcCommunicator!.stop()
         this.router!.stop()
         this.recursiveOperationManager!.stop()
-        if (this.config.transport === undefined) {
-            // if the transport was not given in config, the instance was created in start() and
+        if (this.options.transport === undefined) {
+            // if the transport was not given in options, the instance was created in start() and
             // this component is responsible for stopping it
             await this.transport!.stop()
         }
@@ -657,9 +657,9 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return new DhtNodeRpcRemote(
             this.localPeerDescriptor!,
             peerDescriptor,
-            this.config.serviceId,
+            this.options.serviceId,
             this.rpcCommunicator!,
-            this.config.rpcRequestTimeout
+            this.options.rpcRequestTimeout
         )
     }
 }

--- a/packages/dht/src/dht/ExternalApiRpcLocal.ts
+++ b/packages/dht/src/dht/ExternalApiRpcLocal.ts
@@ -14,7 +14,7 @@ import { Any } from '../proto/google/protobuf/any'
 import { DhtAddress, getNodeIdFromPeerDescriptor } from '../identifiers'
 import { getDhtAddressFromRaw } from '../identifiers'
 
-interface ExternalApiRpcLocalConfig {
+interface ExternalApiRpcLocalOptions {
     executeRecursiveOperation: (
         targetId: DhtAddress,
         operation: RecursiveOperation,
@@ -29,15 +29,15 @@ interface ExternalApiRpcLocalConfig {
 
 export class ExternalApiRpcLocal implements IExternalApiRpc {
 
-    private readonly config: ExternalApiRpcLocalConfig
+    private readonly options: ExternalApiRpcLocalOptions
 
-    constructor(config: ExternalApiRpcLocalConfig) {
-        this.config = config
+    constructor(options: ExternalApiRpcLocalOptions) {
+        this.options = options
     }
 
     async externalFetchData(request: ExternalFetchDataRequest, context: ServerCallContext): Promise<ExternalFetchDataResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const result = await this.config.executeRecursiveOperation(
+        const result = await this.options.executeRecursiveOperation(
             getDhtAddressFromRaw(request.key),
             RecursiveOperation.FETCH_DATA,
             getNodeIdFromPeerDescriptor(senderPeerDescriptor)
@@ -47,7 +47,7 @@ export class ExternalApiRpcLocal implements IExternalApiRpc {
 
     async externalStoreData(request: ExternalStoreDataRequest, context: ServerCallContext): Promise<ExternalStoreDataResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const result = await this.config.storeDataToDht(
+        const result = await this.options.storeDataToDht(
             getDhtAddressFromRaw(request.key),
             request.data!,
             getNodeIdFromPeerDescriptor(senderPeerDescriptor)

--- a/packages/dht/src/dht/ExternalApiRpcRemote.ts
+++ b/packages/dht/src/dht/ExternalApiRpcRemote.ts
@@ -11,7 +11,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
             key: getRawFromDhtAddress(key)
         }
         const options = this.formDhtRpcOptions({
-            // TODO use config option or named constant?
+            // TODO use options option or named constant?
             timeout: 10000
         })
         try {
@@ -28,7 +28,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
             data
         }
         const options = this.formDhtRpcOptions({
-            // TODO use config option or named constant?
+            // TODO use options option or named constant?
             timeout: 10000
         })
         try {

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -17,7 +17,7 @@ import { RingIdRaw, getRingIdRawFromPeerDescriptor } from './contact/ringIdentif
 
 const logger = new Logger(module)
 
-interface PeerManagerConfig {
+interface PeerManagerOptions {
     numberOfNodesPerKBucket: number
     maxContactCount: number
     localNodeId: DhtAddress
@@ -71,17 +71,17 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     private ringContacts: RingContactList<DhtNodeRpcRemote>
     private randomContacts: RandomContactList<DhtNodeRpcRemote>
     private stopped: boolean = false
-    private readonly config: PeerManagerConfig
+    private readonly options: PeerManagerOptions
 
-    constructor(config: PeerManagerConfig) {
+    constructor(options: PeerManagerOptions) {
         super()
-        this.config = config
+        this.options = options
         this.neighbors = new KBucket<DhtNodeRpcRemote>({
-            localNodeId: getRawFromDhtAddress(this.config.localNodeId),
-            numberOfNodesPerKBucket: this.config.numberOfNodesPerKBucket,
-            numberOfNodesToPing: this.config.numberOfNodesPerKBucket
+            localNodeId: getRawFromDhtAddress(this.options.localNodeId),
+            numberOfNodesPerKBucket: this.options.numberOfNodesPerKBucket,
+            numberOfNodesToPing: this.options.numberOfNodesPerKBucket
         })
-        this.ringContacts = new RingContactList<DhtNodeRpcRemote>(getRingIdRawFromPeerDescriptor(this.config.localPeerDescriptor))
+        this.ringContacts = new RingContactList<DhtNodeRpcRemote>(getRingIdRawFromPeerDescriptor(this.options.localPeerDescriptor))
         this.ringContacts.on('contactAdded', (contact: DhtNodeRpcRemote) => {
             this.emit('ringContactAdded', contact.getPeerDescriptor())
         })
@@ -95,8 +95,8 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             // TODO: Update contact info to the connection manager and reconnect
         })
         this.nearbyContacts = new SortedContactList({
-            referenceId: this.config.localNodeId,
-            maxSize: this.config.maxContactCount,
+            referenceId: this.options.localNodeId,
+            maxSize: this.options.maxContactCount,
             allowToContainReferenceId: false
         })
         this.nearbyContacts.on('contactRemoved', (contact: DhtNodeRpcRemote) => {
@@ -104,13 +104,13 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
                 return
             }
             this.emit('nearbyContactRemoved', contact.getPeerDescriptor())
-            this.randomContacts.addContact(this.config.createDhtNodeRpcRemote(contact.getPeerDescriptor()))
+            this.randomContacts.addContact(this.options.createDhtNodeRpcRemote(contact.getPeerDescriptor()))
         })
         this.nearbyContacts.on('contactAdded', (contact: DhtNodeRpcRemote) =>
             this.emit('nearbyContactAdded', contact.getPeerDescriptor())
         )
         this.activeContacts = new Set()
-        this.randomContacts = new RandomContactList(this.config.localNodeId, this.config.maxContactCount)
+        this.randomContacts = new RandomContactList(this.options.localNodeId, this.options.maxContactCount)
         this.randomContacts.on('contactRemoved', (removedContact: DhtNodeRpcRemote) =>
             this.emit('randomContactRemoved', removedContact.getPeerDescriptor())
         )
@@ -124,12 +124,12 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         const sortingList: SortedContactList<DhtNodeRpcRemote> = new SortedContactList({
-            referenceId: this.config.localNodeId,
+            referenceId: this.options.localNodeId,
             allowToContainReferenceId: false
         })
         sortingList.addContacts(oldContacts)
         const removableNodeId = sortingList.getFurthestContacts(1)[0].getNodeId()
-        this.config.connectionLocker?.weakUnlockConnection(removableNodeId, this.config.lockId)
+        this.options.connectionLocker?.weakUnlockConnection(removableNodeId, this.options.lockId)
         this.neighbors.remove(getRawFromDhtAddress(removableNodeId))
         this.neighbors.add(newContact)
     }
@@ -138,7 +138,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         if (this.stopped) {
             return
         }
-        this.config.connectionLocker?.weakUnlockConnection(nodeId, this.config.lockId)
+        this.options.connectionLocker?.weakUnlockConnection(nodeId, this.options.lockId)
         logger.trace(`Removed contact ${nodeId}`)
         if (this.neighbors.count() === 0) {
             this.emit('kBucketEmpty')
@@ -149,12 +149,12 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         if (this.stopped) {
             return
         }
-        if (contact.getNodeId() !== this.config.localNodeId) {
+        if (contact.getNodeId() !== this.options.localNodeId) {
             const peerDescriptor = contact.getPeerDescriptor()
             const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
             // Important to lock here, before the ping result is known
-            this.config.connectionLocker?.weakLockConnection(nodeId, this.config.lockId)
-            if (this.config.hasConnection(contact.getNodeId())) {
+            this.options.connectionLocker?.weakLockConnection(nodeId, this.options.lockId)
+            if (this.options.hasConnection(contact.getNodeId())) {
                 logger.trace(`Added new contact ${nodeId}`)
             } else {    // open connection by pinging
                 logger.trace('starting ping ' + nodeId)
@@ -163,12 +163,12 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
                         logger.trace(`Added new contact ${nodeId}`)
                     } else {
                         logger.trace('ping failed ' + nodeId)
-                        this.config.connectionLocker?.weakUnlockConnection(nodeId, this.config.lockId)
+                        this.options.connectionLocker?.weakUnlockConnection(nodeId, this.options.lockId)
                         this.removeContact(nodeId)
                         this.addNearbyContactToNeighbors()
                     }
                 }).catch((_e) => {
-                    this.config.connectionLocker?.weakUnlockConnection(nodeId, this.config.lockId)
+                    this.options.connectionLocker?.weakUnlockConnection(nodeId, this.options.lockId)
                     this.removeContact(nodeId)
                     this.addNearbyContactToNeighbors()
                 })
@@ -246,7 +246,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
     ): { left: DhtNodeRpcRemote[], right: DhtNodeRpcRemote[] } {
         const closest = new RingContactList<DhtNodeRpcRemote>(ringIdRaw, excludedIds)
         this.ringContacts.getAllContacts().map((contact) => closest.addContact(contact))
-        // TODO use config option or named constant?
+        // TODO use options option or named constant?
         return closest.getClosestContacts(limit ?? 8)
     }
     
@@ -279,9 +279,9 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
             return
         }
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
-        if (nodeId !== this.config.localNodeId) {
+        if (nodeId !== this.options.localNodeId) {
             logger.trace(`Adding new contact ${nodeId}`)
-            const remote = this.config.createDhtNodeRpcRemote(peerDescriptor)
+            const remote = this.options.createDhtNodeRpcRemote(peerDescriptor)
             const isInNeighbors = (this.neighbors.get(peerDescriptor.nodeId) !== null)
             const isInNearbyContacts = (this.nearbyContacts.getContact(nodeId) !== undefined)
             const isInRingContacts = this.ringContacts.getContact(peerDescriptor) !== undefined

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -8,7 +8,7 @@ import { getClosestNodes } from '../contact/getClosestNodes'
 
 const logger = new Logger(module)
 
-interface DiscoverySessionConfig {
+interface DiscoverySessionOptions {
     targetId: DhtAddress
     parallelism: number
     noProgressLimit: number
@@ -25,31 +25,31 @@ export class DiscoverySession {
     private noProgressCounter = 0
     private ongoingRequests: Set<DhtAddress> = new Set()
     private doneGate = new Gate(false)
-    private readonly config: DiscoverySessionConfig
+    private readonly options: DiscoverySessionOptions
 
-    constructor(config: DiscoverySessionConfig) {
-        this.config = config
+    constructor(options: DiscoverySessionOptions) {
+        this.options = options
     }
 
     private addContacts(contacts: PeerDescriptor[]): void {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return
         }
         for (const contact of contacts) {
-            this.config.peerManager.addContact(contact)
+            this.options.peerManager.addContact(contact)
         }
     }
 
     private async fetchClosestNeighborsFromRemote(peerDescriptor: PeerDescriptor): Promise<PeerDescriptor[]> {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return []
         }
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
         logger.trace(`Getting closest neighbors from remote: ${nodeId}`)
-        this.config.contactedPeers.add(nodeId)
-        const remote = this.config.createDhtNodeRpcRemote(peerDescriptor)
-        const returnedContacts = await remote.getClosestPeers(this.config.targetId)
-        this.config.peerManager.setContactActive(nodeId)
+        this.options.contactedPeers.add(nodeId)
+        const remote = this.options.createDhtNodeRpcRemote(peerDescriptor)
+        const returnedContacts = await remote.getClosestPeers(this.options.targetId)
+        this.options.peerManager.setContactActive(nodeId)
         return returnedContacts
     }
 
@@ -58,7 +58,7 @@ export class DiscoverySession {
             return
         }
         this.ongoingRequests.delete(nodeId)
-        const targetId = getRawFromDhtAddress(this.config.targetId)
+        const targetId = getRawFromDhtAddress(this.options.targetId)
         const oldClosestNeighbor = this.getClosestNeighbor()
         const oldClosestDistance = getDistance(targetId, oldClosestNeighbor.nodeId)
         this.addContacts(contacts)
@@ -71,8 +71,8 @@ export class DiscoverySession {
 
     private getClosestNeighbor(): PeerDescriptor {
         return getClosestNodes(
-            this.config.targetId,
-            this.config.peerManager.getNeighbors().map((n) => n.getPeerDescriptor()),
+            this.options.targetId,
+            this.options.peerManager.getNeighbors().map((n) => n.getPeerDescriptor()),
             { maxCount: 1 }
         )[0]
     }
@@ -82,27 +82,27 @@ export class DiscoverySession {
             return
         }
         this.ongoingRequests.delete(nodeId)
-        this.config.peerManager.removeContact(nodeId)
+        this.options.peerManager.removeContact(nodeId)
     }
 
     private findMoreContacts(): void {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return
         }
         const uncontacted = getClosestNodes(
-            this.config.targetId,
-            Array.from(this.config.peerManager.getNearbyContacts().getAllContactsInUndefinedOrder(), (c) => c.getPeerDescriptor()), 
+            this.options.targetId,
+            Array.from(this.options.peerManager.getNearbyContacts().getAllContactsInUndefinedOrder(), (c) => c.getPeerDescriptor()), 
             {
-                maxCount: this.config.parallelism,
-                excludedNodeIds: this.config.contactedPeers
+                maxCount: this.options.parallelism,
+                excludedNodeIds: this.options.contactedPeers
             }
         )
-        if ((uncontacted.length === 0 && this.ongoingRequests.size === 0) || (this.noProgressCounter >= this.config.noProgressLimit)) {
+        if ((uncontacted.length === 0 && this.ongoingRequests.size === 0) || (this.noProgressCounter >= this.options.noProgressLimit)) {
             this.doneGate.open()
             return
         }
         for (const node of uncontacted) {
-            if (this.ongoingRequests.size >= this.config.parallelism) {
+            if (this.ongoingRequests.size >= this.options.parallelism) {
                 break
             }
             const nodeId = getNodeIdFromPeerDescriptor(node)
@@ -118,12 +118,12 @@ export class DiscoverySession {
     }
 
     public async findClosestNodes(timeout: number): Promise<void> {
-        if (this.config.peerManager.getNearbyContactCount(this.config.contactedPeers) === 0) {
+        if (this.options.peerManager.getNearbyContactCount(this.options.contactedPeers) === 0) {
             return
         }
         setImmediate(() => {
             this.findMoreContacts()
         })
-        await withTimeout(this.doneGate.waitUntilOpen(), timeout, 'discovery session timed out', this.config.abortSignal)
+        await withTimeout(this.doneGate.waitUntilOpen(), timeout, 'discovery session timed out', this.options.abortSignal)
     }
 }

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -18,7 +18,7 @@ import { DiscoverySession } from './DiscoverySession'
 import { RingDiscoverySession } from './RingDiscoverySession'
 import { CONTROL_LAYER_NODE_SERVICE_ID } from '../DhtNode'
 
-interface PeerDiscoveryConfig {
+interface PeerDiscoveryOptions {
     localPeerDescriptor: PeerDescriptor
     joinNoProgressLimit: number
     serviceId: ServiceID
@@ -46,10 +46,10 @@ export class PeerDiscovery {
     private rejoinOngoing = false
     private joinCalled = false
     private recoveryIntervalStarted = false
-    private readonly config: PeerDiscoveryConfig
+    private readonly options: PeerDiscoveryOptions
 
-    constructor(config: PeerDiscoveryConfig) {
-        this.config = config
+    constructor(options: PeerDiscoveryOptions) {
+        this.options = options
     }
 
     async joinDht(
@@ -58,12 +58,12 @@ export class PeerDiscovery {
         retry = true
     ): Promise<void> {
         const contactedPeers = new Set<DhtAddress>()
-        const distantJoinConfig = doAdditionalDistantPeerDiscovery 
+        const distantJoinOptions = doAdditionalDistantPeerDiscovery 
             ? { enabled: true, contactedPeers: new Set<DhtAddress>() } : { enabled: false } as const
         await Promise.all(entryPoints.map((entryPoint) => this.joinThroughEntryPoint(
             entryPoint,
             contactedPeers,
-            distantJoinConfig,
+            distantJoinOptions,
             retry
         )))
     }
@@ -80,40 +80,40 @@ export class PeerDiscovery {
         }
         this.joinCalled = true
         logger.debug(
-            `Joining ${this.config.serviceId === CONTROL_LAYER_NODE_SERVICE_ID
-                ? 'The Streamr Network' : `Control Layer for ${this.config.serviceId}`}`
+            `Joining ${this.options.serviceId === CONTROL_LAYER_NODE_SERVICE_ID
+                ? 'The Streamr Network' : `Control Layer for ${this.options.serviceId}`}`
             + ` via entrypoint ${getNodeIdFromPeerDescriptor(entryPointDescriptor)}`
         )
-        if (areEqualPeerDescriptors(entryPointDescriptor, this.config.localPeerDescriptor)) {
+        if (areEqualPeerDescriptors(entryPointDescriptor, this.options.localPeerDescriptor)) {
             return
         }
-        this.config.connectionLocker?.lockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
-        this.config.peerManager.addContact(entryPointDescriptor)
-        const targetId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
+        this.options.connectionLocker?.lockConnection(entryPointDescriptor, `${this.options.serviceId}::joinDht`)
+        this.options.peerManager.addContact(entryPointDescriptor)
+        const targetId = getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
         const sessions = [this.createSession(targetId, contactedPeers)]
         if (additionalDistantJoin.enabled) {
             sessions.push(this.createSession(createDistantDhtAddress(targetId), additionalDistantJoin.contactedPeers))
         }
         await this.runSessions(sessions, entryPointDescriptor, retry)
-        this.config.connectionLocker?.unlockConnection(entryPointDescriptor, `${this.config.serviceId}::joinDht`)
+        this.options.connectionLocker?.unlockConnection(entryPointDescriptor, `${this.options.serviceId}::joinDht`)
 
     }
 
     async joinRing(): Promise<void> {
         const contactedPeers = new Set<DhtAddress>()
-        const sessions = [this.createRingSession(getRingIdRawFromPeerDescriptor(this.config.localPeerDescriptor), contactedPeers)]
+        const sessions = [this.createRingSession(getRingIdRawFromPeerDescriptor(this.options.localPeerDescriptor), contactedPeers)]
         await this.runRingSessions(sessions)
     }
 
     private createSession(targetId: DhtAddress, contactedPeers: Set<DhtAddress>): DiscoverySession {
         const sessionOptions = {
             targetId,
-            parallelism: this.config.parallelism,
-            noProgressLimit: this.config.joinNoProgressLimit,
-            peerManager: this.config.peerManager,
+            parallelism: this.options.parallelism,
+            noProgressLimit: this.options.joinNoProgressLimit,
+            peerManager: this.options.peerManager,
             contactedPeers,
-            abortSignal: this.config.abortSignal,
-            createDhtNodeRpcRemote: this.config.createDhtNodeRpcRemote
+            abortSignal: this.options.abortSignal,
+            createDhtNodeRpcRemote: this.options.createDhtNodeRpcRemote
         }
         return new DiscoverySession(sessionOptions)
     }
@@ -121,12 +121,12 @@ export class PeerDiscovery {
     private createRingSession(targetId: RingIdRaw, contactedPeers: Set<DhtAddress>): RingDiscoverySession {
         const sessionOptions = {
             targetId,
-            parallelism: this.config.parallelism,
-            noProgressLimit: this.config.joinNoProgressLimit,
-            peerManager: this.config.peerManager,
+            parallelism: this.options.parallelism,
+            noProgressLimit: this.options.joinNoProgressLimit,
+            peerManager: this.options.peerManager,
             contactedPeers,
-            abortSignal: this.config.abortSignal,
-            createDhtNodeRpcRemote: this.config.createDhtNodeRpcRemote
+            abortSignal: this.options.abortSignal,
+            createDhtNodeRpcRemote: this.options.createDhtNodeRpcRemote
         }
         return new RingDiscoverySession(sessionOptions)
     }
@@ -135,17 +135,17 @@ export class PeerDiscovery {
         try {
             for (const session of sessions) {
                 this.ongoingDiscoverySessions.set(session.id, session)
-                await session.findClosestNodes(this.config.joinTimeout)
+                await session.findClosestNodes(this.options.joinTimeout)
             }
         } catch (_e) {
-            logger.debug(`DHT join on ${this.config.serviceId} timed out`)
+            logger.debug(`DHT join on ${this.options.serviceId} timed out`)
         } finally {
             if (!this.isStopped()) {
-                if (this.config.peerManager.getNeighborCount() === 0) {
+                if (this.options.peerManager.getNeighborCount() === 0) {
                     if (retry) {
                         // TODO should we catch possible promise rejection?
-                        // TODO use config option or named constant?
-                        setAbortableTimeout(() => this.rejoinDht(entryPointDescriptor), 1000, this.config.abortSignal)
+                        // TODO use options option or named constant?
+                        setAbortableTimeout(() => this.rejoinDht(entryPointDescriptor), 1000, this.options.abortSignal)
                     }
                 } else {
                     await this.ensureRecoveryIntervalIsRunning()
@@ -159,10 +159,10 @@ export class PeerDiscovery {
         try {
             for (const session of sessions) {
                 this.ongoingRingDiscoverySessions.set(session.id, session)
-                await session.findClosestNodes(this.config.joinTimeout)
+                await session.findClosestNodes(this.options.joinTimeout)
             }
         } catch (_e) {
-            logger.debug(`Ring join on ${this.config.serviceId} timed out`)
+            logger.debug(`Ring join on ${this.options.serviceId} timed out`)
         } finally {
             sessions.forEach((session) => this.ongoingDiscoverySessions.delete(session.id))
         }
@@ -176,17 +176,17 @@ export class PeerDiscovery {
         if (this.isStopped() || this.rejoinOngoing) {
             return
         }
-        logger.debug(`Rejoining DHT ${this.config.serviceId}`)
+        logger.debug(`Rejoining DHT ${this.options.serviceId}`)
         this.rejoinOngoing = true
         try {
             await this.joinThroughEntryPoint(entryPoint, contactedPeers, { enabled: true, contactedPeers: distantJoinContactPeers })
-            logger.debug(`Rejoined DHT successfully ${this.config.serviceId}!`)
+            logger.debug(`Rejoined DHT successfully ${this.options.serviceId}!`)
         } catch (err) {
-            logger.warn(`Rejoining DHT ${this.config.serviceId} failed`)
+            logger.warn(`Rejoining DHT ${this.options.serviceId} failed`)
             if (!this.isStopped()) {
                 // TODO should we catch possible promise rejection?
-                // TODO use config option or named constant?
-                setAbortableTimeout(() => this.rejoinDht(entryPoint), 5000, this.config.abortSignal)
+                // TODO use options option or named constant?
+                setAbortableTimeout(() => this.rejoinDht(entryPoint), 5000, this.options.abortSignal)
             }
         } finally {
             this.rejoinOngoing = false
@@ -196,8 +196,8 @@ export class PeerDiscovery {
     private async ensureRecoveryIntervalIsRunning(): Promise<void> {
         if (!this.recoveryIntervalStarted) {
             this.recoveryIntervalStarted = true
-            // TODO use config option or named constant?
-            await scheduleAtInterval(() => this.fetchClosestAndRandomNeighbors(), 60000, true, this.config.abortSignal)
+            // TODO use options option or named constant?
+            await scheduleAtInterval(() => this.fetchClosestAndRandomNeighbors(), 60000, true, this.options.abortSignal)
         }
     }
 
@@ -205,29 +205,29 @@ export class PeerDiscovery {
         if (this.isStopped()) {
             return
         }
-        const localNodeId = getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
-        const nodes = this.getClosestNeighbors(localNodeId, this.config.parallelism)
+        const localNodeId = getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
+        const nodes = this.getClosestNeighbors(localNodeId, this.options.parallelism)
         const randomNodes = this.getClosestNeighbors(createRandomDhtAddress(), 1)
         await Promise.allSettled([
             ...nodes.map(async (node: PeerDescriptor) => {
-                const remote = this.config.createDhtNodeRpcRemote(node)
+                const remote = this.options.createDhtNodeRpcRemote(node)
                 const contacts = await remote.getClosestPeers(localNodeId)
                 for (const contact of contacts) {
-                    this.config.peerManager.addContact(contact)
+                    this.options.peerManager.addContact(contact)
                 }
             }),
             ...randomNodes.map(async (node: PeerDescriptor) => {
-                const remote = this.config.createDhtNodeRpcRemote(node)
+                const remote = this.options.createDhtNodeRpcRemote(node)
                 const contacts = await remote.getClosestPeers(createRandomDhtAddress())
                 for (const contact of contacts) {
-                    this.config.peerManager.addContact(contact)
+                    this.options.peerManager.addContact(contact)
                 }
             })
         ])
     }
 
     private getClosestNeighbors(referenceId: DhtAddress, maxCount: number): PeerDescriptor[] {
-        return getClosestNodes(referenceId, this.config.peerManager.getNeighbors().map((n) => n.getPeerDescriptor()), { maxCount })
+        return getClosestNodes(referenceId, this.options.peerManager.getNeighbors().map((n) => n.getPeerDescriptor()), { maxCount })
     }
 
     public isJoinOngoing(): boolean {
@@ -239,6 +239,6 @@ export class PeerDiscovery {
     }
 
     private isStopped() {
-        return this.config.abortSignal.aborted
+        return this.options.abortSignal.aborted
     }
 }

--- a/packages/dht/src/dht/discovery/RingDiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/RingDiscoverySession.ts
@@ -9,7 +9,7 @@ import { RingId, RingIdRaw, getLeftDistance, getRingIdFromPeerDescriptor, getRin
 
 const logger = new Logger(module)
 
-interface RingDiscoverySessionConfig {
+interface RingDiscoverySessionOptions {
     targetId: RingIdRaw
     parallelism: number
     noProgressLimit: number
@@ -25,33 +25,33 @@ export class RingDiscoverySession {
     private noProgressCounter = 0
     private ongoingRequests: Set<DhtAddress> = new Set()
     private doneGate = new Gate(false)
-    private readonly config: RingDiscoverySessionConfig
+    private readonly options: RingDiscoverySessionOptions
     private numContactedPeers = 0
     private targetIdAsRingId: RingId
 
-    constructor(config: RingDiscoverySessionConfig) {
-        this.config = config
-        this.targetIdAsRingId = getRingIdFromRaw(this.config.targetId)
+    constructor(options: RingDiscoverySessionOptions) {
+        this.options = options
+        this.targetIdAsRingId = getRingIdFromRaw(this.options.targetId)
     }
 
     private addContacts(contacts: PeerDescriptor[]): void {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return
         }
         for (const contact of contacts) {
-            this.config.peerManager.addContact(contact)
+            this.options.peerManager.addContact(contact)
         }
     }
 
     private async fetchClosestContactsFromRemote(contact: DhtNodeRpcRemote): Promise<RingContacts> {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return { left: [], right: [] }
         }
         logger.trace(`Getting closest ring peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
         this.numContactedPeers++
-        this.config.contactedPeers.add(contact.getNodeId())
-        const returnedContacts = await contact.getClosestRingPeers(this.config.targetId)
-        this.config.peerManager.setContactActive(contact.getNodeId())
+        this.options.contactedPeers.add(contact.getNodeId())
+        const returnedContacts = await contact.getClosestRingPeers(this.options.targetId)
+        this.options.peerManager.setContactActive(contact.getNodeId())
         return returnedContacts
     }
 
@@ -60,7 +60,7 @@ export class RingDiscoverySession {
             return
         }
         this.ongoingRequests.delete(nodeId)
-        const oldClosestContacts = this.config.peerManager.getClosestRingContactsTo(this.config.targetId, 1)
+        const oldClosestContacts = this.options.peerManager.getClosestRingContactsTo(this.options.targetId, 1)
         const oldClosestLeftDistance = getLeftDistance(
             this.targetIdAsRingId,
             getRingIdFromPeerDescriptor(oldClosestContacts.left[0].getPeerDescriptor())
@@ -70,7 +70,7 @@ export class RingDiscoverySession {
             getRingIdFromPeerDescriptor(oldClosestContacts.right[0].getPeerDescriptor())
         )
         this.addContacts(contacts.left.concat(contacts.right))
-        const newClosestContacts = this.config.peerManager.getClosestRingContactsTo(this.config.targetId, 1)
+        const newClosestContacts = this.options.peerManager.getClosestRingContactsTo(this.options.targetId, 1)
         const newClosestLeftDistance = getLeftDistance(this.targetIdAsRingId,
             getRingIdFromPeerDescriptor(newClosestContacts.left[0].getPeerDescriptor()))
         const newClosestRightDistance = getLeftDistance(this.targetIdAsRingId,
@@ -85,20 +85,20 @@ export class RingDiscoverySession {
             return
         }
         this.ongoingRequests.delete(peer.getNodeId())
-        this.config.peerManager.removeContact(peer.getNodeId())
+        this.options.peerManager.removeContact(peer.getNodeId())
     }
 
     private findMoreContacts(): void {
-        if (this.config.abortSignal.aborted || this.doneGate.isOpen()) {
+        if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return
         }
-        const uncontacted = this.config.peerManager.getClosestRingContactsTo(
-            this.config.targetId,
-            this.config.parallelism,
-            this.config.contactedPeers
+        const uncontacted = this.options.peerManager.getClosestRingContactsTo(
+            this.options.targetId,
+            this.options.parallelism,
+            this.options.contactedPeers
         )
         if ((uncontacted.left.length === 0 && uncontacted.right.length === 0)
-            || this.noProgressCounter >= this.config.noProgressLimit) {
+            || this.noProgressCounter >= this.options.noProgressLimit) {
             this.doneGate.open()
             return
         }
@@ -122,7 +122,7 @@ export class RingDiscoverySession {
         }
 
         for (const nextPeer of merged) {
-            if (this.ongoingRequests.size >= this.config.parallelism) {
+            if (this.ongoingRequests.size >= this.options.parallelism) {
                 break
             }
             this.ongoingRequests.add(nextPeer.getNodeId())
@@ -137,12 +137,12 @@ export class RingDiscoverySession {
     }
 
     public async findClosestNodes(timeout: number): Promise<void> {
-        if (this.config.peerManager.getNearbyContactCount(this.config.contactedPeers) === 0) {
+        if (this.options.peerManager.getNearbyContactCount(this.options.contactedPeers) === 0) {
             return
         }
         setImmediate(() => {
             this.findMoreContacts()
         })
-        await withTimeout(this.doneGate.waitUntilOpen(), timeout, 'discovery session timed out', this.config.abortSignal)
+        await withTimeout(this.doneGate.waitUntilOpen(), timeout, 'discovery session timed out', this.options.abortSignal)
     }
 }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -27,7 +27,7 @@ import { DhtAddress, areEqualPeerDescriptors, getDhtAddressFromRaw, getNodeIdFro
 import { getDistance } from '../PeerManager'
 import { ConnectionsView } from '../../exports'
 
-interface RecursiveOperationManagerConfig {
+interface RecursiveOperationManagerOptions {
     rpcCommunicator: RoutingRpcCommunicator
     sessionTransport: ITransport
     router: Router
@@ -47,21 +47,21 @@ export class RecursiveOperationManager {
 
     private ongoingSessions: Map<string, RecursiveOperationSession> = new Map()
     private stopped = false
-    private readonly config: RecursiveOperationManagerConfig
+    private readonly options: RecursiveOperationManagerOptions
 
-    constructor(config: RecursiveOperationManagerConfig) {
-        this.config = config
+    constructor(options: RecursiveOperationManagerOptions) {
+        this.options = options
         this.registerLocalRpcMethods()
     }
 
     private registerLocalRpcMethods() {
         const rpcLocal = new RecursiveOperationRpcLocal({
             doRouteRequest: (routedMessage: RouteMessageWrapper) => this.doRouteRequest(routedMessage),
-            addContact: (contact: PeerDescriptor) => this.config.addContact(contact),
-            isMostLikelyDuplicate: (requestId: string) => this.config.router.isMostLikelyDuplicate(requestId),
-            addToDuplicateDetector: (requestId: string) => this.config.router.addToDuplicateDetector(requestId)
+            addContact: (contact: PeerDescriptor) => this.options.addContact(contact),
+            isMostLikelyDuplicate: (requestId: string) => this.options.router.isMostLikelyDuplicate(requestId),
+            addToDuplicateDetector: (requestId: string) => this.options.router.addToDuplicateDetector(requestId)
         })
-        this.config.rpcCommunicator.registerRpcMethod(
+        this.options.rpcCommunicator.registerRpcMethod(
             RouteMessageWrapper,
             RouteMessageAck,
             'routeRequest',
@@ -85,23 +85,23 @@ export class RecursiveOperationManager {
             return { closestNodes: [] }
         }
         const session = new RecursiveOperationSession({
-            transport: this.config.sessionTransport,
+            transport: this.options.sessionTransport,
             targetId,
-            localPeerDescriptor: this.config.localPeerDescriptor,
-            // TODO use config option or named constant?
-            waitedRoutingPathCompletions: this.config.connectionsView.getConnectionCount() > 1 ? 2 : 1,
+            localPeerDescriptor: this.options.localPeerDescriptor,
+            // TODO use options option or named constant?
+            waitedRoutingPathCompletions: this.options.connectionsView.getConnectionCount() > 1 ? 2 : 1,
             operation,
             // TODO would it make sense to give excludedPeer as one of the fields RecursiveOperationSession?
             doRouteRequest: (routedMessage: RouteMessageWrapper) => {
                 return this.doRouteRequest(routedMessage, excludedPeer)
             }
         })
-        if (this.config.connectionsView.getConnectionCount() === 0) {
-            const dataEntries = Array.from(this.config.localDataStore.values(targetId))
+        if (this.options.connectionsView.getConnectionCount() === 0) {
+            const dataEntries = Array.from(this.options.localDataStore.values(targetId))
             session.onResponseReceived(
-                getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor),
-                [this.config.localPeerDescriptor],
-                [this.config.localPeerDescriptor],
+                getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor),
+                [this.options.localPeerDescriptor],
+                [this.options.localPeerDescriptor],
                 dataEntries,
                 true
             )
@@ -111,27 +111,27 @@ export class RecursiveOperationManager {
         if (waitForCompletion === true) {
             try {
                 await runAndWaitForEvents3<RecursiveOperationSessionEvents>(
-                    [() => session.start(this.config.serviceId)],
+                    [() => session.start(this.options.serviceId)],
                     [[session, 'completed']],
-                    // TODO use config option or named constant?
+                    // TODO use options option or named constant?
                     15000
                 )
             } catch (err) {
                 logger.debug('start failed', { err })
             }
         } else {
-            session.start(this.config.serviceId)
+            session.start(this.options.serviceId)
             // Wait for delete operation to be sent out by the router
             // TODO: Add a feature to wait for the router to pass the message?
             await wait(50)
         }
         if (operation === RecursiveOperation.FETCH_DATA) {
-            const dataEntries = Array.from(this.config.localDataStore.values(targetId))
+            const dataEntries = Array.from(this.options.localDataStore.values(targetId))
             if (dataEntries.length > 0) {
-                this.sendResponse([this.config.localPeerDescriptor], this.config.localPeerDescriptor, session.getId(), [], dataEntries, true)
+                this.sendResponse([this.options.localPeerDescriptor], this.options.localPeerDescriptor, session.getId(), [], dataEntries, true)
             }
         } else if (operation === RecursiveOperation.DELETE_DATA) {
-            this.config.localDataStore.markAsDeleted(targetId, getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor))
+            this.options.localDataStore.markAsDeleted(targetId, getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor))
         }
         this.ongoingSessions.delete(session.getId())
         session.stop()
@@ -146,25 +146,25 @@ export class RecursiveOperationManager {
         dataEntries: DataEntry[],
         noCloserNodesFound: boolean = false
     ): void {
-        const isOwnNode = areEqualPeerDescriptors(this.config.localPeerDescriptor, targetPeerDescriptor)
+        const isOwnNode = areEqualPeerDescriptors(this.options.localPeerDescriptor, targetPeerDescriptor)
         if (isOwnNode && this.ongoingSessions.has(serviceId)) {
             this.ongoingSessions.get(serviceId)!
                 .onResponseReceived(
-                    getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor),
+                    getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor),
                     routingPath,
                     closestConnectedNodes,
                     dataEntries,
                     noCloserNodesFound
                 )
         } else {
-            // TODO use config option or named constant?
-            const remoteCommunicator = new ListeningRpcCommunicator(serviceId, this.config.sessionTransport, { rpcRequestTimeout: 15000 })
+            // TODO use options option or named constant?
+            const remoteCommunicator = new ListeningRpcCommunicator(serviceId, this.options.sessionTransport, { rpcRequestTimeout: 15000 })
             const rpcRemote = new RecursiveOperationSessionRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 targetPeerDescriptor,
                 remoteCommunicator,
                 RecursiveOperationSessionRpcClient,
-                // TODO use config option or named constant?
+                // TODO use options option or named constant?
                 10000
             )
             rpcRemote.sendResponse(routingPath, closestConnectedNodes, dataEntries, noCloserNodesFound)
@@ -178,15 +178,15 @@ export class RecursiveOperationManager {
         }
         const targetId = getDhtAddressFromRaw(routedMessage.target)
         const request = (routedMessage.message!.body as { recursiveOperationRequest: RecursiveOperationRequest }).recursiveOperationRequest
-        // TODO use config option or named constant?
+        // TODO use options option or named constant?
         const closestConnectedNodes = this.getClosestConnectedNodes(targetId, 5)
         const dataEntries = (request.operation === RecursiveOperation.FETCH_DATA) 
-            ? Array.from(this.config.localDataStore.values(targetId))
+            ? Array.from(this.options.localDataStore.values(targetId))
             : []
         if (request.operation === RecursiveOperation.DELETE_DATA) {
-            this.config.localDataStore.markAsDeleted(targetId, getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!))
+            this.options.localDataStore.markAsDeleted(targetId, getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!))
         }
-        if (areEqualBinaries(this.config.localPeerDescriptor.nodeId, routedMessage.target)) {
+        if (areEqualBinaries(this.options.localPeerDescriptor.nodeId, routedMessage.target)) {
             // TODO this is also very similar case to what we do at line 255, could simplify the code paths?
             this.sendResponse(
                 routedMessage.routingPath,
@@ -198,7 +198,7 @@ export class RecursiveOperationManager {
             )
             return createRouteMessageAck(routedMessage)
         } else {
-            const ack = this.config.router.doRouteMessage(routedMessage, RoutingMode.RECURSIVE, excludedPeer)
+            const ack = this.options.router.doRouteMessage(routedMessage, RoutingMode.RECURSIVE, excludedPeer)
             if ((ack.error === undefined) || (ack.error === RouteMessageError.NO_TARGETS)) {
                 const noCloserContactsFound = (ack.error === RouteMessageError.NO_TARGETS) ||
                     (
@@ -220,7 +220,7 @@ export class RecursiveOperationManager {
     }
 
     private getClosestConnectedNodes(referenceId: DhtAddress, limit: number): PeerDescriptor[] {
-        const connectedNodes = this.config.connectionsView.getConnections().map((c) => this.config.createDhtNodeRpcRemote(c))
+        const connectedNodes = this.options.connectionsView.getConnections().map((c) => this.options.createDhtNodeRpcRemote(c))
         const sorted = new SortedContactList<DhtNodeRpcRemote>({
             referenceId,
             maxSize: limit,
@@ -233,7 +233,7 @@ export class RecursiveOperationManager {
     private isPeerCloserToIdThanSelf(peer: PeerDescriptor, nodeIdOrDataKey: DhtAddress): boolean {
         const nodeIdOrDataKeyRaw = getRawFromDhtAddress(nodeIdOrDataKey)
         const distance1 = getDistance(peer.nodeId, nodeIdOrDataKeyRaw)
-        const distance2 = getDistance(this.config.localPeerDescriptor.nodeId, nodeIdOrDataKeyRaw)
+        const distance2 = getDistance(this.options.localPeerDescriptor.nodeId, nodeIdOrDataKeyRaw)
         return distance1 < distance2
     }
 

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
@@ -7,7 +7,7 @@ import { getNodeIdFromPeerDescriptor } from '../../identifiers'
 
 const logger = new Logger(module)
 
-interface RecursiveOperationRpcLocalConfig {
+interface RecursiveOperationRpcLocalOptions {
     doRouteRequest: (routedMessage: RouteMessageWrapper) => RouteMessageAck
     addContact: (contact: PeerDescriptor, setActive?: boolean) => void
     isMostLikelyDuplicate: (requestId: string) => boolean
@@ -16,19 +16,19 @@ interface RecursiveOperationRpcLocalConfig {
 
 export class RecursiveOperationRpcLocal implements IRecursiveOperationRpc {
 
-    private readonly config: RecursiveOperationRpcLocalConfig
+    private readonly options: RecursiveOperationRpcLocalOptions
 
-    constructor(config: RecursiveOperationRpcLocalConfig) {
-        this.config = config
+    constructor(options: RecursiveOperationRpcLocalOptions) {
+        this.options = options
     }
 
     async routeRequest(routedMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
-        if (this.config.isMostLikelyDuplicate(routedMessage.requestId)) {
+        if (this.options.isMostLikelyDuplicate(routedMessage.requestId)) {
             return createRouteMessageAck(routedMessage, RouteMessageError.DUPLICATE)
         }
         const remoteNodeId = getNodeIdFromPeerDescriptor(getPreviousPeer(routedMessage) ?? routedMessage.sourcePeer!)
         logger.trace(`Received routeRequest call from ${remoteNodeId}`)
-        this.config.addToDuplicateDetector(routedMessage.requestId)
-        return this.config.doRouteRequest(routedMessage)
+        this.options.addToDuplicateDetector(routedMessage.requestId)
+        return this.options.doRouteRequest(routedMessage)
     }
 }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
@@ -8,7 +8,7 @@ import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
 
 const logger = new Logger(module)
 
-interface RecursiveOperationSessionRpcLocalConfig {
+interface RecursiveOperationSessionRpcLocalOptions {
     onResponseReceived: (
         remoteNodeId: DhtAddress,
         routingPath: PeerDescriptor[],
@@ -20,16 +20,16 @@ interface RecursiveOperationSessionRpcLocalConfig {
 
 export class RecursiveOperationSessionRpcLocal implements IRecursiveOperationSessionRpc {
 
-    private readonly config: RecursiveOperationSessionRpcLocalConfig
+    private readonly options: RecursiveOperationSessionRpcLocalOptions
 
-    constructor(config: RecursiveOperationSessionRpcLocalConfig) {
-        this.config = config
+    constructor(options: RecursiveOperationSessionRpcLocalOptions) {
+        this.options = options
     }
     
     async sendResponse(report: RecursiveOperationResponse, context: ServerCallContext): Promise<Empty> {
         const remoteNodeId = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
         logger.trace('RecursiveOperationResponse arrived: ' + JSON.stringify(report))
-        this.config.onResponseReceived(remoteNodeId, report.routingPath, report.closestConnectedNodes, report.dataEntries, report.noCloserNodesFound)
+        this.options.onResponseReceived(remoteNodeId, report.routingPath, report.closestConnectedNodes, report.dataEntries, report.noCloserNodesFound)
         return {}
     }
 }

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -64,7 +64,7 @@ export interface RoutingSessionEvents {
 
 export enum RoutingMode { ROUTE, FORWARD, RECURSIVE }
 
-interface RoutingSessionConfig {
+interface RoutingSessionOptions {
     rpcCommunicator: RoutingRpcCommunicator
     localPeerDescriptor: PeerDescriptor
     routedMessage: RouteMessageWrapper
@@ -83,11 +83,11 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
     private failedHopCounter = 0
     private successfulHopCounter = 0
     private stopped = false
-    private readonly config: RoutingSessionConfig
+    private readonly options: RoutingSessionOptions
 
-    constructor(config: RoutingSessionConfig) {
+    constructor(options: RoutingSessionOptions) {
         super()
-        this.config = config
+        this.options = options
     }
 
     private onRequestFailed(nodeId: DhtAddress) {
@@ -129,7 +129,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             return
         }
         this.successfulHopCounter += 1
-        if (this.successfulHopCounter >= this.config.parallelism) {
+        if (this.successfulHopCounter >= this.options.parallelism) {
             this.emit('routingSucceeded')
             return
         }
@@ -146,12 +146,12 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             return false
         }
         const msg = {
-            ...this.config.routedMessage,
-            routingPath: this.config.routedMessage.routingPath.concat([this.config.localPeerDescriptor])
+            ...this.options.routedMessage,
+            routingPath: this.options.routedMessage.routingPath.concat([this.options.localPeerDescriptor])
         }
-        if (this.config.mode === RoutingMode.FORWARD) {
+        if (this.options.mode === RoutingMode.FORWARD) {
             return contact.getRouterRpcRemote().forwardMessage(msg)
-        } else if (this.config.mode === RoutingMode.RECURSIVE) {
+        } else if (this.options.mode === RoutingMode.RECURSIVE) {
             return contact.getRecursiveOperationRpcRemote().routeRequest(msg)
         } else {
             return contact.getRouterRpcRemote().routeMessage(msg)
@@ -160,30 +160,30 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
 
     updateAndGetRoutablePeers(): RoutingRemoteContact[] {
         logger.trace('getRoutablePeers() sessionId: ' + this.sessionId)
-        const previousPeer = getPreviousPeer(this.config.routedMessage)
+        const previousPeer = getPreviousPeer(this.options.routedMessage)
         const previousId = previousPeer ? getNodeIdFromPeerDescriptor(previousPeer) : undefined
-        const targetId = getDhtAddressFromRaw(this.config.routedMessage.target)
+        const targetId = getDhtAddressFromRaw(this.options.routedMessage.target)
         let routingTable: RoutingTable
-        if (this.config.routingTablesCache.has(targetId, previousId)) {
-            routingTable = this.config.routingTablesCache.get(targetId, previousId)!
+        if (this.options.routingTablesCache.has(targetId, previousId)) {
+            routingTable = this.options.routingTablesCache.get(targetId, previousId)!
         } else {
             routingTable = new SortedContactList<RoutingRemoteContact>({
-                referenceId: getDhtAddressFromRaw(this.config.routedMessage.target),
+                referenceId: getDhtAddressFromRaw(this.options.routedMessage.target),
                 maxSize: ROUTING_TABLE_MAX_SIZE,
                 allowToContainReferenceId: true,
                 nodeIdDistanceLimit: previousId
             })
-            const contacts = this.config.getConnections()
+            const contacts = this.options.getConnections()
                 .map((peer) => new RoutingRemoteContact(
                     peer,
-                    this.config.localPeerDescriptor,
-                    this.config.rpcCommunicator
+                    this.options.localPeerDescriptor,
+                    this.options.rpcCommunicator
                 ))
             routingTable.addContacts(contacts)
-            this.config.routingTablesCache.set(targetId, routingTable, previousId)
+            this.options.routingTablesCache.set(targetId, routingTable, previousId)
         }
         return routingTable.getClosestContacts()
-            .filter((contact) => !this.contactedPeers.has(contact.getNodeId()) && !this.config.excludedNodeIds.has(contact.getNodeId()))
+            .filter((contact) => !this.contactedPeers.has(contact.getNodeId()) && !this.options.excludedNodeIds.has(contact.getNodeId()))
     }
 
     sendMoreRequests(uncontacted: RoutingRemoteContact[]): void {
@@ -195,7 +195,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
             this.emitFailure()
             return
         }
-        while ((this.ongoingRequests.size < this.config.parallelism) && (uncontacted.length > 0) && !this.stopped) {
+        while ((this.ongoingRequests.size < this.options.parallelism) && (uncontacted.length > 0) && !this.stopped) {
             const nextPeer = uncontacted.shift()
             // eslint-disable-next-line max-len
             logger.trace(`Sending routeMessage request to contact: ${getNodeIdFromPeerDescriptor(nextPeer!.getPeerDescriptor())} (sessionId=${this.sessionId})`)
@@ -221,19 +221,19 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
 
     private addParallelRootIfSource(nodeId: DhtAddress) {
         if (
-            this.config.mode === RoutingMode.RECURSIVE
-            && areEqualPeerDescriptors(this.config.localPeerDescriptor, this.config.routedMessage.sourcePeer!)
+            this.options.mode === RoutingMode.RECURSIVE
+            && areEqualPeerDescriptors(this.options.localPeerDescriptor, this.options.routedMessage.sourcePeer!)
         ) {
-            this.config.routedMessage.parallelRootNodeIds.push(nodeId)
+            this.options.routedMessage.parallelRootNodeIds.push(nodeId)
         }
     }
 
     private deleteParallelRootIfSource(nodeId: DhtAddress) {
         if (
-            this.config.mode === RoutingMode.RECURSIVE
-            && areEqualPeerDescriptors(this.config.localPeerDescriptor, this.config.routedMessage.sourcePeer!)
+            this.options.mode === RoutingMode.RECURSIVE
+            && areEqualPeerDescriptors(this.options.localPeerDescriptor, this.options.routedMessage.sourcePeer!)
         ) {
-            pull(this.config.routedMessage.parallelRootNodeIds, nodeId)
+            pull(this.options.routedMessage.parallelRootNodeIds, nodeId)
         }
     }
 

--- a/packages/dht/src/transport/ListeningRpcCommunicator.ts
+++ b/packages/dht/src/transport/ListeningRpcCommunicator.ts
@@ -1,6 +1,6 @@
 import { ITransport } from './ITransport' 
 import { RoutingRpcCommunicator } from './RoutingRpcCommunicator'
-import { RpcCommunicatorConfig } from '@streamr/proto-rpc'
+import { RpcCommunicatorOptions } from '@streamr/proto-rpc'
 import { Message } from '../proto/packages/dht/protos/DhtRpc'
 import { ServiceID } from '../types/ServiceID'
 
@@ -8,8 +8,8 @@ export class ListeningRpcCommunicator extends RoutingRpcCommunicator {
     private readonly transport: ITransport
     private readonly listener: (msg: Message) => void
 
-    constructor(ownServiceId: ServiceID, transport: ITransport, config?: RpcCommunicatorConfig) {
-        super(ownServiceId, (msg, opts) => transport.send(msg, opts), config)
+    constructor(ownServiceId: ServiceID, transport: ITransport, options?: RpcCommunicatorOptions) {
+        super(ownServiceId, (msg, opts) => transport.send(msg, opts), options)
         this.listener = (msg: Message) => {
             this.handleMessageFromPeer(msg)
         }

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -1,6 +1,6 @@
 import { Message, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { v4 } from 'uuid'
-import { RpcCommunicator, RpcCommunicatorConfig } from '@streamr/proto-rpc'
+import { RpcCommunicator, RpcCommunicatorOptions } from '@streamr/proto-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 import { RpcMessage } from '../proto/packages/proto-rpc/protos/ProtoRpc'
 import { ServiceID } from '../types/ServiceID'
@@ -13,9 +13,9 @@ export class RoutingRpcCommunicator extends RpcCommunicator<DhtCallContext> {
     constructor(
         ownServiceId: ServiceID,
         sendFn: (msg: Message, opts: SendOptions) => Promise<void>,
-        config?: RpcCommunicatorConfig
+        options?: RpcCommunicatorOptions
     ) {
-        super(config)
+        super(options)
         this.ownServiceId = ownServiceId
         this.sendFn = sendFn
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -1,7 +1,7 @@
 import { Logger, MetricsContext, waitForEvent3 } from '@streamr/utils'
 import { MarkOptional } from 'ts-essentials'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
-import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../../src/connection/ConnectorFacade'
+import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import { createPeerDescriptor } from '../../src/helpers/createPeerDescriptor'
@@ -30,7 +30,7 @@ describe('ConnectionManager', () => {
     const mockConnectorTransport2 = new SimulatorTransport(mockPeerDescriptor2, simulator)
     let createLocalPeerDescriptor: jest.Mock<PeerDescriptor, [ConnectivityResponse]>
 
-    const createConnectionManager = (opts: MarkOptional<DefaultConnectorFacadeConfig, 'createLocalPeerDescriptor'>) => {
+    const createConnectionManager = (opts: MarkOptional<DefaultConnectorFacadeOptions, 'createLocalPeerDescriptor'>) => {
         return new ConnectionManager({
             createConnectorFacade: () => new DefaultConnectorFacade({
                 createLocalPeerDescriptor: async (response) => createLocalPeerDescriptor(response),

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -1,6 +1,6 @@
 import { MetricsContext, waitForCondition } from '@streamr/utils'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
-import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../../src/connection/ConnectorFacade'
+import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
@@ -19,7 +19,7 @@ const BASE_MESSAGE: Message = {
     }
 }
 
-const createConnectionManager = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultConnectorFacadeConfig, 'createLocalPeerDescriptor'>) => {
+const createConnectionManager = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultConnectorFacadeOptions, 'createLocalPeerDescriptor'>) => {
     return new ConnectionManager({
         createConnectorFacade: () => new DefaultConnectorFacade({
             createLocalPeerDescriptor: async () => localPeerDescriptor,

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -2,7 +2,7 @@
 
 import { MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
-import { DefaultConnectorFacade, DefaultConnectorFacadeConfig } from '../../src/connection/ConnectorFacade'
+import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import * as Err from '../../src/helpers/errors'
@@ -13,7 +13,7 @@ import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
 
 const SERVICE_ID = 'test'
 
-const createConfig = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultConnectorFacadeConfig, 'createLocalPeerDescriptor'>) => {
+const createOptions = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultConnectorFacadeOptions, 'createLocalPeerDescriptor'>) => {
     return {
         createConnectorFacade: () => new DefaultConnectorFacade({
             createLocalPeerDescriptor: async () => localPeerDescriptor,
@@ -60,21 +60,21 @@ describe('Websocket Connection Management', () => {
         connectorTransport3 = new SimulatorTransport(biggerNoWsServerConnectorPeerDescriptor, simulator)
         await connectorTransport3.start()
 
-        const config1 = createConfig(wsServerConnectorPeerDescriptor, {
+        const options1 = createOptions(wsServerConnectorPeerDescriptor, {
             transport: connectorTransport1,
             websocketHost: '127.0.0.1',
             websocketPortRange: { min: 12223, max: 12223 }
         })
-        const config2 = createConfig(noWsServerConnectorPeerDescriptor, {
+        const options2 = createOptions(noWsServerConnectorPeerDescriptor, {
             transport: connectorTransport2
         })
-        const config3 = createConfig(biggerNoWsServerConnectorPeerDescriptor, {
+        const options3 = createOptions(biggerNoWsServerConnectorPeerDescriptor, {
             transport: connectorTransport3
         })
 
-        wsServerManager = new ConnectionManager(config1)
-        noWsServerManager = new ConnectionManager(config2)
-        biggerNoWsServerManager = new ConnectionManager(config3)
+        wsServerManager = new ConnectionManager(options1)
+        noWsServerManager = new ConnectionManager(options2)
+        biggerNoWsServerManager = new ConnectionManager(options3)
 
         await wsServerManager.start()
         await noWsServerManager.start()

--- a/packages/dht/test/unit/DiscoverySession.test.ts
+++ b/packages/dht/test/unit/DiscoverySession.test.ts
@@ -12,7 +12,7 @@ const NODE_COUNT = 40
 const MIN_NEIGHBOR_COUNT = 2  // nodes can get more neighbors when we merge network partitions
 const PARALLELISM = 1
 const NO_PROGRESS_LIMIT = 1
-const QUERY_BATCH_SIZE = 5  // the default value in DhtNode's config, not relevant in this test
+const QUERY_BATCH_SIZE = 5  // the default value in DhtNode's options, not relevant in this test
 
 const createPeerDescriptor = (nodeId: DhtAddress): PeerDescriptor => {
     return {

--- a/packages/proto-rpc/src/RpcCommunicator.ts
+++ b/packages/proto-rpc/src/RpcCommunicator.ts
@@ -31,7 +31,7 @@ interface RpcCommunicatorEvents<T extends ProtoCallContext> {
     outgoingMessage: (message: RpcMessage, requestId: string, callContext?: T) => void
 }
 
-export interface RpcCommunicatorConfig {
+export interface RpcCommunicatorOptions {
     rpcRequestTimeout?: number
 }
 
@@ -40,14 +40,14 @@ class OngoingRequest {
     private deferredPromises: ResultParts
     private timeoutRef?: NodeJS.Timeout
 
-    constructor(deferredPromises: ResultParts, timeoutConfig?: { timeout: number, onTimeout: () => void }) {
+    constructor(deferredPromises: ResultParts, timeoutOptions?: { timeout: number, onTimeout: () => void }) {
         this.deferredPromises = deferredPromises
-        if (timeoutConfig) {
+        if (timeoutOptions) {
             this.timeoutRef = setTimeout(() => {
                 const error = new Err.RpcTimeout('Rpc request timed out', new Error())
                 this.rejectDeferredPromises(error, StatusCode.DEADLINE_EXCEEDED)
-                timeoutConfig.onTimeout()
-            }, timeoutConfig.timeout)
+                timeoutOptions.onTimeout()
+            }, timeoutOptions.timeout)
         }
         
     }
@@ -125,7 +125,7 @@ export class RpcCommunicator<T extends ProtoCallContext> extends EventEmitter<Rp
     private readonly rpcRequestTimeout: number
     private outgoingMessageListener?: OutgoingMessageListener<T>
 
-    constructor(params?: RpcCommunicatorConfig) {
+    constructor(params?: RpcCommunicatorOptions) {
         super()
 
         this.rpcRequestTimeout = params?.rpcRequestTimeout ?? 5000

--- a/packages/proto-rpc/src/exports.ts
+++ b/packages/proto-rpc/src/exports.ts
@@ -1,4 +1,4 @@
-export { RpcCommunicator, RpcCommunicatorConfig, StatusCode } from './RpcCommunicator'
+export { RpcCommunicator, RpcCommunicatorOptions, StatusCode } from './RpcCommunicator'
 export { ProtoRpcOptions, ProtoCallContext } from './ProtoCallContext'
 export { toProtoRpcClient, ProtoRpcClient, ClassType } from './toProtoRpcClient'
 export { ClientTransport } from './ClientTransport'

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -11,7 +11,7 @@ import { StreamID, StreamPartID, toStreamPartID } from '@streamr/protocol'
 import { Logger, MetricsContext, waitForCondition } from '@streamr/utils'
 import { pull } from 'lodash'
 import { version as applicationVersion } from '../package.json'
-import { ContentDeliveryManager, ContentDeliveryManagerConfig } from './logic/ContentDeliveryManager'
+import { ContentDeliveryManager, ContentDeliveryManagerOptions } from './logic/ContentDeliveryManager'
 import { ControlLayerNode } from './logic/ControlLayerNode'
 import { NodeInfoClient } from './logic/node-info/NodeInfoClient'
 import { NODE_INFO_RPC_SERVICE_ID, NodeInfoRpcLocal } from './logic/node-info/NodeInfoRpcLocal'
@@ -19,7 +19,7 @@ import { NodeInfoResponse, ProxyDirection, StreamMessage } from './proto/package
 
 export interface NetworkOptions {
     layer0?: DhtNodeOptions
-    networkNode?: ContentDeliveryManagerConfig
+    networkNode?: ContentDeliveryManagerOptions
     metricsContext?: MetricsContext
 }
 

--- a/packages/trackerless-network/src/exports.ts
+++ b/packages/trackerless-network/src/exports.ts
@@ -1,6 +1,6 @@
 export { NetworkStack, NetworkOptions, NodeInfo } from './NetworkStack'
 export { NetworkNode, createNetworkNode } from './NetworkNode'
-export { ContentDeliveryManagerConfig } from './logic/ContentDeliveryManager'
+export { ContentDeliveryManagerOptions } from './logic/ContentDeliveryManager'
 export { ProxyDirection, GroupKeyRequest, GroupKeyResponse } from './proto/packages/trackerless-network/protos/NetworkRpc'
 export { streamPartIdToDataKey } from './logic/ContentDeliveryManager'
 export {

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -39,7 +39,7 @@ export interface Events {
     entryPointLeaveDetected: () => void
 }
 
-export interface StrictContentDeliveryLayerNodeConfig {
+export interface StrictContentDeliveryLayerNodeOptions {
     streamPartId: StreamPartID
     discoveryLayerNode: DiscoveryLayerNode
     transport: ITransport
@@ -73,44 +73,44 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
 
     private started = false
     private readonly duplicateDetectors: Map<string, DuplicateMessageDetector>
-    private config: StrictContentDeliveryLayerNodeConfig
+    private options: StrictContentDeliveryLayerNodeOptions
     private readonly contentDeliveryRpcLocal: ContentDeliveryRpcLocal
     private abortController: AbortController = new AbortController()
 
-    constructor(config: StrictContentDeliveryLayerNodeConfig) {
+    constructor(options: StrictContentDeliveryLayerNodeOptions) {
         super()
-        this.config = config
+        this.options = options
         this.duplicateDetectors = new Map()
         this.contentDeliveryRpcLocal = new ContentDeliveryRpcLocal({
-            localPeerDescriptor: this.config.localPeerDescriptor,
-            streamPartId: this.config.streamPartId,
-            rpcCommunicator: this.config.rpcCommunicator,
+            localPeerDescriptor: this.options.localPeerDescriptor,
+            streamPartId: this.options.streamPartId,
+            rpcCommunicator: this.options.rpcCommunicator,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: DhtAddress) => this.broadcast(message, previousNode),
             onLeaveNotice: (remoteNodeId: DhtAddress, sourceIsStreamEntryPoint: boolean) => {
                 if (this.abortController.signal.aborted) {
                     return
                 }
-                const contact = this.config.nearbyNodeView.get(remoteNodeId)
-                || this.config.randomNodeView.get(remoteNodeId)
-                || this.config.neighbors.get(remoteNodeId)
-                || this.config.proxyConnectionRpcLocal?.getConnection(remoteNodeId)?.remote
+                const contact = this.options.nearbyNodeView.get(remoteNodeId)
+                || this.options.randomNodeView.get(remoteNodeId)
+                || this.options.neighbors.get(remoteNodeId)
+                || this.options.proxyConnectionRpcLocal?.getConnection(remoteNodeId)?.remote
                 // TODO: check integrity of notifier?
                 if (contact) {
-                    this.config.discoveryLayerNode.removeContact(remoteNodeId)
-                    this.config.neighbors.remove(remoteNodeId)
-                    this.config.nearbyNodeView.remove(remoteNodeId)
-                    this.config.randomNodeView.remove(remoteNodeId)
-                    this.config.leftNodeView.remove(remoteNodeId)
-                    this.config.rightNodeView.remove(remoteNodeId)
-                    this.config.neighborFinder.start([remoteNodeId])
-                    this.config.proxyConnectionRpcLocal?.removeConnection(remoteNodeId)
+                    this.options.discoveryLayerNode.removeContact(remoteNodeId)
+                    this.options.neighbors.remove(remoteNodeId)
+                    this.options.nearbyNodeView.remove(remoteNodeId)
+                    this.options.randomNodeView.remove(remoteNodeId)
+                    this.options.leftNodeView.remove(remoteNodeId)
+                    this.options.rightNodeView.remove(remoteNodeId)
+                    this.options.neighborFinder.start([remoteNodeId])
+                    this.options.proxyConnectionRpcLocal?.removeConnection(remoteNodeId)
                 }
                 if (sourceIsStreamEntryPoint) {
                     this.emit('entryPointLeaveDetected')
                 }
             },
-            markForInspection: (remoteNodeId: DhtAddress, messageId: MessageID) => this.config.inspector.markMessage(remoteNodeId, messageId)
+            markForInspection: (remoteNodeId: DhtAddress, messageId: MessageID) => this.options.inspector.markMessage(remoteNodeId, messageId)
         })
     }
 
@@ -118,92 +118,92 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         this.started = true
         this.registerDefaultServerMethods()
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'nearbyContactAdded', 
             () => this.onNearbyContactAdded(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'nearbyContactRemoved',
             () => this.onNearbyContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'randomContactAdded',
             () => this.onRandomContactAdded(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'randomContactRemoved',
             () => this.onRandomContactRemoved(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'ringContactAdded',
             () => this.onRingContactsUpdated(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.discoveryLayerNode as any,
+            this.options.discoveryLayerNode as any,
             'ringContactRemoved',
             () => this.onRingContactsUpdated(),
             this.abortController.signal
         )
         addManagedEventListener<any, any>(
-            this.config.transport as any,
+            this.options.transport as any,
             'disconnected',
             (peerDescriptor: PeerDescriptor) => this.onNodeDisconnected(peerDescriptor),
             this.abortController.signal
         )
         addManagedEventListener(
-            this.config.neighbors,
+            this.options.neighbors,
             'nodeAdded',
             (id, remote) => {
-                this.config.propagation.onNeighborJoined(id)
-                this.config.connectionLocker.weakLockConnection(
+                this.options.propagation.onNeighborJoined(id)
+                this.options.connectionLocker.weakLockConnection(
                     getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
-                    this.config.streamPartId
+                    this.options.streamPartId
                 )
                 this.emit('neighborConnected', id)
             },
             this.abortController.signal
         )
         addManagedEventListener(
-            this.config.neighbors,
+            this.options.neighbors,
             'nodeRemoved',
             (_id, remote) => {
-                this.config.connectionLocker.weakUnlockConnection(
+                this.options.connectionLocker.weakUnlockConnection(
                     getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
-                    this.config.streamPartId
+                    this.options.streamPartId
                 )
             },
             this.abortController.signal
         )
-        if (this.config.proxyConnectionRpcLocal !== undefined) {
+        if (this.options.proxyConnectionRpcLocal !== undefined) {
             addManagedEventListener(
-                this.config.proxyConnectionRpcLocal,
+                this.options.proxyConnectionRpcLocal,
                 'newConnection',
-                (id: DhtAddress) => this.config.propagation.onNeighborJoined(id),
+                (id: DhtAddress) => this.options.propagation.onNeighborJoined(id),
                 this.abortController.signal
             )
         }
-        this.config.neighborFinder.start()
-        await this.config.neighborUpdateManager.start()
+        this.options.neighborFinder.start()
+        await this.options.neighborUpdateManager.start()
     }
 
     private registerDefaultServerMethods(): void {
-        this.config.rpcCommunicator.registerRpcNotification(StreamMessage, 'sendStreamMessage',
+        this.options.rpcCommunicator.registerRpcNotification(StreamMessage, 'sendStreamMessage',
             (msg: StreamMessage, context) => this.contentDeliveryRpcLocal.sendStreamMessage(msg, context))
-        this.config.rpcCommunicator.registerRpcNotification(LeaveStreamPartNotice, 'leaveStreamPartNotice',
+        this.options.rpcCommunicator.registerRpcNotification(LeaveStreamPartNotice, 'leaveStreamPartNotice',
             (req: LeaveStreamPartNotice, context) => this.contentDeliveryRpcLocal.leaveStreamPartNotice(req, context))
-        this.config.rpcCommunicator.registerRpcMethod(TemporaryConnectionRequest, TemporaryConnectionResponse, 'openConnection',
-            (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.openConnection(req, context))
-        this.config.rpcCommunicator.registerRpcNotification(CloseTemporaryConnection, 'closeConnection',
-            (req: TemporaryConnectionRequest, context) => this.config.temporaryConnectionRpcLocal.closeConnection(req, context))
+        this.options.rpcCommunicator.registerRpcMethod(TemporaryConnectionRequest, TemporaryConnectionResponse, 'openConnection',
+            (req: TemporaryConnectionRequest, context) => this.options.temporaryConnectionRpcLocal.openConnection(req, context))
+        this.options.rpcCommunicator.registerRpcNotification(CloseTemporaryConnection, 'closeConnection',
+            (req: TemporaryConnectionRequest, context) => this.options.temporaryConnectionRpcLocal.closeConnection(req, context))
     }
 
     private onRingContactsUpdated(): void {
@@ -211,23 +211,23 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const contacts = this.config.discoveryLayerNode.getRingContacts()
-        this.config.leftNodeView.replaceAll(contacts.left.map((peer) => 
+        const contacts = this.options.discoveryLayerNode.getRingContacts()
+        this.options.leftNodeView.replaceAll(contacts.left.map((peer) => 
             new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 peer,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient,
-                this.config.rpcRequestTimeout
+                this.options.rpcRequestTimeout
             )
         ))
-        this.config.rightNodeView.replaceAll(contacts.right.map((peer) =>
+        this.options.rightNodeView.replaceAll(contacts.right.map((peer) =>
             new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 peer,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient,
-                this.config.rpcRequestTimeout
+                this.options.rpcRequestTimeout
             )
         ))
     }
@@ -237,10 +237,10 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const closestContacts = this.config.discoveryLayerNode.getClosestContacts()
+        const closestContacts = this.options.discoveryLayerNode.getClosestContacts()
         this.updateNearbyNodeView(closestContacts)
-        if (this.config.neighbors.size() < this.config.neighborTargetCount) {
-            this.config.neighborFinder.start()
+        if (this.options.neighbors.size() < this.options.neighborTargetCount) {
+            this.options.neighborFinder.start()
         }
     }
 
@@ -249,31 +249,31 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const closestContacts = this.config.discoveryLayerNode.getClosestContacts()
+        const closestContacts = this.options.discoveryLayerNode.getClosestContacts()
         this.updateNearbyNodeView(closestContacts)
     }
 
     private updateNearbyNodeView(nodes: PeerDescriptor[]) {
-        this.config.nearbyNodeView.replaceAll(Array.from(nodes).map((descriptor) =>
+        this.options.nearbyNodeView.replaceAll(Array.from(nodes).map((descriptor) =>
             new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 descriptor,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient,
-                this.config.rpcRequestTimeout
+                this.options.rpcRequestTimeout
             )
         ))
-        for (const descriptor of this.config.discoveryLayerNode.getNeighbors()) {
-            if (this.config.nearbyNodeView.size() >= this.config.nodeViewSize) {
+        for (const descriptor of this.options.discoveryLayerNode.getNeighbors()) {
+            if (this.options.nearbyNodeView.size() >= this.options.nodeViewSize) {
                 break
             }
-            this.config.nearbyNodeView.add(
+            this.options.nearbyNodeView.add(
                 new ContentDeliveryRpcRemote(
-                    this.config.localPeerDescriptor,
+                    this.options.localPeerDescriptor,
                     descriptor,
-                    this.config.rpcCommunicator,
+                    this.options.rpcCommunicator,
                     ContentDeliveryRpcClient,
-                    this.config.rpcRequestTimeout
+                    this.options.rpcRequestTimeout
                 )
             )
         }
@@ -283,18 +283,18 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
-        this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
+        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        this.options.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 descriptor,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient,
-                this.config.rpcRequestTimeout
+                this.options.rpcRequestTimeout
             )
         ))
-        if (this.config.neighbors.size() < this.config.neighborTargetCount) {
-            this.config.neighborFinder.start()
+        if (this.options.neighbors.size() < this.options.neighborTargetCount) {
+            this.options.neighborFinder.start()
         }
     }
 
@@ -303,30 +303,30 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.config.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
-        this.config.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
+        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        this.options.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 descriptor,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient,
-                this.config.rpcRequestTimeout
+                this.options.rpcRequestTimeout
             )
         ))
     }
 
     private onNodeDisconnected(peerDescriptor: PeerDescriptor): void {
         const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
-        if (this.config.neighbors.has(nodeId)) {
-            this.config.neighbors.remove(nodeId)
-            this.config.neighborFinder.start([nodeId])
-            this.config.temporaryConnectionRpcLocal.removeNode(nodeId)
+        if (this.options.neighbors.has(nodeId)) {
+            this.options.neighbors.remove(nodeId)
+            this.options.neighborFinder.start([nodeId])
+            this.options.temporaryConnectionRpcLocal.removeNode(nodeId)
         }
     }
 
     hasProxyConnection(nodeId: DhtAddress): boolean {
-        if (this.config.proxyConnectionRpcLocal) {
-            return this.config.proxyConnectionRpcLocal.hasConnection(nodeId)
+        if (this.options.proxyConnectionRpcLocal) {
+            return this.options.proxyConnectionRpcLocal.hasConnection(nodeId)
         }
         return false
     }
@@ -336,22 +336,22 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             return
         }
         this.abortController.abort()
-        this.config.proxyConnectionRpcLocal?.stop()
-        this.config.neighbors.getAll().map((remote) => {
-            remote.leaveStreamPartNotice(this.config.streamPartId, this.config.isLocalNodeEntryPoint())
-            this.config.connectionLocker.weakUnlockConnection(
+        this.options.proxyConnectionRpcLocal?.stop()
+        this.options.neighbors.getAll().map((remote) => {
+            remote.leaveStreamPartNotice(this.options.streamPartId, this.options.isLocalNodeEntryPoint())
+            this.options.connectionLocker.weakUnlockConnection(
                 getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
-                this.config.streamPartId
+                this.options.streamPartId
             )
         })
-        this.config.rpcCommunicator.destroy()
+        this.options.rpcCommunicator.destroy()
         this.removeAllListeners()
-        this.config.nearbyNodeView.stop()
-        this.config.neighbors.stop()
-        this.config.randomNodeView.stop()
-        this.config.neighborFinder.stop()
-        this.config.neighborUpdateManager.stop()
-        this.config.inspector.stop()
+        this.options.nearbyNodeView.stop()
+        this.options.neighbors.stop()
+        this.options.randomNodeView.stop()
+        this.options.neighborFinder.stop()
+        this.options.neighborUpdateManager.stop()
+        this.options.inspector.stop()
     }
 
     broadcast(msg: StreamMessage, previousNode?: DhtAddress): void {
@@ -359,40 +359,40 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             markAndCheckDuplicate(this.duplicateDetectors, msg.messageId!, msg.previousMessageRef)
         }
         this.emit('message', msg)
-        const skipBackPropagation = previousNode !== undefined && !this.config.temporaryConnectionRpcLocal.hasNode(previousNode)
-        this.config.propagation.feedUnseenMessage(msg, this.getPropagationTargets(msg), skipBackPropagation ? previousNode : null)
+        const skipBackPropagation = previousNode !== undefined && !this.options.temporaryConnectionRpcLocal.hasNode(previousNode)
+        this.options.propagation.feedUnseenMessage(msg, this.getPropagationTargets(msg), skipBackPropagation ? previousNode : null)
     }
 
     inspect(peerDescriptor: PeerDescriptor): Promise<boolean> {
-        return this.config.inspector.inspect(peerDescriptor)
+        return this.options.inspector.inspect(peerDescriptor)
     }
 
     private getPropagationTargets(msg: StreamMessage): DhtAddress[] {
-        let propagationTargets = this.config.neighbors.getIds()
-        if (this.config.proxyConnectionRpcLocal) {
-            propagationTargets = propagationTargets.concat(this.config.proxyConnectionRpcLocal.getPropagationTargets(msg))
+        let propagationTargets = this.options.neighbors.getIds()
+        if (this.options.proxyConnectionRpcLocal) {
+            propagationTargets = propagationTargets.concat(this.options.proxyConnectionRpcLocal.getPropagationTargets(msg))
         }
-        propagationTargets = propagationTargets.concat(this.config.temporaryConnectionRpcLocal.getNodes().getIds())
+        propagationTargets = propagationTargets.concat(this.options.temporaryConnectionRpcLocal.getNodes().getIds())
         return propagationTargets
     }
 
     getOwnNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.config.localPeerDescriptor)
+        return getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
     }
 
     getOutgoingHandshakeCount(): number {
-        return this.config.handshaker.getOngoingHandshakes().size
+        return this.options.handshaker.getOngoingHandshakes().size
     }
 
     getNeighbors(): PeerDescriptor[] {
         if (!this.started && this.isStopped()) {
             return []
         }
-        return this.config.neighbors.getAll().map((n) => n.getPeerDescriptor())
+        return this.options.neighbors.getAll().map((n) => n.getPeerDescriptor())
     }
 
     getNearbyNodeView(): NodeList {
-        return this.config.nearbyNodeView
+        return this.options.nearbyNodeView
     }
 
     private isStopped() {

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -54,7 +54,7 @@ interface Metrics extends MetricsDefinition {
     broadcastBytesPerSecond: Metric
 }
 
-export interface ContentDeliveryManagerConfig {
+export interface ContentDeliveryManagerOptions {
     metricsContext?: MetricsContext
     streamPartitionNeighborTargetCount?: number
     streamPartitionMinPropagationTargets?: number
@@ -73,17 +73,17 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
     private controlLayerNode?: ControlLayerNode
     private readonly metricsContext: MetricsContext
     private readonly metrics: Metrics
-    private readonly config: ContentDeliveryManagerConfig
+    private readonly options: ContentDeliveryManagerOptions
     private readonly streamParts: Map<StreamPartID, StreamPartDelivery>
     private readonly knownStreamPartEntryPoints: Map<StreamPartID, PeerDescriptor[]> = new Map()
     private started = false
     private destroyed = false
 
-    constructor(config: ContentDeliveryManagerConfig) {
+    constructor(options: ContentDeliveryManagerOptions) {
         super()
-        this.config = config
+        this.options = options
         this.streamParts = new Map()
-        this.metricsContext = config.metricsContext ?? new MetricsContext()
+        this.metricsContext = options.metricsContext ?? new MetricsContext()
         this.metrics = {
             broadcastMessagesPerSecond: new RateMetric(),
             broadcastBytesPerSecond: new RateMetric()
@@ -238,9 +238,9 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             serviceId: 'layer1::' + streamPartId,
             peerDescriptor: this.controlLayerNode!.getLocalPeerDescriptor(),
             entryPoints,
-            numberOfNodesPerKBucket: 4,  // TODO use config option or named constant?
+            numberOfNodesPerKBucket: 4,  // TODO use options option or named constant?
             rpcRequestTimeout: EXISTING_CONNECTION_TIMEOUT,
-            dhtJoinTimeout: 20000,  // TODO use config option or named constant?
+            dhtJoinTimeout: 20000,  // TODO use options option or named constant?
             periodicallyPingNeighbors: true,
             periodicallyPingRingContacts: true
         })
@@ -257,10 +257,10 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             discoveryLayerNode,
             connectionLocker: this.connectionLocker!,
             localPeerDescriptor: this.controlLayerNode!.getLocalPeerDescriptor(),
-            minPropagationTargets: this.config.streamPartitionMinPropagationTargets,
-            neighborTargetCount: this.config.streamPartitionNeighborTargetCount,
-            acceptProxyConnections: this.config.acceptProxyConnections,
-            rpcRequestTimeout: this.config.rpcRequestTimeout,
+            minPropagationTargets: this.options.streamPartitionMinPropagationTargets,
+            neighborTargetCount: this.options.streamPartitionNeighborTargetCount,
+            acceptProxyConnections: this.options.acceptProxyConnections,
+            rpcRequestTimeout: this.options.rpcRequestTimeout,
             isLocalNodeEntryPoint
         })
     }
@@ -273,7 +273,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
         connectionCount?: number
     ): Promise<void> {
         // TODO explicit default value for "acceptProxyConnections" or make it required
-        if (this.config.acceptProxyConnections) {
+        if (this.options.acceptProxyConnections) {
             throw new Error('cannot set proxies when acceptProxyConnections=true')
         }
         const enable = (nodes.length > 0) && ((connectionCount === undefined) || (connectionCount > 0))
@@ -308,7 +308,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             localPeerDescriptor: this.controlLayerNode!.getLocalPeerDescriptor(),
             streamPartId,
             connectionLocker: this.connectionLocker!,
-            minPropagationTargets: this.config.streamPartitionMinPropagationTargets
+            minPropagationTargets: this.options.streamPartitionMinPropagationTargets
         })
     }
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -10,7 +10,7 @@ import { IContentDeliveryRpc } from '../proto/packages/trackerless-network/proto
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { StreamPartID } from '@streamr/protocol'
 
-export interface ContentDeliveryRpcLocalConfig {
+export interface ContentDeliveryRpcLocalOptions {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     markAndCheckDuplicate: (messageId: MessageID, previousMessageRef?: MessageRef) => boolean
@@ -22,26 +22,26 @@ export interface ContentDeliveryRpcLocalConfig {
 
 export class ContentDeliveryRpcLocal implements IContentDeliveryRpc {
     
-    private readonly config: ContentDeliveryRpcLocalConfig
+    private readonly options: ContentDeliveryRpcLocalOptions
 
-    constructor(config: ContentDeliveryRpcLocalConfig) {
-        this.config = config
+    constructor(options: ContentDeliveryRpcLocalOptions) {
+        this.options = options
     }
 
     async sendStreamMessage(message: StreamMessage, context: ServerCallContext): Promise<Empty> {
         const previousNode = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
-        this.config.markForInspection(previousNode, message.messageId!)
-        if (this.config.markAndCheckDuplicate(message.messageId!, message.previousMessageRef)) {
-            this.config.broadcast(message, previousNode)
+        this.options.markForInspection(previousNode, message.messageId!)
+        if (this.options.markAndCheckDuplicate(message.messageId!, message.previousMessageRef)) {
+            this.options.broadcast(message, previousNode)
         }
         return Empty
     }
 
     async leaveStreamPartNotice(message: LeaveStreamPartNotice, context: ServerCallContext): Promise<Empty> {
-        if (message.streamPartId === this.config.streamPartId) {
+        if (message.streamPartId === this.options.streamPartId) {
             const sourcePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
             const remoteNodeId = getNodeIdFromPeerDescriptor(sourcePeerDescriptor)
-            this.config.onLeaveNotice(remoteNodeId, message.isEntryPoint)
+            this.options.onLeaveNotice(remoteNodeId, message.isEntryPoint)
         }
         return Empty
     }

--- a/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
@@ -2,7 +2,7 @@ import { DhtAddress, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } fro
 import { Handshaker } from './neighbor-discovery/Handshaker'
 import { NeighborFinder } from './neighbor-discovery/NeighborFinder'
 import { NeighborUpdateManager } from './neighbor-discovery/NeighborUpdateManager'
-import { StrictContentDeliveryLayerNodeConfig, ContentDeliveryLayerNode } from './ContentDeliveryLayerNode'
+import { StrictContentDeliveryLayerNodeOptions, ContentDeliveryLayerNode } from './ContentDeliveryLayerNode'
 import { NodeList } from './NodeList'
 import { Propagation } from './propagation/Propagation'
 import { StreamMessage } from '../proto/packages/trackerless-network/protos/NetworkRpc'
@@ -12,7 +12,7 @@ import { Inspector } from './inspect/Inspector'
 import { TemporaryConnectionRpcLocal } from './temporary-connection/TemporaryConnectionRpcLocal'
 import { formStreamPartContentDeliveryServiceId } from './formStreamPartDeliveryServiceId'
 
-type ContentDeliveryLayerNodeConfig = MarkOptional<StrictContentDeliveryLayerNodeConfig,
+type ContentDeliveryLayerNodeOptions = MarkOptional<StrictContentDeliveryLayerNodeOptions,
     'nearbyNodeView' | 'randomNodeView' | 'neighbors' | 'leftNodeView' | 'rightNodeView' | 'propagation'
     | 'handshaker' | 'neighborFinder' | 'neighborUpdateManager' | 'neighborTargetCount'
     | 'rpcCommunicator' | 'nodeViewSize'
@@ -23,36 +23,36 @@ type ContentDeliveryLayerNodeConfig = MarkOptional<StrictContentDeliveryLayerNod
         neighborUpdateInterval?: number
     }
 
-const createConfigWithDefaults = (config: ContentDeliveryLayerNodeConfig): StrictContentDeliveryLayerNodeConfig => {
-    const ownNodeId = getNodeIdFromPeerDescriptor(config.localPeerDescriptor)
-    const rpcCommunicator = config.rpcCommunicator ?? new ListeningRpcCommunicator(
-        formStreamPartContentDeliveryServiceId(config.streamPartId),
-        config.transport
+const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): StrictContentDeliveryLayerNodeOptions => {
+    const ownNodeId = getNodeIdFromPeerDescriptor(options.localPeerDescriptor)
+    const rpcCommunicator = options.rpcCommunicator ?? new ListeningRpcCommunicator(
+        formStreamPartContentDeliveryServiceId(options.streamPartId),
+        options.transport
     )
-    const neighborTargetCount = config.neighborTargetCount ?? 4
-    const maxContactCount = config.maxContactCount ?? 20
-    const minPropagationTargets = config.minPropagationTargets ?? 2
-    const acceptProxyConnections = config.acceptProxyConnections ?? false
-    const neighborUpdateInterval = config.neighborUpdateInterval ?? 10000
-    const neighbors = config.neighbors ?? new NodeList(ownNodeId, maxContactCount)
-    const leftNodeView = config.leftNodeView ?? new NodeList(ownNodeId, maxContactCount)
-    const rightNodeView = config.rightNodeView ?? new NodeList(ownNodeId, maxContactCount)
-    const nearbyNodeView = config.nearbyNodeView ?? new NodeList(ownNodeId, maxContactCount)
-    const randomNodeView = config.randomNodeView ?? new NodeList(ownNodeId, maxContactCount)
+    const neighborTargetCount = options.neighborTargetCount ?? 4
+    const maxContactCount = options.maxContactCount ?? 20
+    const minPropagationTargets = options.minPropagationTargets ?? 2
+    const acceptProxyConnections = options.acceptProxyConnections ?? false
+    const neighborUpdateInterval = options.neighborUpdateInterval ?? 10000
+    const neighbors = options.neighbors ?? new NodeList(ownNodeId, maxContactCount)
+    const leftNodeView = options.leftNodeView ?? new NodeList(ownNodeId, maxContactCount)
+    const rightNodeView = options.rightNodeView ?? new NodeList(ownNodeId, maxContactCount)
+    const nearbyNodeView = options.nearbyNodeView ?? new NodeList(ownNodeId, maxContactCount)
+    const randomNodeView = options.randomNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const ongoingHandshakes = new Set<DhtAddress>()
 
     const temporaryConnectionRpcLocal = new TemporaryConnectionRpcLocal({
         rpcCommunicator,
-        localPeerDescriptor: config.localPeerDescriptor,
-        streamPartId: config.streamPartId,
-        connectionLocker: config.connectionLocker
+        localPeerDescriptor: options.localPeerDescriptor,
+        streamPartId: options.streamPartId,
+        connectionLocker: options.connectionLocker
     })
     const proxyConnectionRpcLocal = acceptProxyConnections ? new ProxyConnectionRpcLocal({
-        localPeerDescriptor: config.localPeerDescriptor,
-        streamPartId: config.streamPartId,
+        localPeerDescriptor: options.localPeerDescriptor,
+        streamPartId: options.streamPartId,
         rpcCommunicator
     }) : undefined
-    const propagation = config.propagation ?? new Propagation({
+    const propagation = options.propagation ?? new Propagation({
         minPropagationTargets,
         sendToNeighbor: async (neighborId: DhtAddress, msg: StreamMessage): Promise<void> => {
             const remote = neighbors.get(neighborId) ?? temporaryConnectionRpcLocal.getNodes().get(neighborId)
@@ -66,9 +66,9 @@ const createConfigWithDefaults = (config: ContentDeliveryLayerNodeConfig): Stric
             }
         }
     })
-    const handshaker = config.handshaker ?? new Handshaker({
-        localPeerDescriptor: config.localPeerDescriptor,
-        streamPartId: config.streamPartId,
+    const handshaker = options.handshaker ?? new Handshaker({
+        localPeerDescriptor: options.localPeerDescriptor,
+        streamPartId: options.streamPartId,
         rpcCommunicator,
         neighbors,
         leftNodeView,
@@ -76,10 +76,10 @@ const createConfigWithDefaults = (config: ContentDeliveryLayerNodeConfig): Stric
         nearbyNodeView,
         randomNodeView,
         maxNeighborCount: neighborTargetCount,
-        rpcRequestTimeout: config.rpcRequestTimeout,
+        rpcRequestTimeout: options.rpcRequestTimeout,
         ongoingHandshakes
     })
-    const neighborFinder = config.neighborFinder ?? new NeighborFinder({
+    const neighborFinder = options.neighborFinder ?? new NeighborFinder({
         neighbors,
         leftNodeView,
         rightNodeView,
@@ -88,25 +88,25 @@ const createConfigWithDefaults = (config: ContentDeliveryLayerNodeConfig): Stric
         doFindNeighbors: (excludedIds) => handshaker.attemptHandshakesOnContacts(excludedIds),
         minCount: neighborTargetCount
     })
-    const neighborUpdateManager = config.neighborUpdateManager ?? new NeighborUpdateManager({
+    const neighborUpdateManager = options.neighborUpdateManager ?? new NeighborUpdateManager({
         neighbors,
         nearbyNodeView,
-        localPeerDescriptor: config.localPeerDescriptor,
+        localPeerDescriptor: options.localPeerDescriptor,
         neighborFinder,
-        streamPartId: config.streamPartId,
+        streamPartId: options.streamPartId,
         rpcCommunicator,
         neighborUpdateInterval,
         neighborTargetCount,
         ongoingHandshakes
     })
-    const inspector = config.inspector ?? new Inspector({
-        localPeerDescriptor: config.localPeerDescriptor,
+    const inspector = options.inspector ?? new Inspector({
+        localPeerDescriptor: options.localPeerDescriptor,
         rpcCommunicator,
-        streamPartId: config.streamPartId,
-        connectionLocker: config.connectionLocker
+        streamPartId: options.streamPartId,
+        connectionLocker: options.connectionLocker
     })
     return {
-        ...config,
+        ...options,
         neighbors,
         leftNodeView,
         rightNodeView,
@@ -125,6 +125,6 @@ const createConfigWithDefaults = (config: ContentDeliveryLayerNodeConfig): Stric
     }
 }
 
-export const createContentDeliveryLayerNode = (config: ContentDeliveryLayerNodeConfig): ContentDeliveryLayerNode => {
-    return new ContentDeliveryLayerNode(createConfigWithDefaults(config))
+export const createContentDeliveryLayerNode = (options: ContentDeliveryLayerNodeOptions): ContentDeliveryLayerNode => {
+    return new ContentDeliveryLayerNode(createConfigWithDefaults(options))
 }

--- a/packages/trackerless-network/src/logic/inspect/InspectSession.ts
+++ b/packages/trackerless-network/src/logic/inspect/InspectSession.ts
@@ -7,7 +7,7 @@ export interface Events {
     done: () => void
 }
 
-interface InspectSessionConfig {
+interface InspectSessionOptions {
     inspectedNode: DhtAddress
 }
 
@@ -20,9 +20,9 @@ export class InspectSession extends EventEmitter<Events> {
     private readonly inspectionMessages: Map<string, boolean> = new Map()
     private readonly inspectedNode: DhtAddress
 
-    constructor(config: InspectSessionConfig) {
+    constructor(options: InspectSessionOptions) {
         super()
-        this.inspectedNode = config.inspectedNode
+        this.inspectedNode = options.inspectedNode
     }
 
     markMessage(remoteNodeId: DhtAddress, messageId: MessageID): void {

--- a/packages/trackerless-network/src/logic/inspect/Inspector.ts
+++ b/packages/trackerless-network/src/logic/inspect/Inspector.ts
@@ -6,7 +6,7 @@ import { Logger, waitForEvent3 } from '@streamr/utils'
 import { TemporaryConnectionRpcRemote } from '../temporary-connection/TemporaryConnectionRpcRemote'
 import { StreamPartID } from '@streamr/protocol'
 
-interface InspectorConfig {
+interface InspectorOptions {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     rpcCommunicator: ListeningRpcCommunicator
@@ -30,14 +30,14 @@ export class Inspector {
     private readonly openInspectConnection: (peerDescriptor: PeerDescriptor, lockId: LockID) => Promise<void>
     private readonly closeInspectConnection: (peerDescriptor: PeerDescriptor, lockId: LockID) => Promise<void>
 
-    constructor(config: InspectorConfig) {
-        this.streamPartId = config.streamPartId
-        this.localPeerDescriptor = config.localPeerDescriptor
-        this.rpcCommunicator = config.rpcCommunicator
-        this.connectionLocker = config.connectionLocker
-        this.inspectionTimeout = config.inspectionTimeout ?? DEFAULT_TIMEOUT
-        this.openInspectConnection = config.openInspectConnection ?? this.defaultOpenInspectConnection
-        this.closeInspectConnection = config.closeInspectConnection ?? this.defaultCloseInspectConnection
+    constructor(options: InspectorOptions) {
+        this.streamPartId = options.streamPartId
+        this.localPeerDescriptor = options.localPeerDescriptor
+        this.rpcCommunicator = options.rpcCommunicator
+        this.connectionLocker = options.connectionLocker
+        this.inspectionTimeout = options.inspectionTimeout ?? DEFAULT_TIMEOUT
+        this.openInspectConnection = options.openInspectConnection ?? this.defaultOpenInspectConnection
+        this.closeInspectConnection = options.closeInspectConnection ?? this.defaultCloseInspectConnection
     }
 
     async defaultOpenInspectConnection(peerDescriptor: PeerDescriptor, lockId: LockID): Promise<void> {

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborFinder.ts
@@ -2,7 +2,7 @@ import { setAbortableTimeout } from '@streamr/utils'
 import { NodeList } from '../NodeList'
 import { DhtAddress } from '@streamr/dht'
 
-interface FindNeighborsSessionConfig {
+interface FindNeighborsSessionOptions {
     neighbors: NodeList
     nearbyNodeView: NodeList
     leftNodeView: NodeList
@@ -17,11 +17,11 @@ const INTERVAL = 250
 
 export class NeighborFinder {
     private readonly abortController: AbortController
-    private readonly config: FindNeighborsSessionConfig
+    private readonly options: FindNeighborsSessionOptions
     private running = false
 
-    constructor(config: FindNeighborsSessionConfig) {
-        this.config = config
+    constructor(options: FindNeighborsSessionOptions) {
+        this.options = options
         this.abortController = new AbortController()
     }
 
@@ -29,14 +29,14 @@ export class NeighborFinder {
         if (!this.running) {
             return
         }
-        const newExcludes = await this.config.doFindNeighbors(excluded)
+        const newExcludes = await this.options.doFindNeighbors(excluded)
         const uniqueContactCount = new Set([
-            ...this.config.nearbyNodeView.getIds(),
-            ...this.config.leftNodeView.getIds(),
-            ...this.config.rightNodeView.getIds(),
-            ...this.config.randomNodeView.getIds()
+            ...this.options.nearbyNodeView.getIds(),
+            ...this.options.leftNodeView.getIds(),
+            ...this.options.rightNodeView.getIds(),
+            ...this.options.randomNodeView.getIds()
         ]).size
-        if (this.config.neighbors.size() < this.config.minCount && newExcludes.length < uniqueContactCount) {
+        if (this.options.neighbors.size() < this.options.minCount && newExcludes.length < uniqueContactCount) {
             // TODO should we catch possible promise rejection?
             setAbortableTimeout(() => this.findNeighbors(newExcludes), INTERVAL, this.abortController.signal)
         } else {

--- a/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
@@ -21,7 +21,7 @@ interface ProxyConnection {
     remote: ContentDeliveryRpcRemote
 }
 
-interface ProxyConnectionRpcLocalConfig {
+interface ProxyConnectionRpcLocalOptions {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     rpcCommunicator: ListeningRpcCommunicator
@@ -33,13 +33,13 @@ export interface Events {
 
 export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IProxyConnectionRpc {
 
-    private readonly config: ProxyConnectionRpcLocalConfig
+    private readonly options: ProxyConnectionRpcLocalOptions
     private readonly connections: Map<DhtAddress, ProxyConnection> = new Map()
 
-    constructor(config: ProxyConnectionRpcLocalConfig) {
+    constructor(options: ProxyConnectionRpcLocalOptions) {
         super()
-        this.config = config
-        this.config.rpcCommunicator.registerRpcMethod(ProxyConnectionRequest, ProxyConnectionResponse, 'requestConnection',
+        this.options = options
+        this.options.rpcCommunicator.registerRpcMethod(ProxyConnectionRequest, ProxyConnectionResponse, 'requestConnection',
             (msg: ProxyConnectionRequest, context) => this.requestConnection(msg, context))
     }
 
@@ -56,7 +56,7 @@ export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IPr
     }
 
     stop(): void {
-        this.connections.forEach((connection) => connection.remote.leaveStreamPartNotice(this.config.streamPartId, false))
+        this.connections.forEach((connection) => connection.remote.leaveStreamPartNotice(this.options.streamPartId, false))
         this.connections.clear()
         this.removeAllListeners()
     }
@@ -91,16 +91,16 @@ export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IPr
             direction: request.direction,
             userId: toEthereumAddress(binaryToHex(request.userId, true)),
             remote: new ContentDeliveryRpcRemote(
-                this.config.localPeerDescriptor,
+                this.options.localPeerDescriptor,
                 senderPeerDescriptor,
-                this.config.rpcCommunicator,
+                this.options.rpcCommunicator,
                 ContentDeliveryRpcClient
             )
         })
         const response: ProxyConnectionResponse = {
             accepted: true
         }
-        logger.trace(`Accepted connection request from ${remoteNodeId} to ${this.config.streamPartId}`)
+        logger.trace(`Accepted connection request from ${remoteNodeId} to ${this.options.streamPartId}`)
         this.emit('newConnection', remoteNodeId)
         return response
     }


### PR DESCRIPTION
## Background

In `dht`, `trackerless-network` and `proto-rpc` packages we use style where options of a class are passed as an object argument. That argument may contain some config values, class dependencies and/or functions. 

E.g. for a `Foobar` class we typically had `FoobarConfig` interface.

## Changes

Renamed the interfaces to have `Options` suffix instead of `Config` suffix. Renamed also related class fields, i.e. typically just `config` -> `options`.