### PR TITLE
refactor(client): Change `StreamrClient#getNode` return type

### DIFF
--- a/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
+++ b/packages/broker/src/plugins/consoleMetrics/ConsoleMetricsPlugin.ts
@@ -20,7 +20,7 @@ export class ConsoleMetricsPlugin extends Plugin<ConsoleMetricsPluginConfig> {
     private readonly abortController = new AbortController()
 
     async start(streamrClient: StreamrClient): Promise<void> {
-        const metricsContext = (await (streamrClient.getNode())).getMetricsContext()
+        const metricsContext = await streamrClient.getNode().getMetricsContext()
         metricsContext.createReportProducer((report: MetricsReport) => {
             // omit timestamp info as that is printed by the logger
             const data = omit(report, 'period')

--- a/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/broker/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -53,9 +53,9 @@ describe('Subscriber Plugin', () => {
     })
 
     it('subscribes to the configured list of streams', async () => {
-        const node = await client.getNode()
-        await waitForCondition(() => {
-            const streams = node.getStreamParts().map((stream) => stream.toString())
+        const node = client.getNode()
+        await waitForCondition(async () => {
+            const streams = (await node.getStreamParts()).map((stream) => stream.toString())
             return streams.includes('stream-0#0')
                 && streams.includes('stream-0#1')
                 && streams.includes('stream-1#0')

--- a/packages/client/src/MetricsPublisher.ts
+++ b/packages/client/src/MetricsPublisher.ts
@@ -68,9 +68,8 @@ export class MetricsPublisher {
         this.eventEmitter = eventEmitter
         this.destroySignal = destroySignal
         const ensureStarted = pOnce(async () => {
-            const node = await this.node.getNode()
-            const metricsContext = node.getMetricsContext()
-            const nodeId = node.getNodeId()
+            const metricsContext = await this.node.getMetricsContext()
+            const nodeId = await this.node.getNodeId()
             this.config.periods.forEach((config) => {
                 return metricsContext.createReportProducer(async (report: MetricsReport) => {
                     await this.publish(report, config.streamId, nodeId)

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -99,10 +99,6 @@ export class NetworkNodeFacade {
         destroySignal.onDestroy.listen(this.destroy)
     }
 
-    private assertNotDestroyed(): void {
-        this.destroySignal.assertNotDestroyed()
-    }
-
     private async getNetworkOptions(): Promise<NetworkOptions> {
         const entryPoints = await this.getEntryPoints()
         const localPeerDescriptor: PeerDescriptor | undefined = this.config.network.controlLayer.peerDescriptor ? 
@@ -156,7 +152,7 @@ export class NetworkNodeFacade {
             } else {
                 this.eventEmitter.emit('start')
             }
-            this.assertNotDestroyed()
+            this.destroySignal.assertNotDestroyed()
             return node
         } finally {
             this.startNodeComplete = true
@@ -164,7 +160,7 @@ export class NetworkNodeFacade {
     })
 
     private async initNode(): Promise<NetworkNodeStub> {
-        this.assertNotDestroyed()
+        this.destroySignal.assertNotDestroyed()
         if (this.cachedNode) { return this.cachedNode }
         const node = this.networkNodeFactory.createNetworkNode(await this.getNetworkOptions())
         if (!this.destroySignal.isDestroyed()) {
@@ -176,7 +172,7 @@ export class NetworkNodeFacade {
     startNode: () => Promise<unknown> = this.startNodeTask
 
     getNode(): Promise<NetworkNodeStub> {
-        this.assertNotDestroyed()
+        this.destroySignal.assertNotDestroyed()
         return this.startNodeTask()
     }
 

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -241,9 +241,12 @@ export class NetworkNodeFacade {
         return node.getOptions()
     }
 
-    async inspect(peerDescriptor: NetworkPeerDescriptor, streamPartId: StreamPartID): Promise<boolean> {
-        const node = await this.getNode()
-        return node.inspect(peerDescriptorTranslator(peerDescriptor), streamPartId)
+    async inspect(node: NetworkPeerDescriptor, streamPartId: StreamPartID): Promise<boolean> {
+        if (this.isStarting()) {
+            await this.startNodeTask(false)
+        }
+        const peerDescriptor = peerDescriptorTranslator(node)
+        return this.cachedNode!.inspect(peerDescriptor, streamPartId)
     }
 
     async setProxies(
@@ -252,9 +255,11 @@ export class NetworkNodeFacade {
         direction: ProxyDirection,
         connectionCount?: number
     ): Promise<void> {
+        if (this.isStarting()) {
+            await this.startNodeTask(false)
+        }
         const peerDescriptors = nodes.map(peerDescriptorTranslator)
-        const node = await this.getNode()
-        await node.setProxies(
+        await this.cachedNode!.setProxies(
             streamPartId,
             peerDescriptors,
             direction,
@@ -264,9 +269,11 @@ export class NetworkNodeFacade {
     }
 
     async setStreamPartEntryPoints(streamPartId: StreamPartID, nodeDescriptors: NetworkPeerDescriptor[]): Promise<void> {
+        if (this.isStarting()) {
+            await this.startNodeTask(false)
+        }
         const peerDescriptors = nodeDescriptors.map(peerDescriptorTranslator)
-        const node = await this.getNode()
-        node.setStreamPartEntryPoints(streamPartId, peerDescriptors)
+        this.cachedNode!.setStreamPartEntryPoints(streamPartId, peerDescriptors)
     }
 
     private isStarting(): boolean {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -3,7 +3,11 @@
  */
 import { DhtAddress, PeerDescriptor } from '@streamr/dht'
 import { StreamMessage, StreamPartID } from '@streamr/protocol'
-import { NetworkOptions, ProxyDirection, createNetworkNode as createNetworkNode_ } from '@streamr/trackerless-network'
+import {
+    NetworkOptions,
+    ProxyDirection,
+    createNetworkNode as createNetworkNode_
+} from '@streamr/trackerless-network'
 import { EthereumAddress, MetricsContext } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 import { Lifecycle, inject, scoped } from 'tsyringe'
@@ -158,7 +162,6 @@ export class NetworkNodeFacade {
             if (!this.destroySignal.isDestroyed()) {
                 await node.start(doJoin)
             }
-
             if (this.destroySignal.isDestroyed()) {
                 await node.stop()
             } else {
@@ -199,6 +202,67 @@ export class NetworkNodeFacade {
             )
         }
         return this.cachedNode!.broadcast(streamMessage)
+    }
+
+    async join(streamPartId: StreamPartID, neighborRequirement?: { minCount: number, timeout: number }): Promise<void> {
+        const node = await this.getNode()
+        await node.join(streamPartId, neighborRequirement)
+    }
+
+    async leave(streamPartId: StreamPartID): Promise<void> {
+        const node = await this.getNode()
+        await node.leave(streamPartId)
+    }
+
+    // TODO should we remove publishToNode method and use the broacast method instead?
+    async broadcast(msg: StreamMessage): Promise<void> {
+        const node = await this.getNode()
+        node.broadcast(msg)
+    }
+    
+    async addMessageListener(listener: (msg: StreamMessage) => void): Promise<void> {
+        const node = await this.getNode()
+        node.addMessageListener(listener)
+    }
+
+    async removeMessageListener(listener: (msg: StreamMessage) => void): Promise<void> {
+        const node = await this.getNode()
+        node.removeMessageListener(listener)
+    }
+
+    async isProxiedStreamPart(streamPartId: StreamPartID): Promise<boolean> {
+        const node = await this.getNode()
+        return node.isProxiedStreamPart(streamPartId)
+    }
+
+    async getMetricsContext(): Promise<MetricsContext> {
+        const node = await this.getNode()
+        return node.getMetricsContext()
+    }
+
+    async getPeerDescriptor(): Promise<PeerDescriptor> {
+        const node = await this.getNode()
+        return node.getPeerDescriptor()
+    }
+
+    async getDiagnosticInfo(): Promise<Record<string, unknown>> {
+        const node = await this.getNode()
+        return node.getDiagnosticInfo()
+    }
+
+    async getStreamParts(): Promise<ReadonlyArray<StreamPartID>> {
+        const node = await this.getNode()
+        return node.getStreamParts()
+    }
+
+    async getNeighbors(streamPartId: StreamPartID): Promise<ReadonlyArray<DhtAddress>> {
+        const node = await this.getNode()
+        return node.getNeighbors(streamPartId)
+    }
+
+    async getOptions(): Promise<NetworkOptions> {
+        const node = await this.getNode()
+        return node.getOptions()
     }
 
     async inspect(node: NetworkPeerDescriptor, streamPartId: StreamPartID): Promise<boolean> {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -121,17 +121,6 @@ export class NetworkNodeFacade {
         }
     }
 
-    private async initNode(): Promise<NetworkNodeStub> {
-        this.assertNotDestroyed()
-        if (this.cachedNode) { return this.cachedNode }
-
-        const node = this.networkNodeFactory.createNetworkNode(await this.getNetworkOptions())
-        if (!this.destroySignal.isDestroyed()) {
-            this.cachedNode = node
-        }
-        return node
-    }
-
     /**
      * Stop network node, or wait for it to stop if already stopping.
      * Subsequent calls to getNode/start will fail.
@@ -173,6 +162,16 @@ export class NetworkNodeFacade {
             this.startNodeComplete = true
         }
     })
+
+    private async initNode(): Promise<NetworkNodeStub> {
+        this.assertNotDestroyed()
+        if (this.cachedNode) { return this.cachedNode }
+        const node = this.networkNodeFactory.createNetworkNode(await this.getNetworkOptions())
+        if (!this.destroySignal.isDestroyed()) {
+            this.cachedNode = node
+        }
+        return node
+    }
 
     startNode: () => Promise<unknown> = this.startNodeTask
 

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -176,7 +176,10 @@ export class NetworkNodeFacade {
 
     startNode: () => Promise<unknown> = this.startNodeTask
 
-    getNode: () => Promise<NetworkNodeStub> = this.startNodeTask
+    getNode(): Promise<NetworkNodeStub> {
+        this.assertNotDestroyed()
+        return this.startNodeTask()
+    }
 
     async getNodeId(): Promise<DhtAddress> {
         const node = await this.getNode()

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -140,6 +140,7 @@ export class NetworkNodeFacade {
     /**
      * Start network node, or wait for it to start if already started.
      */
+    // TODO: doJoin parameter seems problematic here; see ticket NET-1319
     private startNodeTask = pOnce(async (doJoin: boolean = true) => {
         this.startNodeCalled = true
         try {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -267,12 +267,9 @@ export class NetworkNodeFacade {
         return node.getOptions()
     }
 
-    async inspect(node: NetworkPeerDescriptor, streamPartId: StreamPartID): Promise<boolean> {
-        if (this.isStarting()) {
-            await this.startNodeTask(false)
-        }
-        const peerDescriptor = peerDescriptorTranslator(node)
-        return this.cachedNode!.inspect(peerDescriptor, streamPartId)
+    async inspect(peerDescriptor: NetworkPeerDescriptor, streamPartId: StreamPartID): Promise<boolean> {
+        const node = await this.getNode()
+        return node.inspect(peerDescriptorTranslator(peerDescriptor), streamPartId)
     }
 
     async setProxies(
@@ -281,11 +278,9 @@ export class NetworkNodeFacade {
         direction: ProxyDirection,
         connectionCount?: number
     ): Promise<void> {
-        if (this.isStarting()) {
-            await this.startNodeTask(false)
-        }
         const peerDescriptors = nodes.map(peerDescriptorTranslator)
-        await this.cachedNode!.setProxies(
+        const node = await this.getNode()
+        await node.setProxies(
             streamPartId,
             peerDescriptors,
             direction,
@@ -295,11 +290,9 @@ export class NetworkNodeFacade {
     }
 
     async setStreamPartEntryPoints(streamPartId: StreamPartID, nodeDescriptors: NetworkPeerDescriptor[]): Promise<void> {
-        if (this.isStarting()) {
-            await this.startNodeTask(false)
-        }
         const peerDescriptors = nodeDescriptors.map(peerDescriptorTranslator)
-        this.cachedNode!.setStreamPartEntryPoints(streamPartId, peerDescriptors)
+        const node = await this.getNode()
+        node.setStreamPartEntryPoints(streamPartId, peerDescriptors)
     }
 
     private isStarting(): boolean {

--- a/packages/client/src/NetworkNodeFacade.ts
+++ b/packages/client/src/NetworkNodeFacade.ts
@@ -185,27 +185,6 @@ export class NetworkNodeFacade {
         return node.getNodeId()
     }
 
-    /**
-     * Calls publish on node after starting it.
-     * Basically a wrapper around: (await getNode()).publish(…)
-     * but will be sync in case that node is already started.
-     * Zalgo intentional. See below.
-     */
-    async publishToNode(streamMessage: StreamMessage): Promise<void> {
-        // NOTE: function is intentionally not async for performance reasons.
-        // Will call cachedNode.publish immediately if cachedNode is set.
-        // Otherwise will wait for node to start.
-        this.destroySignal.assertNotDestroyed()
-        if (this.isStarting()) {
-            // use .then instead of async/await so
-            // this.cachedNode.publish call can be sync
-            return this.startNodeTask().then((node) =>
-                node.broadcast(streamMessage)
-            )
-        }
-        return this.cachedNode!.broadcast(streamMessage)
-    }
-
     async join(streamPartId: StreamPartID, neighborRequirement?: { minCount: number, timeout: number }): Promise<void> {
         const node = await this.getNode()
         await node.join(streamPartId, neighborRequirement)
@@ -216,7 +195,6 @@ export class NetworkNodeFacade {
         await node.leave(streamPartId)
     }
 
-    // TODO should we remove publishToNode method and use the broacast method instead?
     async broadcast(msg: StreamMessage): Promise<void> {
         const node = await this.getNode()
         node.broadcast(msg)

--- a/packages/client/src/StreamrClient.ts
+++ b/packages/client/src/StreamrClient.ts
@@ -23,7 +23,7 @@ import {
 import { DestroySignal } from './DestroySignal'
 import { Message, convertStreamMessageToMessage } from './Message'
 import { MetricsPublisher } from './MetricsPublisher'
-import { NetworkNodeFacade, NetworkNodeStub } from './NetworkNodeFacade'
+import { NetworkNodeFacade } from './NetworkNodeFacade'
 import { RpcProviderSource } from './RpcProviderSource'
 import { Stream, StreamMetadata } from './Stream'
 import { StreamIDBuilder } from './StreamIDBuilder'
@@ -593,8 +593,8 @@ export class StreamrClient {
     /**
      * @deprecated This in an internal method
      */
-    getNode(): Promise<NetworkNodeStub> {
-        return this.node.getNode()
+    getNode(): NetworkNodeFacade {
+        return this.node
     }
 
     async inspect(node: NetworkPeerDescriptor, streamDefinition: StreamDefinition): Promise<boolean> {
@@ -667,7 +667,7 @@ export class StreamrClient {
     })
 
     async getPeerDescriptor(): Promise<NetworkPeerDescriptor> {
-        return convertPeerDescriptorToNetworkPeerDescriptor((await this.node.getNode()).getPeerDescriptor())
+        return convertPeerDescriptorToNetworkPeerDescriptor(await this.node.getPeerDescriptor())
     }
 
     /**
@@ -683,7 +683,7 @@ export class StreamrClient {
      * @remark returned object's structure can change without semver considerations
      */
     async getDiagnosticInfo(): Promise<Record<string, unknown>> {
-        return (await this.node.getNode()).getDiagnosticInfo()
+        return this.node.getDiagnosticInfo()
     }
 
     /**

--- a/packages/client/src/exports.ts
+++ b/packages/client/src/exports.ts
@@ -43,7 +43,6 @@ export {
 export { GroupKey as EncryptionKey } from './encryption/GroupKey'
 export { UpdateEncryptionKeyOptions } from './encryption/LocalGroupKeyStore'
 export { CONFIG_TEST } from './ConfigTest'
-export { NetworkNodeStub } from './NetworkNodeFacade'
 export { StreamDefinition } from './types'
 export { formStorageNodeAssignmentStreamId } from './utils/utils'
 export { SignerWithProvider } from './Authentication'

--- a/packages/client/src/publish/Publisher.ts
+++ b/packages/client/src/publish/Publisher.ts
@@ -108,7 +108,7 @@ export class Publisher {
                     },
                     partition
                 )
-                await this.node.publishToNode(message)
+                await this.node.broadcast(message)
                 return message
             } catch (e) {
                 const errorCode = (e instanceof StreamrClientError) ? e.code : 'UNKNOWN_ERROR'

--- a/packages/client/test/end-to-end/start-node.test.ts
+++ b/packages/client/test/end-to-end/start-node.test.ts
@@ -12,7 +12,7 @@ describe('start node', () => {
                 }
             }
         })
-        const node = await client.getNode()
-        expect(node.getPeerDescriptor().websocket).toBeUndefined()
+        const node = client.getNode()
+        expect((await node.getPeerDescriptor()).websocket).toBeUndefined()
     })
 })

--- a/packages/client/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/client/test/integration/GroupKeyPersistence.test.ts
@@ -156,9 +156,9 @@ describe('Group Key Persistence', () => {
             const sub2 = await subscriber2.subscribe({
                 stream: stream.id,
             })
-            const node2 = await subscriber2.getNode()
+            const node2 = subscriber2.getNode()
             await until(async () => {
-                return node2.getNeighbors(toStreamPartID(stream.id, DEFAULT_PARTITION)).length >= 1
+                return (await node2.getNeighbors(toStreamPartID(stream.id, DEFAULT_PARTITION))).length >= 1
             })
 
             await Promise.all([

--- a/packages/client/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/client/test/integration/PublisherKeyExchange.test.ts
@@ -1,7 +1,5 @@
 import 'reflect-metadata'
 
-import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
-import { Wallet } from 'ethers'
 import {
     ContentType,
     EncryptionType,
@@ -12,12 +10,14 @@ import {
     StreamPartIDUtils
 } from '@streamr/protocol'
 import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { convertBytesToGroupKeyResponse } from '@streamr/trackerless-network'
+import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
+import { Wallet } from 'ethers'
+import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
-import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { createRelativeTestStreamId, startPublisherKeyExchangeSubscription } from '../test-utils/utils'
-import { convertBytesToGroupKeyResponse } from '@streamr/trackerless-network'
 
 describe('PublisherKeyExchange', () => {
 
@@ -118,7 +118,7 @@ describe('PublisherKeyExchange', () => {
             permissions: [StreamPermission.PUBLISH],
             user: erc1271ContractAddress
         })
-        environment.getChain().erc1271AllowedAddresses.add(erc1271ContractAddress, toEthereumAddress(publisherWallet.address))
+        environment.getChain().addErc1271AllowedAddress(erc1271ContractAddress, toEthereumAddress(publisherWallet.address))
 
         const key = GroupKey.generate()
         await publisherClient.updateEncryptionKey({

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata'
 
-import { Wallet } from 'ethers'
 import { fastWallet } from '@streamr/test-utils'
 import { toEthereumAddress } from '@streamr/utils'
+import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -47,7 +47,7 @@ describe('Subscriber', () => {
     
             const sub = await subscriber.subscribe(stream.id)
     
-            const publisherNode = environment.startNode()
+            const publisherNode = environment.createNode()
             await publisherNode.broadcast(await createMockMessage({
                 stream,
                 publisher: publisherWallet,
@@ -99,7 +99,7 @@ describe('Subscriber', () => {
     
             const sub = await subscriber.subscribe({ streamId: stream.id, raw: true })
     
-            const publisherNode = environment.startNode()
+            const publisherNode = environment.createNode()
             await publisherNode.broadcast(await createMockMessage({
                 stream,
                 publisher: publisherWallet,

--- a/packages/client/test/integration/Subscriber.test.ts
+++ b/packages/client/test/integration/Subscriber.test.ts
@@ -74,7 +74,7 @@ describe('Subscriber', () => {
     
             const sub = await subscriber.subscribe(stream.id)
     
-            const publisherNode = await publisher.getNode()
+            const publisherNode = publisher.getNode()
             await publisherNode.broadcast(await createMockMessage({
                 stream,
                 publisher: publisherWallet,
@@ -126,7 +126,7 @@ describe('Subscriber', () => {
     
             const sub = await subscriber.subscribe({ streamId: stream.id, raw: true })
     
-            const publisherNode = await publisher.getNode()
+            const publisherNode = publisher.getNode()
             await publisherNode.broadcast(await createMockMessage({
                 stream,
                 publisher: publisherWallet,

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -47,7 +47,7 @@ describe('SubscriberKeyExchange', () => {
     }
 
     const triggerGroupKeyRequest = async (streamPartId: StreamPartID, key: GroupKey, publisher: StreamrClient): Promise<void> => {
-        const publisherNode = await publisher.getNode()
+        const publisherNode = publisher.getNode()
         await publisherNode.broadcast(await createMockMessage({
             streamPartId,
             publisher: publisherWallet,

--- a/packages/client/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/client/test/integration/SubscriberKeyExchange.test.ts
@@ -1,7 +1,5 @@
 import 'reflect-metadata'
 
-import { EthereumAddress, toEthereumAddress, waitForCondition } from '@streamr/utils'
-import { Wallet } from 'ethers'
 import {
     ContentType,
     EncryptionType,
@@ -14,16 +12,18 @@ import {
     toStreamPartID
 } from '@streamr/protocol'
 import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { EthereumAddress, toEthereumAddress, waitForCondition } from '@streamr/utils'
+import { Wallet } from 'ethers'
+import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
-import { StreamrClient } from '../../src/StreamrClient'
+import { convertBytesToGroupKeyRequest } from '@streamr/trackerless-network'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import {
     createMockMessage,
     createRelativeTestStreamId,
     getLocalGroupKeyStore
 } from '../test-utils/utils'
-import { convertBytesToGroupKeyRequest } from '@streamr/trackerless-network'
 
 describe('SubscriberKeyExchange', () => {
 
@@ -136,7 +136,7 @@ describe('SubscriberKeyExchange', () => {
             const erc1271Contract = randomEthereumAddress()
             const streamId = await createStream(toEthereumAddress(erc1271Contract))
             const streamPartId = toStreamPartID(streamId, 0)
-            environment.getChain().erc1271AllowedAddresses.add(erc1271Contract, toEthereumAddress(subscriberWallet.address))
+            environment.getChain().addErc1271AllowedAddress(erc1271Contract, toEthereumAddress(subscriberWallet.address))
 
             const groupKey = GroupKey.generate()
             const publisher = environment.createClient({

--- a/packages/client/test/integration/gap-fill.test.ts
+++ b/packages/client/test/integration/gap-fill.test.ts
@@ -1,18 +1,18 @@
 import 'reflect-metadata'
 
-import { Wallet } from 'ethers'
 import { StreamMessage } from '@streamr/protocol'
 import { fastWallet, testOnlyInNodeJs } from '@streamr/test-utils'
 import { collect, toEthereumAddress } from '@streamr/utils'
+import { Wallet } from 'ethers'
+import { mock } from 'jest-mock-extended'
 import { GroupKey } from '../../src/encryption/GroupKey'
+import { MessageSigner } from '../../src/signature/MessageSigner'
+import { SignatureValidator } from '../../src/signature/SignatureValidator'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { createGroupKeyQueue, createStreamRegistry, createTestStream, startFailingStorageNode } from '../test-utils/utils'
 import { createPrivateKeyAuthentication } from './../../src/Authentication'
 import { Stream } from './../../src/Stream'
 import { MessageFactory } from './../../src/publish/MessageFactory'
-import { mock } from 'jest-mock-extended'
-import { SignatureValidator } from '../../src/signature/SignatureValidator'
-import { MessageSigner } from '../../src/signature/MessageSigner'
 
 const GROUP_KEY = GroupKey.generate()
 
@@ -26,7 +26,7 @@ describe('gap fill', () => {
     const createMessage = (timestamp: number) => messageFactory.createMessage({}, { timestamp })
 
     const publish = async (msg: StreamMessage) => {
-        const node = environment.startNode()
+        const node = environment.createNode()
         await node.broadcast(msg)
     }
 

--- a/packages/client/test/integration/invalid-messages.test.ts
+++ b/packages/client/test/integration/invalid-messages.test.ts
@@ -54,7 +54,7 @@ describe('client behaviour on invalid message', () => {
             streamPartId: toStreamPartID(streamId, 0),
             publisher: publisherWallet
         })
-        const networkNode = environment.startNode()
+        const networkNode = environment.createNode()
         await networkNode.broadcast(msg)
         await wait(PROPAGATION_WAIT_TIME)
         expect(true).toEqual(true) // we never get here if subscriberClient crashes

--- a/packages/client/test/integration/parallel-key-exchange.test.ts
+++ b/packages/client/test/integration/parallel-key-exchange.test.ts
@@ -82,7 +82,7 @@ describe('parallel key exchange', () => {
                 }, {
                     timestamp: Date.now()
                 })
-                const node = await publisher.client!.getNode()
+                const node = publisher.client!.getNode()
                 await node.broadcast(msg)
                 await wait(10)
             }

--- a/packages/client/test/test-utils/fake/FakeChain.ts
+++ b/packages/client/test/test-utils/fake/FakeChain.ts
@@ -3,7 +3,6 @@ import { StreamMetadata } from '../../../src/Stream'
 import { StreamPermission } from '../../../src/permission'
 import { EthereumAddress, Multimap } from '@streamr/utils'
 import { StorageNodeMetadata } from '../../../src/contracts/StorageNodeRegistry'
-import { StorageNodeAssignmentEvent } from '../../../src/contracts/StreamStorageRegistry'
 import { EventEmitter } from 'eventemitter3'
 
 export type PublicPermissionTarget = 'public'
@@ -14,8 +13,13 @@ export interface StreamRegistryItem {
     permissions: Multimap<EthereumAddress | PublicPermissionTarget, StreamPermission>
 }
 
+export interface FakeStorageNodeAssignmentEvent {
+    readonly streamId: StreamID
+    readonly nodeAddress: EthereumAddress
+}
+
 export interface Events {
-    streamAddedToStorageNode: (payload: Omit<StorageNodeAssignmentEvent, 'blockNumber'>) => void
+    streamAddedToStorageNode: (payload: FakeStorageNodeAssignmentEvent) => void
 }
 
 export class FakeChain {
@@ -42,7 +46,7 @@ export class FakeChain {
         const existedBefore = this.storageAssignments.has(streamId, nodeAddress)
         this.storageAssignments.add(streamId, nodeAddress)
         if (!existedBefore) {
-        this.eventEmitter.emit('streamAddedToStorageNode', { streamId, nodeAddress })
+            this.eventEmitter.emit('streamAddedToStorageNode', { streamId, nodeAddress })
         }
     }
 

--- a/packages/client/test/test-utils/fake/FakeChain.ts
+++ b/packages/client/test/test-utils/fake/FakeChain.ts
@@ -3,6 +3,8 @@ import { StreamMetadata } from '../../../src/Stream'
 import { StreamPermission } from '../../../src/permission'
 import { EthereumAddress, Multimap } from '@streamr/utils'
 import { StorageNodeMetadata } from '../../../src/contracts/StorageNodeRegistry'
+import { StorageNodeAssignmentEvent } from '../../../src/contracts/StreamStorageRegistry'
+import { EventEmitter } from 'eventemitter3'
 
 export type PublicPermissionTarget = 'public'
 export const PUBLIC_PERMISSION_TARGET: PublicPermissionTarget = 'public'
@@ -12,9 +14,56 @@ export interface StreamRegistryItem {
     permissions: Multimap<EthereumAddress | PublicPermissionTarget, StreamPermission>
 }
 
+export interface Events {
+    streamAddedToStorageNode: (payload: Omit<StorageNodeAssignmentEvent, 'blockNumber'>) => void
+}
+
 export class FakeChain {
-    readonly streams: Map<StreamID, StreamRegistryItem> = new Map()
-    readonly storageAssignments: Multimap<StreamID, EthereumAddress> = new Multimap()
-    readonly storageNodeMetadatas: Map<EthereumAddress, StorageNodeMetadata> = new Map()
-    readonly erc1271AllowedAddresses: Multimap<EthereumAddress, EthereumAddress> = new Multimap()
+
+    private readonly streams: Map<StreamID, StreamRegistryItem> = new Map()
+    private readonly storageAssignments: Multimap<StreamID, EthereumAddress> = new Multimap()
+    private readonly storageNodeMetadatas: Map<EthereumAddress, StorageNodeMetadata> = new Map()
+    private readonly erc1271AllowedAddresses: Multimap<EthereumAddress, EthereumAddress> = new Multimap()
+    private readonly eventEmitter = new EventEmitter<Events>
+
+    getStream(streamId: StreamID): StreamRegistryItem | undefined {
+        return this.streams.get(streamId)
+    }
+
+    setStream(streamId: StreamID, registryItem: StreamRegistryItem): void {
+        this.streams.set(streamId, registryItem)
+    }
+
+    getStorageAssignments(streamId: StreamID): EthereumAddress[] {
+        return this.storageAssignments.get(streamId)
+    }
+
+    addStorageAssignment(streamId: StreamID, nodeAddress: EthereumAddress): void {
+        this.storageAssignments.add(streamId, nodeAddress)
+        this.eventEmitter.emit('streamAddedToStorageNode', { streamId, nodeAddress })
+    }
+
+    removeStorageAssignment(streamId: StreamID, nodeAddress: EthereumAddress): void {
+        this.storageAssignments.remove(streamId, nodeAddress)
+    }
+
+    getStorageNodeMetadata(nodeAddress: EthereumAddress): StorageNodeMetadata | undefined {
+        return this.storageNodeMetadatas.get(nodeAddress)
+    }
+
+    setStorageNodeMetadata(nodeAddress: EthereumAddress, metadata: StorageNodeMetadata): void {
+        this.storageNodeMetadatas.set(nodeAddress, metadata)
+    }
+
+    hasErc1271AllowedAddress(contractAddress: EthereumAddress, clientWalletAddress: EthereumAddress): boolean {
+        return this.erc1271AllowedAddresses.has(contractAddress, clientWalletAddress)
+    }
+
+    addErc1271AllowedAddress(contractAddress: EthereumAddress, clientWalletAddress: EthereumAddress): void {
+        this.erc1271AllowedAddresses.add(contractAddress, clientWalletAddress)
+    }
+
+    on<E extends keyof Events>(eventName: E, listener: Events[E]): void {
+        this.eventEmitter.on(eventName, listener)
+    }
 }

--- a/packages/client/test/test-utils/fake/FakeChain.ts
+++ b/packages/client/test/test-utils/fake/FakeChain.ts
@@ -39,8 +39,11 @@ export class FakeChain {
     }
 
     addStorageAssignment(streamId: StreamID, nodeAddress: EthereumAddress): void {
+        const existedBefore = this.storageAssignments.has(streamId, nodeAddress)
         this.storageAssignments.add(streamId, nodeAddress)
+        if (!existedBefore) {
         this.eventEmitter.emit('streamAddedToStorageNode', { streamId, nodeAddress })
+        }
     }
 
     removeStorageAssignment(streamId: StreamID, nodeAddress: EthereumAddress): void {

--- a/packages/client/test/test-utils/fake/FakeERC1271ContractFacade.ts
+++ b/packages/client/test/test-utils/fake/FakeERC1271ContractFacade.ts
@@ -17,7 +17,7 @@ export class FakeERC1271ContractFacade implements Methods<ERC1271ContractFacade>
     // eslint-disable-next-line class-methods-use-this
     async isValidSignature(contractAddress: EthereumAddress, payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
         const clientWalletAddress = toEthereumAddress(recoverAddress(signature, payload))
-        return this.chain.erc1271AllowedAddresses.has(contractAddress, clientWalletAddress)
+        return this.chain.hasErc1271AllowedAddress(contractAddress, clientWalletAddress)
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/client/test/test-utils/fake/FakeNetworkNode.ts
@@ -55,9 +55,8 @@ export class FakeNetworkNode implements NetworkNodeStub {
         this.network.send(msg, this.id, (node: FakeNetworkNode) => node.subscriptions.has(msg.getStreamPartID()))
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getStreamParts(): StreamPartID[] {
-        throw new Error('not implemented')
+        return [...this.subscriptions]
     }
 
     getNeighbors(streamPartId: StreamPartID): ReadonlyArray<DhtAddress> {

--- a/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -20,7 +20,7 @@ export class FakeStorageNodeRegistry implements Methods<StorageNodeRegistry> {
 
     // eslint-disable-next-line class-methods-use-this
     async getStorageNodeMetadata(nodeAddress: EthereumAddress): Promise<StorageNodeMetadata> {
-        const metadata = this.chain.storageNodeMetadatas.get(nodeAddress)
+        const metadata = this.chain.getStorageNodeMetadata(nodeAddress)
         if (metadata !== undefined) {
             return metadata
         } else {

--- a/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamRegistry.ts
@@ -38,7 +38,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
     }
 
     async createStream(streamId: StreamID, metadata: StreamMetadata): Promise<Stream> {
-        if (this.chain.streams.has(streamId)) {
+        if (this.chain.getStream(streamId) !== undefined) {
             throw new Error(`Stream already exists: ${streamId}`)
         }
         const authenticatedUser: EthereumAddress = await this.authentication.getAddress()
@@ -48,12 +48,12 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
             metadata,
             permissions
         }
-        this.chain.streams.set(streamId, registryItem)
+        this.chain.setStream(streamId, registryItem)
         return this.streamFactory.createStream(streamId, metadata)
     }
 
     async getStream(id: StreamID): Promise<Stream> {
-        const registryItem = this.chain.streams.get(id)
+        const registryItem = this.chain.getStream(id)
         if (registryItem !== undefined) {
             return this.streamFactory.createStream(id, registryItem.metadata)
         } else {
@@ -63,7 +63,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
 
     // eslint-disable-next-line class-methods-use-this
     async updateStream(streamId: StreamID, metadata: StreamMetadata): Promise<Stream> {
-        const registryItem = this.chain.streams.get(streamId)
+        const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {
             throw new Error('Stream not found')
         } else {
@@ -74,7 +74,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
 
     async hasPermission(query: PermissionQuery): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(query.streamId)
-        const registryItem = this.chain.streams.get(streamId)
+        const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {
             return false
         }
@@ -90,7 +90,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
 
     async getPermissions(streamIdOrPath: string): Promise<PermissionAssignment[]> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        const registryItem = this.chain.streams.get(streamId)
+        const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {
             return []
         }
@@ -142,7 +142,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         ) => void
     ): Promise<void> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        const registryItem = this.chain.streams.get(streamId)
+        const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {
             throw new Error('Stream not found')
         } else {

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -1,62 +1,39 @@
-import { StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
-import { EthereumAddress } from '@streamr/utils'
 import { Methods } from '@streamr/test-utils'
+import { EthereumAddress } from '@streamr/utils'
 import { Lifecycle, scoped } from 'tsyringe'
 import { Stream } from '../../../src/Stream'
 import { StreamIDBuilder } from '../../../src/StreamIDBuilder'
 import { StreamStorageRegistry } from '../../../src/contracts/StreamStorageRegistry'
 import { FakeChain } from './FakeChain'
-import { FakeNetwork } from './FakeNetwork'
-import { FakeStorageNode } from './FakeStorageNode'
 
 @scoped(Lifecycle.ContainerScoped)
 export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry> {
 
     private readonly chain: FakeChain
-    private readonly network: FakeNetwork
     private readonly streamIdBuilder: StreamIDBuilder
 
     constructor(
         chain: FakeChain,
-        network: FakeNetwork,
         streamIdBuilder: StreamIDBuilder
     ) {
         this.chain = chain
-        this.network = network
         this.streamIdBuilder = streamIdBuilder
     }
 
     async getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
         if (streamIdOrPath !== undefined) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-            return this.chain.storageAssignments.get(streamId)
+            return this.chain.getStorageAssignments(streamId)
         } else {
             throw new Error('not implemented')
-        }
-    }
-
-    async getRandomStorageNodeFor(streamPartId: StreamPartID): Promise<FakeStorageNode> {
-        const nodeAddresses = await this.getStorageNodes(StreamPartIDUtils.getStreamID(streamPartId))
-        if (nodeAddresses.length > 0) {
-            const chosenAddress = nodeAddresses[Math.floor(Math.random() * nodeAddresses.length)]
-            const storageNode = this.getStorageNode(chosenAddress)
-            if (storageNode !== undefined) {
-                return storageNode 
-            } else {
-                throw new Error('no storage node online: ' + chosenAddress)
-            }
-        } else {
-            throw new Error('no storage node assignments for ' + streamPartId)
         }
     }
 
     async addStreamToStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
         if (!(await this.isStoredStream(streamIdOrPath, nodeAddress))) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-            const node = this.getStorageNode(nodeAddress)
-            if (node !== undefined) {
-                this.chain.storageAssignments.add(streamId, nodeAddress)
-                await node.addAssignment(streamId)
+            if (this.isStorageNode(nodeAddress)) {
+                this.chain.addStorageAssignment(streamId, nodeAddress)
             } else {
                 throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
             }
@@ -66,9 +43,8 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
     async removeStreamFromStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
         if (await this.isStoredStream(streamIdOrPath, nodeAddress)) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-            const node = this.getStorageNode(nodeAddress)
-            if (node !== undefined) {
-                this.chain.storageAssignments.remove(streamId, nodeAddress)
+            if (this.isStorageNode(nodeAddress)) {
+                this.chain.removeStorageAssignment(streamId, nodeAddress)
             } else {
                 throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
             }
@@ -80,9 +56,8 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
         return assignments.includes(nodeAddress)
     }
 
-    private getStorageNode(address: EthereumAddress): FakeStorageNode | undefined {
-        const node = this.network.getNodes().find((node) => (node instanceof FakeStorageNode) && (node.getAddress() === address))
-        return node as (FakeStorageNode | undefined)
+    private isStorageNode(address: EthereumAddress): boolean {
+        return this.chain.getStorageNodeMetadata(address) !== undefined
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
+++ b/packages/client/test/test-utils/fake/FakeStreamStorageRegistry.ts
@@ -30,24 +30,20 @@ export class FakeStreamStorageRegistry implements Methods<StreamStorageRegistry>
     }
 
     async addStreamToStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
-        if (!(await this.isStoredStream(streamIdOrPath, nodeAddress))) {
-            const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-            if (this.isStorageNode(nodeAddress)) {
-                this.chain.addStorageAssignment(streamId, nodeAddress)
-            } else {
-                throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
-            }
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        if (this.isStorageNode(nodeAddress)) {
+            this.chain.addStorageAssignment(streamId, nodeAddress)
+        } else {
+            throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
         }
     }
 
     async removeStreamFromStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
-        if (await this.isStoredStream(streamIdOrPath, nodeAddress)) {
-            const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-            if (this.isStorageNode(nodeAddress)) {
-                this.chain.removeStorageAssignment(streamId, nodeAddress)
-            } else {
-                throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
-            }
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        if (this.isStorageNode(nodeAddress)) {
+            this.chain.removeStorageAssignment(streamId, nodeAddress)
+        } else {
+            throw new Error(`No storage node ${nodeAddress} for ${streamId}`)
         }
     }
 

--- a/packages/client/test/test-utils/utils.ts
+++ b/packages/client/test/test-utils/utils.ts
@@ -162,7 +162,7 @@ export const getLocalGroupKeyStore = (userAddress: EthereumAddress): LocalGroupK
 export const startPublisherKeyExchangeSubscription = async (
     publisherClient: StreamrClient,
     streamPartId: StreamPartID): Promise<void> => {
-    const node = await publisherClient.getNode()
+    const node = publisherClient.getNode()
     await node.join(streamPartId)
 }
 

--- a/packages/client/test/unit/MetricsPublisher.test.ts
+++ b/packages/client/test/unit/MetricsPublisher.test.ts
@@ -23,11 +23,9 @@ describe('MetricsPublisher', () => {
         const publisher: Pick<Publisher, 'publish'> = {
             publish: publishReportMessage
         }
-        const node: Pick<NetworkNodeFacade, 'getNode'> = {
-            getNode: async () => ({
-                getMetricsContext: () => metricsContext,
-                getNodeId: () => NODE_ID
-            }) as any,
+        const node: Pick<NetworkNodeFacade, 'getMetricsContext' | 'getNodeId'> = {
+            getMetricsContext: async () => metricsContext,
+            getNodeId: async () => NODE_ID
         }
         const eventEmitter = new StreamrClientEventEmitter()
         new MetricsPublisher(

--- a/packages/client/test/unit/Resends.test.ts
+++ b/packages/client/test/unit/Resends.test.ts
@@ -10,12 +10,11 @@ import {
     toStreamID
 } from '@streamr/protocol'
 import { isRunningInElectron, randomEthereumAddress, startTestServer } from '@streamr/test-utils'
-import { collect, toLengthPrefixedFrame } from '@streamr/utils'
+import { convertStreamMessageToBytes } from '@streamr/trackerless-network'
+import { collect, hexToBinary, toLengthPrefixedFrame } from '@streamr/utils'
 import range from 'lodash/range'
 import { Resends } from '../../src/subscribe/Resends'
-import { mockLoggerFactory, MOCK_CONTENT } from '../test-utils/utils'
-import { hexToBinary } from '@streamr/utils'
-import { convertStreamMessageToBytes } from '@streamr/trackerless-network'
+import { MOCK_CONTENT, mockLoggerFactory } from '../test-utils/utils'
 
 const createResends = (serverUrl: string) => {
     return new Resends(

--- a/packages/client/test/unit/SubscriptionSession.test.ts
+++ b/packages/client/test/unit/SubscriptionSession.test.ts
@@ -2,7 +2,7 @@ import { SubscriptionSession } from '../../src/subscribe/SubscriptionSession'
 import { StreamMessage, toStreamID, toStreamPartID } from '@streamr/protocol'
 import { MessagePipelineFactory } from '../../src/subscribe/MessagePipelineFactory'
 import { mock } from 'jest-mock-extended'
-import { NetworkNodeFacade, NetworkNodeStub } from '../../src/NetworkNodeFacade'
+import { NetworkNodeFacade } from '../../src/NetworkNodeFacade'
 import { Subscription } from '../../src'
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { PushPipeline } from '../../src/utils/PushPipeline'
@@ -27,10 +27,7 @@ describe('SubscriptionSession', () => {
         pushPipeline.onBeforeFinally = Signal.once()
         pushPipeline.pipe.mockReturnValue(pushPipeline as any)
         pipelineFactory.createMessagePipeline.mockReturnValue(pushPipeline)
-
         const networkNodeFacade = mock<NetworkNodeFacade>()
-        networkNodeFacade.getNode.mockResolvedValue(mock<NetworkNodeStub>())
-
         session = new SubscriptionSession(STREAM_PART_ID, pipelineFactory, networkNodeFacade)
     })
 

--- a/packages/client/test/unit/validateStreamMessage2.test.ts
+++ b/packages/client/test/unit/validateStreamMessage2.test.ts
@@ -1,16 +1,18 @@
+import 'reflect-metadata'
+
 import {
     ContentType,
     EncryptedGroupKey,
+    EncryptionType,
     GroupKeyRequest,
     GroupKeyResponse,
     MessageID,
     MessageRef,
+    SignatureType,
     StreamMessage,
-    ValidationError,
-    toStreamID,
     StreamMessageType,
-    EncryptionType,
-    SignatureType
+    ValidationError,
+    toStreamID
 } from '@streamr/protocol'
 import {
     convertGroupKeyRequestToBytes,
@@ -18,14 +20,14 @@ import {
 } from '@streamr/trackerless-network'
 import { EthereumAddress, hexToBinary, utf8ToBinary } from '@streamr/utils'
 import assert from 'assert'
+import { mock } from 'jest-mock-extended'
 import { Authentication } from '../../src/Authentication'
 import { Stream } from '../../src/Stream'
-import { validateStreamMessage } from '../../src/utils/validateStreamMessage'
-import { createRandomAuthentication, MOCK_CONTENT } from '../test-utils/utils'
-import { SignatureValidator } from '../../src/signature/SignatureValidator'
-import { mock } from 'jest-mock-extended'
 import { ERC1271ContractFacade } from '../../src/contracts/ERC1271ContractFacade'
 import { MessageSigner } from '../../src/signature/MessageSigner'
+import { SignatureValidator } from '../../src/signature/SignatureValidator'
+import { validateStreamMessage } from '../../src/utils/validateStreamMessage'
+import { MOCK_CONTENT, createRandomAuthentication } from '../test-utils/utils'
 
 const groupKeyMessageToStreamMessage = async (
     groupKeyMessage: GroupKeyRequest | GroupKeyResponse,


### PR DESCRIPTION
## Summary

Changed `StreamrClient#getNode` to return `NetworkNodeFacade` instead of `NetworkNodeStub`. Now the `NetworkNodeStub` is just an internal implementation detail in the `NetworkNodeFacade` class.

## Changes

- Refactored all client's internal classes to use `NetworkNodeFacade` instead of `NetworkNodeStub`
  - `SubscriptionSession`, `PublisherKeyExchange`, `SubscriberKeyExchange`, `MetricsPublisher`
- Refactored usages in Broker
- Refactored `FakeEnvironment` nodes to be instances of `NetworkNodeFacade` instead of `NetworkNodeStub`
  - As `FakeStorageNode` is no longer a `NetworkNodeStub`, some refactoring was needed. Now `FakeChain` emits events when storage node assignments are written to the chain.  `FakeStorageNode` listens to those events. `FakeStorageNode` and `StreamrClient` teardowns are implemented using the `DestroySignal` functionality.