### PR TITLE
build(docker): Fix `FROM ... AS` casing

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=20
-FROM node:${NODE_VERSION}-bullseye as build
+FROM node:${NODE_VERSION}-bullseye AS build
 WORKDIR /usr/src/network
 COPY . .
 RUN --mount=type=cache,target=/root/.npm \


### PR DESCRIPTION
Fixes a warning in GitHub:
```
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```

See https://docs.docker.com/reference/build-checks/from-as-casing/. Doesn't change any functionality.