### PR TITLE
test(node): Update `@streamr/network-contracts` dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8125,10 +8125,10 @@
             "resolved": "packages/geoip-location",
             "link": true
         },
-        "node_modules/@streamr/network-contracts-ethers6": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/@streamr/network-contracts-ethers6/-/network-contracts-ethers6-7.1.4.tgz",
-            "integrity": "sha512-4ee9UA34LOdPfg7gg8i2E0kRhFEmqGzw7d3jPqPBTqT0zvTuGHtgdj5e3n7plo9iB+uG7xlgTddUNnqDXlcBOQ==",
+        "node_modules/@streamr/network-contracts": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@streamr/network-contracts/-/network-contracts-8.2.0.tgz",
+            "integrity": "sha512-ANAixOnXOOTjfrmkowXbgnZRXhcwRP8PfzyZ4Lvt1GhSaXClYI17OVD1JbvuCjHzWbMdyWZK3hDdTI8jpd7QBg==",
             "dev": true
         },
         "node_modules/@streamr/node": {
@@ -28982,7 +28982,7 @@
             },
             "devDependencies": {
                 "@inquirer/testing": "^2.1.34",
-                "@streamr/network-contracts-ethers6": "^7.1.4",
+                "@streamr/network-contracts": "^8.2.0",
                 "@streamr/test-utils": "101.1.2",
                 "@types/cors": "^2.8.17",
                 "@types/express": "^4.17.21",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@inquirer/testing": "^2.1.34",
-    "@streamr/network-contracts-ethers6": "^7.1.4",
+    "@streamr/network-contracts": "^8.2.0",
     "@streamr/test-utils": "101.1.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -1,4 +1,4 @@
-import type { Operator } from '@streamr/network-contracts-ethers6'
+import type { Operator } from '@streamr/network-contracts'
 import {
     ProxyDirection,
     StreamPermission,

--- a/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
+++ b/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
@@ -1,4 +1,4 @@
-import { Operator, StreamrConfig, streamrConfigABI } from '@streamr/network-contracts-ethers6'
+import { Operator, StreamrConfig, streamrConfigABI } from '@streamr/network-contracts'
 import {
     SetupOperatorContractOpts,
     _operatorContractUtils,

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,5 +1,5 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { StreamrConfig, streamrConfigABI } from '@streamr/network-contracts-ethers6'
+import { StreamrConfig, streamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils } from '@streamr/sdk'
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { Logger, StreamID, TheGraphClient, wait, waitForCondition } from '@streamr/utils'

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -1,6 +1,6 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import type { Operator, Sponsorship } from '@streamr/network-contracts-ethers6'
-import { StreamrConfig, streamrConfigABI } from '@streamr/network-contracts-ethers6'
+import type { Operator, Sponsorship } from '@streamr/network-contracts'
+import { StreamrConfig, streamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils } from '@streamr/sdk'
 import { fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { waitForCondition } from '@streamr/utils'


### PR DESCRIPTION
Previously there was a separate package for `ethers` v6. Switched to default `@streamr/network-contracts` package as it now supports `ethers` v6. 