### PR TITLE
refactor: Fix `@typescript-eslint/no-unused-vars` warnings

### DIFF
--- a/packages/autocertifier-server/src/DnsServer.ts
+++ b/packages/autocertifier-server/src/DnsServer.ts
@@ -170,7 +170,7 @@ export class DnsServer {
             let subdomainRecord: Subdomain | undefined
             try {
                 subdomainRecord = await this.db.getSubdomain(subdomain)
-            } catch (e) {
+            } catch {
                 logger.error('handleAQuery exception')
             }
 

--- a/packages/cdn-location/src/getLocalRegion.ts
+++ b/packages/cdn-location/src/getLocalRegion.ts
@@ -14,7 +14,7 @@ export const getLocalAirportCode: () => Promise<string | undefined> = async () =
     let airportCode: string
     try {
         airportCode = await fetchAirportCodeFromCdn()
-    } catch (error) {
+    } catch {
         return undefined
     }
     return airportCode

--- a/packages/cli-tools/src/config.ts
+++ b/packages/cli-tools/src/config.ts
@@ -27,7 +27,7 @@ const tryReadConfigFile = (fileName: string): Config | undefined | never => {
     let content
     try {
         content = readFileSync(fileName, 'utf8')
-    } catch (e: any) {
+    } catch {
         return undefined
     }
     const json = JSON.parse(content)

--- a/packages/dht/src/connection/connectivityChecker.ts
+++ b/packages/dht/src/connection/connectivityChecker.ts
@@ -23,7 +23,7 @@ export const connectAsync = async ({ url, allowSelfSignedCertificate, timeoutMs 
             () => { socket.connect(url, allowSelfSignedCertificate) }],
         socket, ['connected', 'error'],
         timeoutMs)
-    } catch (e) {
+    } catch {
         throw new Err.ConnectionFailed('WebSocket connection timed out')
     }
     if (result.winnerName === 'error') {

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -106,7 +106,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
                 logger.trace(`Setting remote descriptor for peer: ${remoteNodeId}`)
                 this.connection.setRemoteDescription(description, type as DescriptionType)
                 this.remoteDescriptionSet = true
-            } catch (err) {
+            } catch {
                 logger.debug(`Failed to set remote descriptor for peer ${remoteNodeId}`)
             }
         } else {
@@ -121,7 +121,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
                 try {
                     logger.trace(`Setting remote candidate for peer: ${remoteNodeId}`)
                     this.connection.addRemoteCandidate(candidate, mid)
-                } catch (err) {
+                } catch {
                     logger.debug(`Failed to set remote candidate for peer ${remoteNodeId}`)
                 }
             } else {

--- a/packages/dht/src/dht/ExternalApiRpcRemote.ts
+++ b/packages/dht/src/dht/ExternalApiRpcRemote.ts
@@ -17,7 +17,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
         try {
             const data = await this.getClient().externalFetchData(request, options)
             return data.entries
-        } catch (err) {
+        } catch {
             return []
         }
     }
@@ -34,7 +34,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
         try {
             const response = await this.getClient().externalStoreData(request, options)
             return response.storers
-        } catch (err) {
+        } catch {
             return []
         }
     }

--- a/packages/dht/src/dht/discovery/PeerDiscovery.ts
+++ b/packages/dht/src/dht/discovery/PeerDiscovery.ts
@@ -181,7 +181,7 @@ export class PeerDiscovery {
         try {
             await this.joinThroughEntryPoint(entryPoint, contactedPeers, { enabled: true, contactedPeers: distantJoinContactPeers })
             logger.debug(`Rejoined DHT successfully ${this.options.serviceId}!`)
-        } catch (err) {
+        } catch {
             logger.warn(`Rejoining DHT ${this.options.serviceId} failed`)
             if (!this.isStopped()) {
                 // TODO should we catch possible promise rejection?

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -135,7 +135,7 @@ export class Router {
                     // TODO use options option or named constant?
                     await withTimeout(eventReceived, 10000)
                     logger.trace('raceEvents ended from routingSession: ' + session.sessionId)
-                } catch (e) {
+                } catch {
                     logger.trace('raceEvents timed out for routingSession ' + session.sessionId) 
                 }
                 session.stop()

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -83,7 +83,7 @@ describe('Kademlia correctness', () => {
                     }
                     correctNeighbors++
                 }
-            } catch (e) {
+            } catch {
                 console.error('Node ' + getNodeIdFromPeerDescriptor(nodes[i].getLocalPeerDescriptor()) + ' had only ' 
                     + kademliaNeighbors.length + ' kademlia neighbors')
             }

--- a/packages/dht/test/benchmark/RingCorrectness.test.ts
+++ b/packages/dht/test/benchmark/RingCorrectness.test.ts
@@ -126,7 +126,7 @@ describe('Ring correctness', () => {
                     }
                     correctNeighbors++
                 }
-            } catch (e) {
+            } catch {
                 console.error('Node ' + getNodeIdFromPeerDescriptor(nodes[i].getLocalPeerDescriptor()) + ' had only '
                     + kademliaNeighbors.length + ' kademlia neighbors')
             }

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -259,7 +259,7 @@ export const waitForStableTopology = async (nodes: DhtNode[], maxConnectionCount
         connectionManager.garbageCollectConnections(maxConnectionCount, MAX_IDLE_TIME)
         try {
             await waitForCondition(() => connectionManager.getConnections().length <= maxConnectionCount, waitTime)
-        } catch (err) {
+        } catch {
             // the topology is very likely stable, but we can't be sure (maybe the node has more than maxConnectionCount
             // locked connections and therefore it is ok to that garbage collector was not able to remove any of those
             // connections

--- a/packages/geoip-location/src/downloadGeoIpDatabase.ts
+++ b/packages/geoip-location/src/downloadGeoIpDatabase.ts
@@ -56,7 +56,7 @@ const downloadNewDb = async (
     } catch (e) {
         try {
             fs.rmSync(downloadFolder, { recursive: true })
-        } catch (e2) {
+        } catch {
             // ignore error when removing the temporary folder
         }
         throw e
@@ -67,7 +67,7 @@ const downloadNewDb = async (
     if (!isDbFileValid(dbFileInDownloadFolder, remoteHash)) {
         try {
             fs.rmSync(downloadFolder, { recursive: true })
-        } catch (e2) {
+        } catch {
             // ignore error when removing the temporary folder
         }
         throw new Error('Downloaded database hash does not match the expected hash')
@@ -81,7 +81,7 @@ const downloadNewDb = async (
     } finally {
         try {
             fs.rmSync(downloadFolder, { recursive: true })
-        } catch (e2) {
+        } catch {
             // ignore error when removing the temporary folder
         }
     }
@@ -131,7 +131,7 @@ const isDbFileValid = async (dbFile: string, remoteHash: string): Promise<boolea
         } else {
             return true
         }
-    } catch (e) {
+    } catch {
         // if the local db does not exist, or some other exception occurres db is not considered valid
         return false
     }

--- a/packages/geoip-location/test/helpers/TestServer.ts
+++ b/packages/geoip-location/test/helpers/TestServer.ts
@@ -60,7 +60,7 @@ export class TestServer extends EventEmitter<TestServerEvents> {
         // save db and hash data to CACHE_PATH
         try {
             fs.mkdirSync(CACHE_PATH, { recursive: true })
-        } catch (e) {
+        } catch {
             // ignore error when creating the cache folder
         }
         // ensure there is never an incomplete file in the fs

--- a/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
@@ -37,7 +37,7 @@ describe('GeoIpLocator', () => {
 
         try {
             fs.unlinkSync(dbDir + '/' + DB_FILENAME)
-        } catch (e) {
+        } catch {
             // ignore
         }
 
@@ -49,7 +49,7 @@ describe('GeoIpLocator', () => {
         // delete the db
         try {
             fs.unlinkSync(dbDir + '/' + DB_FILENAME)
-        } catch (e) {
+        } catch {
             // ignore
         }
 

--- a/packages/geoip-location/test/unit/downloadGeoIpDatabase.test.ts
+++ b/packages/geoip-location/test/unit/downloadGeoIpDatabase.test.ts
@@ -22,7 +22,7 @@ describe('downloadGeoIpDatabase', () => {
     beforeEach(() => {
         try {
             fs.rmSync(path, { recursive: true })
-        } catch (e) {
+        } catch {
             // ignore error when removing the test data
         }
     })

--- a/packages/node/src/config/ConfigWizard.ts
+++ b/packages/node/src/config/ConfigWizard.ts
@@ -123,7 +123,7 @@ export async function start(): Promise<void> {
                 } else {
                     log(`> ${content}`)
                 }
-            } catch (e) {
+            } catch {
                 resume()
 
                 log('> x Failed to fetch node\'s balance')
@@ -162,7 +162,7 @@ export async function start(): Promise<void> {
                 }
 
                 log(`> *https://streamr.network/hub/network/operators/${operator}*`)
-            } catch (e) {
+            } catch {
                 resume()
 
                 log('> x Failed to fetch operator nodes')

--- a/packages/proto-rpc/test/unit/ConversionWrappers.test.ts
+++ b/packages/proto-rpc/test/unit/ConversionWrappers.test.ts
@@ -18,7 +18,7 @@ describe('ConversionWrappers', () => {
         let errorCount = 0
         try {
             parseWrapper<RpcMessage>(() => RpcMessage.fromBinary(Buffer.from('adda')))
-        } catch (err) {
+        } catch {
             errorCount += 1
         }
         expect(errorCount).toEqual(1)
@@ -41,7 +41,7 @@ describe('ConversionWrappers', () => {
                 )
             )
 
-        } catch (err) {
+        } catch {
             errorCount += 1
         }
         expect(errorCount).toEqual(1)

--- a/packages/sdk/src/contracts/StreamRegistry.ts
+++ b/packages/sdk/src/contracts/StreamRegistry.ts
@@ -221,7 +221,7 @@ export class StreamRegistry {
                     // eslint-disable-next-line no-underscore-dangle
                     this.config._timeouts.ensStreamCreation.retryInterval
                 )
-            } catch (e) {
+            } catch {
                 throw new Error(`unable to create stream "${streamId}"`)
             }
         } else {

--- a/packages/sdk/src/subscribe/Resends.ts
+++ b/packages/sdk/src/subscribe/Resends.ts
@@ -85,7 +85,7 @@ const getHttpErrorTransform = (): (error: any) => Promise<StreamrClientError> =>
             try {
                 const json = JSON.parse(body)
                 descriptionSnippet = `: ${json.error}`
-            } catch (err) {
+            } catch {
                 descriptionSnippet = ''
             }
             message = `Storage node fetch failed${descriptionSnippet}, httpStatus=${err.response.status}, url=${err.response.url}`

--- a/packages/sdk/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StreamRegistry.test.ts
@@ -257,7 +257,7 @@ describe('StreamRegistry', () => {
             await until(async () => {
                 try {
                     return (await client.getStream(createdStream.id)).getMetadata().description === createdStream.getMetadata().description
-                } catch (err) {
+                } catch {
                     return false
                 }
             }, 100000, 1000)

--- a/packages/trackerless-network/src/logic/PeerDescriptorStoreManager.ts
+++ b/packages/trackerless-network/src/logic/PeerDescriptorStoreManager.ts
@@ -45,7 +45,7 @@ export class PeerDescriptorStoreManager {
         try {
             const result = await this.options.fetchDataFromDht(this.options.key)
             return parsePeerDescriptor(result)
-        } catch (err) {
+        } catch {
             return []
         }
     }
@@ -65,7 +65,7 @@ export class PeerDescriptorStoreManager {
         const dataToStore = Any.pack(localPeerDescriptor, PeerDescriptor)
         try {
             await this.options.storeDataToDht(this.options.key, dataToStore)
-        } catch (err) {
+        } catch {
             logger.warn('Failed to store local node', { key: this.options.key })
         }
     }
@@ -79,7 +79,7 @@ export class PeerDescriptorStoreManager {
                     || discovered.some((peerDescriptor) => areEqualPeerDescriptors(peerDescriptor, this.options.localPeerDescriptor))) {
                     await this.storeLocalNode()
                 }
-            } catch (err) {
+            } catch {
                 logger.debug('Failed to keep local node', { key: this.options.key })
             }
         }, this.options.storeInterval ?? 60000, false, this.abortController.signal)

--- a/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
+++ b/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
@@ -27,7 +27,7 @@ const exponentialRunOff = async (
         const delay = baseDelay * factor
         try {
             await task()
-        } catch (e: any) {
+        } catch {
             logger.debug(`${description} failed, retrying in ${delay} ms`)
         }
         try { // Abort controller throws unexpected errors in destroy?

--- a/packages/trackerless-network/src/logic/inspect/Inspector.ts
+++ b/packages/trackerless-network/src/logic/inspect/Inspector.ts
@@ -73,7 +73,7 @@ export class Inspector {
         try {
             await waitForEvent3<InspectSessionEvents>(session, 'done', this.inspectionTimeout)
             success = true
-        } catch (err) {
+        } catch {
             logger.trace('Inspect session timed out, removing')
         } finally {
             await this.closeInspectConnection(peerDescriptor, lockId)

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -33,7 +33,7 @@ export const retry = async <T>(task: () => Promise<T>, description: string, abor
         try {
             const result = await task()
             return result
-        } catch (e: any) {
+        } catch {
             logger.warn(`Failed ${description} (retrying after delay)`, {
                 delayInMs: delay
             })

--- a/packages/utils/src/signingUtils.ts
+++ b/packages/utils/src/signingUtils.ts
@@ -59,7 +59,7 @@ export function verifySignature(address: EthereumAddress, payload: Uint8Array, s
     try {
         const recoveredAddress = toEthereumAddress(recoverAddress(signature, payload))
         return recoveredAddress === address
-    } catch (err) {
+    } catch {
         return false
     }
 }


### PR DESCRIPTION
Removed some unused variables. Eslint 's `typescript-eslint/no-unused-vars` rule would warn about these when we upgrade to eslint v9.

All the modifications are about `try ... catch` blocks: we catch an error, but ignore the throw error object. 