### PR TITLE
NET-1322: add simple test for explicit polling

### DIFF
--- a/packages/sdk/src/contracts/ChainEventPoller.ts
+++ b/packages/sdk/src/contracts/ChainEventPoller.ts
@@ -6,7 +6,7 @@ type EventName = string
 type Listener = (...args: any[]) => void
 
 const BLOCK_NUMBER_QUERY_RETRY_DELAY = 1000
-const POLLS_SINCE_LAST_FROM_BLOCK_UPDATE_THRESHOLD = 30
+export const POLLS_SINCE_LAST_FROM_BLOCK_UPDATE_THRESHOLD = 30
 
 export class ChainEventPoller {
 


### PR DESCRIPTION
## Summary

Add missing test for the explicit block polling of `ChainEventPoller`. Ideally I would write more test coverage for edge cases here but unfortunately I don't have the time to do so. However, good to have this test at least merged.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
