### PR TITLE
fix(sdk): [NET-1337] Fix `ReviewRequest` event parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Fix operator review request event parsing
+
 #### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
-- Fix operator review request event parsing
+- Fix operator review request event parsing (https://github.com/streamr-dev/network/pull/2714)
 
 #### Security
 

--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -206,8 +206,8 @@ export class Operator {
         const reviewRequestTransform = (
             sponsorship: string,
             targetOperator: string,
-            voteStartTimestampInSecs: number,
-            voteEndTimestampInSecs: number,
+            voteStartTimestampInSecs: bigint,
+            voteEndTimestampInSecs: bigint,
             metadataAsString?: string
         ) => {
             const partition = parsePartitionFromReviewRequestMetadata(metadataAsString)
@@ -215,8 +215,8 @@ export class Operator {
                 sponsorship: toEthereumAddress(sponsorship),
                 targetOperator: toEthereumAddress(targetOperator),
                 partition,
-                votingPeriodStartTimestamp: voteStartTimestampInSecs * 1000,
-                votingPeriodEndTimestamp: voteEndTimestampInSecs * 1000
+                votingPeriodStartTimestamp: Number(voteStartTimestampInSecs) * 1000,
+                votingPeriodEndTimestamp: Number(voteEndTimestampInSecs) * 1000
             }
         }
         initContractEventGateway({

--- a/packages/sdk/src/contracts/contract.ts
+++ b/packages/sdk/src/contracts/contract.ts
@@ -185,7 +185,7 @@ export const initContractEventGateway = <
                 try {
                     targetEvent = opts.transformation(...args)
                 } catch (err) {
-                    logger.debug('Skip emit event', {
+                    logger.error('Skip emit event', {
                         eventName: opts.targetName,
                         reason: err?.message
                     })

--- a/packages/sdk/test/unit/Operator.test.ts
+++ b/packages/sdk/test/unit/Operator.test.ts
@@ -91,7 +91,7 @@ describe('Operator', () => {
         it('emitting ReviewRequest with valid metadata causes listener to be invoked', async () => {
             const operator = createOperator(
                 'ReviewRequest',
-                [SPONSORSHIP_ADDRESS, OPERATOR_CONTRACT_ADDRESS, 1000, 1050, '{ "partition": 7 }']
+                [SPONSORSHIP_ADDRESS, OPERATOR_CONTRACT_ADDRESS, 1000n, 1050n, '{ "partition": 7 }']
             )
             const listener = jest.fn()
             operator.on('reviewRequested', listener)
@@ -109,7 +109,7 @@ describe('Operator', () => {
         it('emitting ReviewRequest with invalid metadata causes listener to not be invoked', async () => {
             const operator = createOperator(
                 'ReviewRequest',
-                [SPONSORSHIP_ADDRESS, OPERATOR_CONTRACT_ADDRESS, 1000, 1050, '{ "partition": 666 }']
+                [SPONSORSHIP_ADDRESS, OPERATOR_CONTRACT_ADDRESS, 1000n, 1050n, '{ "partition": 666 }']
             )
             const listener = jest.fn()
             operator.on('reviewRequested', listener)


### PR DESCRIPTION
Fixed timestamp handling when parsing `ReviewRequest` events. The timestamps are received as `bigints` ethers v6, the code assumed the values to be plain numbers.

Also change the log level of event transformer error logging.
