### PR TITLE
chore: remove broker git tag releasing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,10 +67,10 @@ jobs:
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_token }}
 
-      - name: Get current Broker git tag (for Docker meta)
+      - name: Get current version git tag (for Docker meta)
         run: |
           git fetch --tags origin --force
-          echo "broker_head_tag=$(git tag --points-at HEAD --list 'broker/v*')" >> $GITHUB_ENV
+          echo "version_head_tag=$(git tag --points-at HEAD --list 'v*')" >> $GITHUB_ENV
 
 
       - name: Docker meta
@@ -82,7 +82,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=match,pattern=broker/(v.*),group=1,value=${{ env.broker_head_tag }}
+            type=raw,value=${{ env.version_head_tag }},enable=${{ version_head_tag != '' }}
             type=raw,value=${{ inputs.branch }},enable=${{ inputs.branch != 'main' }}
             type=raw,value=dev,enable=${{ inputs.branch == 'main' }}
             type=raw,value=latest,enable=${{ inputs.include_latest_tag }}

--- a/release-git-tags.sh
+++ b/release-git-tags.sh
@@ -24,5 +24,4 @@ fi
 
 git commit -m "release: $TAG"
 git tag $TAG
-git tag broker/$TAG # TODO: This tag needed to activate tagged release of docker images, remove once 1.0 merged to main
-git push --atomic origin main $TAG broker/$TAG
+git push --atomic origin main $TAG


### PR DESCRIPTION
## Summary

- Release script `release.sh` no longer creates `broker/vX.Y.Z` git tags
- Docker release workflow looks for `vX.Y.Z` git tags (instead of `broker/vX.Y.Z`)

The `broker/vX.Y.Z` tag was a remnant from the time when node (then called broker) had its own versioning separate from the sdk (then called client). This PR addresses that technical debt.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [ ] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
