### PR TITLE
fix(trackerless-network) [NET-1119]: account for propagation expiration ttl properly

### DIFF
--- a/packages/trackerless-network/src/logic/propagation/FifoMapWithTTL.ts
+++ b/packages/trackerless-network/src/logic/propagation/FifoMapWithTTL.ts
@@ -102,7 +102,15 @@ export class FifoMapWithTTL<K, V> {
         return item.value
     }
 
-    values(): Item<K, V>[] {
-        return [...this.items.values()]
+    values(): V[] {
+        const keys = [...this.items.keys()]
+        const values = []
+        for (const key of keys) {
+            const value = this.get(key)
+            if (value !== undefined) {
+                values.push(value)
+            }
+        }
+        return values
     }
 }

--- a/packages/trackerless-network/src/logic/propagation/PropagationTaskStore.ts
+++ b/packages/trackerless-network/src/logic/propagation/PropagationTaskStore.ts
@@ -27,7 +27,7 @@ export class PropagationTaskStore {
     }
 
     get(): PropagationTask[] {
-        return this.tasks.values().map((task) => task.value)
+        return this.tasks.values()
     }
 
     add(task: PropagationTask): void {

--- a/packages/trackerless-network/test/unit/FifoMapWithTtl.test.ts
+++ b/packages/trackerless-network/test/unit/FifoMapWithTtl.test.ts
@@ -177,6 +177,30 @@ describe('FifoMapWithTtl', () => {
                 time = 150
                 expect(fifoMap.get('hello')).toEqual('world')
             })
+
+            it('#values returns non-expired items', () => {
+                time = 0
+                fifoMap.set('hello', 'world')
+                time = 50
+                fifoMap.set('foo', 'bar')
+                time = 100
+                fifoMap.set('lorem', 'ipsum')
+                time = 120
+                fifoMap.set('dolor', 'sit')
+
+                expect(fifoMap.values()).toEqual(['bar', 'ipsum', 'sit'])
+
+                time = 130
+                fifoMap.set('amet', 'consectetur')
+
+                expect(fifoMap.values()).toEqual(['bar', 'ipsum', 'sit', 'consectetur'])
+
+                time = 200
+                expect(fifoMap.values()).toEqual(['sit', 'consectetur'])
+
+                time = 300
+                expect(fifoMap.values()).toEqual([])
+            })
         })
 
         describe('onItemDropped callback', () => {


### PR DESCRIPTION
## Summary

Filter out expired items in the method `FifoMapWithTTL#values` otherwise messages older than `ttlInMs` (30 secs) could be returned.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
