### PR TITLE
ci(deps): Update `@streamr/network-contracts-ethers6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8149,11 +8149,10 @@
             "link": true
         },
         "node_modules/@streamr/network-contracts-ethers6": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@streamr/network-contracts-ethers6/-/network-contracts-ethers6-7.1.3.tgz",
-            "integrity": "sha512-//3UVK49wK02pK6K6XKbCM2njDpQq1FrqT+o0US7G4f2s8yyQbgI11CXOZsIROxYPv5ipPLVgu5cIt8M6SYEIQ==",
-            "dev": true,
-            "license": "STREAMR NETWORK OPEN SOURCE LICENSE"
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@streamr/network-contracts-ethers6/-/network-contracts-ethers6-7.1.4.tgz",
+            "integrity": "sha512-4ee9UA34LOdPfg7gg8i2E0kRhFEmqGzw7d3jPqPBTqT0zvTuGHtgdj5e3n7plo9iB+uG7xlgTddUNnqDXlcBOQ==",
+            "dev": true
         },
         "node_modules/@streamr/node": {
             "resolved": "packages/node",
@@ -28981,7 +28980,7 @@
             },
             "devDependencies": {
                 "@inquirer/testing": "^2.1.31",
-                "@streamr/network-contracts-ethers6": "7.1.3",
+                "@streamr/network-contracts-ethers6": "^7.1.4",
                 "@streamr/test-utils": "101.1.0",
                 "@types/cors": "^2.8.17",
                 "@types/express": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,30 +3408,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@ensdomains/buffer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@ensdomains/buffer/-/buffer-0.1.1.tgz",
-            "integrity": "sha512-92SfSiNS8XorgU7OUBHo/i1ZU7JV7iz/6bKuLPNVsMxV79/eI7fJR6jfJJc40zAHjs3ha+Xo965Idomlq3rqnw=="
-        },
-        "node_modules/@ensdomains/ens-contracts": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-1.1.4.tgz",
-            "integrity": "sha512-kjdcjaznMtE2lwjAVTX2irs8mgNgJCVuB5hnhFhiMaO8dR/tlHQ5UhtZjhSYRhkZd0hLXYrMkXp6thnwpG+ltg==",
-            "dependencies": {
-                "@ensdomains/buffer": "^0.1.1",
-                "@ensdomains/solsha1": "0.0.3",
-                "@openzeppelin/contracts": "^4.1.0",
-                "dns-packet": "^5.3.0"
-            }
-        },
-        "node_modules/@ensdomains/solsha1": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@ensdomains/solsha1/-/solsha1-0.0.3.tgz",
-            "integrity": "sha512-uhuG5LzRt/UJC0Ux83cE2rCKwSleRePoYdQVcqPN1wyf3/ekMzT/KZUF9+v7/AG5w9jlMLCQkUM50vfjr0Yu9Q==",
-            "dependencies": {
-                "hash-test-vectors": "^1.3.2"
-            }
-        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -5355,11 +5331,6 @@
                 "url": "https://opencollective.com/js-sdsl"
             }
         },
-        "node_modules/@leichtgewicht/ip-codec": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
-        },
         "node_modules/@lerna/create": {
             "version": "8.1.8",
             "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.8.tgz",
@@ -7207,11 +7178,6 @@
             "dependencies": {
                 "@octokit/openapi-types": "^18.0.0"
             }
-        },
-        "node_modules/@openzeppelin/contracts": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.6.tgz",
-            "integrity": "sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA=="
         },
         "node_modules/@peculiar/asn1-cms": {
             "version": "2.3.8",
@@ -12951,17 +12917,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/dns-packet": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
-            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-            "dependencies": {
-                "@leichtgewicht/ip-codec": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/dns2": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/dns2/-/dns2-2.1.0.tgz",
@@ -15608,11 +15563,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/hash-test-vectors": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/hash-test-vectors/-/hash-test-vectors-1.3.2.tgz",
-            "integrity": "sha512-PKd/fitmsrlWGh3OpKbgNLE04ZQZsvs1ZkuLoQpeIKuwx+6CYVNdW6LaPIS1QAdZvV40+skk0w4YomKnViUnvQ=="
         },
         "node_modules/hash.js": {
             "version": "1.1.7",
@@ -28995,7 +28945,6 @@
             "version": "101.1.0",
             "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
             "dependencies": {
-                "@ensdomains/ens-contracts": "1.1.4",
                 "@inquirer/prompts": "^5.3.8",
                 "@streamr/config": "^5.3.13",
                 "@streamr/dht": "101.1.0",
@@ -29032,7 +28981,7 @@
             },
             "devDependencies": {
                 "@inquirer/testing": "^2.1.31",
-                "@streamr/network-contracts-ethers6": "^7.1.3",
+                "@streamr/network-contracts-ethers6": "7.1.3",
                 "@streamr/test-utils": "101.1.0",
                 "@types/cors": "^2.8.17",
                 "@types/express": "^4.17.21",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@inquirer/testing": "^2.1.31",
-    "@streamr/network-contracts-ethers6": "7.1.3",
+    "@streamr/network-contracts-ethers6": "^7.1.4",
     "@streamr/test-utils": "101.1.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,7 +30,6 @@
   "author": "Streamr Network AG <contact@streamr.network>",
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "dependencies": {
-    "@ensdomains/ens-contracts": "1.1.4",
     "@inquirer/prompts": "^5.3.8",
     "@streamr/config": "^5.3.13",
     "@streamr/dht": "101.1.0",
@@ -59,7 +58,7 @@
   },
   "devDependencies": {
     "@inquirer/testing": "^2.1.31",
-    "@streamr/network-contracts-ethers6": "^7.1.3",
+    "@streamr/network-contracts-ethers6": "7.1.3",
     "@streamr/test-utils": "101.1.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
Updated to v7.1.4. Also the `@ensdomains/ens-contracts` dependency is no longer needed (it was temporarily added in https://github.com/streamr-dev/network/pull/2506)