### PR TITLE
test(node): `OperatorPlugin` inspection config options

### DIFF
--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -57,6 +57,10 @@ export interface OperatorPluginConfig {
     }
     inspectRandomNode: {
         intervalInMs: number
+        maxInspectionCount: number
+    }
+    reviewSuspectNode: {
+        maxInspectionCount: number
     }
     closeExpiredFlags: {
         intervalInMs: number
@@ -201,6 +205,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                         streamPartAssignments,
                         streamrClient,
                         this.pluginConfig.heartbeatTimeoutInMs,
+                        this.pluginConfig.inspectRandomNode.maxInspectionCount,
                         async (targetOperatorContractAddress) => {
                             return streamrClient.getOperator(targetOperatorContractAddress).fetchRedundancyFactor()
                         },
@@ -247,7 +252,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                                         endTime: event.votingPeriodEndTimestamp
                                     },
                                     inspectionIntervalInMs: 8 * 60 * 1000,
-                                    maxInspections: 10,
+                                    maxInspectionCount: this.pluginConfig.reviewSuspectNode.maxInspectionCount,
                                     abortSignal: this.abortController.signal
                                 })
                             }

--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -61,6 +61,7 @@ export interface OperatorPluginConfig {
     }
     reviewSuspectNode: {
         maxInspectionCount: number
+        maxDelayBeforeFirstInspectionInMs: number
     }
     closeExpiredFlags: {
         intervalInMs: number
@@ -245,7 +246,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                                     getRedundancyFactor: async (targetOperatorContractAddress) => {
                                         return streamrClient.getOperator(targetOperatorContractAddress).fetchRedundancyFactor()
                                     },
-                                    maxSleepTime: 5 * 60 * 1000,
+                                    maxDelayBeforeFirstInspectionInMs: this.pluginConfig.reviewSuspectNode.maxDelayBeforeFirstInspectionInMs,
                                     heartbeatTimeoutInMs: this.pluginConfig.heartbeatTimeoutInMs,
                                     votingPeriod: {
                                         startTime: event.votingPeriodStartTimestamp,

--- a/packages/node/src/plugins/operator/config.schema.json
+++ b/packages/node/src/plugins/operator/config.schema.json
@@ -125,6 +125,26 @@
           "description": "How often to run (in milliseconds)",
           "minimum": 0,
           "default": 900000
+        },
+        "maxInspectionCount": {
+          "type": "integer",
+          "description": "How many rounds of analysis are performed at most",
+          "minimum": 1,
+          "default": 10
+        }
+      }
+    },
+    "reviewSuspectNode": {
+      "type": "object",
+      "description": "Review suspect node settings",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "maxInspectionCount": {
+          "type": "integer",
+          "description": "How many rounds of analysis are performed at most",
+          "minimum": 1,
+          "default": 10
         }
       }
     },

--- a/packages/node/src/plugins/operator/config.schema.json
+++ b/packages/node/src/plugins/operator/config.schema.json
@@ -145,6 +145,12 @@
           "description": "How many rounds of analysis are performed at most",
           "minimum": 1,
           "default": 10
+        },
+        "maxDelayBeforeFirstInspectionInMs": {
+          "type": "integer",
+          "description": "The maximum time (in milliseconds) to wait before the 1st inspection round",
+          "minimum": 0,
+          "default": 300000
         }
       }
     },

--- a/packages/node/src/plugins/operator/inspectOverTime.ts
+++ b/packages/node/src/plugins/operator/inspectOverTime.ts
@@ -129,7 +129,7 @@ class InspectionOverTimeTask {
 
         await this.initializeNewOperatorFleetState()
 
-        this.logger.info('Sleep', { timeInMs: this.delayBeforeFirstInspectionInMs })
+        this.logger.debug('Sleep', { timeInMs: this.delayBeforeFirstInspectionInMs })
         await wait(this.delayBeforeFirstInspectionInMs, this.abortSignal)
 
         for (const attemptNo of range(1, this.maxInspectionCount + 1)) {
@@ -176,7 +176,7 @@ class InspectionOverTimeTask {
                 }
 
                 const sleepTime = Math.max(this.inspectionIntervalInMs - timeElapsedInMs, 0)
-                this.logger.info('Sleep', { timeInMs: sleepTime })
+                this.logger.debug('Sleep', { timeInMs: sleepTime })
                 await wait(sleepTime, this.abortSignal)
             }
         }

--- a/packages/node/src/plugins/operator/inspectOverTime.ts
+++ b/packages/node/src/plugins/operator/inspectOverTime.ts
@@ -19,7 +19,7 @@ interface InspectOverTimeOpts {
     sleepTimeInMsBeforeFirstInspection: number
     heartbeatTimeoutInMs: number
     inspectionIntervalInMs: number
-    maxInspections: number
+    maxInspectionCount: number
     waitUntilPassOrDone: boolean
     abortSignal: AbortSignal
     traceId: string
@@ -47,7 +47,7 @@ class InspectionOverTimeTask {
     private readonly sleepTimeInMsBeforeFirstInspection: number
     private readonly heartbeatTimeoutInMs: number
     private readonly inspectionIntervalInMs: number
-    private readonly maxInspections: number
+    private readonly maxInspectionCount: number
     private readonly abortSignal: AbortSignal
     private readonly findNodesForTargetGivenFleetStateFn: FindNodesForTargetGivenFleetStateFn
     private readonly inspectTargetFn: InspectTargetFn
@@ -67,7 +67,7 @@ class InspectionOverTimeTask {
         sleepTimeInMsBeforeFirstInspection,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs,
-        maxInspections,
+        maxInspectionCount,
         abortSignal: userAbortSignal,
         traceId,
         findNodesForTargetGivenFleetStateFn = findNodesForTargetGivenFleetState,
@@ -80,7 +80,7 @@ class InspectionOverTimeTask {
         this.sleepTimeInMsBeforeFirstInspection = sleepTimeInMsBeforeFirstInspection
         this.heartbeatTimeoutInMs = heartbeatTimeoutInMs
         this.inspectionIntervalInMs = inspectionIntervalInMs
-        this.maxInspections = maxInspections
+        this.maxInspectionCount = maxInspectionCount
         this.abortSignal = composeAbortSignals(userAbortSignal, this.abortController.signal)
         this.findNodesForTargetGivenFleetStateFn = findNodesForTargetGivenFleetStateFn
         this.inspectTargetFn = inspectTargetFn
@@ -124,7 +124,7 @@ class InspectionOverTimeTask {
             target: this.target,
             heartbeatTimeoutInMs: this.heartbeatTimeoutInMs,
             inspectionIntervalInMs: this.inspectionIntervalInMs,
-            maxInspections: this.maxInspections
+            maxInspectionCount: this.maxInspectionCount
         })
 
         await this.initializeNewOperatorFleetState()
@@ -132,7 +132,7 @@ class InspectionOverTimeTask {
         this.logger.info('Sleep', { timeInMs: this.sleepTimeInMsBeforeFirstInspection })
         await wait(this.sleepTimeInMsBeforeFirstInspection, this.abortSignal)
 
-        for (const attemptNo of range(1, this.maxInspections + 1)) {
+        for (const attemptNo of range(1, this.maxInspectionCount + 1)) {
             const startTime = Date.now()
             this.logger.info('Inspecting target', { attemptNo, target: this.target })
 
@@ -162,7 +162,7 @@ class InspectionOverTimeTask {
                 target: this.target
             })
 
-            if (attemptNo !== this.maxInspections) {
+            if (attemptNo !== this.maxInspectionCount) {
                 // TODO: remove when NET-1169 landed;
                 //  workaround subscribe bug in @streamr/sdk (sometimes messages don't come thru to heartbeat stream)
                 if (this.fleetState?.getNodeIds().length === 0) {

--- a/packages/node/src/plugins/operator/inspectOverTime.ts
+++ b/packages/node/src/plugins/operator/inspectOverTime.ts
@@ -16,7 +16,7 @@ interface InspectOverTimeOpts {
     streamrClient: StreamrClient
     createOperatorFleetState: CreateOperatorFleetStateFn
     getRedundancyFactor: (operatorContractAddress: EthereumAddress) => Promise<number | undefined>
-    sleepTimeInMsBeforeFirstInspection: number
+    delayBeforeFirstInspectionInMs: number
     heartbeatTimeoutInMs: number
     inspectionIntervalInMs: number
     maxInspectionCount: number
@@ -44,7 +44,7 @@ class InspectionOverTimeTask {
     private readonly streamrClient: StreamrClient
     private readonly createOperatorFleetState: CreateOperatorFleetStateFn
     private readonly getRedundancyFactor: (operatorContractAddress: EthereumAddress) => Promise<number | undefined>
-    private readonly sleepTimeInMsBeforeFirstInspection: number
+    private readonly delayBeforeFirstInspectionInMs: number
     private readonly heartbeatTimeoutInMs: number
     private readonly inspectionIntervalInMs: number
     private readonly maxInspectionCount: number
@@ -64,7 +64,7 @@ class InspectionOverTimeTask {
         streamrClient,
         createOperatorFleetState,
         getRedundancyFactor,
-        sleepTimeInMsBeforeFirstInspection,
+        delayBeforeFirstInspectionInMs,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs,
         maxInspectionCount,
@@ -77,7 +77,7 @@ class InspectionOverTimeTask {
         this.streamrClient = streamrClient
         this.createOperatorFleetState = createOperatorFleetState
         this.getRedundancyFactor = getRedundancyFactor
-        this.sleepTimeInMsBeforeFirstInspection = sleepTimeInMsBeforeFirstInspection
+        this.delayBeforeFirstInspectionInMs = delayBeforeFirstInspectionInMs
         this.heartbeatTimeoutInMs = heartbeatTimeoutInMs
         this.inspectionIntervalInMs = inspectionIntervalInMs
         this.maxInspectionCount = maxInspectionCount
@@ -129,8 +129,8 @@ class InspectionOverTimeTask {
 
         await this.initializeNewOperatorFleetState()
 
-        this.logger.info('Sleep', { timeInMs: this.sleepTimeInMsBeforeFirstInspection })
-        await wait(this.sleepTimeInMsBeforeFirstInspection, this.abortSignal)
+        this.logger.info('Sleep', { timeInMs: this.delayBeforeFirstInspectionInMs })
+        await wait(this.delayBeforeFirstInspectionInMs, this.abortSignal)
 
         for (const attemptNo of range(1, this.maxInspectionCount + 1)) {
             const startTime = Date.now()

--- a/packages/node/src/plugins/operator/inspectRandomNode.ts
+++ b/packages/node/src/plugins/operator/inspectRandomNode.ts
@@ -32,7 +32,7 @@ export async function inspectRandomNode(
         streamrClient,
         createOperatorFleetState,
         getRedundancyFactor,
-        sleepTimeInMsBeforeFirstInspection: 0,
+        delayBeforeFirstInspectionInMs: 0,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs: 8 * 60 * 1000,
         maxInspectionCount,

--- a/packages/node/src/plugins/operator/inspectRandomNode.ts
+++ b/packages/node/src/plugins/operator/inspectRandomNode.ts
@@ -11,6 +11,7 @@ export async function inspectRandomNode(
     assignments: StreamPartAssignments,
     streamrClient: StreamrClient,
     heartbeatTimeoutInMs: number,
+    maxInspectionCount: number,
     getRedundancyFactor: (operatorContractAddress: EthereumAddress) => Promise<number | undefined>,
     createOperatorFleetState: CreateOperatorFleetStateFn,
     abortSignal: AbortSignal,
@@ -34,7 +35,7 @@ export async function inspectRandomNode(
         sleepTimeInMsBeforeFirstInspection: 0,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs: 8 * 60 * 1000,
-        maxInspections: 10,
+        maxInspectionCount,
         waitUntilPassOrDone: true,
         abortSignal,
         traceId

--- a/packages/node/src/plugins/operator/reviewSuspectNode.ts
+++ b/packages/node/src/plugins/operator/reviewSuspectNode.ts
@@ -21,7 +21,7 @@ export interface ReviewProcessOpts {
         endTime: number
     }
     inspectionIntervalInMs: number
-    maxInspections: number
+    maxInspectionCount: number
     abortSignal: AbortSignal
 }
 
@@ -37,7 +37,7 @@ export const reviewSuspectNode = async ({
     heartbeatTimeoutInMs,
     votingPeriod,
     inspectionIntervalInMs,
-    maxInspections,
+    maxInspectionCount,
     abortSignal
 }: ReviewProcessOpts): Promise<void> => {
     if (Date.now() + maxSleepTime > votingPeriod.startTime) {
@@ -58,7 +58,7 @@ export const reviewSuspectNode = async ({
         sleepTimeInMsBeforeFirstInspection,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs,
-        maxInspections,
+        maxInspectionCount,
         waitUntilPassOrDone: false,
         abortSignal,
         traceId: randomString(6)

--- a/packages/node/src/plugins/operator/reviewSuspectNode.ts
+++ b/packages/node/src/plugins/operator/reviewSuspectNode.ts
@@ -14,7 +14,7 @@ export interface ReviewProcessOpts {
     streamrClient: StreamrClient
     createOperatorFleetState: CreateOperatorFleetStateFn
     getRedundancyFactor: (operatorContractAddress: EthereumAddress) => Promise<number | undefined>
-    maxSleepTime: number
+    maxDelayBeforeFirstInspectionInMs: number
     heartbeatTimeoutInMs: number
     votingPeriod: {
         startTime: number
@@ -33,19 +33,19 @@ export const reviewSuspectNode = async ({
     streamrClient,
     createOperatorFleetState,
     getRedundancyFactor,
-    maxSleepTime,
+    maxDelayBeforeFirstInspectionInMs,
     heartbeatTimeoutInMs,
     votingPeriod,
     inspectionIntervalInMs,
     maxInspectionCount,
     abortSignal
 }: ReviewProcessOpts): Promise<void> => {
-    if (Date.now() + maxSleepTime > votingPeriod.startTime) {
-        throw new Error('Max sleep time overlaps with voting period')
+    if (Date.now() + maxDelayBeforeFirstInspectionInMs > votingPeriod.startTime) {
+        throw new Error('Max delay time overlaps with voting period')
     }
     const streamId = await myOperator.getStreamId(sponsorshipAddress)
-    // random sleep time to make sure multiple instances of voters don't all inspect at the same time
-    const sleepTimeInMsBeforeFirstInspection = random(maxSleepTime)
+    // random wait time to make sure multiple instances of voters don't all inspect at the same time
+    const delayBeforeFirstInspectionInMs = random(maxDelayBeforeFirstInspectionInMs)
     const consumeResults = inspectOverTime({
         target: {
             sponsorshipAddress: sponsorshipAddress,
@@ -55,7 +55,7 @@ export const reviewSuspectNode = async ({
         streamrClient,
         createOperatorFleetState,
         getRedundancyFactor,
-        sleepTimeInMsBeforeFirstInspection,
+        delayBeforeFirstInspectionInMs,
         heartbeatTimeoutInMs,
         inspectionIntervalInMs,
         maxInspectionCount,


### PR DESCRIPTION
Added new config options for `OperatorPlugin`. These are need for inspection smoke test (which will be implemented in a follow-up PR).
- `inspectRandomNode.maxInspectionCount`
- `reviewSuspectNode.maxInspectionCount`
- `reviewSuspectNode.maxDelayBeforeFirstInspectionInMs`

Also changed the log level of two log statements.
