### PR TITLE
fix(sdk): Fix `getEthersOverrides()` in `Operator#voteOnFlag()`

### DIFF
--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -576,7 +576,7 @@ export class Operator {
             sponsorshipAddress,
             targetOperator,
             voteData,
-            { ...this.getEthersOverrides(), gasLimit }
+            { ...(await this.getEthersOverrides()), gasLimit }
         )).wait()
     }
 


### PR DESCRIPTION
The `getEthersOverrides()` values were ignored in `Operator#voteOnFlag()`. The spread operator didn't work correctly as we didn't `await` the `Promise`.

## Background

The `getEthersOverrides()` method was sync until https://github.com/streamr-dev/network/pull/2506, and the usage was not updated in that PR.