### PR TITLE
feat(sdk): Remove support for legacy encryption keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Removed
 
+- Remove support for legacy encryption keys
+
 #### Fixed
 
 - Fixed flag expiration time in `Operator#getExpiredFlags` (https://github.com/streamr-dev/network/pull/2739)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Removed
 
-- Remove support for legacy encryption keys
+- Remove support for legacy encryption keys (https://github.com/streamr-dev/network/pull/2757)
 
 #### Fixed
 

--- a/packages/sdk/src/encryption/LocalGroupKeyStore.ts
+++ b/packages/sdk/src/encryption/LocalGroupKeyStore.ts
@@ -69,20 +69,8 @@ export class LocalGroupKeyStore {
         if (value !== undefined) {
             return new GroupKey(keyId, Buffer.from(value, 'hex'))
         } else {
-            return this.getLegacyKey(keyId)
+            return undefined
         }
-    }
-
-    /**
-     * Legacy keys refer to group keys migrated from a previous version of the client where group keys were not tied
-     * to a specific publisherId, therefore any publisherId for a given legacy key id is considered a match.
-     *
-     * TODO: remove this functionality in the future
-     */
-    private async getLegacyKey(keyId: string): Promise<GroupKey | undefined> {
-        const persistence = await this.persistenceManager.getPersistence(NAMESPACES.ENCRYPTION_KEYS)
-        const value = await persistence.get(formLookupKey1(keyId, 'LEGACY'))
-        return value !== undefined ? new GroupKey(keyId, Buffer.from(value, 'hex')) : undefined
     }
 
     async set(keyId: string, publisherId: EthereumAddress, data: Buffer): Promise<void> {


### PR DESCRIPTION
Legacy encryption keys were added for client version 8.1.0 ((https://github.com/streamr-dev/network/pull/1128). These keys don't include `publisherId` because it wasn't stored in the old database they came from. From version 8.1.0 onwards, all new keys include `publisherId`, so we no longer need to support legacy keys.