### PR TITLE
build: `noEmit` in `tsconfig.jest.json` files

### DIFF
--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "generate-protoc-code": "./proto.sh",
     "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },

--- a/packages/autocertifier-client/tsconfig.jest.json
+++ b/packages/autocertifier-client/tsconfig.jest.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "noImplicitOverride": false
-    },
     "include": [
         "src/**/*",
         "test/**/*"

--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -17,7 +17,7 @@
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
     "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit test/integration",

--- a/packages/autocertifier-server/tsconfig.jest.json
+++ b/packages/autocertifier-server/tsconfig.jest.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "noImplicitOverride": false
-    },
     "include": [
         "src/**/*",
         "test/**/*"

--- a/packages/cdn-location/package.json
+++ b/packages/cdn-location/package.json
@@ -13,7 +13,7 @@
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
     "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/integration",

--- a/packages/cdn-location/tsconfig.jest.json
+++ b/packages/cdn-location/tsconfig.jest.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "noImplicitOverride": false
-    },
     "include": [
         "src/**/*",
         "test/**/*"

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "check": "tsc -p ./tsconfig.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run build && jest --bail --forceExit"

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.jest.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
   "include": [
     "src/**/*",
     "test/**/*"

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -15,7 +15,7 @@
     "generate-protoc-code": "./proto.sh",
     "build": "tsc -b tsconfig.node.json",
     "build-browser": "webpack --mode=development --progress",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.jest.json",
     "compilerOptions": {
-        "outDir": "dist",
+        "noEmit": true,
         "noImplicitOverride": false
     },
     "include": [

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -18,7 +18,7 @@
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
     "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit",

--- a/packages/geoip-location/tsconfig.jest.json
+++ b/packages/geoip-location/tsconfig.jest.json
@@ -1,9 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "noImplicitOverride": false
-    },
     "include": [
         "src/**/*",
         "test/**/*"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,7 +19,7 @@
   "types": "./dist/src/exports.d.ts",
   "scripts": {
     "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-sequential",

--- a/packages/node/tsconfig.jest.json
+++ b/packages/node/tsconfig.jest.json
@@ -1,8 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist"
-    },
     "include": [
         "src/**/*",
         "src/**/*.json",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -15,7 +15,7 @@
     "generate-protoc-code": "./proto.sh",
     "build": "tsc -b tsconfig.node.json",
     "build-browser": "webpack --mode=development --progress",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration",

--- a/packages/proto-rpc/tsconfig.jest.json
+++ b/packages/proto-rpc/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.jest.json",
     "compilerOptions": {
-        "outDir": "dist",
+        "noEmit": true,
         "noImplicitOverride": false
     },
     "include": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,7 @@
     "build-browser": "npm run build-browser-development && npm run build-browser-production",
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist vendor *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "generate-protoc-code": "./proto.sh",

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.jest.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "declarationDir": "dist/types",
+        "noEmit": true,
         "lib": ["es2021", "dom"],
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "test": "jest",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"

--- a/packages/test-utils/tsconfig.jest.json
+++ b/packages/test-utils/tsconfig.jest.json
@@ -1,8 +1,5 @@
 {
     "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "outDir": "dist"
-    },
     "include": [
         "src/**/*",
         "test/**/*"

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -15,7 +15,7 @@
     "build": "tsc -b tsconfig.node.json",
     "build-browser": "webpack --mode=development --progress",
     "generate-protoc-code": "./proto.sh",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../tsconfig.jest.json",
     "compilerOptions": {
-        "outDir": "dist",
+        "noEmit": true,
         "noImplicitOverride": false
     },
     "include": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
   "types": "./dist/src/exports.d.ts",
   "scripts": {
     "build": "tsc --build tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json --noEmit",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist vendor *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",

--- a/packages/utils/tsconfig.jest.json
+++ b/packages/utils/tsconfig.jest.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.jest.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
   "include": [
     "src/**/*",
     "test/**/*"

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,7 @@
 {
     "extends": "./tsconfig.node.json",
     "compilerOptions": {
-        "types": ["node", "jest"]
+        "types": ["node", "jest"],
+        "noEmit": true
     }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.node.json",
     "compilerOptions": {
-        "types": ["node", "jest"],
-        "noEmit": true
+        "noEmit": true,
+        "types": ["node", "jest"]
     }
 }


### PR DESCRIPTION
Added `"noEmit": true` compiler option to `tsconfig.jest.json` files.

This resolves VS Code issue. The "problems" section in VS Code was usually full of errors like this:
```
Cannot write file ' ... /network/packages/sdk/dist/types/src/Authentication.d.ts' because it would overwrite input file.ts
```

## Other changes

- Unified `tsconfig.jest.json` files by removing some obsolete `"noImplicitOverride": false` settings
- Changed `cli-tools` to use `tsconfig.jest.json` instead of `tsconfig.json` for the `check` task