### PR TITLE
fix(sdk): Flag expiration timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Fixed flag expiration time in `Operator#getExpiredFlags` (https://github.com/streamr-dev/network/pull/2739)
+
 #### Security
 
 ### @streamr/node

--- a/packages/node/src/plugins/operator/config.schema.json
+++ b/packages/node/src/plugins/operator/config.schema.json
@@ -142,7 +142,7 @@
         },
         "maxAgeInMs": {
           "type": "integer",
-          "description": "The maximum age (in milliseconds) of a flag before it is expired",
+          "description": "After the voting ends, how soon (in milliseconds) does the flag expire",
           "minimum": 0,
           "default": 86400000
         }

--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -306,14 +306,14 @@ export class Operator {
 
     // TODO could move this method as this is functionality is not specific to one Operator contract instance
     async getExpiredFlags(sponsorshipAddresses: EthereumAddress[], maxAgeInMs: number): Promise<Flag[]> {
-        const maxFlagStartTime = Math.floor((Date.now() - maxAgeInMs) / 1000)
+        const maxVoteEndTimestamp = Math.floor((Date.now() - maxAgeInMs) / 1000)
         const createQuery = (lastId: string, pageSize: number) => {
             return {
                 query: `
                 {
                     flags (where : {
                         id_gt: "${lastId}",
-                        flaggingTimestamp_lt: ${maxFlagStartTime},
+                        voteEndTimestamp_lt: ${maxVoteEndTimestamp},
                         result_in: ["waiting", "voting"],
                         sponsorship_in: ${JSON.stringify(sponsorshipAddresses)}
                     }, first: ${pageSize}) {


### PR DESCRIPTION
Before this PR the expiration timestamp is now calculated by adding `maxAge` to `flaggingTimestamp`. Now `voteEndTimestamp` is used instead of `flaggingTimestamp`. It ensures that the flag can't expire before the voting ends.

## Behavior before the fix

If a small value was configured for `maxAge`, the flag expired before the voting ended. In that case the `closeExpiredFlags` service tried to close the "expired" flag during the voting time. That caused the operator to cast a `NO_KICK` vote instead of closing the flag.

This is not an issue in the production environment, as the default value for `maxAge` is one day.