### PR TITLE
chore(node): introduce `streamr-node` and `streamr-node-init` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Changes before Tatum release are not documented in this file.
 
 #### Deprecated
 
+- Deprecate command `streamr-broker`. Use `streamr-node` instead.
+- Deprecate command `streamr-broker-init`. Use `streamr-node-init` instead.
+
 #### Removed
 
 #### Fixed

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -29,4 +29,4 @@ EXPOSE 32200/tcp
 WORKDIR /home/streamr/network/packages/node
 
 # start node from default config (needs mounted volume, e.g. docker run -v $(cd ~/.streamr/config;pwd):/home/streamr/.streamr/config IMAGE
-CMD ["/usr/local/bin/npm", "exec", "-c", "streamr-broker"]
+CMD ["/usr/local/bin/npm", "exec", "-c", "streamr-node"]

--- a/docs/docs/guides/how-to-run-streamr-node.md
+++ b/docs/docs/guides/how-to-run-streamr-node.md
@@ -157,7 +157,7 @@ There can be plenty of output from npm. If the installation fails with an error,
 ### Step 2: Configure your node
 To activate the **Config Wizard**, run,
 ```
-streamr-broker-init
+streamr-node-init
 ```
 
 #### Using the Config Wizard
@@ -179,7 +179,7 @@ If you're running a node to become an Operator, then you could now jump back to 
 ### Step 3: Start the Streamr node
 To start your Streamr node, run,
 ```
-streamr-broker PATH_TO_CONFIG_FILE
+streamr-node PATH_TO_CONFIG_FILE
 ```
 
 You should start to see logging similar to this:

--- a/docs/docs/guides/how-to-update-your-streamr-node.md
+++ b/docs/docs/guides/how-to-update-your-streamr-node.md
@@ -57,5 +57,5 @@ npm install -g @streamr/node
 
 And then you can run the node:
 ```
-`streamr-broker`
+`streamr-node`
 ```

--- a/docs/docs/guides/use-any-language-or-device.md
+++ b/docs/docs/guides/use-any-language-or-device.md
@@ -27,7 +27,7 @@ $ npm i -g @streamr/node
 Before the Streamr node can be started, its configuration files need to be created using the following command:
 
 ```shell
-$ streamr-broker-init
+$ streamr-node-init
 ```
 
 During initiziliation make sure to enable the `mqtt-plugin` and assign a port to it (default is 1883). Other plugins are unnecessary. For more in depth information on installing a Streamr node, see the guide on [running a Streamr node](../guides/how-to-run-streamr-node.md).
@@ -43,7 +43,7 @@ $ cat ~/.streamr/config/default.json
 #### Start the Streamr node
 
 ```shell
-$ streamr-broker
+$ streamr-node
 ```
 
 The node's address (its public key) is displayed when the Streamr node is started. Record this as the `BrokerNodeAddress`, it's needed in the next step!
@@ -204,7 +204,7 @@ The most common issues are:
 To include more verbose logging you could run the Streamr node with these additional flags:
 
 ```shell
-$ LOG_LEVEL=trace DEBUG=Streamr* streamr-broker
+$ LOG_LEVEL=trace DEBUG=Streamr* streamr-node
 ```
 
 ## All done 🎉

--- a/docs/docs/help/operator-faq.md
+++ b/docs/docs/help/operator-faq.md
@@ -189,7 +189,7 @@ WARN [2023-11-10T10:01:42.867] (NodeWebRtcConnection): Failed to set remote cand
 Connectivity issue. 
 
 **Solution:**
-Port 32200 or configured port for streamr-broker is not open. Check your firewall/docker/router configuration that the port 32200 is open and/or traffic is forwarded through this port.
+Port 32200 or configured port for streamr-node is not open. Check your firewall/docker/router configuration that the port 32200 is open and/or traffic is forwarded through this port.
 
 #### Issue: 
 I’m receiving the following warning message.
@@ -201,7 +201,7 @@ I’m receiving the following warning message.
       "message": "The Graph did not synchronize to block 42303755 (timed out after 60000 ms)",
       "stack":
           Error: The Graph did not synchronize to block 42303755 (timed out after 60000 ms)
-              at Timeout.<anonymous> (C:\Users\jarno\AppData\Roaming\nvm\v18.16.0\node_modules\streamr-broker\node_modules\@streamr\utils\dist\src\withTimeout.js:20:24)
+              at Timeout.<anonymous> (C:\Users\jarno\AppData\Roaming\nvm\v18.16.0\node_modules\@streamr\node\node_modules\@streamr\utils\dist\src\withTimeout.js:20:24)
               at listOnTimeout (node:internal/timers:569:17)
               at process.processTimers (node:internal/timers:512:7)
       "code": "TimeoutError"

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -34,11 +34,11 @@ First [install](#install) the package globally if you have not yet.
 
 Create a configuration file with interactive tool:
 ```
-streamr-broker-init 
+streamr-node-init
 ```
 Then run the command broker with the desired configuration file:
 ```
-streamr-broker <configFile>
+streamr-node <configFile>
 ```
 
 ## Configuration

--- a/packages/node/bin/broker.ts
+++ b/packages/node/bin/broker.ts
@@ -1,36 +1,11 @@
 #!/usr/bin/env node
-import { program } from 'commander'
-import pkg from '../package.json'
+import { Logger } from '@streamr/utils'
 
-import { createBroker } from '../src/broker'
-import { readConfigAndMigrateIfNeeded } from '../src/config/migration'
-import { overrideConfigToEnvVarsIfGiven } from '../src/config/config'
+// TODO: remove this file and the package.json entry in the future
+// eslint-disable-next-line max-len
+const deprecationMessage = 'The command "streamr-broker" is deprecated and will be removed in the future. Please switch to command "streamr-node" instead.'
+console.warn(deprecationMessage)
+new Logger(module).warn(deprecationMessage)
 
-program
-    .version(pkg.version)
-    .name('broker')
-    .description('Run broker under environment specified by given configuration file.')
-    .arguments('[configFile]')
-    .option('--test', 'test the configuration (does not start the broker)')
-    .action(async (configFile) => {
-        try {
-            const config = readConfigAndMigrateIfNeeded(configFile)
-            overrideConfigToEnvVarsIfGiven(config)
-            const broker = await createBroker(config)
-            if (!program.opts().test) {
-                await broker.start()
-            } else {
-                // eslint-disable-next-line no-console
-                console.info('the configuration is valid')
-                // TODO remove process.exit(0)
-                // We should not need explicit exit call if all setTimeouts are cleared.
-                // Currently there is only one leaking timeout in PingPongWs (created
-                // by NodeClientWsEndpoint from the createNetworkNode() call)
-                process.exit(0)
-            }
-        } catch (err) {
-            console.error(err)
-            process.exit(1)
-        }
-    })
-    .parse(process.argv)
+// side-effect: runs the command
+import './streamr-node'

--- a/packages/node/bin/config-wizard.ts
+++ b/packages/node/bin/config-wizard.ts
@@ -1,17 +1,9 @@
 #!/usr/bin/env node
-import { program } from 'commander'
-import pkg from '../package.json'
-import { start } from '../src/config/ConfigWizard'
 
-program
-    .version(pkg.version)
-    .name('broker-config-wizard')
-    .description('Run the configuration wizard for the broker')
+// TODO: remove this file and the package.json entry in the future
+// eslint-disable-next-line max-len
+const deprecationMessage = 'The command "streamr-broker-init" is deprecated and will be removed in the future. Please switch to command "streamr-node-init" instead.'
+console.warn(deprecationMessage)
 
-;(async () => {
-    try {
-        await start()
-    } catch (e) {
-        console.error('Streamr Node Config Wizard encountered an error:\n', e)
-    }
-})()
+// side-effect: runs the command
+import './streamr-node-init'

--- a/packages/node/bin/streamr-node-init.ts
+++ b/packages/node/bin/streamr-node-init.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { program } from 'commander'
+import pkg from '../package.json'
+import { start } from '../src/config/ConfigWizard'
+
+program
+    .version(pkg.version)
+    .name('streamr-node-init')
+    .description('Run the configuration wizard for the Streamr node.')
+
+;(async () => {
+    try {
+        await start()
+    } catch (e) {
+        console.error('Streamr Node Config Wizard encountered an error:\n', e)
+    }
+})()

--- a/packages/node/bin/streamr-node.ts
+++ b/packages/node/bin/streamr-node.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { program } from 'commander'
+import pkg from '../package.json'
+
+import { createBroker } from '../src/broker'
+import { readConfigAndMigrateIfNeeded } from '../src/config/migration'
+import { overrideConfigToEnvVarsIfGiven } from '../src/config/config'
+
+program
+    .version(pkg.version)
+    .name('streamr-node')
+    .description('Run a Streamr node in the environment specified by given configuration file.')
+    .arguments('[configFile]')
+    .option('--test', 'test the configuration (does not start the node)')
+    .action(async (configFile) => {
+        try {
+            const config = readConfigAndMigrateIfNeeded(configFile)
+            overrideConfigToEnvVarsIfGiven(config)
+            const broker = await createBroker(config)
+            if (!program.opts().test) {
+                await broker.start()
+            } else {
+                // eslint-disable-next-line no-console
+                console.info('the configuration is valid')
+                // TODO remove process.exit(0)
+                // We should not need explicit exit call if all setTimeouts are cleared.
+                // Currently there is only one leaking timeout in PingPongWs (created
+                // by NodeClientWsEndpoint from the createNetworkNode() call)
+                process.exit(0)
+            }
+        } catch (err) {
+            console.error(err)
+            process.exit(1)
+        }
+    })
+    .parse(process.argv)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,6 +10,8 @@
   "bin": {
     "streamr-broker": "dist/bin/broker.js",
     "streamr-broker-init": "dist/bin/config-wizard.js",
+    "streamr-node": "dist/bin/streamr-node.js",
+    "streamr-node-init": "dist/bin/streamr-node-init.js",
     "delete-expired-data": "dist/bin/delete-expired-data.js",
     "entry-point": "dist/bin/entry-point.js"
   },

--- a/packages/node/src/config/ConfigWizard.ts
+++ b/packages/node/src/config/ConfigWizard.ts
@@ -172,7 +172,7 @@ export async function start(): Promise<void> {
         log(`
             >
             > You can start your Streamr node now with
-            > *streamr-broker ${storagePath}*
+            > *streamr-node ${storagePath}*
             >
             > For environment specific run instructions, see
             > *https://docs.streamr.network/guides/how-to-run-streamr-node*

--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -157,7 +157,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('prints out the generated private key onto the screen if told to', async () => {
@@ -220,7 +220,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Flee Kit Stomach\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('validates given private key', async () => {
@@ -299,7 +299,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('validates the operator address', async () => {
@@ -387,7 +387,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables websocket plugin on a custom port', async () => {
@@ -445,7 +445,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables mqtt plugin on the default port', async () => {
@@ -507,7 +507,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables mqtt plugin on a custom port', async () => {
@@ -569,7 +569,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables http plugin on the default port', async () => {
@@ -632,7 +632,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables http plugin on a custom port', async () => {
@@ -693,7 +693,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables all pubsub plugins on default ports', async () => {
@@ -766,7 +766,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('enables all pubsub plugins on custom ports', async () => {
@@ -837,7 +837,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('validates port number values', async () => {
@@ -947,7 +947,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('disallows taking default ports if they are inexplicitly used', async () => {
@@ -1024,7 +1024,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('allows to uses a custom file path for the config file', async () => {
@@ -1234,7 +1234,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-broker ${storagePath}\n`)
+        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
     })
 
     it('tells the user to fund their node address if the balance is too low', async () => {


### PR DESCRIPTION
## Summary

- Add commands `streamr-node` and `streamr-node-init`
- Deprecate `streamr-broker` and `streamr-broker-init` (same behavior but with warning message)
- Update docs to account for new commands (left out Brubeck section, it is based on the old stuff anyways)
- Update Dockerfile entrypoint command 

Example of deprecation warning when running old command
```
The command "streamr-broker" is deprecated and will be removed in the future. Please switch to command "streamr-node" instead.
WARN [2024-07-04T13:38:01.485] (.                        ): The command "streamr-broker" is deprecated and will be removed in the future. Please switch to command "streamr-node" instead.
INFO [2024-07-04T13:38:02.232] (broker                   ): Start Streamr node version 101.0.0-beta.4
INFO [2024-07-04T13:38:02.430] (NetworkStack             ): Starting a Streamr Network Node
INFO [2024-07-04T13:38:03.929] (AutoCertifierClient      ): updateSubdomainIp() called for e12f6842-d716-4379-a1a8-5051ed202d04.streamr-nodes.xyz
INFO [2024-07-04T13:38:03.994] (AutoCertifierClient      ): hasSession() called 1 ongoing sessions
INFO [2024-07-04T13:38:04.468] (AutoCertifierClient      ): 2147483647 milliseconds until certificate update
INFO [2024-07-04T13:38:04.902] (NetworkStack             ): Node id is f8619ca67b65ec5310426a8715c14ad1976e381b
```

- [x] TODO: test linked binaries by hand

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
