### PR TITLE
chore(sdk): reduce Propagation buffer time to 10 secs

### DIFF
--- a/packages/trackerless-network/src/logic/propagation/Propagation.ts
+++ b/packages/trackerless-network/src/logic/propagation/Propagation.ts
@@ -12,7 +12,7 @@ interface ConstructorOptions {
 }
 
 const DEFAULT_MAX_MESSAGES = 150
-const DEFAULT_TTL = 30 * 1000
+const DEFAULT_TTL = 5 * 1000
 
 /**
  * Message propagation logic of a node. Given a message, this class will actively attempt to propagate it to

--- a/packages/trackerless-network/src/logic/propagation/Propagation.ts
+++ b/packages/trackerless-network/src/logic/propagation/Propagation.ts
@@ -12,7 +12,7 @@ interface ConstructorOptions {
 }
 
 const DEFAULT_MAX_MESSAGES = 150
-const DEFAULT_TTL = 5 * 1000
+const DEFAULT_TTL = 10 * 1000
 
 /**
  * Message propagation logic of a node. Given a message, this class will actively attempt to propagate it to


### PR DESCRIPTION
## Summary

Reduce propagation buffer time to 10 secs. Useful for video streaming case so we don't end up propagation old frames.
