### PR TITLE
refactor(client)[!]: Rename `resendComplete` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ Changes before Tatum release are not documented in this file.
 - Update to ethers.js library to v6 (https://github.com/streamr-dev/network/pull/2506)
 - Restructured `contracts` config structure (https://github.com/streamr-dev/network/pull/2581)
 - Improve reliability of JSON RPC interactions by adding retry redundancy (https://github.com/streamr-dev/network/pull/2562)
-- Renamed events: (https://github.com/streamr-dev/network/pull/2604)
+- Renamed events: (https://github.com/streamr-dev/network/pull/2604, https://github.com/streamr-dev/network/pull/2605)
   - `createStream` -> `streamCreated`
   - `addToStorageNode` -> `streamAddedToStorageNode`
   - `removeFromStorageNode` -> `streamRemovedFromFromStorageNode`
+  - Subscription: `resendComplete` -> `resendCompleted`
 
 #### Deprecated
 

--- a/docs/docs/usage/streams/store-and-retrieve.md
+++ b/docs/docs/usage/streams/store-and-retrieve.md
@@ -133,7 +133,7 @@ If you choose one of the above resend options when subscribing, you can listen o
 
 ```ts
 const sub = await streamr.subscribe(options);
-sub.once('resendComplete', () => {
+sub.once('resendCompleted', () => {
   console.log(
     'Received all requested historical messages! Now switching to real time!'
   );

--- a/packages/client/src/subscribe/Subscription.ts
+++ b/packages/client/src/subscribe/Subscription.ts
@@ -16,7 +16,7 @@ export interface SubscriptionEvents {
     /**
      * Emitted when a resend is complete.
      */
-    resendComplete: () => void
+    resendCompleted: () => void
 }
 
 /**

--- a/packages/client/src/subscribe/resendSubscription.ts
+++ b/packages/client/src/subscribe/resendSubscription.ts
@@ -38,7 +38,7 @@ export const initResendSubscription = (
                 await subscription.handleError(err)
             }
         }
-        eventEmitter.emit('resendComplete')
+        eventEmitter.emit('resendCompleted')
         yield* src
     }
     subscription.pipe(resendThenRealtime)

--- a/packages/client/test/integration/Resends2.test.ts
+++ b/packages/client/test/integration/Resends2.test.ts
@@ -114,7 +114,7 @@ describe('Resends2', () => {
                     expect(receivedMsgs).toEqual([])
                 })
 
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
                 const publishedStream2 = await publishTestMessages(3)
 
                 const receivedMsgs: any[] = []
@@ -146,7 +146,7 @@ describe('Resends2', () => {
                 const onResent = jest.fn(() => {
                     expect(receivedMsgs).toEqual([])
                 })
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
 
                 await publishTestMessages(3)
                 await collect(sub, 3)
@@ -167,7 +167,7 @@ describe('Resends2', () => {
                 })
 
                 const onResent = jest.fn(() => {})
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
                 const onSubError = jest.fn()
                 sub.on('error', onSubError) // suppress
 
@@ -199,7 +199,7 @@ describe('Resends2', () => {
                 const onResent = jest.fn(() => {
                     expect(receivedMsgs).toEqual([])
                 })
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
 
                 for await (const msg of sub) {
                     receivedMsgs.push(msg)
@@ -371,7 +371,7 @@ describe('Resends2', () => {
                 expect(await client.getSubscriptions(stream.id)).toHaveLength(1)
 
                 const onResent = jest.fn()
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
                 const receivedMsgsPromise = collect(sub, MAX_MESSAGES + REALTIME_MESSAGES)
                 await waitForCondition(() => onResent.mock.calls.length > 0)
 
@@ -409,7 +409,7 @@ describe('Resends2', () => {
                     expect(receivedMsgs).toEqual(publishedBefore)
                 })
 
-                sub.once('resendComplete', onResent)
+                sub.once('resendCompleted', onResent)
 
                 for await (const msg of sub) {
                     receivedMsgs.push(msg)

--- a/packages/client/test/integration/events.test.ts
+++ b/packages/client/test/integration/events.test.ts
@@ -34,7 +34,7 @@ describe('events', () => {
                 }
             }, () => {})
             const onResendComplete = jest.fn()
-            subscription.once('resendComplete', onResendComplete)
+            subscription.once('resendCompleted', onResendComplete)
             await client.destroy()
             expect(onResendComplete).not.toBeCalled()
             // @ts-expect-error private

--- a/packages/client/test/integration/sequential-resend-subscribe.test.ts
+++ b/packages/client/test/integration/sequential-resend-subscribe.test.ts
@@ -73,7 +73,7 @@ describe('sequential resend subscribe', () => {
             })
 
             const onResent = jest.fn()
-            sub.once('resendComplete', onResent)
+            sub.once('resendCompleted', onResent)
 
             const expectedMessageCount = published.length + 1 // the realtime message which we publish next
             const receivedMsgsPromise = collect(sub, expectedMessageCount)

--- a/packages/client/test/unit/resendSubscription.test.ts
+++ b/packages/client/test/unit/resendSubscription.test.ts
@@ -132,7 +132,7 @@ describe('resend subscription', () => {
         const onResendComplete = jest.fn().mockImplementation(
             () => latestMessageWhenResendComplete = last(outputMessages.values())!
         )
-        sub.on('resendComplete', onResendComplete)
+        sub.on('resendCompleted', onResendComplete)
         startConsuming()
 
         const bufferedRealtimeMessages = await publishAndWaitUntilConsumed('bufferedRealtime')


### PR DESCRIPTION
Renamed subscription event: `resendComplete` -> `resendCompleted`