### PR TITLE
chore(eslint): enable `@typescript-eslint/no-misused-promises` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,12 +88,14 @@ module.exports = {
             allowNever: true,
             allow: [{ from: 'lib', name: ['Error'] }]
         }],
+        '@typescript-eslint/no-misused-promises': ['error', {
+            'checksVoidReturn': false
+         }],
         // TODO: in follow up PRs, select which rules we should enable and fix the code. When all recommended rules
         //  have been enabled, consider enabling the "strict" preset.
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/await-thenable': 'off',
-        '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',


### PR DESCRIPTION
Enabled the rule. This warned about two issues, there are separate PRs about those:
- https://github.com/streamr-dev/network/pull/2783
- https://github.com/streamr-dev/network/pull/2784