### PR TITLE
refactor(proto-rpc): NET-1335 Remove unused eventemitter from RpcCommunicator

### DIFF
--- a/packages/dht/test/integration/DhtNodeRpcRemote.test.ts
+++ b/packages/dht/test/integration/DhtNodeRpcRemote.test.ts
@@ -27,10 +27,10 @@ describe('DhtNodeRpcRemote', () => {
         serverRpcCommunicator = new RpcCommunicator()
         serverRpcCommunicator.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers', mockDhtRpc.getClosestPeers)
         serverRpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping', mockDhtRpc.ping)
-        clientRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        clientRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             serverRpcCommunicator.handleIncomingMessage(message)
         })
-        serverRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        serverRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             clientRpcCommunicator.handleIncomingMessage(message)
         })
         rpcRemote = new DhtNodeRpcRemote(clientPeerDescriptor, serverPeerDescriptor, SERVICE_ID, clientRpcCommunicator)

--- a/packages/dht/test/integration/DhtRpc.test.ts
+++ b/packages/dht/test/integration/DhtRpc.test.ts
@@ -18,7 +18,7 @@ describe('DhtRpc', () => {
     const neighbors = createMockPeers()
     const mockDhtRpc = createMockDhtRpc(neighbors)
 
-    const outgoingListener2 = (message: RpcMessage) => {
+    const outgoingListener2 = async (message: RpcMessage) => {
         rpcCommunicator1.handleIncomingMessage(message)
     }
 
@@ -29,11 +29,11 @@ describe('DhtRpc', () => {
         rpcCommunicator2 = new RpcCommunicator()
         rpcCommunicator2.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers', mockDhtRpc.getClosestPeers)
 
-        rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator1.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator2.handleIncomingMessage(message)
         })
 
-        rpcCommunicator2.on('outgoingMessage', outgoingListener2)
+        rpcCommunicator2.setOutgoingMessageListener(outgoingListener2)
 
         client1 = toProtoRpcClient(new DhtNodeRpcClient(rpcCommunicator1.getRpcClientTransport()))
         client2 = toProtoRpcClient(new DhtNodeRpcClient(rpcCommunicator1.getRpcClientTransport()))
@@ -67,8 +67,7 @@ describe('DhtRpc', () => {
     })
 
     it('Default RPC timeout, client side', async () => {
-        rpcCommunicator2.off('outgoingMessage', outgoingListener2)
-        rpcCommunicator2.on('outgoingMessage', async () => {
+        rpcCommunicator2.setOutgoingMessageListener(async () => {
             await wait(3000)
         })
         const response2 = client2.getClosestPeers(

--- a/packages/dht/test/integration/RouterRpcRemote.test.ts
+++ b/packages/dht/test/integration/RouterRpcRemote.test.ts
@@ -20,10 +20,10 @@ describe('RemoteRouter', () => {
         clientRpcCommunicator = new RpcCommunicator()
         serverRpcCommunicator = new RpcCommunicator()
         serverRpcCommunicator.registerRpcMethod(RouteMessageWrapper, RouteMessageAck, 'routeMessage', mockRouterRpc.routeMessage)
-        clientRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        clientRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             serverRpcCommunicator.handleIncomingMessage(message)
         })
-        serverRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        serverRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             clientRpcCommunicator.handleIncomingMessage(message)
         })
         remoteRouter = new RouterRpcRemote(clientPeerDescriptor, serverPeerDescriptor, clientRpcCommunicator, RouterRpcClient)

--- a/packages/dht/test/integration/StoreRpcRemote.test.ts
+++ b/packages/dht/test/integration/StoreRpcRemote.test.ts
@@ -30,10 +30,10 @@ describe('StoreRpcRemote', () => {
         clientRpcCommunicator = new RpcCommunicator()
         serverRpcCommunicator = new RpcCommunicator()
         serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', mockStoreRpc.storeData)
-        clientRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        clientRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             serverRpcCommunicator.handleIncomingMessage(message)
         })
-        serverRpcCommunicator.on('outgoingMessage', (message: RpcMessage) => {
+        serverRpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage) => {
             clientRpcCommunicator.handleIncomingMessage(message)
         })
         rpcRemote = new StoreRpcRemote(clientPeerDescriptor, serverPeerDescriptor, clientRpcCommunicator, StoreRpcClient)

--- a/packages/dht/test/integration/WebrtcConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectorRpc.test.ts
@@ -64,11 +64,11 @@ describe('WebRTC rpc messages', () => {
         rpcCommunicator2.registerRpcNotification(IceCandidate, 'iceCandidate', serverFunctions.iceCandidate)
         rpcCommunicator2.registerRpcNotification(WebrtcConnectionRequest, 'requestConnection', serverFunctions.requestConnection)
 
-        rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator1.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator2.handleIncomingMessage(message)
         })
 
-        rpcCommunicator2.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator2.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator1.handleIncomingMessage(message)
         })
 

--- a/packages/dht/test/integration/WebsocketClientConnectorRpc.test.ts
+++ b/packages/dht/test/integration/WebsocketClientConnectorRpc.test.ts
@@ -32,11 +32,11 @@ describe('WebsocketClientConnectorRpc', () => {
             mockWebsocketClientConnectorRpc.requestConnection
         )
 
-        rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator1.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator2.handleIncomingMessage(message)
         })
 
-        rpcCommunicator2.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator2.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator1.handleIncomingMessage(message)
         })
 

--- a/packages/proto-rpc/src/RpcCommunicator.ts
+++ b/packages/proto-rpc/src/RpcCommunicator.ts
@@ -12,7 +12,6 @@ import {
 } from './proto/ProtoRpc'
 import { Empty } from './proto/google/protobuf/empty'
 import { MethodOptions, ServerRegistry } from './ServerRegistry'
-import EventEmitter from 'eventemitter3'
 import { DeferredState, ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Logger } from '@streamr/utils'
 import { ProtoCallContext, ProtoRpcOptions } from './ProtoCallContext'

--- a/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
+++ b/packages/proto-rpc/test/integration/ClientRpcTransport.test.ts
@@ -10,7 +10,7 @@ import { Any } from '../../src/proto/google/protobuf/any'
 describe('DhtClientRpcTransport', () => {
     it('Happy Path getClosestNeighbors', async () => {
         const rpcCommunicator = new RpcCommunicator()
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
             //const request = RpcMessage.fromBinary(message)
             const responseBody: ClosestPeersResponse = {
                 peers: getMockPeers(),

--- a/packages/proto-rpc/test/integration/toProtoRpcClient.test.ts
+++ b/packages/proto-rpc/test/integration/toProtoRpcClient.test.ts
@@ -54,10 +54,10 @@ describe('toProtoRpcClient', () => {
         const helloClient = toProtoRpcClient(new HelloRpcServiceClient(communicator2.getRpcClientTransport()))
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
-        communicator1.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator1.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator2.handleIncomingMessage(msg)
         })
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 
@@ -79,10 +79,10 @@ describe('toProtoRpcClient', () => {
         const wakeUpClient = toProtoRpcClient(new WakeUpRpcServiceClient(communicator2.getRpcClientTransport()))
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
-        communicator1.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator1.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator2.handleIncomingMessage(msg)
         })
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 
@@ -107,10 +107,10 @@ describe('toProtoRpcClient', () => {
         const optionalClient = toProtoRpcClient(new OptionalServiceClient(communicator2.getRpcClientTransport()))
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
-        communicator1.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator1.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator2.handleIncomingMessage(msg)
         })
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 
@@ -149,7 +149,7 @@ describe('toProtoRpcClient', () => {
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
 
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 
@@ -201,10 +201,10 @@ describe('toProtoRpcClient', () => {
         const helloClient = new HelloRpcServiceClient(communicator2.getRpcClientTransport())
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
-        communicator1.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator1.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator2.handleIncomingMessage(msg)
         })
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 
@@ -230,10 +230,10 @@ describe('toProtoRpcClient', () => {
         const wakeUpClient = new WakeUpRpcServiceClient(communicator2.getRpcClientTransport())
 
         // Simulate a network connection, in real life the message blobs would be transferred over a network
-        communicator1.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator1.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator2.handleIncomingMessage(msg)
         })
-        communicator2.on('outgoingMessage', (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
+        communicator2.setOutgoingMessageListener(async (msg: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             communicator1.handleIncomingMessage(msg)
         })
 

--- a/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
+++ b/packages/proto-rpc/test/unit/RpcCommunicator.test.ts
@@ -145,8 +145,7 @@ describe('RpcCommunicator', () => {
     it('Success responses to requests', async () => {
         let successCounter = 0
         rpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping', MockDhtRpc.ping)
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
-            //const pongWrapper = RpcMessage.fromBinary(message)
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _callContext?: ProtoCallContext) => {
             if (!message.errorType) {
                 successCounter += 1
             }
@@ -159,8 +158,7 @@ describe('RpcCommunicator', () => {
     it('Success responses to new registration method', async () => {
         let successCounter = 0
         rpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping', MockDhtRpc.ping)
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
-            //const pongWrapper = RpcMessage.fromBinary(message)
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
             if (!message.errorType) {
                 successCounter += 1
             }
@@ -172,7 +170,7 @@ describe('RpcCommunicator', () => {
 
     it('Error response on unknown method', async () => {
         let errorCounter = 0
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
             //const pongWrapper = RpcMessage.fromBinary(message)
             if (message.errorType && message.errorType === RpcErrorType.UNKNOWN_RPC_METHOD) {
                 errorCounter += 1
@@ -187,8 +185,7 @@ describe('RpcCommunicator', () => {
         let errorCounter = 0
 
         rpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping', MockDhtRpc.respondPingWithTimeout)
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
-            //const pongWrapper = RpcMessage.fromBinary(message)
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
             if (message.errorType !== undefined && message.errorType === RpcErrorType.SERVER_TIMEOUT as RpcErrorType) {
                 errorCounter += 1
             }
@@ -201,8 +198,7 @@ describe('RpcCommunicator', () => {
     it('Error response on server timeout', async () => {
         let errorCounter = 0
         rpcCommunicator.registerRpcMethod(PingRequest, PingResponse, 'ping', MockDhtRpc.throwPingError)
-        rpcCommunicator.on('outgoingMessage', (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
-            //const pongWrapper = RpcMessage.fromBinary(message)
+        rpcCommunicator.setOutgoingMessageListener(async (message: RpcMessage, _requestId: string, _ucallContext?: ProtoCallContext) => {
             if (message.errorType !== undefined && message.errorType === RpcErrorType.SERVER_ERROR) {
                 errorCounter += 1
             }

--- a/packages/trackerless-network/test/integration/NetworkRpc.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkRpc.test.ts
@@ -21,7 +21,7 @@ describe('Network RPC', () => {
     beforeEach(() => {
         rpcCommunicator1 = new RpcCommunicator()
         rpcCommunicator2 = new RpcCommunicator()
-        rpcCommunicator1.on('outgoingMessage', (message: RpcMessage) => {
+        rpcCommunicator1.setOutgoingMessageListener(async (message: RpcMessage) => {
             rpcCommunicator2.handleIncomingMessage(message)
         })
         client = toProtoRpcClient(new ContentDeliveryRpcClient(rpcCommunicator1.getRpcClientTransport()))


### PR DESCRIPTION
## Summary

Removed unused EventEmitter from the RpcCommunicator
