### PR TITLE
fix(sdk): Fix `Operator#voteOnFlag` gas estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Fixed gas estimation in `Operator#voteOnFlag` (https://github.com/streamr-dev/network/pull/2734)
+
 #### Security
 
 ### @streamr/node

--- a/packages/sdk/src/contracts/contract.ts
+++ b/packages/sdk/src/contracts/contract.ts
@@ -90,7 +90,7 @@ const createWrappedContractMethod = (
 ) => {
     const originalMethod = contract[methodName]
     const methodFullName = `${contractName}.${methodName}`
-    return async (...args: any) => {
+    const fn = async (...args: any) => {
         const returnValue = await withErrorHandling(() => concurrencyLimit(() => {
             eventEmitter.emit('onMethodExecute', methodFullName)
             return originalMethod(...args)
@@ -106,6 +106,10 @@ const createWrappedContractMethod = (
         }
         return returnValue
     }
+    // TODO add also other methods in the future if needed:
+    // https://docs.ethers.org/v6/api/contract/#BaseContractMethod
+    fn.estimateGas = (...args: any) => originalMethod.estimateGas(...args)
+    return fn
 }
 
 /**

--- a/packages/sdk/test/end-to-end/Operator.test.ts
+++ b/packages/sdk/test/end-to-end/Operator.test.ts
@@ -192,7 +192,7 @@ describe('Operator', () => {
         await expect(async () => operator.closeFlag(
             toEthereumAddress(await sponsorship1.getAddress()),
             toEthereumAddress(await deployedOperator.operatorContract.getAddress())
-        )).rejects.toThrow()
+        )).rejects.toThrow('action="estimateGas"')
         const nonceAfter = await wallet.getNonce()
         expect(nonceAfter).toEqual(nonceBefore)
     })


### PR DESCRIPTION
We call the `estimateGas` function via the decorated contract. Before the PR the decorated contract didn't have any of these `BaseContractMethod` implemented. Therefore a call to `voteOnFlag` always failed with error
```
this.contract.voteOnFlag.estimateGas is not a function
```

Added the method to the decorated contract. Also modified to the test case to assert the expected error.