### PR TITLE
NET-1323: `integration/Find.test.ts` flakyness reduced

### DIFF
--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -20,12 +20,12 @@ describe('Find correctness', () => {
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, K, 40, 60000)
+            const node = await createMockConnectionDhtNode(simulator, undefined, K, 15, 60000)
             nodes.push(node)
         }
         await entryPoint.joinDht([entrypointDescriptor])
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
-        await waitForStableTopology(nodes, 20)
+        await waitForStableTopology(nodes, 15, 45 * 1000)
     }, 90000)
 
     afterEach(async () => {
@@ -40,6 +40,6 @@ describe('Find correctness', () => {
         const closestNodes = await entryPoint.findClosestNodesFromDht(getDhtAddressFromRaw(targetId))
         expect(closestNodes.length).toBeGreaterThanOrEqual(5)
         expect(getDhtAddressFromRaw(targetId)).toEqual(getNodeIdFromPeerDescriptor(closestNodes[0]))
-    }, 30000)
+    }, 90000)
 
 })

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -252,13 +252,13 @@ export const createMockPeers = (): PeerDescriptor[] => {
  * unlocked connections have been garbage collected, i.e. we typically have connections only to the nodes which
  * are neighbors.
  */
-export const waitForStableTopology = async (nodes: DhtNode[], maxConnectionCount: number = 10000): Promise<void> => {
+export const waitForStableTopology = async (nodes: DhtNode[], maxConnectionCount: number = 10000, waitTime = 20000): Promise<void> => {
     const MAX_IDLE_TIME = 100
     const connectionManagers = nodes.map((n) => n.getTransport() as ConnectionManager)
     await Promise.all(connectionManagers.map(async (connectionManager) => {
         connectionManager.garbageCollectConnections(maxConnectionCount, MAX_IDLE_TIME)
         try {
-            await waitForCondition(() => connectionManager.getConnections().length <= maxConnectionCount, 20000)
+            await waitForCondition(() => connectionManager.getConnections().length <= maxConnectionCount, waitTime)
         } catch (err) {
             // the topology is very likely stable, but we can't be sure (maybe the node has more than maxConnectionCount
             // locked connections and therefore it is ok to that garbage collector was not able to remove any of those


### PR DESCRIPTION
## Summary

Test falkyness reduced by improving network stability at the cost of increased test run time.