### PR TITLE
fix(geoip-location): Fix error handling in `downloadGeoIpDatabase`

### DIFF
--- a/packages/geoip-location/src/downloadGeoIpDatabase.ts
+++ b/packages/geoip-location/src/downloadGeoIpDatabase.ts
@@ -118,7 +118,7 @@ const downloadRemoteHash = async (remoteHashUrl: string, abortSignal: AbortSigna
     return (await response.text()).trim()
 }
 
-const isDbFileValid = async (dbFile: string, remoteHash: string): Promise<boolean> => {
+const isDbFileValid = (dbFile: string, remoteHash: string): boolean => {
     // check if the local db exists and calculate its hash
 
     try {
@@ -166,7 +166,7 @@ export const downloadGeoIpDatabase = async (
     const dbFileInDbFolder = dbFolder + DB_NAME + DB_SUFFIX
 
     const remoteHash = await downloadRemoteHash(remoteHashUrl, abortSignal)
-    const dbValid = await isDbFileValid(dbFileInDbFolder, remoteHash)
+    const dbValid = isDbFileValid(dbFileInDbFolder, remoteHash)
     if (dbValid === false) {
         await downloadNewDb(dbDownloadUrl, dbFolder, remoteHash, abortSignal)
         // return new reader if db was downloaded


### PR DESCRIPTION
The code inside this if statement was never run:
```ts
if (!isDbFileValid(dbFileInDownloadFolder, remoteHash)) {
    try {
        fs.rmSync(downloadFolder, { recursive: true })
    } catch {
        // ignore error when removing the temporary folder
    }
    throw new Error('Downloaded database hash does not match the expected hash')
}
```

The `isDbFileValid` method was async but the call doesn't `await` it. Therefore the if clause was always `false`.

## Fix

Modified to `isDbFileValid` to be a sync function as there was nothing async in in the implementation.