### PR TITLE
build: Use `allowJs: false` in `tsconfig.json` 

### DIFF
--- a/packages/sdk/bin/generate-config-validator.js
+++ b/packages/sdk/bin/generate-config-validator.js
@@ -30,3 +30,9 @@ ajv.addFormat('ethereum-private-key', /^(0x)?[a-zA-Z0-9]{64}$/)
 const validate = ajv.compile(CONFIG_SCHEMA)
 const moduleCode = standaloneCode(ajv, validate)
 fs.writeFileSync(path.join(__dirname, '../src/generated/validateConfig.js'), moduleCode)
+
+const typeDefinition = `
+const validateConfig = (data: unknown) => boolean;
+export default validateConfig;
+`
+fs.writeFileSync(path.join(__dirname, '../src/generated/validateConfig.d.ts'), typeDefinition)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "prebuild": "node bin/generate-config-validator.js && bash vendor-hack.sh",
     "postbuild": "bash copy-package.sh && bash fix-esm.sh",
-    "build": "tsc --build ./tsconfig.node.json",
+    "build": "tsc --build ./tsconfig.node.json && cp src/exports-commonjs.js dist/src/",
     "build-browser": "npm run build-browser-development && npm run build-browser-production",
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",

--- a/packages/sdk/src/generated/validateConfig.d.ts
+++ b/packages/sdk/src/generated/validateConfig.d.ts
@@ -1,0 +1,3 @@
+
+const validateConfig = (data: unknown) => boolean;
+export default validateConfig;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,7 @@
     "display": "Node 18 – Streamr",
     "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
-        "allowJs": true,
+        "allowJs": false,
         "composite": true,
         "declaration": true,
         "noImplicitOverride": true,


### PR DESCRIPTION
Do not allow TypeScript to process JavaScript files. We don't typically have JS files in our `src` folders: the only exception is `exports-common.js` in `sdk`.

Changing this setting resolves a VS Code issue. The "problems" section in VS Code is usually full of errors like this:
```
Cannot write file ' ... /network/packages/sdk/dist/types/src/Authentication.d.ts' because it would overwrite input file.ts
```

There may be other ways to solve this issue.