### PR TITLE
fix(network): exclude initial ws neighbors for parallel operations

### DIFF
--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -83,7 +83,9 @@ export class Handshaker {
                 true
             )
             if (wsNode) {
-                neighbors.set(getNodeIdFromPeerDescriptor(wsNode.getPeerDescriptor()), wsNode)
+                const wsNodeId = getNodeIdFromPeerDescriptor(wsNode.getPeerDescriptor())
+                excludedIds.push(wsNodeId)
+                neighbors.set(wsNodeId, wsNode)
             }   
         }
         // Add the closest left and then right contacts from the ring if possible.


### PR DESCRIPTION
## Summary

As we run parallel handshaking algorithms now it makes sense to push the WS node to the excluded list immediately. This way the same WS server cannot be picked

## Future improvements

Explore more general exclusion in general. Parallel handshaking operations can be done to the same nodes. Naively pushing attempted handshakes to the exclude list breaks some tests.
