### PR TITLE
feat(node): Do not run `checkOperatorValueBreach` immediately

### DIFF
--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -159,7 +159,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                     logger.warn('Encountered error', { err })
                 }),
                 this.pluginConfig.checkOperatorValueBreachIntervalInMs,
-                true,
+                false,
                 this.abortController.signal
             )
             await fleetState.waitUntilReady()

--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -139,6 +139,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
         // start tasks in background so that operations which take significant amount of time (e.g. fleetState.waitUntilReady())
         // don't block the startup of Broker
         setImmediate(async () => {
+
             setAbortableInterval(() => {
                 (async () => {
                     await announceNodeToStream(
@@ -147,23 +148,10 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                     )
                 })()
             }, this.pluginConfig.heartbeatUpdateIntervalInMs, this.abortController.signal)
-            const stakedOperatorsCache = new Cache(() => operator.getStakedOperators(), STAKED_OPERATORS_CACHE_MAX_AGE)
-            await scheduleAtInterval(
-                async () => checkOperatorValueBreach(
-                    operator,
-                    streamrClient,
-                    () => stakedOperatorsCache.get(),
-                    this.pluginConfig.maintainOperatorValue.minSponsorshipEarningsInWithdraw,
-                    this.pluginConfig.maintainOperatorValue.maxSponsorshipsInWithdraw
-                ).catch((err) => {
-                    logger.warn('Encountered error', { err })
-                }),
-                this.pluginConfig.checkOperatorValueBreachIntervalInMs,
-                false,
-                this.abortController.signal
-            )
+
             await fleetState.waitUntilReady()
             const isLeader = await createIsLeaderFn(streamrClient, fleetState, logger)
+
             try {
                 await scheduleAtInterval(async () => {
                     if (isLeader()) {
@@ -178,6 +166,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                 logger.fatal('Encountered fatal error in announceNodeToContract', { err })
                 process.exit(1)
             }
+
             await scheduleAtInterval(
                 async () => {
                     if (isLeader()) {
@@ -228,6 +217,22 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                     logger.error('Encountered error while closing expired flags', { err })
                 }
             }, this.pluginConfig.closeExpiredFlags.intervalInMs, false, this.abortController.signal)
+
+            const stakedOperatorsCache = new Cache(() => operator.getStakedOperators(), STAKED_OPERATORS_CACHE_MAX_AGE)
+            await scheduleAtInterval(
+                async () => checkOperatorValueBreach(
+                    operator,
+                    streamrClient,
+                    () => stakedOperatorsCache.get(),
+                    this.pluginConfig.maintainOperatorValue.minSponsorshipEarningsInWithdraw,
+                    this.pluginConfig.maintainOperatorValue.maxSponsorshipsInWithdraw
+                ).catch((err) => {
+                    logger.warn('Encountered error', { err })
+                }),
+                this.pluginConfig.checkOperatorValueBreachIntervalInMs,
+                false,
+                this.abortController.signal
+            )
 
             addManagedEventListener(
                 operator,


### PR DESCRIPTION
## Changes

Changed the `executeAtStart` parameter of `checkOperatorValueBreach` scheduler. Now the task is not run immediately after the plugin starts. Instead it is first run after one hour. This is maybe a good change as `checkOperatorValueBreach` is not a high priority task.

## Style

Moved the code block to be the last scheduled operation. This doesn't the functionality, but is more readable: 
- first we schedule important tasks which are run immediately (`announceNodeToStream`, `announceNodeToContract`, `maintainOperatorValue`)
- then lower priority task which are not run immediately (`inspectRandomNode`, `closeExpiredFlags`, `checkOperatorValueBreach`)
