### PR TITLE
fix: NET-1343 don't send a transaction when asked to close a non-existing flag

### DIFF
--- a/packages/node/src/plugins/operator/closeExpiredFlags.ts
+++ b/packages/node/src/plugins/operator/closeExpiredFlags.ts
@@ -21,6 +21,10 @@ export const closeExpiredFlags = async (
         const operatorAddress = flag.targetOperator
         const sponsorship = flag.sponsorship
         logger.info('Close expired flag', { flag })
-        await operator.closeFlag(sponsorship, operatorAddress)
+        try {
+            await operator.closeFlag(sponsorship, operatorAddress)
+        } catch (e) {
+            logger.warn('Failed to close flag (does it exist?)', { sponsorship, operatorAddress, error: e })
+        }
     }
 }

--- a/packages/node/src/plugins/operator/closeExpiredFlags.ts
+++ b/packages/node/src/plugins/operator/closeExpiredFlags.ts
@@ -23,8 +23,8 @@ export const closeExpiredFlags = async (
         logger.info('Close expired flag', { flag })
         try {
             await operator.closeFlag(sponsorship, operatorAddress)
-        } catch (e) {
-            logger.warn('Failed to close flag (does it exist?)', { sponsorship, operatorAddress, error: e })
+        } catch (err) {
+            logger.warn('Failed to close flag (does it exist?)', { sponsorship, operatorAddress, err })
         }
     }
 }

--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -575,6 +575,8 @@ export class Operator {
     async voteOnFlag(sponsorshipAddress: EthereumAddress, targetOperator: EthereumAddress, kick: boolean): Promise<void> {
         const voteData = kick ? VOTE_KICK : VOTE_NO_KICK
         await this.connectToContract()
+        // estimateGas throws if transaction would fail, ignore the return value
+        await this.contract!.voteOnFlag.estimateGas(sponsorshipAddress, targetOperator, voteData)
         // typical gas cost 99336, but this has shown insufficient sometimes
         // TODO should we set gasLimit only here, or also for other transactions made by ContractFacade?
         await (await this.contract!.voteOnFlag(

--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -575,15 +575,23 @@ export class Operator {
     async voteOnFlag(sponsorshipAddress: EthereumAddress, targetOperator: EthereumAddress, kick: boolean): Promise<void> {
         const voteData = kick ? VOTE_KICK : VOTE_NO_KICK
         await this.connectToContract()
-        // estimateGas throws if transaction would fail, ignore the return value
-        await this.contract!.voteOnFlag.estimateGas(sponsorshipAddress, targetOperator, voteData)
+
         // typical gas cost 99336, but this has shown insufficient sometimes
+        // this estimate should be very conservative, i.e. higher than any observed flag-resolution gas cost
+        const gasLimit = 1300000n
+
+        // estimateGas throws if transaction would fail, so doing the gas estimation will avoid sending failing transactions
+        const gasEstimate = await this.contract!.voteOnFlag.estimateGas(sponsorshipAddress, targetOperator, voteData) as bigint
+        if (gasEstimate > gasLimit) {
+            throw new Error(`Gas estimate (${gasEstimate}) exceeds limit (${gasLimit})`)
+        }
+
         // TODO should we set gasLimit only here, or also for other transactions made by ContractFacade?
         await (await this.contract!.voteOnFlag(
             sponsorshipAddress,
             targetOperator,
             voteData,
-            { ...this.getEthersOverrides(), gasLimit: '1300000' }
+            { ...this.getEthersOverrides(), gasLimit }
         )).wait()
     }
 

--- a/packages/sdk/test/end-to-end/Operator.test.ts
+++ b/packages/sdk/test/end-to-end/Operator.test.ts
@@ -181,10 +181,10 @@ describe('Operator', () => {
         const wallet = deployedOperator.nodeWallets[0] as Wallet
         const operator = await getOperator(wallet, deployedOperator)
         const nonceBefore = await wallet.getNonce() // nonce = "how many transactions sent so far"
-        await expect(operator.closeFlag(
+        await expect(async () => operator.closeFlag(
             toEthereumAddress(await sponsorship1.getAddress()),
             toEthereumAddress(await deployedOperator.operatorContract.getAddress())
-        )).rejects.toThrowError()
+        )).rejects.toThrow()
         const nonceAfter = await wallet.getNonce()
         expect(nonceAfter).toEqual(nonceBefore)
     })


### PR DESCRIPTION
## Summary

Do estimateGas before sending a transaction with gasLimit (this circumvents the usual estimateGas that catches reverts)

## Changes


## Limitations and future improvements


## Checklist before requesting a review

- [ ] Is this a breaking change? If it is, be clear in summary.
- [X] Read through code myself one more time.
- [ ] Make sure any and all `TODO` comments left behind are meant to be left in.
- [X] Has reasonable passing test coverage?
- [ ] Updated changelog if applicable.
- [ ] Updated documentation if applicable.