### PR TITLE
fix(sdk) [NET-1318]: Avoid reference to @streamr/test-utils from src code

### DIFF
--- a/packages/client/src/contracts/operatorContractUtils.ts
+++ b/packages/client/src/contracts/operatorContractUtils.ts
@@ -1,6 +1,5 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { SignerWithProvider } from '@streamr/sdk'
-import { fastPrivateKey } from '@streamr/test-utils'
 import { Logger, retry } from '@streamr/utils'
 import { Contract, EventLog, JsonRpcProvider, Provider, Wallet, ZeroAddress, parseEther } from 'ethers'
 import { range } from 'lodash'
@@ -14,6 +13,7 @@ import type { SponsorshipFactory as SponsorshipFactoryContract } from '../ethere
 import SponsorshipFactoryArtifact from '../ethereumArtifacts/SponsorshipFactoryAbi.json'
 import type { TestToken as TestTokenContract } from '../ethereumArtifacts/TestToken'
 import TestTokenArtifact from '../ethereumArtifacts/TestTokenAbi.json'
+import crypto from 'crypto'
 
 const TEST_CHAIN_CONFIG = CHAIN_CONFIG.dev2
 
@@ -198,7 +198,8 @@ interface GenerateWalletWithGasAndTokensOpts {
 
 export async function generateWalletWithGasAndTokens(opts?: GenerateWalletWithGasAndTokensOpts): Promise<Wallet & SignerWithProvider> {
     const provider = getProvider()
-    const newWallet = new Wallet(fastPrivateKey())
+    const privateKey = crypto.randomBytes(32).toString('hex')
+    const newWallet = new Wallet(privateKey)
     const adminWallet = getAdminWallet()
     const token = (opts?.chainConfig !== undefined)
         ? new Contract(opts.chainConfig.contracts.DATA, TestTokenArtifact, adminWallet) as unknown as TestTokenContract


### PR DESCRIPTION
## Summary

The reference to `@streamr/test-utils` from `src` directory was causing references to `Express` to be included in the generated webpack bundle. Replaced `fastPrivateKey` call with direct call to `crypto` package.

## Future improvements
- Create eslint rule that forbids using `devDependencies` in source code directories.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
