### PR TITLE
fix(DHT): NET-1354 fix webrtc connections in firefox

### DIFF
--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -175,7 +175,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
     private setupDataChannel(dataChannel: RTCDataChannel): void {
         this.dataChannel = dataChannel
-        this.dataChannel.binaryType = "arraybuffer"
+        this.dataChannel.binaryType = 'arraybuffer'
 
         dataChannel.onopen = () => {
             logger.trace('dc.onOpen')

--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -175,6 +175,8 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
 
     private setupDataChannel(dataChannel: RTCDataChannel): void {
         this.dataChannel = dataChannel
+        this.dataChannel.binaryType = "arraybuffer"
+
         dataChannel.onopen = () => {
             logger.trace('dc.onOpen')
             this.onDataChannelOpen()


### PR DESCRIPTION
## Summary

Fixed webrtc connections in Firefox and any other browser that sets the DataChannel binary type as `blob` by default.
