### PR TITLE
feat(cdn-location): Remove `aws.amazon.com` URL

### DIFF
--- a/packages/cdn-location/README.md
+++ b/packages/cdn-location/README.md
@@ -4,7 +4,7 @@ CDN-location is a small package that provides a way to detect the very rough loc
 
 The location is detected using IATA code returned in HTTP response headers of:
 
-1. https://aws.amazon.com
+1. https://d47ahk2wrqweh.cloudfront.net/cdn-location (a custom Amazon CloudFront distribution)
 2. https://www.fastly.com
 3. https://www.cloudflare.com
 

--- a/packages/cdn-location/src/fetchAirportCodeFromCdn.ts
+++ b/packages/cdn-location/src/fetchAirportCodeFromCdn.ts
@@ -56,12 +56,6 @@ export const fetchAirportCodeFromCdn: () => Promise<string> = async () => {
     }
 
     try {
-        return await fetchAirportCodeFromAmazon('https://aws.amazon.com', timeout)
-    } catch (error) {
-        logger.warn(error)
-    }
-
-    try {
         return await fetchAirportCodeFromFastly(timeout)
     } catch (error) {
         logger.warn(error)

--- a/packages/cdn-location/test/integration/fetchAirportCodeFromCdn.test.ts
+++ b/packages/cdn-location/test/integration/fetchAirportCodeFromCdn.test.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@streamr/utils'
-import { fetchAirportCodeFromAmazon, 
+import {
     fetchAirportCodeFromCdn, 
     fetchAirportCodeFromCloudflare, 
     fetchAirportCodeFromFastly } from '../../src/fetchAirportCodeFromCdn'

--- a/packages/cdn-location/test/integration/fetchAirportCodeFromCdn.test.ts
+++ b/packages/cdn-location/test/integration/fetchAirportCodeFromCdn.test.ts
@@ -8,12 +8,6 @@ import { airportCodeToRegion } from '../../src/airportCodeToRegion'
 const logger = new Logger(module)
 
 describe('fetchAirportCodeFromCdn', () => {
-    
-    it('fetches airport code from Amazon', async () => {
-        const airportCode = await fetchAirportCodeFromAmazon('https://aws.amazon.com', 5000)
-        logger.info(`Airport code from Amazon: ${airportCode}`)
-        expect(typeof airportCodeToRegion[airportCode][0]).toBe('number')
-    })
 
     it('fetches airport code from Fastly', async () => {
         const airportCode = await fetchAirportCodeFromFastly(5000)


### PR DESCRIPTION
It seems that the `aws.amazon.com` responses no longer include the `X-Amz-Cf-Pop` header used by our `cdn-location` functionality. Therefore removed the URL from the list.