### PR TITLE
refactor(trackerless-network): Remove `StreamMessageType` enum

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -47,12 +47,6 @@ message MessageRef {
   int32 sequenceNumber = 2;
 }
 
-enum StreamMessageType {
-  MESSAGE = 0;
-  GROUP_KEY_REQUEST = 1;
-  GROUP_KEY_RESPONSE = 2;
-}
-
 enum ContentType {
   JSON = 0;
   BINARY = 1;

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -360,23 +360,6 @@ export interface NodeInfoResponse {
     version: string;
 }
 /**
- * @generated from protobuf enum StreamMessageType
- */
-export enum StreamMessageType {
-    /**
-     * @generated from protobuf enum value: MESSAGE = 0;
-     */
-    MESSAGE = 0,
-    /**
-     * @generated from protobuf enum value: GROUP_KEY_REQUEST = 1;
-     */
-    GROUP_KEY_REQUEST = 1,
-    /**
-     * @generated from protobuf enum value: GROUP_KEY_RESPONSE = 2;
-     */
-    GROUP_KEY_RESPONSE = 2
-}
-/**
  * @generated from protobuf enum ContentType
  */
 export enum ContentType {


### PR DESCRIPTION
## Background

We refactored `trackerless-network`'s `StreamMessage` structure in https://github.com/streamr-dev/network/pull/2380. In that PR we removed the usage of `StreamMessageType` enum and started to use `protobuf` sub entities instead.

## Changes

Removed the enum definition as it is no longer used.

There is a separate enum with the same name in the `protocol` package. That is still needed as `protocol`'s `StreamMessage` class uses it.