### PR TITLE
NET-1252 (network): Fix nodes running multiple keep intervals in PeerDescriptorStoreManager

### DIFF
--- a/packages/trackerless-network/src/logic/StreamPartReconnect.ts
+++ b/packages/trackerless-network/src/logic/StreamPartReconnect.ts
@@ -18,6 +18,7 @@ export class StreamPartReconnect {
         await scheduleAtInterval(async () => {
             const entryPoints = await this.peerDescriptorStoreManager.fetchNodes()
             await this.discoveryLayerNode.joinDht(entryPoints)
+            // Is is necessary to store the node as an entry point here?
             if (!this.peerDescriptorStoreManager.isLocalNodeStored() && entryPoints.length < MAX_NODE_COUNT) {
                 await this.peerDescriptorStoreManager.storeAndKeepLocalNode()
             }

--- a/packages/trackerless-network/src/logic/StreamPartReconnect.ts
+++ b/packages/trackerless-network/src/logic/StreamPartReconnect.ts
@@ -1,5 +1,5 @@
 import { scheduleAtInterval } from '@streamr/utils'
-import { PeerDescriptorStoreManager } from './PeerDescriptorStoreManager'
+import { MAX_NODE_COUNT, PeerDescriptorStoreManager } from './PeerDescriptorStoreManager'
 import { DiscoveryLayerNode } from './DiscoveryLayerNode'
 
 const DEFAULT_RECONNECT_INTERVAL = 30 * 1000
@@ -18,7 +18,7 @@ export class StreamPartReconnect {
         await scheduleAtInterval(async () => {
             const entryPoints = await this.peerDescriptorStoreManager.fetchNodes()
             await this.discoveryLayerNode.joinDht(entryPoints)
-            if (this.peerDescriptorStoreManager.isLocalNodeStored()) {
+            if (!this.peerDescriptorStoreManager.isLocalNodeStored() && entryPoints.length < MAX_NODE_COUNT) {
                 await this.peerDescriptorStoreManager.storeAndKeepLocalNode()
             }
             if (this.discoveryLayerNode.getNeighborCount() > 0) {


### PR DESCRIPTION
## Summary

Fixed bug with long running nodes running multiple keep intervals in to PeerDescriptorStoreManager. The problem occured in small stream networks and nodes under poor internet connectivity.

## Future improvements

Should move the guarding logic to a common place