### PR TITLE
logging(network): reduce failed network split avoidance log level to trace

### DIFF
--- a/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
+++ b/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
@@ -28,7 +28,7 @@ const exponentialRunOff = async (
         try {
             await task()
         } catch {
-            logger.debug(`${description} failed, retrying in ${delay} ms`)
+            logger.trace(`${description} failed, retrying in ${delay} ms`)
         }
         try { // Abort controller throws unexpected errors in destroy?
             await wait(delay, abortSignal)


### PR DESCRIPTION
## Summary

reduced the log level of these lines to trace:
`DEBUG [2024-10-02T11:21:36.950] (StreamPartNetworkSplitAvo): avoid network split failed, retrying in 32000 ms`