### PR TITLE
chore(eslint): Enable `@typescript-eslint/await-thenable` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,11 +88,11 @@ module.exports = {
             allowNever: true,
             allow: [{ from: 'lib', name: ['Error'] }]
         }],
+        '@typescript-eslint/await-thenable': 'error',
         // TODO: in follow up PRs, select which rules we should enable and fix the code. When all recommended rules
         //  have been enabled, consider enabling the "strict" preset.
         '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
-        '@typescript-eslint/await-thenable': 'off',
         '@typescript-eslint/no-misused-promises': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',

--- a/packages/autocertifier-server/src/DnsServer.ts
+++ b/packages/autocertifier-server/src/DnsServer.ts
@@ -4,6 +4,10 @@ import { DnsHandler, DnsRequest, DnsResponse, Packet, createServer } from 'dns2'
 import { Database, Subdomain } from './Database'
 import { Logger } from '@streamr/utils'
 
+type AsyncDnsHandler = (
+    ...args: Parameters<DnsHandler>
+) => Promise<void>
+
 const logger = new Logger(module)
 
 // https://help.dnsfilter.com/hc/en-us/articles/4408415850003-DNS-Return-Codes
@@ -193,7 +197,7 @@ export class DnsServer {
         send(response)
     }
 
-    private handleQuery: DnsHandler = async (request: DnsRequest, send: (response: DnsResponse) => void): Promise<void> => {
+    private handleQuery: AsyncDnsHandler = async (request: DnsRequest, send: (response: DnsResponse) => void): Promise<void> => {
 
         const response = Packet.createResponseFromRequest(request)
         // @ts-ignore private field

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -224,7 +224,7 @@ export class WebrtcConnector {
         const attempts = Array.from(this.ongoingConnectAttempts.values())
         await Promise.allSettled(attempts.map(async (conn) => {
             conn.connection.destroy()
-            await conn.managedConnection.close(false)
+            conn.managedConnection.close(false)
         }))
 
         this.rpcCommunicator.destroy()

--- a/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
@@ -114,6 +114,6 @@ export class WebsocketClientConnector {
         await Promise.allSettled(requests.map((conn) => conn.close(true)))
 
         await this.websocketServer?.stop()
-        await this.geoIpLocator?.stop()
+        this.geoIpLocator?.stop()
     }
 }

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -280,7 +280,7 @@ export class WebsocketServerConnector {
         await Promise.allSettled(requests.map((ongoingConnectRequest) => ongoingConnectRequest.pendingConnection.close(true)))
 
         await this.websocketServer?.stop()
-        await this.geoIpLocator?.stop()
+        this.geoIpLocator?.stop()
     }
 
 }

--- a/packages/dht/test/unit/PendingConnection.test.ts
+++ b/packages/dht/test/unit/PendingConnection.test.ts
@@ -21,7 +21,7 @@ describe('PendingConnection', () => {
             throw new Error('disconnected')
         })
         pendingConnection.replaceAsDuplicate()
-        await pendingConnection.close(false)
+        pendingConnection.close(false)
         await wait(50)
     })
 

--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -122,7 +122,7 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
         await fleetState.start()
         await maintainTopologyHelper.start()
 
-        const networkNode = await streamrClient.getNode()
+        const networkNode = streamrClient.getNode()
 
         const rpcServerFunction = async (request: OperatorDiscoveryRequest) => {
             const streamPartId = StreamPartIDUtils.parse(request.streamPartId)

--- a/packages/sdk/test/end-to-end/Operator.test.ts
+++ b/packages/sdk/test/end-to-end/Operator.test.ts
@@ -211,7 +211,7 @@ describe('Operator', () => {
         }
 
         beforeAll(async () => (
-            operator = await createClient(deployedOperator.operatorWallet.privateKey).getOperator(
+            operator = createClient(deployedOperator.operatorWallet.privateKey).getOperator(
                 toEthereumAddress(await deployedOperator.operatorContract.getAddress())
             )
         ))


### PR DESCRIPTION
Also:
- removed `await` from sync method calls, which this rule warned about
- fixed type for `DnsServer#handleQuery`