### PR TITLE
chore(sdk): Use `MaxUint256` in permissions

### DIFF
--- a/packages/sdk/src/permission.ts
+++ b/packages/sdk/src/permission.ts
@@ -1,5 +1,5 @@
 import { UserID } from '@streamr/utils'
-import { MaxInt256 } from 'ethers'
+import { MaxUint256 } from 'ethers'
 
 export enum StreamPermission {
     EDIT = 'edit',
@@ -102,8 +102,8 @@ export const convertStreamPermissionsToChainPermission = (permissions: StreamPer
     return {
         canEdit: permissions.includes(StreamPermission.EDIT),
         canDelete: permissions.includes(StreamPermission.DELETE),
-        publishExpiration: permissions.includes(StreamPermission.PUBLISH) ? MaxInt256 : 0n,
-        subscribeExpiration: permissions.includes(StreamPermission.SUBSCRIBE) ? MaxInt256 : 0n,
+        publishExpiration: permissions.includes(StreamPermission.PUBLISH) ? MaxUint256 : 0n,
+        subscribeExpiration: permissions.includes(StreamPermission.SUBSCRIBE) ? MaxUint256 : 0n,
         canGrant: permissions.includes(StreamPermission.GRANT)
     }
 }


### PR DESCRIPTION
Changed `setPermissions()` to use `MaxUint256` instead of the signed version (`MaxInt256`) when it writes a permission record to the contract.

This change doesn't change functionality in practice, as both values are enormously big numbers. But changed this for consistency: e.g. if we grant the same permission with `grantPermission`, the contract correctly writes `MaxUint256` to `publishExpiration` and `subscribeExpiration`.