### PR TITLE
refactor(sdk): Use `signer.getAddress()` in `Authentication`

### DIFF
--- a/packages/sdk/src/Authentication.ts
+++ b/packages/sdk/src/Authentication.ts
@@ -41,15 +41,7 @@ export const createAuthentication = (config: Pick<StrictStreamrClientConfig, 'au
         const signer = provider.getSigner()
         return {
             getAddress: pMemoize(async () => {
-                try {
-                    if (!('request' in ethereum && typeof ethereum.request === 'function')) {
-                        throw new Error(`invalid ethereum provider ${ethereum}`)
-                    }
-                    const accounts = await ethereum.request({ method: 'eth_requestAccounts' })
-                    return toEthereumAddress(accounts[0])
-                } catch {
-                    throw new Error('no addresses connected and selected in the custom authentication provider')
-                }
+                return toEthereumAddress(await (await signer).getAddress())
             }),
             createMessageSignature: pLimitFn(async (payload: Uint8Array) => {
                 // sign one at a time & wait a moment before asking for next signature


### PR DESCRIPTION
Simplify `Authentication#getAddress()` by using a method from the `Signer` interface.

This is a cherry-pick from @harbu's https://github.com/streamr-dev/network/pull/2589.