### PR TITLE
fix (DHT): NET-1347 fix hanging sends to connecting connections with `connect: false`

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -283,7 +283,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         if (!connection && opts.connect) {
             connection = this.connectorFacade.createConnection(peerDescriptor)
             this.onNewConnection(connection)
-        } else if (!connection) {
+        } else if (!connection || (connection && !this.endpoints.get(nodeId)!.connected && !opts.connect)) {
             throw new Err.SendFailed('No connection to target, connect flag is false')
         }
         const binary = Message.toBinary(message)

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -85,7 +85,7 @@ export class StoreManager {
     private async replicateDataToContact(dataEntry: DataEntry, contact: PeerDescriptor): Promise<void> {
         const rpcRemote = this.options.createRpcRemote(contact)
         try {
-            await rpcRemote.replicateData({ entry: dataEntry })
+            await rpcRemote.replicateData({ entry: dataEntry }, true)
         } catch (e) {
             logger.trace('replicateData() threw an exception ' + e)
         }
@@ -145,7 +145,7 @@ export class StoreManager {
             await Promise.all(neighbors.map(async (neighbor) => {
                 const rpcRemote = this.options.createRpcRemote(neighbor)
                 try {
-                    await rpcRemote.replicateData({ entry: dataEntry })
+                    await rpcRemote.replicateData({ entry: dataEntry }, false)
                 } catch (err) {
                     logger.trace('Failed to replicate data in replicateDataToClosestNodes', { err })
                 }

--- a/packages/dht/src/dht/store/StoreRpcRemote.ts
+++ b/packages/dht/src/dht/store/StoreRpcRemote.ts
@@ -19,9 +19,11 @@ export class StoreRpcRemote extends RpcRemote<StoreRpcClient> {
         }
     }
 
-    async replicateData(request: ReplicateDataRequest): Promise<void> {
+    async replicateData(request: ReplicateDataRequest, connect: boolean): Promise<void> {
         const options = this.formDhtRpcOptions({
-            timeout: EXISTING_CONNECTION_TIMEOUT
+            timeout: EXISTING_CONNECTION_TIMEOUT,
+            notification: true,
+            connect
         })
         return this.getClient().replicateData(request, options)
     }

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -70,7 +70,7 @@ describe('StoreManager', () => {
                 await waitForCondition(() => replicateData.mock.calls.length === 1)
                 expect(replicateData).toHaveBeenCalledWith({
                     entry: DATA_ENTRY
-                })
+                }, true)
                 expect(setAllEntriesAsStale).not.toHaveBeenCalled()
             })
     


### PR DESCRIPTION
## Summary

No longer allow sending in the connection manager to connecting connections. This fixes a problem with stopping of the nodes taking more than 15 seconds.

This is the intended behaviour as connections should be opened if the connect flag is set false.

## Future improvements

- Fix problem with timeouts not working for notifications in the proto-rpc package.