### PR TITLE
refactor(dht): Unify naming of `DhtAddress` converter functions

### DIFF
--- a/packages/autocertifier-server/src/StreamrChallenger.ts
+++ b/packages/autocertifier-server/src/StreamrChallenger.ts
@@ -5,8 +5,8 @@ import {
     WebsocketClientConnection,
     ManagedConnection,
     RoutingRpcCommunicator,
-    createRandomDhtAddress,
-    getRawFromDhtAddress,
+    randomDhtAddress,
+    toDhtAddressRaw,
     PendingConnection,
     IConnection,
     createOutgoingHandshaker
@@ -20,7 +20,7 @@ const logger = new Logger(module)
 // This is a dummy peer descriptor that is used to connect to the streamr websocket
 // To ensure that the autocertified subdomain is used for the Streamr Network
 const LOCAL_PEER_DESCRIPTOR: PeerDescriptor = {
-    nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+    nodeId: toDhtAddressRaw(randomDhtAddress()),
     type: NodeType.NODEJS,
 }
 
@@ -32,7 +32,7 @@ export const runStreamrChallenge = (
 ): Promise<void> => {
     return new Promise((resolve, reject) => {
         const remotePeerDescriptor: PeerDescriptor = {
-            nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+            nodeId: toDhtAddressRaw(randomDhtAddress()),
             type: NodeType.NODEJS,
             websocket: {
                 host: streamrWebSocketIp,

--- a/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
+++ b/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
@@ -8,8 +8,8 @@ import {
     PeerDescriptor,
     Simulator,
     SimulatorTransport,
-    createRandomDhtAddress,
-    getRawFromDhtAddress
+    randomDhtAddress,
+    toDhtAddressRaw
 } from '@streamr/dht'
 import path from 'path'
 import { MetricsContext, waitForCondition } from '@streamr/utils'
@@ -22,7 +22,7 @@ describe('StreamrChallenger', () => {
     let mockTransport: SimulatorTransport
 
     const mockPeerDescriptor1: PeerDescriptor = {
-        nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+        nodeId: toDhtAddressRaw(randomDhtAddress()),
         type: NodeType.NODEJS,
         websocket: {
             host: '127.0.0.1',

--- a/packages/dht/src/connection/ConnectionLockRpcLocal.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcLocal.ts
@@ -13,7 +13,7 @@ import { IConnectionLockRpc } from '../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 import { getNodeIdOrUnknownFromPeerDescriptor } from './ConnectionManager'
 import { LockID } from './ConnectionLockStates'
-import { DhtAddress, areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../identifiers'
+import { DhtAddress, areEqualPeerDescriptors, toNodeId } from '../identifiers'
 
 interface ConnectionLockRpcLocalOptions {
     addRemoteLocked: (id: DhtAddress, lockId: LockID) => void
@@ -40,7 +40,7 @@ export class ConnectionLockRpcLocal implements IConnectionLockRpc {
             }
             return response
         }
-        const remoteNodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        const remoteNodeId = toNodeId(senderPeerDescriptor)
         this.options.addRemoteLocked(remoteNodeId, lockRequest.lockId)
         const response: LockResponse = {
             accepted: true
@@ -50,7 +50,7 @@ export class ConnectionLockRpcLocal implements IConnectionLockRpc {
 
     async unlockRequest(unlockRequest: UnlockRequest, context: ServerCallContext): Promise<Empty> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const nodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        const nodeId = toNodeId(senderPeerDescriptor)
         this.options.removeRemoteLocked(nodeId, unlockRequest.lockId)
         return {}
     }

--- a/packages/dht/src/connection/ConnectionLockRpcRemote.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcRemote.ts
@@ -3,14 +3,14 @@ import { RpcRemote } from '../dht/contact/RpcRemote'
 import { DisconnectMode, DisconnectNotice, LockRequest, UnlockRequest } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionLockRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
 import { LockID } from './ConnectionLockStates'
-import { getNodeIdFromPeerDescriptor } from '../identifiers'
+import { toNodeId } from '../identifiers'
 
 const logger = new Logger(module)
 
 export class ConnectionLockRpcRemote extends RpcRemote<ConnectionLockRpcClient> {
 
     public async lockRequest(lockId: LockID): Promise<boolean> {
-        logger.trace(`Requesting locked connection to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Requesting locked connection to ${toNodeId(this.getPeerDescriptor())}`)
         const request: LockRequest = {
             lockId
         }
@@ -25,7 +25,7 @@ export class ConnectionLockRpcRemote extends RpcRemote<ConnectionLockRpcClient> 
     }
 
     public unlockRequest(lockId: LockID): void {
-        logger.trace(`Requesting connection to be unlocked from ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Requesting connection to be unlocked from ${toNodeId(this.getPeerDescriptor())}`)
         const request: UnlockRequest = {
             lockId
         }
@@ -38,7 +38,7 @@ export class ConnectionLockRpcRemote extends RpcRemote<ConnectionLockRpcClient> 
     }
 
     public async gracefulDisconnect(disconnectMode: DisconnectMode): Promise<void> {
-        logger.trace(`Notifying a graceful disconnect to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())}`)
+        logger.trace(`Notifying a graceful disconnect to ${toNodeId(this.getPeerDescriptor())}`)
         const request: DisconnectNotice = {
             disconnectMode
         }

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -4,7 +4,7 @@ import { v4 } from 'uuid'
 import { Message, HandshakeRequest, HandshakeResponse, PeerDescriptor, HandshakeError } from '../proto/packages/dht/protos/DhtRpc'
 import { IConnection } from './IConnection'
 import { LOCAL_PROTOCOL_VERSION, isMaybeSupportedVersion } from '../helpers/version'
-import { getNodeIdFromPeerDescriptor } from '../identifiers'
+import { toNodeId } from '../identifiers'
 import { PendingConnection } from './PendingConnection'
 
 const logger = new Logger(module)
@@ -43,7 +43,7 @@ export const createOutgoingHandshaker = (
         }
     }
     const handshakeCompletedListener = (peerDescriptor: PeerDescriptor) => {
-        logger.trace('handshake completed for outgoing connection, ' + getNodeIdFromPeerDescriptor(peerDescriptor))
+        logger.trace('handshake completed for outgoing connection, ' + toNodeId(peerDescriptor))
         pendingConnection.onHandshakeCompleted(connection)
         stopHandshaker()
     }

--- a/packages/dht/src/connection/ManagedConnection.ts
+++ b/packages/dht/src/connection/ManagedConnection.ts
@@ -4,7 +4,7 @@ import { PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { Logger } from '@streamr/utils'
 import EventEmitter from 'eventemitter3'
 import { getNodeIdOrUnknownFromPeerDescriptor } from './ConnectionManager'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../identifiers'
+import { DhtAddress, toNodeId } from '../identifiers'
 import { createRandomConnectionId } from './Connection'
 
 export interface ManagedConnectionEvents {
@@ -83,7 +83,7 @@ export class ManagedConnection extends EventEmitter<ManagedConnectionEvents> {
     }
 
     getNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+        return toNodeId(this.remotePeerDescriptor)
     }
 
     getLastUsedTimestamp(): number {

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -7,7 +7,7 @@ import { Logger } from '@streamr/utils'
 import { getRegionDelayMatrix } from './pings'
 import Heap from 'heap'
 import { debugVars } from '../../helpers/debugHelpers'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -183,11 +183,11 @@ export class Simulator {
     }
 
     public addConnector(connector: SimulatorConnector): void {
-        this.connectors.set(getNodeIdFromPeerDescriptor(connector.getPeerDescriptor()), connector)
+        this.connectors.set(toNodeId(connector.getPeerDescriptor()), connector)
     }
 
     private executeConnectOperation(operation: ConnectOperation): void {
-        const target = this.connectors.get(getNodeIdFromPeerDescriptor(operation.targetDescriptor))
+        const target = this.connectors.get(toNodeId(operation.targetDescriptor))
 
         if (!target) {
             logger.error('Target connector not found when executing connect operation')

--- a/packages/dht/src/connection/simulator/SimulatorConnection.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnection.ts
@@ -4,7 +4,7 @@ import { Message, PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { Connection } from '../Connection'
 import { Logger } from '@streamr/utils'
 import { protoToString } from '../../helpers/protoToString'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -45,15 +45,15 @@ export class SimulatorConnection extends Connection implements IConnection {
             this.simulator.send(this, data)
 
         } else {
-            const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
-            const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
+            const localNodeId = toNodeId(this.localPeerDescriptor)
+            const targetNodeId = toNodeId(this.targetPeerDescriptor)
             logger.error(localNodeId + ', ' + targetNodeId + 'tried to send() on a stopped connection')
         }
     }
 
     public async close(gracefulLeave: boolean): Promise<void> {
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
-        const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
+        const localNodeId = toNodeId(this.localPeerDescriptor)
+        const targetNodeId = toNodeId(this.targetPeerDescriptor)
 
         logger.trace(localNodeId + ', ' + targetNodeId + ' close()')
         if (!this.stopped) {
@@ -104,7 +104,7 @@ export class SimulatorConnection extends Connection implements IConnection {
 
     public handleIncomingDisconnection(): void {
         if (!this.stopped) {
-            const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+            const localNodeId = toNodeId(this.localPeerDescriptor)
             logger.trace(localNodeId + ' handleIncomingDisconnection()')
             this.stopped = true
             this.doDisconnect(false)
@@ -114,7 +114,7 @@ export class SimulatorConnection extends Connection implements IConnection {
     }
 
     public destroy(): void {
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
+        const localNodeId = toNodeId(this.localPeerDescriptor)
         if (!this.stopped) {
             logger.trace(localNodeId + ' destroy()')
             this.removeAllListeners()
@@ -125,8 +125,8 @@ export class SimulatorConnection extends Connection implements IConnection {
     }
 
     private doDisconnect(gracefulLeave: boolean) {
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor)
-        const targetNodeId = getNodeIdFromPeerDescriptor(this.targetPeerDescriptor)
+        const localNodeId = toNodeId(this.localPeerDescriptor)
+        const targetNodeId = toNodeId(this.targetPeerDescriptor)
         logger.trace(localNodeId + ' doDisconnect()')
         this.stopped = true
 

--- a/packages/dht/src/connection/simulator/SimulatorConnector.ts
+++ b/packages/dht/src/connection/simulator/SimulatorConnector.ts
@@ -7,7 +7,7 @@ import {
 import { Logger } from '@streamr/utils'
 import { Simulator } from './Simulator'
 import { SimulatorConnection } from './SimulatorConnection'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 import { acceptHandshake, createIncomingHandshaker, createOutgoingHandshaker, rejectHandshake } from '../Handshaker'
 import { PendingConnection } from '../PendingConnection'
 
@@ -32,8 +32,8 @@ export class SimulatorConnector {
     }
 
     public connect(targetPeerDescriptor: PeerDescriptor): PendingConnection {
-        logger.trace('connect() ' + getNodeIdFromPeerDescriptor(targetPeerDescriptor))
-        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        logger.trace('connect() ' + toNodeId(targetPeerDescriptor))
+        const nodeId = toNodeId(targetPeerDescriptor)
         const existingConnection = this.connectingConnections.get(nodeId)
         if (existingConnection) {
             return existingConnection
@@ -65,7 +65,7 @@ export class SimulatorConnector {
     public handleIncomingConnection(sourceConnection: SimulatorConnection): void {
         // connection is incoming, so remotePeerDescriptor is localPeerDescriptor
         const remotePeerDescriptor = sourceConnection.localPeerDescriptor
-        const remoteNodeId = getNodeIdFromPeerDescriptor(sourceConnection.localPeerDescriptor)
+        const remoteNodeId = toNodeId(sourceConnection.localPeerDescriptor)
         logger.trace(remoteNodeId + ' incoming connection, stopped: ' + this.stopped)
         if (this.stopped) {
             return

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -10,7 +10,7 @@ import { IllegalRtcPeerConnectionState } from '../../helpers/errors'
 import { iceServerAsString } from './iceServerAsString'
 import { IceServer } from './WebrtcConnector'
 import { PortRange } from '../ConnectionManager'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 import { createRandomConnectionId } from '../Connection'
 
 const logger = new Logger(module)
@@ -72,7 +72,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     }
 
     public start(isOffering: boolean): void {
-        const nodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+        const nodeId = toNodeId(this.remotePeerDescriptor)
         this.offering = isOffering
         logger.trace(`Starting new connection for peer ${nodeId}`, { isOffering })
         this.connection = new PeerConnection(nodeId, {
@@ -101,7 +101,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     public async setRemoteDescription(description: string, type: string): Promise<void> {
         if (this.connection) {
-            const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+            const remoteNodeId = toNodeId(this.remotePeerDescriptor)
             try {
                 logger.trace(`Setting remote descriptor for peer: ${remoteNodeId}`)
                 this.connection.setRemoteDescription(description, type as DescriptionType)
@@ -117,7 +117,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     public addRemoteCandidate(candidate: string, mid: string): void {
         if (this.connection) {
             if (this.remoteDescriptionSet) {
-                const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+                const remoteNodeId = toNodeId(this.remotePeerDescriptor)
                 try {
                     logger.trace(`Setting remote candidate for peer: ${remoteNodeId}`)
                     this.connection.addRemoteCandidate(candidate, mid)
@@ -138,7 +138,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
             try {
                 this.dataChannel!.sendMessageBinary(data as Buffer)
             } catch (err) {
-                const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+                const remoteNodeId = toNodeId(this.remotePeerDescriptor)
                 logger.debug('Failed to send binary message to ' + remoteNodeId + err)
             }
         }
@@ -150,7 +150,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     private doClose(gracefulLeave: boolean, reason?: string): void {
         if (!this.closed) {
-            const remoteNodeId = getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)
+            const remoteNodeId = toNodeId(this.remotePeerDescriptor)
             logger.trace(`Closing Node WebRTC Connection to ${remoteNodeId}` + `${(reason !== undefined) ? `, reason: ${reason}` : ''}`)
 
             this.closed = true
@@ -210,7 +210,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     }
 
     private onDataChannelOpen(): void {
-        logger.trace(`DataChannel opened for peer ${getNodeIdFromPeerDescriptor(this.remotePeerDescriptor)}`)
+        logger.trace(`DataChannel opened for peer ${toNodeId(this.remotePeerDescriptor)}`)
         this.emit('connected')
     }
 

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -15,7 +15,7 @@ import * as Err from '../../helpers/errors'
 import { PortRange } from '../ConnectionManager'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { WebrtcConnectorRpcLocal } from './WebrtcConnectorRpcLocal'
-import { DhtAddress, areEqualPeerDescriptors, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, areEqualPeerDescriptors, toNodeId } from '../../identifiers'
 import { getOfferer } from '../../helpers/offering'
 import { acceptHandshake, createIncomingHandshaker, createOutgoingHandshaker, rejectHandshake } from '../Handshaker'
 import { isMaybeSupportedVersion } from '../../helpers/version'
@@ -127,9 +127,9 @@ export class WebrtcConnector {
             throw new Err.CannotConnectToSelf('Cannot open WebRTC Connection to self')
         }
 
-        logger.trace(`Opening WebRTC connection to ${getNodeIdFromPeerDescriptor(targetPeerDescriptor)}`)
+        logger.trace(`Opening WebRTC connection to ${toNodeId(targetPeerDescriptor)}`)
 
-        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const nodeId = toNodeId(targetPeerDescriptor)
         const existingConnection = this.ongoingConnectAttempts.get(nodeId)
         if (existingConnection) {
             return existingConnection.managedConnection
@@ -137,8 +137,8 @@ export class WebrtcConnector {
 
         const connection = this.createConnection(targetPeerDescriptor)
 
-        const localNodeId = getNodeIdFromPeerDescriptor(this.localPeerDescriptor!)
-        const targetNodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const localNodeId = toNodeId(this.localPeerDescriptor!)
+        const targetNodeId = toNodeId(targetPeerDescriptor)
         const offering = (getOfferer(localNodeId, targetNodeId) === 'local')
         let pendingConnection: PendingConnection
         const remoteConnector = new WebrtcConnectorRpcRemote(

--- a/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnectorRpcLocal.ts
@@ -12,7 +12,7 @@ import { IWebrtcConnectorRpc } from '../../proto/packages/dht/protos/DhtRpc.serv
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
 import { NodeWebrtcConnection } from './NodeWebrtcConnection'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 import { ConnectionID } from '../IConnection'
 import { ConnectingConnection } from './WebrtcConnector'
 import { PendingConnection } from '../PendingConnection'
@@ -39,7 +39,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async requestConnection(context: ServerCallContext): Promise<Empty> {
         const targetPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        if (this.options.ongoingConnectAttempts.has(getNodeIdFromPeerDescriptor(targetPeerDescriptor))) {
+        if (this.options.ongoingConnectAttempts.has(toNodeId(targetPeerDescriptor))) {
             return {}
         }
         const pendingConnection = this.options.connect(targetPeerDescriptor, false)
@@ -49,7 +49,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async rtcOffer(request: RtcOffer, context: ServerCallContext): Promise<Empty> {
         const remotePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const nodeId = getNodeIdFromPeerDescriptor(remotePeerDescriptor)
+        const nodeId = toNodeId(remotePeerDescriptor)
         let connection: NodeWebrtcConnection
         let pendingConnection: PendingConnection
 
@@ -69,7 +69,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async rtcAnswer(request: RtcAnswer, context: ServerCallContext): Promise<Empty> {
         const remotePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const nodeId = getNodeIdFromPeerDescriptor(remotePeerDescriptor)
+        const nodeId = toNodeId(remotePeerDescriptor)
         const connection = this.options.ongoingConnectAttempts.get(nodeId)?.connection
         if (!connection) {
             return {}
@@ -83,7 +83,7 @@ export class WebrtcConnectorRpcLocal implements IWebrtcConnectorRpc {
 
     async iceCandidate(request: IceCandidate, context: ServerCallContext): Promise<Empty> {
         const remotePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const nodeId = getNodeIdFromPeerDescriptor(remotePeerDescriptor)
+        const nodeId = toNodeId(remotePeerDescriptor)
         const connection = this.options.ongoingConnectAttempts.get(nodeId)?.connection
         if (!connection) {
             return {}

--- a/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnector.ts
@@ -12,7 +12,7 @@ import { createOutgoingHandshaker } from '../Handshaker'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { expectedConnectionType } from '../../helpers/Connectivity'
 import { Empty } from '../../proto/google/protobuf/empty'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 import { GeoIpLocator } from '@streamr/geoip-location'
 import { PendingConnection } from '../PendingConnection'
 
@@ -73,7 +73,7 @@ export class WebsocketClientConnector {
     }
 
     public connect(targetPeerDescriptor: PeerDescriptor): PendingConnection {
-        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const nodeId = toNodeId(targetPeerDescriptor)
         const existingConnection = this.connectingConnections.get(nodeId)
         if (existingConnection) {
             return existingConnection

--- a/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcLocal.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcLocal.ts
@@ -6,7 +6,7 @@ import {
 import { IWebsocketClientConnectorRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
 import { Empty } from '../../proto/google/protobuf/empty'
-import { getNodeIdFromPeerDescriptor, DhtAddress } from '../../identifiers'
+import { toNodeId, DhtAddress } from '../../identifiers'
 import { PendingConnection } from '../PendingConnection'
 
 interface WebsocketClientConnectorRpcLocalOptions {
@@ -29,7 +29,7 @@ export class WebsocketClientConnectorRpcLocal implements IWebsocketClientConnect
             return {}
         }
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        if (!this.options.hasConnection(getNodeIdFromPeerDescriptor(senderPeerDescriptor))) {
+        if (!this.options.hasConnection(toNodeId(senderPeerDescriptor))) {
             const connection = this.options.connect(senderPeerDescriptor)
             this.options.onNewConnection(connection)
         }

--- a/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcRemote.ts
+++ b/packages/dht/src/connection/websocket/WebsocketClientConnectorRpcRemote.ts
@@ -4,14 +4,14 @@ import {
 import { Logger } from '@streamr/utils'
 import { RpcRemote } from '../../dht/contact/RpcRemote'
 import { WebsocketClientConnectorRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
 export class WebsocketClientConnectorRpcRemote extends RpcRemote<WebsocketClientConnectorRpcClient> {
 
     async requestConnection(): Promise<void> {
-        logger.trace(`Requesting WebSocket connection from ${getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor())}`)
+        logger.trace(`Requesting WebSocket connection from ${toNodeId(this.getLocalPeerDescriptor())}`)
         const request: WebsocketConnectionRequest = {}
         const options = this.formDhtRpcOptions()
         return this.getClient().requestConnection(request, options)

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -2,7 +2,7 @@ import { GeoIpLocator } from '@streamr/geoip-location'
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
 import { Action, connectivityMethodToWebsocketUrl } from './WebsocketClientConnector'
 import { WebsocketServer } from './WebsocketServer'
-import { areEqualPeerDescriptors, DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { areEqualPeerDescriptors, DhtAddress, toNodeId } from '../../identifiers'
 import { AutoCertifierClientFacade } from './AutoCertifierClientFacade'
 import { ConnectivityResponse, HandshakeError, PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { NatType, PortRange, TlsCertificate } from '../ConnectionManager'
@@ -126,7 +126,7 @@ export class WebsocketServerConnector {
         remoteVersion: string,
         targetPeerDescriptor?: PeerDescriptor
     ) {
-        const nodeId = getNodeIdFromPeerDescriptor(sourcePeerDescriptor)
+        const nodeId = toNodeId(sourcePeerDescriptor)
         if (this.ongoingConnectRequests.has(nodeId)) {
             const { pendingConnection, delFunc } = this.ongoingConnectRequests.get(nodeId)!
             if (!isMaybeSupportedVersion(remoteVersion)) {
@@ -195,7 +195,7 @@ export class WebsocketServerConnector {
                     throw new Err.ConnectionFailed('ConnectivityChecker is destroyed')
                 }
             } catch (err) {
-                const error = `Failed to connect to entrypoint with id ${getNodeIdFromPeerDescriptor(entryPoint)} `
+                const error = `Failed to connect to entrypoint with id ${toNodeId(entryPoint)} `
                     + `and URL ${connectivityMethodToWebsocketUrl(entryPoint.websocket!)}`
                 logger.error(error, { err })
                 shuffledEntrypoints.shift()
@@ -227,7 +227,7 @@ export class WebsocketServerConnector {
     }
 
     public connect(targetPeerDescriptor: PeerDescriptor): PendingConnection {
-        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const nodeId = toNodeId(targetPeerDescriptor)
         if (this.ongoingConnectRequests.has(nodeId)) {
             return this.ongoingConnectRequests.get(nodeId)!.pendingConnection
         }
@@ -251,7 +251,7 @@ export class WebsocketServerConnector {
             })
         })
         const pendingConnection = new PendingConnection(targetPeerDescriptor)
-        const nodeId = getNodeIdFromPeerDescriptor(targetPeerDescriptor)
+        const nodeId = toNodeId(targetPeerDescriptor)
         // TODO: can this leak?
         const delFunc = () => {
             pendingConnection.off('connected', delFunc)

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -15,7 +15,7 @@ import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../connec
 import { IceServer } from '../connection/webrtc/WebrtcConnector'
 import { isBrowserEnvironment } from '../helpers/browser/isBrowserEnvironment'
 import { createPeerDescriptor } from '../helpers/createPeerDescriptor'
-import { DhtAddress, KADEMLIA_ID_LENGTH_IN_BYTES, getNodeIdFromPeerDescriptor } from '../identifiers'
+import { DhtAddress, KADEMLIA_ID_LENGTH_IN_BYTES, toNodeId } from '../identifiers'
 import { Any } from '../proto/google/protobuf/any'
 import {
     ClosestPeersRequest,
@@ -381,7 +381,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         this.transport!.on('disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => {
             const isControlLayerNode = (this.connectionLocker !== undefined)
             if (isControlLayerNode) {
-                const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+                const nodeId = toNodeId(peerDescriptor)
                 if (gracefulLeave) {
                     this.peerManager!.removeContact(nodeId)
                 } else {
@@ -500,7 +500,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
     }
 
     public getNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.localPeerDescriptor!)
+        return toNodeId(this.localPeerDescriptor!)
     }
 
     public getNeighborCount(): number {
@@ -524,7 +524,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
 
     private getConnectedEntryPoints(): PeerDescriptor[] {
         return this.options.entryPoints !== undefined ? this.options.entryPoints.filter((entryPoint) =>
-            this.connectionsView!.hasConnection(getNodeIdFromPeerDescriptor(entryPoint))
+            this.connectionsView!.hasConnection(toNodeId(entryPoint))
         ) : []
     }
 

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -1,6 +1,6 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { Logger } from '@streamr/utils'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../identifiers'
+import { DhtAddress, toDhtAddress, toNodeId } from '../identifiers'
 import { Empty } from '../proto/google/protobuf/empty'
 import {
     ClosestPeersRequest,
@@ -39,7 +39,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     async getClosestPeers(request: ClosestPeersRequest, context: ServerCallContext): Promise<ClosestPeersResponse> {
         this.options.addContact((context as DhtCallContext).incomingSourceDescriptor!)
         const peers = getClosestNodes(
-            getDhtAddressFromRaw(request.nodeId), 
+            toDhtAddress(request.nodeId), 
             this.options.getNeighbors(),
             { maxCount: this.options.peerDiscoveryQueryBatchSize }
         )
@@ -63,7 +63,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     }
 
     async ping(request: PingRequest, context: ServerCallContext): Promise<PingResponse> {
-        logger.trace('received ping request: ' + getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!))
+        logger.trace('received ping request: ' + toNodeId((context as DhtCallContext).incomingSourceDescriptor!))
         setImmediate(() => {
             this.options.addContact((context as DhtCallContext).incomingSourceDescriptor!)
         })
@@ -76,7 +76,7 @@ export class DhtNodeRpcLocal implements IDhtNodeRpc {
     async leaveNotice(context: ServerCallContext): Promise<Empty> {
         // TODO check signature??
         const sender = (context as DhtCallContext).incomingSourceDescriptor!
-        const senderNodeId = getNodeIdFromPeerDescriptor(sender)
+        const senderNodeId = toNodeId(sender)
         logger.trace('received leave notice: ' + senderNodeId)
         this.options.removeContact(senderNodeId)
         return {}

--- a/packages/dht/src/dht/DhtNodeRpcRemote.ts
+++ b/packages/dht/src/dht/DhtNodeRpcRemote.ts
@@ -1,7 +1,7 @@
 import { RpcCommunicator } from '@streamr/proto-rpc'
 import { Logger } from '@streamr/utils'
 import { v4 } from 'uuid'
-import { DhtAddress, DhtAddressRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../identifiers'
+import { DhtAddress, DhtAddressRaw, toNodeId, toDhtAddressRaw } from '../identifiers'
 import {
     ClosestPeersRequest,
     ClosestRingPeersRequest,
@@ -46,7 +46,7 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
     async getClosestPeers(nodeId: DhtAddress): Promise<PeerDescriptor[]> {
         logger.trace(`Requesting getClosestPeers on ${this.serviceId} from ${this.getNodeId()}`)
         const request: ClosestPeersRequest = {
-            nodeId: getRawFromDhtAddress(nodeId),
+            nodeId: toDhtAddressRaw(nodeId),
             requestId: v4()
         }
         try {
@@ -102,6 +102,6 @@ export class DhtNodeRpcRemote extends RpcRemote<DhtNodeRpcClient> implements KBu
     }
 
     getNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+        return toNodeId(this.getPeerDescriptor())
     }
 }

--- a/packages/dht/src/dht/ExternalApiRpcLocal.ts
+++ b/packages/dht/src/dht/ExternalApiRpcLocal.ts
@@ -11,7 +11,7 @@ import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
 import { RecursiveOperationResult } from './recursive-operation/RecursiveOperationManager'
 import { Any } from '../proto/google/protobuf/any'
-import { DhtAddress, getNodeIdFromPeerDescriptor, getDhtAddressFromRaw } from '../identifiers'
+import { DhtAddress, toNodeId, toDhtAddress } from '../identifiers'
 
 interface ExternalApiRpcLocalOptions {
     executeRecursiveOperation: (
@@ -37,9 +37,9 @@ export class ExternalApiRpcLocal implements IExternalApiRpc {
     async externalFetchData(request: ExternalFetchDataRequest, context: ServerCallContext): Promise<ExternalFetchDataResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const result = await this.options.executeRecursiveOperation(
-            getDhtAddressFromRaw(request.key),
+            toDhtAddress(request.key),
             RecursiveOperation.FETCH_DATA,
-            getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+            toNodeId(senderPeerDescriptor)
         )
         return ExternalFetchDataResponse.create({ entries: result.dataEntries ?? [] })
     }
@@ -47,9 +47,9 @@ export class ExternalApiRpcLocal implements IExternalApiRpc {
     async externalStoreData(request: ExternalStoreDataRequest, context: ServerCallContext): Promise<ExternalStoreDataResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
         const result = await this.options.storeDataToDht(
-            getDhtAddressFromRaw(request.key),
+            toDhtAddress(request.key),
             request.data!,
-            getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+            toNodeId(senderPeerDescriptor)
         )
         return ExternalStoreDataResponse.create({
             storers: result

--- a/packages/dht/src/dht/ExternalApiRpcRemote.ts
+++ b/packages/dht/src/dht/ExternalApiRpcRemote.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, getRawFromDhtAddress } from '../identifiers'
+import { DhtAddress, toDhtAddressRaw } from '../identifiers'
 import { Any } from '../proto/google/protobuf/any'
 import { DataEntry, ExternalFetchDataRequest, ExternalStoreDataRequest, PeerDescriptor } from '../proto/packages/dht/protos/DhtRpc'
 import { ExternalApiRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
@@ -8,7 +8,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
 
     async externalFetchData(key: DhtAddress): Promise<DataEntry[]> {
         const request: ExternalFetchDataRequest = {
-            key: getRawFromDhtAddress(key)
+            key: toDhtAddressRaw(key)
         }
         const options = this.formDhtRpcOptions({
             // TODO use options option or named constant?
@@ -24,7 +24,7 @@ export class ExternalApiRpcRemote extends RpcRemote<ExternalApiRpcClient> {
 
     async storeData(key: DhtAddress, data: Any): Promise<PeerDescriptor[]> {
         const request: ExternalStoreDataRequest = {
-            key: getRawFromDhtAddress(key),
+            key: toDhtAddressRaw(key),
             data
         }
         const options = this.formDhtRpcOptions({

--- a/packages/dht/src/dht/contact/Contact.ts
+++ b/packages/dht/src/dht/contact/Contact.ts
@@ -1,5 +1,5 @@
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 
 export class Contact {
 
@@ -14,6 +14,6 @@ export class Contact {
     }
 
     public getNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.peerDescriptor)
+        return toNodeId(this.peerDescriptor)
     }
 }

--- a/packages/dht/src/dht/contact/RingContactList.ts
+++ b/packages/dht/src/dht/contact/RingContactList.ts
@@ -1,7 +1,7 @@
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { OrderedMap } from '@js-sdsl/ordered-map'
 import { RingDistance, RingId, RingIdRaw, getLeftDistance, getRightDistance, getRingIdFromPeerDescriptor, getRingIdFromRaw } from './ringIdentifiers'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 import EventEmitter from 'eventemitter3'
 import { Events } from './ContactList'
 
@@ -28,7 +28,7 @@ export class RingContactList<C extends { getPeerDescriptor(): PeerDescriptor }> 
 
     addContact(contact: C): void {
         const id = getRingIdFromPeerDescriptor(contact.getPeerDescriptor())
-        if (id === this.referenceId || this.excludedIds.has(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor()))) {
+        if (id === this.referenceId || this.excludedIds.has(toNodeId(contact.getPeerDescriptor()))) {
             return
         }
         let elementAdded = false

--- a/packages/dht/src/dht/contact/SortedContactList.ts
+++ b/packages/dht/src/dht/contact/SortedContactList.ts
@@ -2,7 +2,7 @@ import { Events } from './ContactList'
 import { sortedIndexBy } from 'lodash'
 import EventEmitter from 'eventemitter3'
 import { getDistance } from '../PeerManager'
-import { DhtAddress, getRawFromDhtAddress } from '../../identifiers'
+import { DhtAddress, toDhtAddressRaw } from '../../identifiers'
 
 // add other getters in the future if needed
 export type ReadonlySortedContactList<C extends { getNodeId: () => DhtAddress }> =
@@ -120,7 +120,7 @@ export class SortedContactList<C extends { getNodeId: () => DhtAddress }> extend
     // TODO inline this method?
     private distanceToReferenceId(id: DhtAddress): number {
         // TODO maybe this class should store the referenceId also as DhtAddressRaw so that we don't need to convert it here?
-        return getDistance(getRawFromDhtAddress(this.options.referenceId), getRawFromDhtAddress(id))
+        return getDistance(toDhtAddressRaw(this.options.referenceId), toDhtAddressRaw(id))
     }
 
     public removeContact(id: DhtAddress): boolean {

--- a/packages/dht/src/dht/discovery/DiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/DiscoverySession.ts
@@ -1,6 +1,6 @@
 import { Gate, Logger, withTimeout } from '@streamr/utils'
 import { v4 } from 'uuid'
-import { DhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../identifiers'
+import { DhtAddress, toNodeId, toDhtAddressRaw } from '../../identifiers'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { PeerManager, getDistance } from '../PeerManager'
@@ -44,7 +44,7 @@ export class DiscoverySession {
         if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return []
         }
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         logger.trace(`Getting closest neighbors from remote: ${nodeId}`)
         this.options.contactedPeers.add(nodeId)
         const remote = this.options.createDhtNodeRpcRemote(peerDescriptor)
@@ -58,7 +58,7 @@ export class DiscoverySession {
             return
         }
         this.ongoingRequests.delete(nodeId)
-        const targetId = getRawFromDhtAddress(this.options.targetId)
+        const targetId = toDhtAddressRaw(this.options.targetId)
         const oldClosestNeighbor = this.getClosestNeighbor()
         const oldClosestDistance = getDistance(targetId, oldClosestNeighbor.nodeId)
         this.addContacts(contacts)
@@ -105,7 +105,7 @@ export class DiscoverySession {
             if (this.ongoingRequests.size >= this.options.parallelism) {
                 break
             }
-            const nodeId = getNodeIdFromPeerDescriptor(node)
+            const nodeId = toNodeId(node)
             this.ongoingRequests.add(nodeId)
             // eslint-disable-next-line promise/catch-or-return
             this.fetchClosestNeighborsFromRemote(node)

--- a/packages/dht/src/dht/discovery/RingDiscoverySession.ts
+++ b/packages/dht/src/dht/discovery/RingDiscoverySession.ts
@@ -1,6 +1,6 @@
 import { Gate, Logger, withTimeout } from '@streamr/utils'
 import { v4 } from 'uuid'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
 import { DhtNodeRpcRemote } from '../DhtNodeRpcRemote'
 import { PeerManager } from '../PeerManager'
@@ -47,7 +47,7 @@ export class RingDiscoverySession {
         if (this.options.abortSignal.aborted || this.doneGate.isOpen()) {
             return { left: [], right: [] }
         }
-        logger.trace(`Getting closest ring peers from contact: ${getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())}`)
+        logger.trace(`Getting closest ring peers from contact: ${toNodeId(contact.getPeerDescriptor())}`)
         this.numContactedPeers++
         this.options.contactedPeers.add(contact.getNodeId())
         const returnedContacts = await contact.getClosestRingPeers(this.options.targetId)

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcLocal.ts
@@ -3,7 +3,7 @@ import { PeerDescriptor, RouteMessageAck, RouteMessageError, RouteMessageWrapper
 import { IRecursiveOperationRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
 import { createRouteMessageAck } from '../routing/RouterRpcLocal'
 import { getPreviousPeer } from '../routing/getPreviousPeer'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -26,7 +26,7 @@ export class RecursiveOperationRpcLocal implements IRecursiveOperationRpc {
         if (this.options.isMostLikelyDuplicate(routedMessage.requestId)) {
             return createRouteMessageAck(routedMessage, RouteMessageError.DUPLICATE)
         }
-        const remoteNodeId = getNodeIdFromPeerDescriptor(getPreviousPeer(routedMessage) ?? routedMessage.sourcePeer!)
+        const remoteNodeId = toNodeId(getPreviousPeer(routedMessage) ?? routedMessage.sourcePeer!)
         logger.trace(`Received routeRequest call from ${remoteNodeId}`)
         this.options.addToDuplicateDetector(routedMessage.requestId)
         return this.options.doRouteRequest(routedMessage)

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationRpcRemote.ts
@@ -4,7 +4,7 @@ import { RouteMessageWrapper } from '../../proto/packages/dht/protos/DhtRpc'
 import { RecursiveOperationRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
 import { RpcRemote } from '../contact/RpcRemote'
 import { getPreviousPeer } from '../routing/getPreviousPeer'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -32,9 +32,9 @@ export class RecursiveOperationRpcRemote extends RpcRemote<RecursiveOperationRpc
         } catch (err) {
             const previousPeer = getPreviousPeer(params)
             const fromNode = previousPeer
-                ? getNodeIdFromPeerDescriptor(previousPeer)
-                : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+                ? toNodeId(previousPeer)
+                : toNodeId(params.sourcePeer!)
+            const toNode = toNodeId(this.getPeerDescriptor())
             logger.debug(`Failed to send routeRequest message from ${fromNode} to ${toNode}`, { err })
             return false
         }

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSession.ts
@@ -17,7 +17,7 @@ import { SortedContactList } from '../contact/SortedContactList'
 import { RecursiveOperationResult } from './RecursiveOperationManager'
 import { ServiceID } from '../../types/ServiceID'
 import { RecursiveOperationSessionRpcLocal } from './RecursiveOperationSessionRpcLocal'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../identifiers'
+import { DhtAddress, toDhtAddress, toNodeId, toDhtAddressRaw } from '../../identifiers'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 
 export interface RecursiveOperationSessionEvents {
@@ -100,7 +100,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
         const routeMessage: RouteMessageWrapper = {
             message: msg,
             requestId: v4(),
-            target: getRawFromDhtAddress(this.options.targetId),
+            target: toDhtAddressRaw(this.options.targetId),
             sourcePeer: this.options.localPeerDescriptor,
             reachableThrough: [],
             routingPath: [],
@@ -151,9 +151,9 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
     }
 
     private addKnownHops(routingPath: PeerDescriptor[]) {
-        const localNodeId = getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
+        const localNodeId = toNodeId(this.options.localPeerDescriptor)
         routingPath.forEach((desc) => {
-            const newNodeId = getNodeIdFromPeerDescriptor(desc)
+            const newNodeId = toNodeId(desc)
             if (localNodeId !== newNodeId) {
                 this.allKnownHops.add(newNodeId)
             }
@@ -161,8 +161,8 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
     }
 
     private setHopAsReported(desc: PeerDescriptor) {
-        const localNodeId = getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
-        const newNodeId = getNodeIdFromPeerDescriptor(desc)
+        const localNodeId = toNodeId(this.options.localPeerDescriptor)
+        const newNodeId = toNodeId(desc)
         if (localNodeId !== newNodeId) {
             this.reportedHops.add(newNodeId)
         }
@@ -180,7 +180,7 @@ export class RecursiveOperationSession extends EventEmitter<RecursiveOperationSe
 
     private processFoundData(dataEntries: DataEntry[]): void {
         dataEntries.forEach((entry) => {
-            const creatorNodeId = getDhtAddressFromRaw(entry.creator)
+            const creatorNodeId = toDhtAddress(entry.creator)
             const existingEntry = this.foundData.get(creatorNodeId)
             if (!existingEntry || existingEntry.createdAt! < entry.createdAt! 
                 || (existingEntry.createdAt! <= entry.createdAt! && entry.deleted)) {

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationSessionRpcLocal.ts
@@ -4,7 +4,7 @@ import { DataEntry, RecursiveOperationResponse, PeerDescriptor } from '../../pro
 import { Logger } from '@streamr/utils'
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { DhtAddress, toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -27,7 +27,7 @@ export class RecursiveOperationSessionRpcLocal implements IRecursiveOperationSes
     }
     
     async sendResponse(report: RecursiveOperationResponse, context: ServerCallContext): Promise<Empty> {
-        const remoteNodeId = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
+        const remoteNodeId = toNodeId((context as DhtCallContext).incomingSourceDescriptor!)
         logger.trace('RecursiveOperationResponse arrived: ' + JSON.stringify(report))
         this.options.onResponseReceived(remoteNodeId, report.routingPath, report.closestConnectedNodes, report.dataEntries, report.noCloserNodesFound)
         return {}

--- a/packages/dht/src/dht/routing/RouterRpcLocal.ts
+++ b/packages/dht/src/dht/routing/RouterRpcLocal.ts
@@ -3,7 +3,7 @@ import { Message, PeerDescriptor, RouteMessageAck, RouteMessageError, RouteMessa
 import { IRouterRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
 import { DuplicateDetector } from './DuplicateDetector'
 import { RoutingMode } from './RoutingSession'
-import { areEqualPeerDescriptors, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { areEqualPeerDescriptors, toDhtAddress, toNodeId } from '../../identifiers'
 import { v4 } from 'uuid'
 
 interface RouterRpcLocalOptions {
@@ -34,8 +34,8 @@ export class RouterRpcLocal implements IRouterRpc {
 
     async routeMessage(routedMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
         if (this.options.duplicateRequestDetector.isMostLikelyDuplicate(routedMessage.requestId)) {
-            logger.trace(`Routing message ${routedMessage.requestId} from ${getNodeIdFromPeerDescriptor(routedMessage.sourcePeer!)} `
-                + `to ${getDhtAddressFromRaw(routedMessage.target)} is likely a duplicate`)
+            logger.trace(`Routing message ${routedMessage.requestId} from ${toNodeId(routedMessage.sourcePeer!)} `
+                + `to ${toDhtAddress(routedMessage.target)} is likely a duplicate`)
             return createRouteMessageAck(routedMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received routeMessage ${routedMessage.requestId}`)
@@ -52,8 +52,8 @@ export class RouterRpcLocal implements IRouterRpc {
 
     async forwardMessage(forwardMessage: RouteMessageWrapper): Promise<RouteMessageAck> {
         if (this.options.duplicateRequestDetector.isMostLikelyDuplicate(forwardMessage.requestId)) {
-            logger.trace(`Forwarding message ${forwardMessage.requestId} from ${getNodeIdFromPeerDescriptor(forwardMessage.sourcePeer!)} `
-                + `to ${getDhtAddressFromRaw(forwardMessage.target)} is likely a duplicate`)
+            logger.trace(`Forwarding message ${forwardMessage.requestId} from ${toNodeId(forwardMessage.sourcePeer!)} `
+                + `to ${toDhtAddress(forwardMessage.target)} is likely a duplicate`)
             return createRouteMessageAck(forwardMessage, RouteMessageError.DUPLICATE)
         }
         logger.trace(`Processing received forward routeMessage ${forwardMessage.requestId}`)

--- a/packages/dht/src/dht/routing/RouterRpcRemote.ts
+++ b/packages/dht/src/dht/routing/RouterRpcRemote.ts
@@ -4,7 +4,7 @@ import { RouteMessageError, RouteMessageWrapper } from '../../proto/packages/dht
 import { RouterRpcClient } from '../../proto/packages/dht/protos/DhtRpc.client'
 import { RpcRemote } from '../contact/RpcRemote'
 import { getPreviousPeer } from './getPreviousPeer'
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 
 const logger = new Logger(module)
 
@@ -39,9 +39,9 @@ export class RouterRpcRemote extends RpcRemote<RouterRpcClient> {
         } catch (err) {
             const previousPeer = getPreviousPeer(params)
             const fromNode = previousPeer
-                ? getNodeIdFromPeerDescriptor(previousPeer)
-                : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+                ? toNodeId(previousPeer)
+                : toNodeId(params.sourcePeer!)
+            const toNode = toNodeId(this.getPeerDescriptor())
             logger.trace(`Failed to send routeMessage from ${fromNode} to ${toNode}`, { err })
             return false
         }
@@ -69,9 +69,9 @@ export class RouterRpcRemote extends RpcRemote<RouterRpcClient> {
         } catch (err) {
             const previousPeer = getPreviousPeer(params)
             const fromNode = previousPeer
-                ? getNodeIdFromPeerDescriptor(previousPeer)
-                : getNodeIdFromPeerDescriptor(params.sourcePeer!)
-            const toNode = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
+                ? toNodeId(previousPeer)
+                : toNodeId(params.sourcePeer!)
+            const toNode = toNodeId(this.getPeerDescriptor())
             logger.trace(`Failed to send forwardMessage from ${fromNode} to ${toNode}`, { err })
             return false
         }

--- a/packages/dht/src/dht/store/LocalDataStore.ts
+++ b/packages/dht/src/dht/store/LocalDataStore.ts
@@ -1,5 +1,5 @@
 import { DataEntry } from '../../proto/packages/dht/protos/DhtRpc'
-import { DhtAddress, getDhtAddressFromRaw } from '../../identifiers'
+import { DhtAddress, toDhtAddress } from '../../identifiers'
 import { MapWithTtl } from '@streamr/utils'
 
 export class LocalDataStore {
@@ -16,8 +16,8 @@ export class LocalDataStore {
     private store: Map<DhtAddress, MapWithTtl<DhtAddress, DataEntry>> = new Map()
 
     public storeEntry(dataEntry: DataEntry): boolean {
-        const key = getDhtAddressFromRaw(dataEntry.key)
-        const creatorNodeId = getDhtAddressFromRaw(dataEntry.creator)
+        const key = toDhtAddress(dataEntry.key)
+        const creatorNodeId = toDhtAddress(dataEntry.creator)
         if (!this.store.has(key)) {
             this.store.set(key, new MapWithTtl((e) => Math.min(e.ttl, this.maxTtl)))
         }

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -3,9 +3,9 @@ import { Logger } from '@streamr/utils'
 import {
     DhtAddress,
     areEqualPeerDescriptors,
-    getDhtAddressFromRaw,
-    getNodeIdFromPeerDescriptor,
-    getRawFromDhtAddress
+    toDhtAddress,
+    toNodeId,
+    toDhtAddressRaw
 } from '../../identifiers'
 import { Any } from '../../proto/google/protobuf/any'
 import { Timestamp } from '../../proto/google/protobuf/timestamp'
@@ -99,8 +99,8 @@ export class StoreManager {
         const ttl = this.options.highestTtl // ToDo: make TTL decrease according to some nice curve
         const createdAt = Timestamp.now()
         for (let i = 0; i < closestNodes.length && successfulNodes.length < this.options.redundancyFactor; i++) {
-            const keyRaw = getRawFromDhtAddress(key)
-            const creatorRaw = getRawFromDhtAddress(creator)
+            const keyRaw = toDhtAddressRaw(key)
+            const creatorRaw = toDhtAddressRaw(creator)
             if (areEqualPeerDescriptors(this.options.localPeerDescriptor, closestNodes[i])) {
                 this.options.localDataStore.storeEntry({
                     key: keyRaw,
@@ -136,7 +136,7 @@ export class StoreManager {
     private async replicateDataToClosestNodes(): Promise<void> {
         const dataEntries = Array.from(this.options.localDataStore.values())
         await Promise.all(dataEntries.map(async (dataEntry) => {
-            const dataKey = getDhtAddressFromRaw(dataEntry.key)
+            const dataKey = toDhtAddress(dataEntry.key)
             const neighbors = getClosestNodes(
                 dataKey,
                 this.options.getNeighbors(),
@@ -159,7 +159,7 @@ export class StoreManager {
             [...this.options.getNeighbors(), this.options.localPeerDescriptor],
             { 
                 maxCount: this.options.redundancyFactor,
-                excludedNodeIds: excludedNode !== undefined ? new Set([getNodeIdFromPeerDescriptor(excludedNode)]) : undefined
+                excludedNodeIds: excludedNode !== undefined ? new Set([toNodeId(excludedNode)]) : undefined
             }
         )
     }

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -11,7 +11,7 @@ import {
 import { IStoreRpc } from '../../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../../rpc-protocol/DhtCallContext'
 import { LocalDataStore } from './LocalDataStore'
-import { areEqualPeerDescriptors, DhtAddress, getDhtAddressFromRaw } from '../../identifiers'
+import { areEqualPeerDescriptors, DhtAddress, toDhtAddress } from '../../identifiers'
 
 interface StoreRpcLocalOptions {
     localDataStore: LocalDataStore
@@ -32,7 +32,7 @@ export class StoreRpcLocal implements IStoreRpc {
 
     async storeData(request: StoreDataRequest): Promise<StoreDataResponse> {
         logger.trace('storeData()')
-        const key = getDhtAddressFromRaw(request.key)
+        const key = toDhtAddress(request.key)
         const isLocalNodeStorer = this.isLocalNodeStorer(key)
         this.options.localDataStore.storeEntry({ 
             key: request.key,
@@ -57,7 +57,7 @@ export class StoreRpcLocal implements IStoreRpc {
         if (wasStored) {
             this.replicateDataToNeighbors((context as DhtCallContext).incomingSourceDescriptor!, request.entry!)
         }
-        const key = getDhtAddressFromRaw(dataEntry.key)
+        const key = toDhtAddress(dataEntry.key)
         if (!this.isLocalNodeStorer(key)) {
             this.options.localDataStore.setAllEntriesAsStale(key)
         }
@@ -70,7 +70,7 @@ export class StoreRpcLocal implements IStoreRpc {
     }
 
     private replicateDataToNeighbors(requestor: PeerDescriptor, dataEntry: DataEntry): void {
-        const dataKey = getDhtAddressFromRaw(dataEntry.key)
+        const dataKey = toDhtAddress(dataEntry.key)
         const storers = this.options.getStorers(dataKey)
         const isLocalNodePrimaryStorer = areEqualPeerDescriptors(storers[0], this.options.localPeerDescriptor)
         // If we are the closest to the data, get storageRedundancyFactor - 1 nearest node to the data, and

--- a/packages/dht/src/dht/store/StoreRpcRemote.ts
+++ b/packages/dht/src/dht/store/StoreRpcRemote.ts
@@ -1,4 +1,4 @@
-import { getNodeIdFromPeerDescriptor } from '../../identifiers'
+import { toNodeId } from '../../identifiers'
 import {
     ReplicateDataRequest,
     StoreDataRequest
@@ -13,8 +13,8 @@ export class StoreRpcRemote extends RpcRemote<StoreRpcClient> {
         try {
             await this.getClient().storeData(request, options)
         } catch (err) {
-            const to = getNodeIdFromPeerDescriptor(this.getPeerDescriptor())
-            const from = getNodeIdFromPeerDescriptor(this.getLocalPeerDescriptor())
+            const to = toNodeId(this.getPeerDescriptor())
+            const from = toNodeId(this.getLocalPeerDescriptor())
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             throw new Error(`Could not store data to ${to} from ${from} ${err}`)
         }

--- a/packages/dht/src/exports.ts
+++ b/packages/dht/src/exports.ts
@@ -25,9 +25,9 @@ export { createOutgoingHandshaker } from './connection/Handshaker'
 export { 
     DhtAddress,
     DhtAddressRaw,
-    getDhtAddressFromRaw,
-    getRawFromDhtAddress,
-    createRandomDhtAddress,
+    toDhtAddress,
+    toDhtAddressRaw,
+    randomDhtAddress,
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor
+    toNodeId
 } from './identifiers'

--- a/packages/dht/src/helpers/createPeerDescriptor.ts
+++ b/packages/dht/src/helpers/createPeerDescriptor.ts
@@ -5,7 +5,7 @@ import {
 import crypto from 'crypto'
 import { isBrowserEnvironment } from '../helpers/browser/isBrowserEnvironment'
 import { createPeerDescriptorSignaturePayload } from '../helpers/createPeerDescriptorSignaturePayload'
-import { DhtAddress, DhtAddressRaw, getRawFromDhtAddress } from '../identifiers'
+import { DhtAddress, DhtAddressRaw, toDhtAddressRaw } from '../identifiers'
 import {
     ConnectivityResponse,
     NodeType,
@@ -34,7 +34,7 @@ export const createPeerDescriptor = (connectivityResponse: ConnectivityResponse,
     const publicKey = crypto.randomBytes(20)  // TODO calculate publicKey from privateKey
     let nodeIdRaw: DhtAddressRaw
     if (nodeId !== undefined) {
-        nodeIdRaw = getRawFromDhtAddress(nodeId)
+        nodeIdRaw = toDhtAddressRaw(nodeId)
     } else {
         nodeIdRaw = calculateNodeIdRaw(connectivityResponse.ipAddress, privateKey)
     }

--- a/packages/dht/src/identifiers.ts
+++ b/packages/dht/src/identifiers.ts
@@ -8,22 +8,22 @@ export const KADEMLIA_ID_LENGTH_IN_BYTES = 20
 export type DhtAddress = BrandedString<'DhtAddress'>
 export type DhtAddressRaw = Uint8Array
 
-export const getDhtAddressFromRaw = (raw: DhtAddressRaw): DhtAddress => {
+export const toDhtAddress = (raw: DhtAddressRaw): DhtAddress => {
     return binaryToHex(raw) as unknown as DhtAddress
 }
 
-export const getRawFromDhtAddress = (address: DhtAddress): DhtAddressRaw => {
+export const toDhtAddressRaw = (address: DhtAddress): DhtAddressRaw => {
     return hexToBinary(address) as unknown as DhtAddressRaw
 }
 
-export const getNodeIdFromPeerDescriptor = (peerDescriptor: PeerDescriptor): DhtAddress => {
-    return getDhtAddressFromRaw(peerDescriptor.nodeId)
+export const toNodeId = (peerDescriptor: PeerDescriptor): DhtAddress => {
+    return toDhtAddress(peerDescriptor.nodeId)
 }
 
 export const areEqualPeerDescriptors = (peerDescriptor1: PeerDescriptor, peerDescriptor2: PeerDescriptor): boolean => {
     return areEqualBinaries(peerDescriptor1.nodeId, peerDescriptor2.nodeId)
 }
 
-export const createRandomDhtAddress = (): DhtAddress => {
-    return getDhtAddressFromRaw(crypto.randomBytes(KADEMLIA_ID_LENGTH_IN_BYTES))
+export const randomDhtAddress = (): DhtAddress => {
+    return toDhtAddress(crypto.randomBytes(KADEMLIA_ID_LENGTH_IN_BYTES))
 }

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -6,7 +6,7 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import { Logger, wait } from '@streamr/utils'
 import { debugVars } from '../../src/helpers/debugHelpers'
-import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toDhtAddress, toNodeId } from '../../src/identifiers'
 
 const logger = new Logger(module)
 
@@ -26,10 +26,10 @@ describe('Find correctness', () => {
     beforeEach(async () => {
 
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[0].data)), undefined)
+        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)), undefined)
 
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[i].data)), undefined)
+            const node = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[i].data)), undefined)
             nodes.push(node)
         }
     })
@@ -55,7 +55,7 @@ describe('Find correctness', () => {
         debugVars['waiting'] = false
         logger.info('waiting over')
 
-        nodes.forEach((node) => logger.info(getNodeIdFromPeerDescriptor(node.getLocalPeerDescriptor()) + ': connections:' +
+        nodes.forEach((node) => logger.info(toNodeId(node.getLocalPeerDescriptor()) + ': connections:' +
             node.getConnectionsView().getConnectionCount() + ', kbucket: ' + node.getNeighborCount()
             + ', localLocked: ' + node.getLocalLockedConnectionCount()
             + ', remoteLocked: ' + node.getRemoteLockedConnectionCount()
@@ -63,10 +63,10 @@ describe('Find correctness', () => {
 
         logger.info('starting find')
         const targetId = Uint8Array.from(dhtIds[9].data)
-        const closestNodes = await nodes[159].findClosestNodesFromDht(getDhtAddressFromRaw(targetId))
+        const closestNodes = await nodes[159].findClosestNodesFromDht(toDhtAddress(targetId))
         logger.info('find over')
         expect(closestNodes).toBeGreaterThanOrEqual(5)
-        expect(getDhtAddressFromRaw(targetId)).toEqual(getNodeIdFromPeerDescriptor(closestNodes[0]))
+        expect(toDhtAddress(targetId)).toEqual(toNodeId(closestNodes[0]))
 
     }, 180000)
 })

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -4,7 +4,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { execSync } from 'child_process'
 import fs from 'fs'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 import { Logger } from '@streamr/utils'
 
 const logger = new Logger(module)
@@ -28,12 +28,12 @@ describe('Kademlia correctness', () => {
 
     beforeEach(async () => {
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[0].data)), 8)
+        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)), 8)
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId()] = 0
 
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[i].data)))
+            const node = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[i].data)))
             nodeIndicesById[node.getNodeId()] = i
             nodes.push(node)
         }
@@ -68,7 +68,7 @@ describe('Kademlia correctness', () => {
                 groundTruthString += groundTruth[i + ''][j].name + ','
             }
 
-            const kademliaNeighbors = nodes[i].getClosestContacts(8).map((p) => getNodeIdFromPeerDescriptor(p))
+            const kademliaNeighbors = nodes[i].getClosestContacts(8).map((p) => toNodeId(p))
 
             let kadString = 'kademliaNeighbors: '
             kademliaNeighbors.forEach((neighbor) => {
@@ -84,7 +84,7 @@ describe('Kademlia correctness', () => {
                     correctNeighbors++
                 }
             } catch {
-                console.error('Node ' + getNodeIdFromPeerDescriptor(nodes[i].getLocalPeerDescriptor()) + ' had only ' 
+                console.error('Node ' + toNodeId(nodes[i].getLocalPeerDescriptor()) + ' had only ' 
                     + kademliaNeighbors.length + ' kademlia neighbors')
             }
             if (correctNeighbors === 0) {

--- a/packages/dht/test/benchmark/RingCorrectness.test.ts
+++ b/packages/dht/test/benchmark/RingCorrectness.test.ts
@@ -4,7 +4,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockRingNode } from '../utils/utils'
 import { execSync } from 'child_process'
 import fs from 'fs'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 import { Logger } from '@streamr/utils'
 import { getRingIdRawFromPeerDescriptor } from '../../src/dht/contact/ringIdentifiers'
 
@@ -43,12 +43,12 @@ describe('Ring correctness', () => {
     beforeEach(async () => {
         jest.setTimeout(60000)
         nodes = []
-        entryPoint = await createMockRingNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[0].data)), regions[0])
+        entryPoint = await createMockRingNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)), regions[0])
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId()] = 0
 
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockRingNode(simulator, getDhtAddressFromRaw(Uint8Array.from(dhtIds[i].data)), regions[i + 1])
+            const node = await createMockRingNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[i].data)), regions[i + 1])
             nodeIndicesById[node.getNodeId()] = i
             nodes.push(node)
         }
@@ -111,7 +111,7 @@ describe('Ring correctness', () => {
                 groundTruthString += groundTruth[i + ''][j].name + ','
             }
 
-            const kademliaNeighbors = nodes[i].getClosestContacts(8).map((p) => getNodeIdFromPeerDescriptor(p))
+            const kademliaNeighbors = nodes[i].getClosestContacts(8).map((p) => toNodeId(p))
 
             let kadString = 'kademliaNeighbors: '
             kademliaNeighbors.forEach((neighbor) => {
@@ -127,7 +127,7 @@ describe('Ring correctness', () => {
                     correctNeighbors++
                 }
             } catch {
-                console.error('Node ' + getNodeIdFromPeerDescriptor(nodes[i].getLocalPeerDescriptor()) + ' had only '
+                console.error('Node ' + toNodeId(nodes[i].getLocalPeerDescriptor()) + ' had only '
                     + kademliaNeighbors.length + ' kademlia neighbors')
             }
             if (correctNeighbors === 0) {

--- a/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
+++ b/packages/dht/test/benchmark/SortedContactListBenchmark.test.ts
@@ -2,7 +2,7 @@
 
 import KBucket from 'k-bucket'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
-import { DhtAddress, DhtAddressRaw, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, DhtAddressRaw, randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 
 const NUM_ADDS = 1000
 
@@ -13,8 +13,8 @@ interface Item {
 }
 
 const createRandomItem = (index: number): Item => {
-    const nodeId = createRandomDhtAddress()
-    const nodeIdRaw = getRawFromDhtAddress(nodeId)
+    const nodeId = randomDhtAddress()
+    const nodeIdRaw = toDhtAddressRaw(nodeId)
     return {
         getNodeId: () => nodeId,
         id: nodeIdRaw,
@@ -38,7 +38,7 @@ describe('SortedContactListBenchmark', () => {
             randomIds.push(createRandomItem(i))
         }
         const list = new SortedContactList({
-            referenceId: createRandomDhtAddress(),
+            referenceId: randomDhtAddress(),
             allowToContainReferenceId: true
         })
 
@@ -48,7 +48,7 @@ describe('SortedContactListBenchmark', () => {
         }
         console.timeEnd('SortedContactList.addContact()')
 
-        const kBucket = new KBucket<Item>({ localNodeId: getRawFromDhtAddress(createRandomDhtAddress()) })
+        const kBucket = new KBucket<Item>({ localNodeId: toDhtAddressRaw(randomDhtAddress()) })
         console.time('KBucket.add()')
         for (let i = 0; i < NUM_ADDS; i++) {
             kBucket.add(randomIds[i])
@@ -64,14 +64,14 @@ describe('SortedContactListBenchmark', () => {
 
         console.time('kBucket closest()')
         for (let i = 0; i < NUM_ADDS; i++) {
-            kBucket.closest(getRawFromDhtAddress(createRandomDhtAddress()), 20)
+            kBucket.closest(toDhtAddressRaw(randomDhtAddress()), 20)
         }
         console.timeEnd('kBucket closest()')
 
         console.time('SortedContactList.getClosestContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: createRandomDhtAddress(),
+                referenceId: randomDhtAddress(),
                 allowToContainReferenceId: true
             })
 
@@ -84,7 +84,7 @@ describe('SortedContactListBenchmark', () => {
         console.time('SortedContactList.getClosestContacts() and addContacts()')
         for (let i = 0; i < NUM_ADDS; i++) {
             const closest = new SortedContactList<Item>({
-                referenceId: createRandomDhtAddress(),
+                referenceId: randomDhtAddress(),
                 allowToContainReferenceId: true
             })
 
@@ -97,10 +97,10 @@ describe('SortedContactListBenchmark', () => {
         const shuffled = shuffleArray(kBucket.toArray())
         console.time('kbucket add and closest')
         for (let i = 0; i < NUM_ADDS; i++) {
-            const bucket2 = new KBucket<Item>({ localNodeId: getRawFromDhtAddress(createRandomDhtAddress()) })
+            const bucket2 = new KBucket<Item>({ localNodeId: toDhtAddressRaw(randomDhtAddress()) })
 
             shuffled.forEach((contact) => bucket2.add(contact))
-            bucket2.closest(getRawFromDhtAddress(createRandomDhtAddress()), 20)
+            bucket2.closest(toDhtAddressRaw(randomDhtAddress()), 20)
         }
         console.timeEnd('kbucket add and closest')
 

--- a/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc-Layer1.test.ts
@@ -1,5 +1,5 @@
 import { DhtNode } from '../../src/dht/DhtNode'
-import { createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { randomDhtAddress, toNodeId } from '../../src/identifiers'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('Layer 1 on Layer 0 with mocked connections', () => {
@@ -26,25 +26,25 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
         layer0EntryPoint = new DhtNode({ peerDescriptor: entrypointDescriptor, websocketServerEnableTls: false })
 
-        const layer0Node1Id = createRandomDhtAddress()
+        const layer0Node1Id = randomDhtAddress()
         layer0Node1 = new DhtNode({
             nodeId: layer0Node1Id,
             entryPoints: [entrypointDescriptor]
         })
 
-        const layer0Node2Id = createRandomDhtAddress()
+        const layer0Node2Id = randomDhtAddress()
         layer0Node2 = new DhtNode({
             nodeId: layer0Node2Id,
             entryPoints: [entrypointDescriptor]
         })
 
-        const layer0Node3Id = createRandomDhtAddress()
+        const layer0Node3Id = randomDhtAddress()
         layer0Node3 = new DhtNode({
             nodeId: layer0Node3Id,
             entryPoints: [entrypointDescriptor]
         })
 
-        const layer0Node4Id = createRandomDhtAddress()
+        const layer0Node4Id = randomDhtAddress()
         layer0Node4 = new DhtNode({
             nodeId: layer0Node4Id,
             entryPoints: [entrypointDescriptor]
@@ -57,7 +57,7 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
         await layer0Node4.start()
 
         layer1EntryPoint = new DhtNode({
-            nodeId: getNodeIdFromPeerDescriptor(entrypointDescriptor),
+            nodeId: toNodeId(entrypointDescriptor),
             transport: layer0EntryPoint,
             connectionsView: layer0EntryPoint.getConnectionsView(),
             serviceId: 'layer1'

--- a/packages/dht/test/end-to-end/Layer0Webrtc.test.ts
+++ b/packages/dht/test/end-to-end/Layer0Webrtc.test.ts
@@ -3,7 +3,7 @@ import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
-import { getNodeIdFromPeerDescriptor } from '../../src/exports'
+import { toNodeId } from '../../src/exports'
 
 describe('Layer0 with WebRTC connections', () => {
 
@@ -64,8 +64,8 @@ describe('Layer0 with WebRTC connections', () => {
             node2.joinDht([epPeerDescriptor]),
             node1.joinDht([epPeerDescriptor])
         ])
-        const nodeId1 = getNodeIdFromPeerDescriptor(node1.getLocalPeerDescriptor())
-        const nodeId2 = getNodeIdFromPeerDescriptor(node2.getLocalPeerDescriptor())
+        const nodeId1 = toNodeId(node1.getLocalPeerDescriptor())
+        const nodeId2 = toNodeId(node2.getLocalPeerDescriptor())
         expect((node1.getTransport() as ConnectionManager).hasConnection(nodeId2)).toEqual(true)
         expect((node2.getTransport() as ConnectionManager).hasConnection(nodeId1)).toEqual(true)
     }, 60000)
@@ -77,8 +77,8 @@ describe('Layer0 with WebRTC connections', () => {
             node3.joinDht([epPeerDescriptor]),
             node4.joinDht([epPeerDescriptor])
         ])
-        const nodeId1 = getNodeIdFromPeerDescriptor(node1.getLocalPeerDescriptor())
-        const nodeId2 = getNodeIdFromPeerDescriptor(node2.getLocalPeerDescriptor())
+        const nodeId1 = toNodeId(node1.getLocalPeerDescriptor())
+        const nodeId2 = toNodeId(node2.getLocalPeerDescriptor())
         expect((node1.getTransport() as ConnectionManager).hasConnection(nodeId2)).toEqual(true)
         expect((node2.getTransport() as ConnectionManager).hasConnection(nodeId1)).toEqual(true)
     })

--- a/packages/dht/test/end-to-end/memory-leak.test.ts
+++ b/packages/dht/test/end-to-end/memory-leak.test.ts
@@ -4,7 +4,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { Message } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 
 const MESSAGE_ID = 'mock-message-id'
 
@@ -19,7 +19,7 @@ describe('memory leak', () => {
             }
         })
         let entryPoint: DhtNode | undefined = new DhtNode({
-            nodeId: getNodeIdFromPeerDescriptor(entryPointDescriptor),
+            nodeId: toNodeId(entryPointDescriptor),
             websocketHost: entryPointDescriptor.websocket!.host,
             websocketPortRange: {
                 min: entryPointDescriptor.websocket!.port,

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -7,7 +7,7 @@ import { ITransport } from '../../src/transport/ITransport'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { getRandomRegion } from '../../dist/src/connection/simulator/pings'
 import { createMockPeerDescriptor } from '../utils/utils'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 
 const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport: ITransport) => {
     return new ConnectionManager({
@@ -56,8 +56,8 @@ describe('Connection Locking', () => {
     })
 
     it('can lock connections', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
@@ -68,8 +68,8 @@ describe('Connection Locking', () => {
     })
 
     it('Multiple services on the same peer', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
@@ -84,8 +84,8 @@ describe('Connection Locking', () => {
     })
 
     it('can unlock connections', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
@@ -101,8 +101,8 @@ describe('Connection Locking', () => {
     })
 
     it('unlocking multiple services', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
@@ -124,8 +124,8 @@ describe('Connection Locking', () => {
     })
 
     it('maintains connection if both sides initially lock and then one end unlocks', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             waitForCondition(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),
@@ -149,8 +149,8 @@ describe('Connection Locking', () => {
     })
 
     it('unlocks after graceful disconnect', async () => {
-        const nodeId1 = getNodeIdFromPeerDescriptor(mockPeerDescriptor1)
-        const nodeId2 = getNodeIdFromPeerDescriptor(mockPeerDescriptor2)
+        const nodeId1 = toNodeId(mockPeerDescriptor1)
+        const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             waitForCondition(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             waitForCondition(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -5,7 +5,7 @@ import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import { createPeerDescriptor } from '../../src/helpers/createPeerDescriptor'
-import { createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 import { ConnectivityResponse, Message, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { TransportEvents } from '../../src/transport/ITransport'
@@ -383,7 +383,7 @@ describe('ConnectionManager', () => {
             messageId: '1',
             targetDescriptor: {
                 // This is not the correct nodeId of peerDescriptor2
-                nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+                nodeId: toDhtAddressRaw(randomDhtAddress()),
                 type: NodeType.NODEJS,
                 websocket: peerDescriptor2.websocket
             },

--- a/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
+++ b/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
@@ -1,7 +1,7 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { getDhtAddressFromRaw } from '../../src/identifiers'
+import { toDhtAddress } from '../../src/identifiers'
 import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
 
 const NUM_OF_NODES_PER_KBUCKET = 8
@@ -11,7 +11,7 @@ const runTest = async (latencyType: LatencyType) => {
     const entrypointDescriptor = createMockPeerDescriptor({
         region: getRandomRegion()
     })
-    const entryPoint = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(entrypointDescriptor.nodeId), NUM_OF_NODES_PER_KBUCKET)
+    const entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(entrypointDescriptor.nodeId), NUM_OF_NODES_PER_KBUCKET)
     const nodes: DhtNode[] = []
     for (let i = 1; i < 100; i++) {
         const node = await createMockConnectionDhtNode(simulator, undefined, NUM_OF_NODES_PER_KBUCKET)

--- a/packages/dht/test/integration/DhtNode.test.ts
+++ b/packages/dht/test/integration/DhtNode.test.ts
@@ -1,7 +1,7 @@
 import { waitForCondition } from '@streamr/utils'
 import { range, without } from 'lodash'
 import { DhtNodeRpcLocal } from '../../src/dht/DhtNodeRpcLocal'
-import { DhtNode, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '../../src/exports'
+import { DhtNode, ListeningRpcCommunicator, toNodeId } from '../../src/exports'
 import { ClosestPeersRequest, ClosestPeersResponse, PeerDescriptor, PingRequest, PingResponse } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { FakeEnvironment } from '../utils/FakeTransport'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -59,8 +59,8 @@ describe('DhtNode', () => {
         await localNode.waitForNetworkConnectivity()
 
         await waitForCondition(() => localNode.getNeighborCount() === otherPeerDescriptors.length + 1)
-        const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => getNodeIdFromPeerDescriptor(n))
-        const actualNodeIds = localNode.getClosestContacts().map((n) => getNodeIdFromPeerDescriptor(n))
+        const expectedNodeIds = without(getAllPeerDescriptors(), localPeerDescriptor).map((n) => toNodeId(n))
+        const actualNodeIds = localNode.getClosestContacts().map((n) => toNodeId(n))
         expect(actualNodeIds).toIncludeSameMembers(expectedNodeIds)
     })
 })

--- a/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
+++ b/packages/dht/test/integration/DhtNodeExternalAPI.test.ts
@@ -1,6 +1,6 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { createRandomDhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { randomDhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { createMockConnectionDhtNode } from '../utils/utils'
 
@@ -27,22 +27,22 @@ describe('DhtNodeExternalApi', () => {
 
     it('fetch data happy path', async () => {
         const entry = createMockDataEntry()
-        await dhtNode1.storeDataToDht(getDhtAddressFromRaw(entry.key), entry.data!)
-        const foundData = await remote.fetchDataFromDhtViaPeer(getDhtAddressFromRaw(entry.key), dhtNode1.getLocalPeerDescriptor())
+        await dhtNode1.storeDataToDht(toDhtAddress(entry.key), entry.data!)
+        const foundData = await remote.fetchDataFromDhtViaPeer(toDhtAddress(entry.key), dhtNode1.getLocalPeerDescriptor())
         expectEqualData(foundData[0], entry)
     })
     
     it('fetch data returns empty array if no data found', async () => {
-        const foundData = await remote.fetchDataFromDhtViaPeer(createRandomDhtAddress(), dhtNode1.getLocalPeerDescriptor())
+        const foundData = await remote.fetchDataFromDhtViaPeer(randomDhtAddress(), dhtNode1.getLocalPeerDescriptor())
         expect(foundData).toEqual([])
     })
 
     it('external store data happy path', async () => {
         const entry = createMockDataEntry()
-        await remote.storeDataToDhtViaPeer(getDhtAddressFromRaw(entry.key), entry.data!, dhtNode1.getLocalPeerDescriptor())
-        const foundData = await remote.fetchDataFromDhtViaPeer(getDhtAddressFromRaw(entry.key), dhtNode1.getLocalPeerDescriptor())
+        await remote.storeDataToDhtViaPeer(toDhtAddress(entry.key), entry.data!, dhtNode1.getLocalPeerDescriptor())
+        const foundData = await remote.fetchDataFromDhtViaPeer(toDhtAddress(entry.key), dhtNode1.getLocalPeerDescriptor())
         expectEqualData(foundData[0], entry)
-        expect(getDhtAddressFromRaw(foundData[0].creator)).toEqual(getNodeIdFromPeerDescriptor(remote.getLocalPeerDescriptor()))
+        expect(toDhtAddress(foundData[0].creator)).toEqual(toNodeId(remote.getLocalPeerDescriptor()))
     })
   
 })

--- a/packages/dht/test/integration/DhtNodeRpcRemote.test.ts
+++ b/packages/dht/test/integration/DhtNodeRpcRemote.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 
 const SERVICE_ID = 'test'
 
@@ -47,7 +47,7 @@ describe('DhtNodeRpcRemote', () => {
     })
 
     it('getClosestPeers happy path', async () => {
-        const neighbors = await rpcRemote.getClosestPeers(getNodeIdFromPeerDescriptor(clientPeerDescriptor))
+        const neighbors = await rpcRemote.getClosestPeers(toNodeId(clientPeerDescriptor))
         expect(neighbors.length).toEqual(createMockPeers().length)
     })
 
@@ -59,7 +59,7 @@ describe('DhtNodeRpcRemote', () => {
 
     it('getClosestPeers error path', async () => {
         serverRpcCommunicator.registerRpcMethod(ClosestPeersRequest, ClosestPeersResponse, 'getClosestPeers', mockDhtRpc.throwGetClosestPeersError)
-        await expect(rpcRemote.getClosestPeers(getNodeIdFromPeerDescriptor(clientPeerDescriptor)))
+        await expect(rpcRemote.getClosestPeers(toNodeId(clientPeerDescriptor)))
             .rejects.toThrow('Closest peers error')
     })
 

--- a/packages/dht/test/integration/DhtRpc.test.ts
+++ b/packages/dht/test/integration/DhtRpc.test.ts
@@ -4,7 +4,7 @@ import { DhtNodeRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.cli
 import { ClosestPeersRequest, ClosestPeersResponse } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { wait } from '@streamr/utils'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
 
 describe('DhtRpc', () => {
@@ -53,7 +53,7 @@ describe('DhtRpc', () => {
             }
         )
         const res1 = await response1
-        expect(res1.peers.map((p) => getNodeIdFromPeerDescriptor(p))).toEqual(neighbors.map((n) => getNodeIdFromPeerDescriptor(n)))
+        expect(res1.peers.map((p) => toNodeId(p))).toEqual(neighbors.map((n) => toNodeId(n)))
 
         const response2 = client2.getClosestPeers(
             { nodeId: peerDescriptor2.nodeId, requestId: '1' },
@@ -63,7 +63,7 @@ describe('DhtRpc', () => {
             }
         )
         const res2 = await response2
-        expect(res2.peers.map((p) => getNodeIdFromPeerDescriptor(p))).toEqual(neighbors.map((n) => getNodeIdFromPeerDescriptor(n)))
+        expect(res2.peers.map((p) => toNodeId(p))).toEqual(neighbors.map((n) => toNodeId(n)))
     })
 
     it('Default RPC timeout, client side', async () => {

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -2,7 +2,7 @@ import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
-import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { toDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 
 const NUM_NODES = 100
 const K = 8
@@ -36,10 +36,10 @@ describe('Find correctness', () => {
     })
 
     it('Entrypoint can find a node from the network (exact match)', async () => {
-        const targetId = getRawFromDhtAddress(nodes[45].getNodeId())
-        const closestNodes = await entryPoint.findClosestNodesFromDht(getDhtAddressFromRaw(targetId))
+        const targetId = toDhtAddressRaw(nodes[45].getNodeId())
+        const closestNodes = await entryPoint.findClosestNodesFromDht(toDhtAddress(targetId))
         expect(closestNodes.length).toBeGreaterThanOrEqual(5)
-        expect(getDhtAddressFromRaw(targetId)).toEqual(getNodeIdFromPeerDescriptor(closestNodes[0]))
+        expect(toDhtAddress(targetId)).toEqual(toNodeId(closestNodes[0]))
     }, 90000)
 
 })

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -1,6 +1,6 @@
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { getDhtAddressFromRaw } from '../../src/identifiers'
+import { toDhtAddress } from '../../src/identifiers'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node, createMockPeerDescriptor } from '../utils/utils'
 
 const NODE_COUNT = 48
@@ -16,7 +16,7 @@ describe('Layer1', () => {
 
     beforeEach(async () => {
         simulator = new Simulator()
-        layer0EntryPoint = await createMockConnectionDhtNode(simulator, getDhtAddressFromRaw(entryPoint0Descriptor.nodeId))
+        layer0EntryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(entryPoint0Descriptor.nodeId))
         await layer0EntryPoint.joinDht([entryPoint0Descriptor])
 
         nodes = []

--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -2,7 +2,7 @@ import { Logger } from '@streamr/utils'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node } from '../utils/utils'
-import { createRandomDhtAddress } from '../../src/identifiers'
+import { randomDhtAddress } from '../../src/identifiers'
 
 const logger = new Logger(module)
 
@@ -22,11 +22,11 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
 
     beforeEach(async () => {
 
-        layer0EntryPoint = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
-        layer0Node1 = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
-        layer0Node2 = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
-        layer0Node3 = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
-        layer0Node4 = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
+        layer0EntryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress())
+        layer0Node1 = await createMockConnectionDhtNode(simulator, randomDhtAddress())
+        layer0Node2 = await createMockConnectionDhtNode(simulator, randomDhtAddress())
+        layer0Node3 = await createMockConnectionDhtNode(simulator, randomDhtAddress())
+        layer0Node4 = await createMockConnectionDhtNode(simulator, randomDhtAddress())
 
         layer1EntryPoint = await createMockConnectionLayer1Node(layer0EntryPoint)
 

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -4,7 +4,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
-import { DhtAddress, createRandomDhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 import { sample } from 'lodash'
 import { DataEntry, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 
@@ -17,7 +17,7 @@ const ENTRY_POINT_INDEX = 0
 const getDataEntries = (node: DhtNode): DataEntry[] => {
     // @ts-expect-error private field
     const store = node.localDataStore
-    return Array.from(store.values(getDhtAddressFromRaw(DATA.key)))
+    return Array.from(store.values(toDhtAddress(DATA.key)))
 }
 
 describe('Replicate data from node to node in DHT', () => {
@@ -27,7 +27,7 @@ describe('Replicate data from node to node in DHT', () => {
     const simulator = new Simulator(LatencyType.FIXED, 20)
 
     beforeEach(async () => {
-        const entryPoint = await createMockConnectionDhtNode(simulator, createRandomDhtAddress(), K, MAX_CONNECTIONS)
+        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress(), K, MAX_CONNECTIONS)
         entryPointDescriptor = entryPoint.getLocalPeerDescriptor()
         await entryPoint.joinDht([entryPointDescriptor])
         nodes = []
@@ -35,7 +35,7 @@ describe('Replicate data from node to node in DHT', () => {
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(
                 simulator,
-                createRandomDhtAddress(),
+                randomDhtAddress(),
                 K,
                 MAX_CONNECTIONS
             )
@@ -54,14 +54,14 @@ describe('Replicate data from node to node in DHT', () => {
     it('Data replicates to the closest node no matter where it is stored', async () => {
         // calculate offline which node is closest to the data
         const sortedList = new SortedContactList<DhtNode>({ 
-            referenceId: getDhtAddressFromRaw(DATA.key),
+            referenceId: toDhtAddress(DATA.key),
             maxSize: 10000, 
             allowToContainReferenceId: true
         })
         nodes.forEach((node) => sortedList.addContact(node))
 
         const closest = sortedList.getClosestContacts()
-        const successfulStorers = await nodes[0].storeDataToDht(getDhtAddressFromRaw(DATA.key), DATA.data!)
+        const successfulStorers = await nodes[0].storeDataToDht(toDhtAddress(DATA.key), DATA.data!)
         expect(successfulStorers.length).toBe(1)
 
         await Promise.all(
@@ -89,16 +89,16 @@ describe('Replicate data from node to node in DHT', () => {
         await waitForStableTopology(nodes)
 
         const randomIndex = Math.floor(Math.random() * nodes.length)
-        const storerDescriptors = await nodes[randomIndex].storeDataToDht(getDhtAddressFromRaw(DATA.key), DATA.data!)
+        const storerDescriptors = await nodes[randomIndex].storeDataToDht(toDhtAddress(DATA.key), DATA.data!)
         const stoppedNodeIds: DhtAddress[] = []
         await Promise.all(storerDescriptors.map(async (storerDescriptor) => {
-            const storer = nodes.find((n) => n.getNodeId() === getNodeIdFromPeerDescriptor(storerDescriptor))!
+            const storer = nodes.find((n) => n.getNodeId() === toNodeId(storerDescriptor))!
             await storer.stop()
             stoppedNodeIds.push(storer.getNodeId())
         }))
 
         const randomNonStoppedNode = sample(nodes.filter((n) => !stoppedNodeIds.includes(n.getNodeId())))!
-        const data = await randomNonStoppedNode.fetchDataFromDht(getDhtAddressFromRaw(DATA.key))
+        const data = await randomNonStoppedNode.fetchDataFromDht(toDhtAddress(DATA.key))
         expect(data).toHaveLength(1)
         expectEqualData(data[0], DATA)
     }, 180000)

--- a/packages/dht/test/integration/RouteMessage.test.ts
+++ b/packages/dht/test/integration/RouteMessage.test.ts
@@ -7,7 +7,7 @@ import { Simulator } from '../../src/connection/simulator/Simulator'
 import { v4 } from 'uuid'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { RoutingMode } from '../../src/dht/routing/RoutingSession'
-import { DhtAddress, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 
 const logger = new Logger(module)
 
@@ -25,18 +25,18 @@ describe('Route Message With Mock Connections', () => {
     beforeEach(async () => {
         routerNodes = []
         simulator = new Simulator()
-        entryPoint = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
+        entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress())
 
         entryPointDescriptor = {
-            nodeId: getRawFromDhtAddress(entryPoint.getNodeId()),
+            nodeId: toDhtAddressRaw(entryPoint.getNodeId()),
             type: NodeType.NODEJS
         }
 
-        sourceNode = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
-        destinationNode = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
+        sourceNode = await createMockConnectionDhtNode(simulator, randomDhtAddress())
+        destinationNode = await createMockConnectionDhtNode(simulator, randomDhtAddress())
 
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, createRandomDhtAddress())
+            const node = await createMockConnectionDhtNode(simulator, randomDhtAddress())
             routerNodes.push(node)
         }
 

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -8,7 +8,7 @@ import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
 import { MockTransport } from '../utils/mock/MockTransport'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 
 const BASE_MESSAGE: Message = {
     serviceId: 'serviceId',
@@ -78,8 +78,8 @@ describe('SimultaneousConnections', () => {
             simTransport1.send(msg1),
             simTransport2.send(msg2)
         ])
-        await waitForCondition(() => simTransport2.hasConnection(getNodeIdFromPeerDescriptor(peerDescriptor1)))
-        await waitForCondition(() => simTransport1.hasConnection(getNodeIdFromPeerDescriptor(peerDescriptor2)))
+        await waitForCondition(() => simTransport2.hasConnection(toNodeId(peerDescriptor1)))
+        await waitForCondition(() => simTransport1.hasConnection(toNodeId(peerDescriptor2)))
     })
 
     describe('Websocket 2 servers', () => {
@@ -159,8 +159,8 @@ describe('SimultaneousConnections', () => {
                 connectionManager2.send(msg2)
             ])
 
-            await waitForCondition(() => connectionManager1.hasConnection(getNodeIdFromPeerDescriptor(wsPeerDescriptor2)))
-            await waitForCondition(() => connectionManager2.hasConnection(getNodeIdFromPeerDescriptor(wsPeerDescriptor1)))
+            await waitForCondition(() => connectionManager1.hasConnection(toNodeId(wsPeerDescriptor2)))
+            await waitForCondition(() => connectionManager2.hasConnection(toNodeId(wsPeerDescriptor1)))
         })
     })
 
@@ -239,8 +239,8 @@ describe('SimultaneousConnections', () => {
                 connectionManager2.send(msg2)
             ])
 
-            await waitForCondition(() => connectionManager1.hasConnection(getNodeIdFromPeerDescriptor(wsPeerDescriptor2)))
-            await waitForCondition(() => connectionManager2.hasConnection(getNodeIdFromPeerDescriptor(wsPeerDescriptor1)))
+            await waitForCondition(() => connectionManager1.hasConnection(toNodeId(wsPeerDescriptor2)))
+            await waitForCondition(() => connectionManager2.hasConnection(toNodeId(wsPeerDescriptor1)))
         })
     })
 
@@ -307,8 +307,8 @@ describe('SimultaneousConnections', () => {
                 connectionManager2.send(msg2)
             ])
 
-            await waitForCondition(() => connectionManager1.hasConnection(getNodeIdFromPeerDescriptor(wrtcPeerDescriptor2)))
-            await waitForCondition(() => connectionManager2.hasConnection(getNodeIdFromPeerDescriptor(wrtcPeerDescriptor1)))
+            await waitForCondition(() => connectionManager1.hasConnection(toNodeId(wrtcPeerDescriptor2)))
+            await waitForCondition(() => connectionManager2.hasConnection(toNodeId(wrtcPeerDescriptor1)))
         })
     })
 

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -1,6 +1,6 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toDhtAddress, toNodeId } from '../../src/identifiers'
 import { PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { createMockConnectionDhtNode, createMockPeerDescriptor, waitForStableTopology } from '../utils/utils'
@@ -44,7 +44,7 @@ describe('Storing data in DHT', () => {
         const storingNodeIndex = 34
         const entry = createMockDataEntry()
         const successfulStorers = await nodes[storingNodeIndex].storeDataToDht(
-            getDhtAddressFromRaw(entry.key),
+            toDhtAddress(entry.key),
             entry.data!
         )
         expect(successfulStorers.length).toBeGreaterThan(4)
@@ -54,12 +54,12 @@ describe('Storing data in DHT', () => {
         const storingNode = getRandomNode()
         const entry = createMockDataEntry()
         const successfulStorers = await storingNode.storeDataToDht(
-            getDhtAddressFromRaw(entry.key),
+            toDhtAddress(entry.key),
             entry.data!
         )
         expect(successfulStorers.length).toBeGreaterThan(4)
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.fetchDataFromDht(getDhtAddressFromRaw(entry.key))
+        const results = await fetchingNode.fetchDataFromDht(toDhtAddress(entry.key))
         results.forEach((result) => {
             expectEqualData(result, entry)
         })
@@ -70,16 +70,16 @@ describe('Storing data in DHT', () => {
         const entry = createMockDataEntry()
         const requestor = createMockPeerDescriptor()
         const successfulStorers = await storingNode.storeDataToDht(
-            getDhtAddressFromRaw(entry.key),
+            toDhtAddress(entry.key),
             entry.data!,
-            getDhtAddressFromRaw(requestor.nodeId)
+            toDhtAddress(requestor.nodeId)
         )
         expect(successfulStorers.length).toBeGreaterThan(4)
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.fetchDataFromDht(getDhtAddressFromRaw(entry.key))
+        const results = await fetchingNode.fetchDataFromDht(toDhtAddress(entry.key))
         results.forEach((result) => {
             expectEqualData(result, entry)
-            expect(getDhtAddressFromRaw(result.creator)).toEqual(getNodeIdFromPeerDescriptor(requestor))
+            expect(toDhtAddress(result.creator)).toEqual(toNodeId(requestor))
         })
     }, 30000)
 })

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -2,7 +2,7 @@ import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator
 import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
-import { createRandomDhtAddress, getDhtAddressFromRaw } from '../../src/identifiers'
+import { randomDhtAddress, toDhtAddress } from '../../src/identifiers'
 import { wait } from '@streamr/utils'
 
 const NUM_NODES = 5
@@ -21,7 +21,7 @@ describe('Storing data in DHT', () => {
     beforeEach(async () => {
         nodes = []
         const entryPoint = await createMockConnectionDhtNode(simulator,
-            createRandomDhtAddress(), K, MAX_CONNECTIONS)
+            randomDhtAddress(), K, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(simulator, 
@@ -39,13 +39,13 @@ describe('Storing data in DHT', () => {
     it('Data can be deleted', async () => {
         const storingNode = getRandomNode()
         const entry = createMockDataEntry()
-        const successfulStorers = await storingNode.storeDataToDht(getDhtAddressFromRaw(entry.key), entry.data!)
+        const successfulStorers = await storingNode.storeDataToDht(toDhtAddress(entry.key), entry.data!)
         expect(successfulStorers.length).toBeGreaterThan(4)
-        await storingNode.deleteDataFromDht(getDhtAddressFromRaw(entry.key), true)
+        await storingNode.deleteDataFromDht(toDhtAddress(entry.key), true)
         // Wait for the delete operation to propagate
         await wait(500)
         const fetchingNode = getRandomNode()
-        const results = await fetchingNode.fetchDataFromDht(getDhtAddressFromRaw(entry.key))
+        const results = await fetchingNode.fetchDataFromDht(toDhtAddress(entry.key))
         results.forEach((result) => {
             expect(result.deleted).toBeTrue()
             expectEqualData(result, entry)
@@ -55,20 +55,20 @@ describe('Storing data in DHT', () => {
     it('Data can be deleted and re-stored', async () => {
         const storingNode = getRandomNode()
         const entry = createMockDataEntry()
-        const successfulStorers1 = await storingNode.storeDataToDht(getDhtAddressFromRaw(entry.key), entry.data!)
+        const successfulStorers1 = await storingNode.storeDataToDht(toDhtAddress(entry.key), entry.data!)
         expect(successfulStorers1.length).toBeGreaterThan(4)
-        await storingNode.deleteDataFromDht(getDhtAddressFromRaw(entry.key), true)
+        await storingNode.deleteDataFromDht(toDhtAddress(entry.key), true)
         // Wait for the delete operation to propagate
         await wait(500)
         const fetchingNode = getRandomNode()
-        const results1 = await fetchingNode.fetchDataFromDht(getDhtAddressFromRaw(entry.key))
+        const results1 = await fetchingNode.fetchDataFromDht(toDhtAddress(entry.key))
         results1.forEach((result) => {
             expect(result.deleted).toBeTrue()
             expectEqualData(result, entry)
         })
-        const successfulStorers2 = await storingNode.storeDataToDht(getDhtAddressFromRaw(entry.key), entry.data!)
+        const successfulStorers2 = await storingNode.storeDataToDht(toDhtAddress(entry.key), entry.data!)
         expect(successfulStorers2.length).toBeGreaterThan(4)
-        const results2 = await fetchingNode.fetchDataFromDht(getDhtAddressFromRaw(entry.key))
+        const results2 = await fetchingNode.fetchDataFromDht(toDhtAddress(entry.key))
         results2.forEach((result) => {
             expect(result.deleted).toBeFalse()
             expectEqualData(result, entry)

--- a/packages/dht/test/integration/StoreOnDhtWithThreeNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithThreeNodes.test.ts
@@ -2,7 +2,7 @@ import { createMockConnectionDhtNode } from '../utils/utils'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
-import { getDhtAddressFromRaw } from '../../src/identifiers'
+import { toDhtAddress } from '../../src/identifiers'
 
 describe('Storing data in DHT with two peers', () => {
 
@@ -41,15 +41,15 @@ describe('Storing data in DHT with two peers', () => {
         const storedData1 = createMockDataEntry()
         const storedData2 = createMockDataEntry()
         // Here we effectively test that fetching "null" data doesn't take too long. A test timeout here indicates an issue. 
-        await node1.fetchDataFromDht(getDhtAddressFromRaw(storedData1.key))
-        await node2.fetchDataFromDht(getDhtAddressFromRaw(storedData1.key))
+        await node1.fetchDataFromDht(toDhtAddress(storedData1.key))
+        await node2.fetchDataFromDht(toDhtAddress(storedData1.key))
         
-        await node1.storeDataToDht(getDhtAddressFromRaw(storedData1.key), storedData1.data!)
-        await node2.storeDataToDht(getDhtAddressFromRaw(storedData1.key), storedData1.data!)
-        await entryPoint.storeDataToDht(getDhtAddressFromRaw(storedData2.key), storedData2.data!)
-        const foundData1 = await node1.fetchDataFromDht(getDhtAddressFromRaw(storedData1.key))
-        const foundData2 = await node2.fetchDataFromDht(getDhtAddressFromRaw(storedData1.key))
-        const foundData3 = await entryPoint.fetchDataFromDht(getDhtAddressFromRaw(storedData2.key))
+        await node1.storeDataToDht(toDhtAddress(storedData1.key), storedData1.data!)
+        await node2.storeDataToDht(toDhtAddress(storedData1.key), storedData1.data!)
+        await entryPoint.storeDataToDht(toDhtAddress(storedData2.key), storedData2.data!)
+        const foundData1 = await node1.fetchDataFromDht(toDhtAddress(storedData1.key))
+        const foundData2 = await node2.fetchDataFromDht(toDhtAddress(storedData1.key))
+        const foundData3 = await entryPoint.fetchDataFromDht(toDhtAddress(storedData2.key))
         expectEqualData(foundData1[0], storedData1)
         expectEqualData(foundData1[1], storedData1)
         expectEqualData(foundData2[0], storedData1)

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -3,7 +3,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { Simulator } from '../../src/connection/simulator/Simulator'
 import { waitForCondition } from '@streamr/utils'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
-import { getDhtAddressFromRaw } from '../../src/identifiers'
+import { toDhtAddress } from '../../src/identifiers'
 
 describe('Storing data in DHT with two peers', () => {
 
@@ -32,10 +32,10 @@ describe('Storing data in DHT with two peers', () => {
     it('Node can store on two peer DHT', async () => {
         const storedData1 = createMockDataEntry()
         const storedData2 = createMockDataEntry()
-        await otherNode.storeDataToDht(getDhtAddressFromRaw(storedData1.key), storedData1.data!)
-        await entryPoint.storeDataToDht(getDhtAddressFromRaw(storedData2.key), storedData2.data!)
-        const foundData1 = await otherNode.fetchDataFromDht(getDhtAddressFromRaw(storedData1.key))
-        const foundData2 = await entryPoint.fetchDataFromDht(getDhtAddressFromRaw(storedData2.key))
+        await otherNode.storeDataToDht(toDhtAddress(storedData1.key), storedData1.data!)
+        await entryPoint.storeDataToDht(toDhtAddress(storedData2.key), storedData2.data!)
+        const foundData1 = await otherNode.fetchDataFromDht(toDhtAddress(storedData1.key))
+        const foundData2 = await entryPoint.fetchDataFromDht(toDhtAddress(storedData2.key))
         expectEqualData(foundData1[0], storedData1)
         expectEqualData(foundData2[0], storedData2)
     })
@@ -44,8 +44,8 @@ describe('Storing data in DHT with two peers', () => {
         await otherNode.stop()
         await waitForCondition(() => entryPoint.getNeighborCount() === 0)
         const storedData = createMockDataEntry()
-        await entryPoint.storeDataToDht(getDhtAddressFromRaw(storedData.key), storedData.data!)
-        const foundData = await entryPoint.fetchDataFromDht(getDhtAddressFromRaw(storedData.key))
+        await entryPoint.storeDataToDht(toDhtAddress(storedData.key), storedData.data!)
+        const foundData = await entryPoint.fetchDataFromDht(toDhtAddress(storedData.key))
         expectEqualData(foundData[0], storedData)
     }, 60000)
 })

--- a/packages/dht/test/integration/StoreRpcRemote.test.ts
+++ b/packages/dht/test/integration/StoreRpcRemote.test.ts
@@ -9,7 +9,7 @@ import { StoreRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.clien
 import { StoreRpcRemote } from '../../src/dht/store/StoreRpcRemote'
 import { createMockDataEntry } from '../utils/mock/mockDataEntry'
 import { DhtCallContext } from '../../src/rpc-protocol/DhtCallContext'
-import { createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { randomDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 
 describe('StoreRpcRemote', () => {
 
@@ -22,7 +22,7 @@ describe('StoreRpcRemote', () => {
     const request: StoreDataRequest = {
         key: data.key,
         data: data.data,
-        creator: getRawFromDhtAddress(createRandomDhtAddress()),
+        creator: toDhtAddressRaw(randomDhtAddress()),
         ttl: 10
     }
 
@@ -47,7 +47,7 @@ describe('StoreRpcRemote', () => {
         serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', mockStoreRpc.throwStoreDataError)
         await expect(rpcRemote.storeData(request)).rejects.toThrowError(
             'Could not store data to'
-            + ` ${getNodeIdFromPeerDescriptor(serverPeerDescriptor)} from ${getNodeIdFromPeerDescriptor(clientPeerDescriptor)}`
+            + ` ${toNodeId(serverPeerDescriptor)} from ${toNodeId(clientPeerDescriptor)}`
             + ' Error: Mock'
         )
     })

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -9,7 +9,7 @@ import * as Err from '../../src/helpers/errors'
 import { Message, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RpcMessage } from '../../src/proto/packages/proto-rpc/protos/ProtoRpc'
 import { TransportEvents } from '../../src/transport/ITransport'
-import { getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { toNodeId } from '../../src/identifiers'
 
 const SERVICE_ID = 'test'
 
@@ -145,7 +145,7 @@ describe('Websocket Connection Management', () => {
             waitForEvent3<TransportEvents>(wsServerManager, 'disconnected', 15000),
             wsServerManager.send(dummyMessage)
         ])
-        expect(wsServerManager.hasConnection(getNodeIdFromPeerDescriptor(dummyMessage.targetDescriptor!))).toBeFalse()
+        expect(wsServerManager.hasConnection(toNodeId(dummyMessage.targetDescriptor!))).toBeFalse()
     }, 20000)
     
     it('Can open connections to peer with server', async () => {
@@ -161,12 +161,12 @@ describe('Websocket Connection Management', () => {
         await noWsServerManager.send(dummyMessage)
         await waitForCondition(
             () => {
-                const nodeId = getNodeIdFromPeerDescriptor(noWsServerConnectorPeerDescriptor)
+                const nodeId = toNodeId(noWsServerConnectorPeerDescriptor)
                 return wsServerManager.hasConnection(nodeId)
             }
         )
         await waitForCondition(
-            () => noWsServerManager.hasConnection(getNodeIdFromPeerDescriptor(wsServerConnectorPeerDescriptor))
+            () => noWsServerManager.hasConnection(toNodeId(wsServerConnectorPeerDescriptor))
         )
     })
 

--- a/packages/dht/test/unit/ConnectionManager.test.ts
+++ b/packages/dht/test/unit/ConnectionManager.test.ts
@@ -1,6 +1,6 @@
 import { MetricsContext } from '@streamr/utils'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
-import { getNodeIdFromPeerDescriptor, PendingConnection } from '../../src/exports'
+import { toNodeId, PendingConnection } from '../../src/exports'
 import { FakeConnectorFacade } from '../utils/FakeConnectorFacade'
 import { MockConnection } from '../utils/mock/MockConnection'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -30,7 +30,7 @@ describe('ConnetionManager', () => {
     it('should replace a duplicate connecting connection', () => {
         const remotePeerDescriptor = createMockPeerDescriptor()
         const pendingConnection1 = new PendingConnection(remotePeerDescriptor)
-        const offerer = getOfferer(getNodeIdFromPeerDescriptor(localPeerDescriptor), getNodeIdFromPeerDescriptor(remotePeerDescriptor))
+        const offerer = getOfferer(toNodeId(localPeerDescriptor), toNodeId(remotePeerDescriptor))
         const accepted1 = fakeConnectorFacade.callOnNewConnection(pendingConnection1)
         expect(accepted1).toBeTrue()
         const pendingConnection2 = new PendingConnection(remotePeerDescriptor)
@@ -45,7 +45,7 @@ describe('ConnetionManager', () => {
     it('should replace a duplicate connected connection', () => {
         const remotePeerDescriptor = createMockPeerDescriptor()
         const pendingConnection1 = new PendingConnection(remotePeerDescriptor)
-        const offerer = getOfferer(getNodeIdFromPeerDescriptor(localPeerDescriptor), getNodeIdFromPeerDescriptor(remotePeerDescriptor))
+        const offerer = getOfferer(toNodeId(localPeerDescriptor), toNodeId(remotePeerDescriptor))
         const accepted1 = fakeConnectorFacade.callOnNewConnection(pendingConnection1)
         expect(accepted1).toBeTrue()
         pendingConnection1.onHandshakeCompleted(new MockConnection())

--- a/packages/dht/test/unit/DiscoverySession.test.ts
+++ b/packages/dht/test/unit/DiscoverySession.test.ts
@@ -3,7 +3,7 @@ import { sampleSize } from 'lodash'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { PeerManager, getDistance } from '../../src/dht/PeerManager'
 import { DiscoverySession } from '../../src/dht/discovery/DiscoverySession'
-import { DhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createTestTopology } from '../utils/topology'
 import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
@@ -16,7 +16,7 @@ const QUERY_BATCH_SIZE = 5  // the default value in DhtNode's options, not relev
 
 const createPeerDescriptor = (nodeId: DhtAddress): PeerDescriptor => {
     return {
-        nodeId: getRawFromDhtAddress(nodeId),
+        nodeId: toDhtAddressRaw(nodeId),
         type: NodeType.NODEJS
     }
 }
@@ -45,9 +45,9 @@ describe('DiscoverySession', () => {
     }
 
     const createMockRpcRemote = (peerDescriptor: PeerDescriptor): Partial<DhtNodeRpcRemote> => {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         return {
-            id: getRawFromDhtAddress(nodeId),
+            id: toDhtAddressRaw(nodeId),
             getPeerDescriptor: () => peerDescriptor,
             getNodeId: () => nodeId,
             getClosestPeers: async (referenceId: DhtAddress) => {
@@ -79,7 +79,7 @@ describe('DiscoverySession', () => {
         // Each queried node should closer to the target than the previous queried node, because we
         // use parallelism=1 and noProgressLimit=1
         const distancesToTarget = queriedNodes
-            .map((nodeId) => getDistance(getRawFromDhtAddress(nodeId), getRawFromDhtAddress(targetId)))
+            .map((nodeId) => getDistance(toDhtAddressRaw(nodeId), toDhtAddressRaw(targetId)))
         for (let i = 1; i < distancesToTarget.length ; i++) {
             expect(distancesToTarget[i]).toBeLessThan(distancesToTarget[i - 1])
         }

--- a/packages/dht/test/unit/LocalDataStore.test.ts
+++ b/packages/dht/test/unit/LocalDataStore.test.ts
@@ -2,7 +2,7 @@ import { wait } from '@streamr/utils'
 import { LocalDataStore } from '../../src/dht/store/LocalDataStore'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { createMockDataEntry } from '../utils/mock/mockDataEntry'
-import { createRandomDhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { randomDhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 
 describe('LocalDataStore', () => {
 
@@ -19,14 +19,14 @@ describe('LocalDataStore', () => {
     it('can store', () => {
         const storedEntry = createMockDataEntry()
         localDataStore.storeEntry(storedEntry)
-        const fetchedEntries = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
+        const fetchedEntries = Array.from(localDataStore.values(toDhtAddress(storedEntry.key)))
         expect(fetchedEntries).toIncludeSameMembers([storedEntry])
     })
 
     it('multiple storers behind one key', () => {
-        const creator1 = createRandomDhtAddress()
-        const creator2 = createRandomDhtAddress()
-        const key = createRandomDhtAddress()
+        const creator1 = randomDhtAddress()
+        const creator2 = randomDhtAddress()
+        const key = randomDhtAddress()
         const storedEntry1 = createMockDataEntry({ key, creator: creator1 })
         const storedEntry2 = createMockDataEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
@@ -36,9 +36,9 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove data entries', () => {
-        const creator1 = createRandomDhtAddress()
-        const creator2 = createRandomDhtAddress()
-        const key = createRandomDhtAddress()
+        const creator1 = randomDhtAddress()
+        const creator2 = randomDhtAddress()
+        const key = randomDhtAddress()
         const storedEntry1 = createMockDataEntry({ key, creator: creator1 })
         const storedEntry2 = createMockDataEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
@@ -49,9 +49,9 @@ describe('LocalDataStore', () => {
     })
 
     it('can remove all data entries', () => {
-        const creator1 = createRandomDhtAddress()
-        const creator2 = createRandomDhtAddress()
-        const key = createRandomDhtAddress()
+        const creator1 = randomDhtAddress()
+        const creator2 = randomDhtAddress()
+        const key = randomDhtAddress()
         const storedEntry1 = createMockDataEntry({ key, creator: creator1 })
         const storedEntry2 = createMockDataEntry({ key, creator: creator2 })
         localDataStore.storeEntry(storedEntry1)
@@ -64,33 +64,33 @@ describe('LocalDataStore', () => {
     it('data is deleted after TTL', async () => {
         const storedEntry = createMockDataEntry({ ttl: 1000 })
         localDataStore.storeEntry(storedEntry)
-        expect(Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))).toHaveLength(1)
+        expect(Array.from(localDataStore.values(toDhtAddress(storedEntry.key)))).toHaveLength(1)
         await wait(1100)
-        expect(Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))).toHaveLength(0)
+        expect(Array.from(localDataStore.values(toDhtAddress(storedEntry.key)))).toHaveLength(0)
     })
 
     describe('mark data as deleted', () => {
 
         it('happy path', () => {
-            const creator1 = createRandomDhtAddress()
+            const creator1 = randomDhtAddress()
             const storedEntry = createMockDataEntry({ creator: creator1 })
             localDataStore.storeEntry(storedEntry)
-            const notDeletedData = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
+            const notDeletedData = Array.from(localDataStore.values(toDhtAddress(storedEntry.key)))
             expect(notDeletedData[0].deleted).toBeFalse()
             const returnValue = localDataStore.markAsDeleted(
-                getDhtAddressFromRaw(storedEntry.key),
+                toDhtAddress(storedEntry.key),
                 creator1
             )
             expect(returnValue).toBe(true)
-            const deletedData = Array.from(localDataStore.values(getDhtAddressFromRaw(storedEntry.key)))
+            const deletedData = Array.from(localDataStore.values(toDhtAddress(storedEntry.key)))
             expect(deletedData[0].deleted).toBeTrue()
         })
 
         it('data not stored', () => {
-            const key = createRandomDhtAddress()
+            const key = randomDhtAddress()
             const returnValue = localDataStore.markAsDeleted(
                 key,
-                getNodeIdFromPeerDescriptor(createMockPeerDescriptor())
+                toNodeId(createMockPeerDescriptor())
             )
             expect(returnValue).toBe(false)
         })
@@ -99,8 +99,8 @@ describe('LocalDataStore', () => {
             const storedEntry = createMockDataEntry()
             localDataStore.storeEntry(storedEntry)
             const returnValue = localDataStore.markAsDeleted(
-                getDhtAddressFromRaw(storedEntry.key),
-                getNodeIdFromPeerDescriptor(createMockPeerDescriptor())
+                toDhtAddress(storedEntry.key),
+                toNodeId(createMockPeerDescriptor())
             )
             expect(returnValue).toBe(false)
         })

--- a/packages/dht/test/unit/PeerManager.test.ts
+++ b/packages/dht/test/unit/PeerManager.test.ts
@@ -3,7 +3,7 @@ import { range, sample, sampleSize } from 'lodash'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { PeerManager } from '../../src/dht/PeerManager'
 import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
-import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 import { NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -16,7 +16,7 @@ const createDhtNodeRpcRemote = (
     const remote = new class extends DhtNodeRpcRemote {
         // eslint-disable-next-line class-methods-use-this
         async ping(): Promise<boolean> {
-            return !pingFailures.has(getNodeIdFromPeerDescriptor(peerDescriptor))
+            return !pingFailures.has(toNodeId(peerDescriptor))
         }
     }(localPeerDescriptor, peerDescriptor, undefined as any, new MockRpcCommunicator())
     return remote
@@ -28,13 +28,13 @@ const createPeerManager = (
     pingFailures: Set<DhtAddress> = new Set()
 ) => {
     const manager = new PeerManager({
-        localNodeId: getNodeIdFromPeerDescriptor(localPeerDescriptor),
+        localNodeId: toNodeId(localPeerDescriptor),
         localPeerDescriptor: localPeerDescriptor,
         isLayer0: true,
         createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => createDhtNodeRpcRemote(peerDescriptor, localPeerDescriptor, pingFailures),
         hasConnection: () => false
     } as any)
-    const contacts = nodeIds.map((n) => ({ nodeId: getRawFromDhtAddress(n), type: NodeType.NODEJS }))
+    const contacts = nodeIds.map((n) => ({ nodeId: toDhtAddressRaw(n), type: NodeType.NODEJS }))
     for (const contact of contacts) {
         manager.addContact(contact)
     }
@@ -44,29 +44,29 @@ const createPeerManager = (
 describe('PeerManager', () => {
 
     it('getNearbyContactCount', () => {
-        const nodeIds = range(10).map(() => createRandomDhtAddress())
+        const nodeIds = range(10).map(() => randomDhtAddress())
         const manager = createPeerManager(nodeIds)
         expect(manager.getNearbyContactCount()).toBe(10)
         expect(manager.getNearbyContactCount(new Set(sampleSize(nodeIds, 2)))).toBe(8)
-        expect(manager.getNearbyContactCount(new Set([sample(nodeIds)!, createRandomDhtAddress()]))).toBe(9)
+        expect(manager.getNearbyContactCount(new Set([sample(nodeIds)!, randomDhtAddress()]))).toBe(9)
     })
 
     it('addContact: ping fails', async () => {
         const localPeerDescriptor = createMockPeerDescriptor()
         const successContacts = range(5).map(() => createMockPeerDescriptor())
         const failureContact = createMockPeerDescriptor()
-        const manager = createPeerManager([], localPeerDescriptor, new Set([getNodeIdFromPeerDescriptor(failureContact)]))
+        const manager = createPeerManager([], localPeerDescriptor, new Set([toNodeId(failureContact)]))
         for (const successContact of successContacts) {
             manager.addContact(successContact)
-            manager.setContactActive(getNodeIdFromPeerDescriptor(successContact))
-            manager.removeNeighbor(getNodeIdFromPeerDescriptor(successContact))
+            manager.setContactActive(toNodeId(successContact))
+            manager.removeNeighbor(toNodeId(successContact))
         }
         expect(manager.getNeighborCount()).toBe(0)
         manager.addContact(failureContact)
-        const closesSuccessContact = getClosestNodes(getNodeIdFromPeerDescriptor(localPeerDescriptor), successContacts)[0]
+        const closesSuccessContact = getClosestNodes(toNodeId(localPeerDescriptor), successContacts)[0]
         await waitForCondition(() => {
             const neighborNodeIds = manager.getNeighbors().map((n) => n.getNodeId())
-            return neighborNodeIds.includes(getNodeIdFromPeerDescriptor(closesSuccessContact))
+            return neighborNodeIds.includes(toNodeId(closesSuccessContact))
         })
         expect(manager.getNeighborCount()).toBe(1)
         expect(manager.getNeighbors()[0].getPeerDescriptor()).toEqualPeerDescriptor(closesSuccessContact)
@@ -83,7 +83,7 @@ describe('PeerManager', () => {
         }
         manager.addContact(failureContact)
         expect(manager.getNeighborCount()).toBe(6)
-        failureSet.add(getNodeIdFromPeerDescriptor(failureContact))
+        failureSet.add(toNodeId(failureContact))
         await manager.pruneOfflineNodes(
             manager.getNeighbors().map((node) => createDhtNodeRpcRemote(node.getPeerDescriptor(), localPeerDescriptor, failureSet))
         )

--- a/packages/dht/test/unit/RandomContactList.test.ts
+++ b/packages/dht/test/unit/RandomContactList.test.ts
@@ -1,9 +1,9 @@
 import { RandomContactList } from '../../src/dht/contact/RandomContactList'
-import { DhtAddress, DhtAddressRaw, getDhtAddressFromRaw } from '../../src/identifiers'
+import { DhtAddress, DhtAddressRaw, toDhtAddress } from '../../src/identifiers'
 
 const createItem = (nodeId: DhtAddressRaw): { getNodeId: () => DhtAddress } => {
     return { 
-        getNodeId: () => getDhtAddressFromRaw(nodeId)
+        getNodeId: () => toDhtAddress(nodeId)
     }
 }
 

--- a/packages/dht/test/unit/RecursiveOperationManager.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationManager.test.ts
@@ -18,7 +18,7 @@ import { MockTransport } from '../utils/mock/MockTransport'
 import { FakeRpcCommunicator } from '../utils/FakeRpcCommunicator'
 import { Router } from '../../src/dht/routing/Router'
 import { ITransport } from '../../src/transport/ITransport'
-import { areEqualPeerDescriptors, createRandomDhtAddress } from '../../src/identifiers'
+import { areEqualPeerDescriptors, randomDhtAddress } from '../../src/identifiers'
 import { MockConnectionsView } from '../utils/mock/MockConnectionsView'
 
 const createMockRouter = (error?: RouteMessageError): Partial<Router> => {
@@ -94,7 +94,7 @@ describe('RecursiveOperationManager', () => {
 
     it('find closest nodes returns self if no peers', async () => {
         const recursiveOperationManager = createRecursiveOperationManager()
-        const res = await recursiveOperationManager.execute(createRandomDhtAddress(), RecursiveOperation.FIND_CLOSEST_NODES)
+        const res = await recursiveOperationManager.execute(randomDhtAddress(), RecursiveOperation.FIND_CLOSEST_NODES)
         expect(areEqualPeerDescriptors(res.closestNodes[0], peerDescriptor1)).toEqual(true)
         recursiveOperationManager.stop()
     })

--- a/packages/dht/test/unit/RecursiveOperationSession.test.ts
+++ b/packages/dht/test/unit/RecursiveOperationSession.test.ts
@@ -3,7 +3,7 @@ import { range } from 'lodash'
 import { RecursiveOperationSession } from '../../src/dht/recursive-operation/RecursiveOperationSession'
 import { RecursiveOperationSessionRpcRemote } from '../../src/dht/recursive-operation/RecursiveOperationSessionRpcRemote'
 import { ServiceID } from '../../src/types/ServiceID'
-import { createRandomDhtAddress } from '../../src/identifiers'
+import { randomDhtAddress } from '../../src/identifiers'
 import { Message, PeerDescriptor, RecursiveOperation } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { RecursiveOperationSessionRpcClient } from '../../src/proto/packages/dht/protos/DhtRpc.client'
 import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
@@ -36,7 +36,7 @@ describe('RecursiveOperationSession', () => {
         const doRouteRequest = jest.fn()
         const session = new RecursiveOperationSession({
             transport: environment.createTransport(localPeerDescriptor),
-            targetId: createRandomDhtAddress(),
+            targetId: randomDhtAddress(),
             localPeerDescriptor,
             waitedRoutingPathCompletions: 3,
             operation: RecursiveOperation.FIND_CLOSEST_NODES,

--- a/packages/dht/test/unit/Router.test.ts
+++ b/packages/dht/test/unit/Router.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor, createWrappedClosestPeersRequest } from '../utils/utils'
 import { FakeRpcCommunicator } from '../utils/FakeRpcCommunicator'
-import { DhtAddress, getNodeIdFromPeerDescriptor, createRandomDhtAddress } from '../../src/identifiers'
+import { DhtAddress, toNodeId, randomDhtAddress } from '../../src/identifiers'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 
 describe('Router', () => {
@@ -73,7 +73,7 @@ describe('Router', () => {
     })
 
     it('doRouteMessage with connections', async () => {
-        connections.set(createRandomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(randomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', {
             message,
             target: peerDescriptor2.nodeId,
@@ -87,7 +87,7 @@ describe('Router', () => {
     })
 
     it('doRouteMessage with parallelRootNodeIds', async () => {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor2)
+        const nodeId = toNodeId(peerDescriptor2)
         connections.set(nodeId, createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', {
             message,
@@ -107,7 +107,7 @@ describe('Router', () => {
     })
 
     it('route server with connections', async () => {
-        connections.set(createRandomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(randomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('routeMessage', routedMessage) as RouteMessageAck
         expect(ack.error).toBeUndefined()
     })
@@ -124,7 +124,7 @@ describe('Router', () => {
     })
 
     it('forward server with connections', async () => {
-        connections.set(createRandomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
+        connections.set(randomDhtAddress(), createMockDhtNodeRpcRemote(peerDescriptor2))
         const ack = await rpcCommunicator.callRpcMethod('forwardMessage', routedMessage) as RouteMessageAck
         expect(ack.error).toBeUndefined()
     })

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -4,7 +4,7 @@ import { Message, PeerDescriptor, RouteMessageWrapper } from '../../src/proto/pa
 import { createMockPeerDescriptor, createWrappedClosestPeersRequest } from '../utils/utils'
 import { DhtNodeRpcRemote } from '../../src/dht/DhtNodeRpcRemote'
 import { RoutingRpcCommunicator } from '../../src/transport/RoutingRpcCommunicator'
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, toNodeId } from '../../src/identifiers'
 import { MockRpcCommunicator } from '../utils/mock/MockRpcCommunicator'
 import { RoutingTablesCache } from '../../src/dht/routing/RoutingTablesCache'
 
@@ -63,16 +63,16 @@ describe('RoutingSession', () => {
     })
 
     it('findMoreContacts', () => {
-        connections.set(getNodeIdFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        connections.set(toNodeId(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
         const contacts = session.updateAndGetRoutablePeers()
         expect(contacts.length).toBe(1)
     })
 
     it('findMoreContacts peer disconnects', () => {
-        connections.set(getNodeIdFromPeerDescriptor(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        connections.set(toNodeId(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
         expect(session.updateAndGetRoutablePeers().length).toBe(1)
-        connections.delete(getNodeIdFromPeerDescriptor(mockPeerDescriptor2))
-        routingTablesCache.onNodeDisconnected(getNodeIdFromPeerDescriptor(mockPeerDescriptor2))
+        connections.delete(toNodeId(mockPeerDescriptor2))
+        routingTablesCache.onNodeDisconnected(toNodeId(mockPeerDescriptor2))
         expect(session.updateAndGetRoutablePeers().length).toBe(0)
     })
 

--- a/packages/dht/test/unit/SortedContactList.test.ts
+++ b/packages/dht/test/unit/SortedContactList.test.ts
@@ -1,9 +1,9 @@
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
-import { DhtAddress, DhtAddressRaw, createRandomDhtAddress, getDhtAddressFromRaw } from '../../src/identifiers'
+import { DhtAddress, DhtAddressRaw, randomDhtAddress, toDhtAddress } from '../../src/identifiers'
 
 const createItem = (nodeId: DhtAddressRaw): { getNodeId: () => DhtAddress } => {
     return { 
-        getNodeId: () => getDhtAddressFromRaw(nodeId)
+        getNodeId: () => toDhtAddress(nodeId)
     }
 }
 
@@ -46,7 +46,7 @@ describe('SortedContactList', () => {
         const list = new SortedContactList({ referenceId: item0.getNodeId(), maxSize: 8, allowToContainReferenceId: false })
         const onContactRemoved = jest.fn()
         list.on('contactRemoved', onContactRemoved)
-        list.removeContact(createRandomDhtAddress())
+        list.removeContact(randomDhtAddress())
         list.addContact(item3)
         list.removeContact(item3.getNodeId())
         list.addContact(item4)
@@ -58,10 +58,10 @@ describe('SortedContactList', () => {
         expect(list.getContact(item2.getNodeId())).toBeFalsy()
         expect(list.getContactIds()).toEqual(list.getContactIds().sort(list.compareIds))
         expect(list.getClosestContacts()).toEqual([item1, item3, item4])
-        const ret = list.removeContact(getDhtAddressFromRaw(Buffer.from([0, 0, 0, 6])))
+        const ret = list.removeContact(toDhtAddress(Buffer.from([0, 0, 0, 6])))
         expect(ret).toEqual(false)
         list.removeContact(item3.getNodeId())
-        list.removeContact(createRandomDhtAddress())
+        list.removeContact(randomDhtAddress())
         expect(list.getClosestContacts()).toEqual([item1, item4])
         expect(onContactRemoved).toHaveBeenNthCalledWith(1, item3)
         expect(onContactRemoved).toHaveBeenNthCalledWith(2, item2)

--- a/packages/dht/test/unit/StoreManager.test.ts
+++ b/packages/dht/test/unit/StoreManager.test.ts
@@ -4,9 +4,9 @@ import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
 import { StoreManager } from '../../src/dht/store/StoreManager'
 import {
     DhtAddress,
-    createRandomDhtAddress,
-    getDhtAddressFromRaw,
-    getRawFromDhtAddress
+    randomDhtAddress,
+    toDhtAddress,
+    toDhtAddressRaw
 } from '../../src/identifiers'
 import { PeerDescriptor, ReplicateDataRequest } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
@@ -14,13 +14,13 @@ import { createMockPeerDescriptor } from '../utils/utils'
 const NODE_COUNT = 10
 
 const DATA_ENTRY = {
-    key: getRawFromDhtAddress(createRandomDhtAddress()),
-    creator: getRawFromDhtAddress(createRandomDhtAddress())
+    key: toDhtAddressRaw(randomDhtAddress()),
+    creator: toDhtAddressRaw(randomDhtAddress())
 }
 const ALL_NODES = range(NODE_COUNT).map(() => createMockPeerDescriptor())
 
 const getNodeCloseToData = (distanceIndex: number) => {
-    const dataKey = getDhtAddressFromRaw(DATA_ENTRY.key)
+    const dataKey = toDhtAddress(DATA_ENTRY.key)
     return getClosestNodes(dataKey, ALL_NODES)[distanceIndex]
 }
 
@@ -42,7 +42,7 @@ describe('StoreManager', () => {
                 recursiveOperationManager: undefined as any,
                 localPeerDescriptor,
                 localDataStore: { 
-                    keys: () => [getDhtAddressFromRaw(DATA_ENTRY.key)],
+                    keys: () => [toDhtAddress(DATA_ENTRY.key)],
                     values: () => [DATA_ENTRY],
                     setAllEntriesAsStale 
                 } as any,
@@ -123,7 +123,7 @@ describe('StoreManager', () => {
                 await wait(50)
                 expect(replicateData).not.toHaveBeenCalled()
                 expect(setAllEntriesAsStale).toHaveBeenCalledTimes(1)
-                expect(setAllEntriesAsStale).toHaveBeenCalledWith(getDhtAddressFromRaw(DATA_ENTRY.key))
+                expect(setAllEntriesAsStale).toHaveBeenCalledWith(toDhtAddress(DATA_ENTRY.key))
             })
 
             it('this node is within redundancy factor, the node has less than redundancyFactor neighbors', async () => {

--- a/packages/dht/test/unit/StoreRpcLocal.test.ts
+++ b/packages/dht/test/unit/StoreRpcLocal.test.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash'
 import { StoreRpcLocal } from '../../src/dht/store/StoreRpcLocal'
-import { areEqualPeerDescriptors, createRandomDhtAddress, DhtAddress, getDhtAddressFromRaw, getRawFromDhtAddress } from '../../src/identifiers'
+import { areEqualPeerDescriptors, randomDhtAddress, DhtAddress, toDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 import { DataEntry, PeerDescriptor, StoreDataRequest } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
@@ -10,14 +10,14 @@ describe('StoreRpcLocal', () => {
 
     const NODE_COUNT = 5
     const DATA_ENTRY = {
-        key: getRawFromDhtAddress(createRandomDhtAddress()),
-        creator: getRawFromDhtAddress(createRandomDhtAddress())
+        key: toDhtAddressRaw(randomDhtAddress()),
+        creator: toDhtAddressRaw(randomDhtAddress())
     }
 
     const ALL_NODES = range(NODE_COUNT).map(() => createMockPeerDescriptor())
 
     const getNodeCloseToData = (distanceIndex: number) => {
-        const dataKey = getDhtAddressFromRaw(DATA_ENTRY.key)
+        const dataKey = toDhtAddress(DATA_ENTRY.key)
         return getClosestNodes(dataKey, ALL_NODES)[distanceIndex]
     }
 
@@ -41,7 +41,7 @@ describe('StoreRpcLocal', () => {
                 } as any,
                 localPeerDescriptor,
                 replicateDataToContact,
-                getStorers: () => getClosestNodes(getDhtAddressFromRaw(DATA_ENTRY.key), ALL_NODES)
+                getStorers: () => getClosestNodes(toDhtAddress(DATA_ENTRY.key), ALL_NODES)
             })
         })
 
@@ -76,7 +76,7 @@ describe('StoreRpcLocal', () => {
                 } as any,
                 localPeerDescriptor,
                 replicateDataToContact,
-                getStorers: () => getClosestNodes(getDhtAddressFromRaw(DATA_ENTRY.key), ALL_NODES)
+                getStorers: () => getClosestNodes(toDhtAddress(DATA_ENTRY.key), ALL_NODES)
             })
         })
 
@@ -110,7 +110,7 @@ describe('StoreRpcLocal', () => {
                 } as any,
                 localPeerDescriptor,
                 replicateDataToContact,
-                getStorers: () => getClosestNodes(getDhtAddressFromRaw(DATA_ENTRY.key), ALL_NODES)
+                getStorers: () => getClosestNodes(toDhtAddress(DATA_ENTRY.key), ALL_NODES)
                     .filter((peerDescriptor) => !areEqualPeerDescriptors(peerDescriptor, localPeerDescriptor))
             })
         })
@@ -147,7 +147,7 @@ describe('StoreRpcLocal', () => {
                 } as any,
                 localPeerDescriptor,
                 replicateDataToContact,
-                getStorers: () => getClosestNodes(getDhtAddressFromRaw(DATA_ENTRY.key), ALL_NODES)
+                getStorers: () => getClosestNodes(toDhtAddress(DATA_ENTRY.key), ALL_NODES)
             })
         })
 

--- a/packages/dht/test/unit/createPeerDescriptor.test.ts
+++ b/packages/dht/test/unit/createPeerDescriptor.test.ts
@@ -2,7 +2,7 @@ import { ipv4ToNumber } from '@streamr/utils'
 import { createPeerDescriptor } from '../../src/helpers/createPeerDescriptor'
 import { isBrowserEnvironment } from '../../src/helpers/browser/isBrowserEnvironment'
 import { NodeType } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 import { getRandomRegion } from '../../dist/src/connection/simulator/pings'
 
 const IP_ADDRESS = '1.2.3.4'
@@ -52,13 +52,13 @@ describe('createPeerDescriptor', () => {
     })
 
     it('explicit nodeId', () => {
-        const nodeId = createRandomDhtAddress()
+        const nodeId = randomDhtAddress()
         const connectivityResponse = {
             ipAddress: ipv4ToNumber(IP_ADDRESS)
         } as any
         const peerDescriptor = createPeerDescriptor(connectivityResponse, region, nodeId)
         expect(peerDescriptor).toEqual({
-            nodeId: getRawFromDhtAddress(nodeId),
+            nodeId: toDhtAddressRaw(nodeId),
             type: isBrowserEnvironment() ? NodeType.BROWSER : NodeType.NODEJS,
             ipAddress: ipv4ToNumber(IP_ADDRESS),
             publicKey: expect.any(Uint8Array),

--- a/packages/dht/test/unit/getClosestNodes.test.ts
+++ b/packages/dht/test/unit/getClosestNodes.test.ts
@@ -1,7 +1,7 @@
 import { range, sampleSize, sortBy } from 'lodash'
 import { getDistance } from '../../src/dht/PeerManager'
 import { getClosestNodes } from '../../src/dht/contact/getClosestNodes'
-import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 import { createMockPeerDescriptor } from '../utils/utils'
 import { PeerDescriptor } from '../../src/exports'
 
@@ -9,8 +9,8 @@ describe('getClosestNodes', () => {
 
     it('happy path', () => {
         const peerDescriptors = range(10).map(() => createMockPeerDescriptor())
-        const referenceId = createRandomDhtAddress()
-        const excluded = new Set<DhtAddress>(sampleSize(peerDescriptors.map((n) => getNodeIdFromPeerDescriptor(n), 2)))
+        const referenceId = randomDhtAddress()
+        const excluded = new Set<DhtAddress>(sampleSize(peerDescriptors.map((n) => toNodeId(n), 2)))
 
         const actual = getClosestNodes(
             referenceId,
@@ -22,8 +22,8 @@ describe('getClosestNodes', () => {
         )
 
         const expected = sortBy(
-            peerDescriptors.filter((n) => !excluded.has(getNodeIdFromPeerDescriptor(n))),
-            (peerDescriptor: PeerDescriptor) => getDistance(peerDescriptor.nodeId, getRawFromDhtAddress(referenceId))
+            peerDescriptors.filter((n) => !excluded.has(toNodeId(n))),
+            (peerDescriptor: PeerDescriptor) => getDistance(peerDescriptor.nodeId, toDhtAddressRaw(referenceId))
         ).slice(0, 5)
         expect(actual).toEqual(expected)
     })

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'eventemitter3'
-import { DhtAddress, getDhtAddressFromRaw, getNodeIdFromPeerDescriptor } from '../../src/identifiers'
+import { DhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
 import { Message, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { DEFAULT_SEND_OPTIONS, ITransport, SendOptions, TransportEvents } from '../../src/transport/ITransport'
 import { ConnectionsView } from '../../src/exports'
@@ -22,8 +22,8 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport,
 
     async send(msg: Message, opts?: SendOptions): Promise<void> {
         const connect = opts?.connect ?? DEFAULT_SEND_OPTIONS.connect
-        const targetNodeId = getNodeIdFromPeerDescriptor(msg.targetDescriptor!)
-        if (connect && !this.connections.some((c) => getNodeIdFromPeerDescriptor(c) === targetNodeId)) {
+        const targetNodeId = toNodeId(msg.targetDescriptor!)
+        if (connect && !this.connections.some((c) => toNodeId(c) === targetNodeId)) {
             this.connect(msg.targetDescriptor!)
         }
         msg.sourceDescriptor = this.localPeerDescriptor
@@ -50,7 +50,7 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport,
 
     // eslint-disable-next-line class-methods-use-this
     hasConnection(nodeId: DhtAddress): boolean {
-        return this.connections.some((c) => getNodeIdFromPeerDescriptor(c) === nodeId)
+        return this.connections.some((c) => toNodeId(c) === nodeId)
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -69,8 +69,8 @@ export class FakeEnvironment {
 
     createTransport(peerDescriptor: PeerDescriptor): FakeTransport {
         const transport = new FakeTransport(peerDescriptor, (msg) => {
-            const targetNode = getDhtAddressFromRaw(msg.targetDescriptor!.nodeId)
-            const targetTransport = this.transports.find((t) => getNodeIdFromPeerDescriptor(t.getLocalPeerDescriptor()) === targetNode)
+            const targetNode = toDhtAddress(msg.targetDescriptor!.nodeId)
+            const targetTransport = this.transports.find((t) => toNodeId(t.getLocalPeerDescriptor()) === targetNode)
             if (targetTransport !== undefined) {
                 targetTransport.emit('message', msg)
             }

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -2,7 +2,7 @@ import { areEqualBinaries } from '@streamr/utils'
 import { printExpected, printReceived } from 'jest-matcher-utils'
 import { isEqual } from 'lodash'
 import { ConnectivityMethod, NodeType, PeerDescriptor } from '../../src/proto/packages/dht/protos/DhtRpc'
-import { getDhtAddressFromRaw } from '../../src/identifiers'
+import { toDhtAddress } from '../../src/identifiers'
 
 // we could ES2015 module syntax (https://jestjs.io/docs/expect#expectextendmatchers),
 // but the IDE doesn't find custom matchers if we do that
@@ -25,7 +25,7 @@ const toEqualPeerDescriptor = (
 ): jest.CustomMatcherResult => {
     const messages: string[] = []
     if (!areEqualBinaries(expected.nodeId, actual.nodeId)) {
-        messages.push(formErrorMessage('nodeId', getDhtAddressFromRaw(expected.nodeId), getDhtAddressFromRaw(actual.nodeId)))
+        messages.push(formErrorMessage('nodeId', toDhtAddress(expected.nodeId), toDhtAddress(actual.nodeId)))
     }
     if (!isEqual(expected.type, actual.type)) {
         const typeNames = { [NodeType.NODEJS]: 'NODEJS', [NodeType.BROWSER]: 'BROWSER' }

--- a/packages/dht/test/utils/mock/mockDataEntry.ts
+++ b/packages/dht/test/utils/mock/mockDataEntry.ts
@@ -3,7 +3,7 @@ import { randomString } from '@streamr/utils'
 import { Timestamp } from '../../../src/proto/google/protobuf/timestamp'
 import { Any } from '../../../src/proto/google/protobuf/any'
 import { DataEntry } from '../../../src/proto/packages/dht/protos/DhtRpc'
-import { DhtAddress, createRandomDhtAddress, getRawFromDhtAddress } from '../../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toDhtAddressRaw } from '../../../src/identifiers'
 import { omit } from 'lodash'
 
 const MockData = new class extends MessageType$<{ foo: string }> {
@@ -18,9 +18,9 @@ export const createMockDataEntry = (
     entry: Partial<Omit<DataEntry, 'key' | 'creator'> & { key: DhtAddress, creator: DhtAddress }> = {}
 ): DataEntry => {
     return { 
-        key: getRawFromDhtAddress(entry.key ?? createRandomDhtAddress()),
+        key: toDhtAddressRaw(entry.key ?? randomDhtAddress()),
         data: Any.pack({ foo: randomString(5) }, MockData),
-        creator: getRawFromDhtAddress(entry.creator ?? createRandomDhtAddress()),
+        creator: toDhtAddressRaw(entry.creator ?? randomDhtAddress()),
         ttl: 10000,
         stale: false,
         deleted: false,

--- a/packages/dht/test/utils/topology.ts
+++ b/packages/dht/test/utils/topology.ts
@@ -1,5 +1,5 @@
 import { Multimap } from '@streamr/utils'
-import { DhtAddress, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 import { minBy, range, without } from 'lodash'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { getDistance } from '../../src/dht/PeerManager'
@@ -47,7 +47,7 @@ const getClosestNodes = (referenceId: DhtAddress, nodeIds: DhtAddress[], count: 
  */
 export const createTestTopology = (nodeCount: number, minNeighorCount: number): Multimap<DhtAddress, DhtAddress> => {
     const topology: Multimap<DhtAddress, DhtAddress> = new Multimap()
-    const nodeIds = range(nodeCount).map(() => createRandomDhtAddress())
+    const nodeIds = range(nodeCount).map(() => randomDhtAddress())
     for (const nodeId of nodeIds) {
         const closestNodes = getClosestNodes(nodeId, nodeIds, minNeighorCount, false)
         for (const closestNode of closestNodes) {
@@ -71,7 +71,7 @@ export const createTestTopology = (nodeCount: number, minNeighorCount: number): 
                 const closestNodedId = getClosestNodes(nodeId, otherNodes, 1, false)[0]
                 return [nodeId, closestNodedId]
             })
-            const mergePair = minBy(closestPairs, (pair) => getDistance(getRawFromDhtAddress(pair[0]), getRawFromDhtAddress(pair[1])))!
+            const mergePair = minBy(closestPairs, (pair) => getDistance(toDhtAddressRaw(pair[0]), toDhtAddressRaw(pair[1])))!
             topology.add(mergePair[0], mergePair[1])
             topology.add(mergePair[1], mergePair[0])
         }

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -27,11 +27,11 @@ import { Empty } from '../../src/proto/google/protobuf/empty'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { wait, waitForCondition } from '@streamr/utils'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
-import { DhtAddress, createRandomDhtAddress, getRawFromDhtAddress } from '../../src/identifiers'
+import { DhtAddress, randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 
 export const createMockPeerDescriptor = (opts?: Partial<Omit<PeerDescriptor, 'nodeId'>>): PeerDescriptor => {
     return {
-        nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+        nodeId: toDhtAddressRaw(randomDhtAddress()),
         type: NodeType.NODEJS,
         ...opts
     }
@@ -46,7 +46,7 @@ export const createMockRingNode = async (
     const dhtJoinTimeout = 45000
 
     const peerDescriptor: PeerDescriptor = {
-        nodeId: getRawFromDhtAddress(nodeId ?? createRandomDhtAddress()),
+        nodeId: toDhtAddressRaw(nodeId ?? randomDhtAddress()),
         type: NodeType.NODEJS,
         region
         //ipAddress: ipv4ToNumber(ipAddress)
@@ -80,7 +80,7 @@ export const createMockConnectionDhtNode = async (
     dhtJoinTimeout = 45000
 ): Promise<DhtNode> => {
     const peerDescriptor: PeerDescriptor = {
-        nodeId: getRawFromDhtAddress(nodeId ?? createRandomDhtAddress()),
+        nodeId: toDhtAddressRaw(nodeId ?? randomDhtAddress()),
         type: NodeType.NODEJS,
         region: getRandomRegion()
     }

--- a/packages/node/bin/entry-point.ts
+++ b/packages/node/bin/entry-point.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { DhtAddress, DhtNode, NodeType, getRawFromDhtAddress } from '@streamr/dht'
+import { DhtAddress, DhtNode, NodeType, toDhtAddressRaw } from '@streamr/dht'
 
 const main = async () => {
     const entryPoint = CHAIN_CONFIG.dev2.entryPoints[0]
     const peerDescriptor = {
         ...entryPoint,
-        nodeId: getRawFromDhtAddress(entryPoint.nodeId as DhtAddress),
+        nodeId: toDhtAddressRaw(entryPoint.nodeId as DhtAddress),
         type: NodeType.NODEJS  // TODO remove this when NET-1070 done
     }
     const dhtNode = new DhtNode({

--- a/packages/sdk/src/utils/utils.ts
+++ b/packages/sdk/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, NodeType, PeerDescriptor, getDhtAddressFromRaw, getRawFromDhtAddress } from '@streamr/dht'
+import { DhtAddress, NodeType, PeerDescriptor, toDhtAddress, toDhtAddressRaw } from '@streamr/dht'
 import {
     LengthPrefixedFrameDecoder,
     Logger, StreamID, TheGraphClient, composeAbortSignals, merge,
@@ -130,7 +130,7 @@ export function peerDescriptorTranslator(json: NetworkPeerDescriptor): PeerDescr
     const type = json.type === NetworkNodeType.BROWSER ? NodeType.BROWSER : NodeType.NODEJS
     const peerDescriptor: PeerDescriptor = {
         ...json,
-        nodeId: getRawFromDhtAddress((json.nodeId ?? (json as any).id) as DhtAddress),
+        nodeId: toDhtAddressRaw((json.nodeId ?? (json as any).id) as DhtAddress),
         type,
         websocket: json.websocket
     }
@@ -143,7 +143,7 @@ export function peerDescriptorTranslator(json: NetworkPeerDescriptor): PeerDescr
 export function convertPeerDescriptorToNetworkPeerDescriptor(descriptor: PeerDescriptor): NetworkPeerDescriptor {
     // TODO maybe we should copy most/all fields of PeerDescription (NET-1255)
     return {
-        nodeId: getDhtAddressFromRaw(descriptor.nodeId),
+        nodeId: toDhtAddress(descriptor.nodeId),
         type: descriptor.type === NodeType.NODEJS ? NetworkNodeType.NODEJS : NetworkNodeType.BROWSER,
         websocket: descriptor.websocket,
         region: descriptor.region

--- a/packages/sdk/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/sdk/test/end-to-end/publish-subscribe.test.ts
@@ -1,5 +1,5 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { DhtAddress, NodeType, getRawFromDhtAddress } from '@streamr/dht'
+import { DhtAddress, NodeType, toDhtAddressRaw } from '@streamr/dht'
 import { fastWallet, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import { createNetworkNode } from '@streamr/trackerless-network'
 import { StreamID, toStreamPartID, waitForCondition } from '@streamr/utils'
@@ -18,7 +18,7 @@ const PAYLOAD = { hello: 'world' }
 async function startNetworkNodeAndListenForAtLeastOneMessage(streamId: StreamID): Promise<unknown[]> {
     const entryPoints = CHAIN_CONFIG.dev2.entryPoints.map((entryPoint) => ({
         ...entryPoint,
-        nodeId: getRawFromDhtAddress(entryPoint.nodeId as DhtAddress),
+        nodeId: toDhtAddressRaw(entryPoint.nodeId as DhtAddress),
         type: NodeType.NODEJS
     }))
     const networkNode = createNetworkNode({

--- a/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, PeerDescriptor, getDhtAddressFromRaw } from '@streamr/dht'
+import { DhtAddress, PeerDescriptor, toDhtAddress } from '@streamr/dht'
 import { ProtoRpcClient } from '@streamr/proto-rpc'
 import {
     ExternalRpcClient,
@@ -26,7 +26,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
     private readonly network: FakeNetwork
 
     constructor(network: FakeNetwork, options: NetworkOptions = {}) {
-        this.id = getDhtAddressFromRaw(crypto.randomBytes(10))
+        this.id = toDhtAddress(crypto.randomBytes(10))
         this.options = options
         this.network = network
     }

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -5,7 +5,7 @@ import {
     ListeningRpcCommunicator,
     PeerDescriptor,
     areEqualPeerDescriptors,
-    getNodeIdFromPeerDescriptor
+    toNodeId
 } from '@streamr/dht'
 import { Logger, MetricsContext, StreamID, StreamPartID, toStreamPartID, waitForCondition } from '@streamr/utils'
 import { pull } from 'lodash'
@@ -106,7 +106,7 @@ export class NetworkStack {
     async start(doJoin = true): Promise<void> {
         logger.info('Starting a Streamr Network Node')
         await this.controlLayerNode!.start()
-        logger.info(`Node id is ${getNodeIdFromPeerDescriptor(this.controlLayerNode!.getLocalPeerDescriptor())}`)
+        logger.info(`Node id is ${toNodeId(this.controlLayerNode!.getLocalPeerDescriptor())}`)
         const connectionManager = this.controlLayerNode!.getTransport() as ConnectionManager
         if ((this.options.layer0?.entryPoints !== undefined) && (this.options.layer0.entryPoints.some((entryPoint) => 
             areEqualPeerDescriptors(entryPoint, this.controlLayerNode!.getLocalPeerDescriptor())

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -4,7 +4,7 @@ import {
     ITransport,
     ListeningRpcCommunicator,
     PeerDescriptor,
-    getNodeIdFromPeerDescriptor,
+    toNodeId,
 } from '@streamr/dht'
 import { Logger, StreamPartID, addManagedEventListener } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
@@ -166,7 +166,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             (id, remote) => {
                 this.options.propagation.onNeighborJoined(id)
                 this.options.connectionLocker.weakLockConnection(
-                    getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
+                    toNodeId(remote.getPeerDescriptor()),
                     this.options.streamPartId
                 )
                 this.emit('neighborConnected', id)
@@ -178,7 +178,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             'nodeRemoved',
             (_id, remote) => {
                 this.options.connectionLocker.weakUnlockConnection(
-                    getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
+                    toNodeId(remote.getPeerDescriptor()),
                     this.options.streamPartId
                 )
             },
@@ -317,7 +317,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
     }
 
     private onNodeDisconnected(peerDescriptor: PeerDescriptor): void {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         if (this.options.neighbors.has(nodeId)) {
             this.options.neighbors.remove(nodeId)
             this.options.neighborFinder.start([nodeId])
@@ -341,7 +341,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         this.options.neighbors.getAll().map((remote) => {
             remote.leaveStreamPartNotice(this.options.streamPartId, this.options.isLocalNodeEntryPoint())
             this.options.connectionLocker.weakUnlockConnection(
-                getNodeIdFromPeerDescriptor(remote.getPeerDescriptor()),
+                toNodeId(remote.getPeerDescriptor()),
                 this.options.streamPartId
             )
         })
@@ -379,7 +379,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
     }
 
     getOwnNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
+        return toNodeId(this.options.localPeerDescriptor)
     }
 
     getOutgoingHandshakeCount(): number {

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -5,8 +5,8 @@ import {
     EXISTING_CONNECTION_TIMEOUT,
     ITransport,
     PeerDescriptor,
-    getDhtAddressFromRaw,
-    getNodeIdFromPeerDescriptor
+    toDhtAddress,
+    toNodeId
 } from '@streamr/dht'
 import {
     Logger,
@@ -66,7 +66,7 @@ export interface ContentDeliveryManagerOptions {
 }
 
 export const streamPartIdToDataKey = (streamPartId: StreamPartID): DhtAddress => {
-    return getDhtAddressFromRaw(new Uint8Array((createHash('sha1').update(streamPartId).digest())))
+    return toDhtAddress(new Uint8Array((createHash('sha1').update(streamPartId).digest())))
 }
 
 export class ContentDeliveryManager extends EventEmitter<Events> {
@@ -364,13 +364,13 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
     }
 
     getNodeId(): DhtAddress {
-        return getNodeIdFromPeerDescriptor(this.controlLayerNode!.getLocalPeerDescriptor())
+        return toNodeId(this.controlLayerNode!.getLocalPeerDescriptor())
     }
 
     getNeighbors(streamPartId: StreamPartID): DhtAddress[] {
         const streamPart = this.streamParts.get(streamPartId)
         return (streamPart !== undefined) && (streamPart.proxied === false)
-            ? streamPart.node.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+            ? streamPart.node.getNeighbors().map((n) => toNodeId(n))
             : []
     }
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { StreamPartID } from '@streamr/utils'
 import { Empty } from '../proto/google/protobuf/empty'
 import {
@@ -29,7 +29,7 @@ export class ContentDeliveryRpcLocal implements IContentDeliveryRpc {
     }
 
     async sendStreamMessage(message: StreamMessage, context: ServerCallContext): Promise<Empty> {
-        const previousNode = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
+        const previousNode = toNodeId((context as DhtCallContext).incomingSourceDescriptor!)
         this.options.markForInspection(previousNode, message.messageId!)
         if (this.options.markAndCheckDuplicate(message.messageId!, message.previousMessageRef)) {
             this.options.broadcast(message, previousNode)
@@ -40,7 +40,7 @@ export class ContentDeliveryRpcLocal implements IContentDeliveryRpc {
     async leaveStreamPartNotice(message: LeaveStreamPartNotice, context: ServerCallContext): Promise<Empty> {
         if (message.streamPartId === this.options.streamPartId) {
             const sourcePeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-            const remoteNodeId = getNodeIdFromPeerDescriptor(sourcePeerDescriptor)
+            const remoteNodeId = toNodeId(sourcePeerDescriptor)
             this.options.onLeaveNotice(remoteNodeId, message.isEntryPoint)
         }
         return Empty

--- a/packages/trackerless-network/src/logic/NodeList.ts
+++ b/packages/trackerless-network/src/logic/NodeList.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, toNodeId } from '@streamr/dht'
 import { sample } from 'lodash'
 import { ContentDeliveryRpcRemote } from './ContentDeliveryRpcRemote'
 import { EventEmitter } from 'eventemitter3'
@@ -36,7 +36,7 @@ export class NodeList extends EventEmitter<Events> {
     }
 
     add(remote: ContentDeliveryRpcRemote): void {
-        const nodeId = getNodeIdFromPeerDescriptor(remote.getPeerDescriptor())
+        const nodeId = toNodeId(remote.getPeerDescriptor())
         if ((this.ownId !== nodeId) && (this.nodes.size < this.limit)) {
             const isExistingNode = this.nodes.has(nodeId)
             this.nodes.set(nodeId, remote)
@@ -107,7 +107,7 @@ export class NodeList extends EventEmitter<Events> {
     }
 
     stop(): void {
-        this.nodes.forEach((node) => this.remove(getNodeIdFromPeerDescriptor(node.getPeerDescriptor())))
+        this.nodes.forEach((node) => this.remove(toNodeId(node.getPeerDescriptor())))
         this.removeAllListeners()
     }
 

--- a/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
+++ b/packages/trackerless-network/src/logic/StreamPartNetworkSplitAvoidance.ts
@@ -1,4 +1,4 @@
-import { areEqualPeerDescriptors, DhtAddress, getNodeIdFromPeerDescriptor, PeerDescriptor } from '@streamr/dht'
+import { areEqualPeerDescriptors, DhtAddress, toNodeId, PeerDescriptor } from '@streamr/dht'
 import { Logger, wait } from '@streamr/utils'
 import { DiscoveryLayerNode } from './DiscoveryLayerNode'
 
@@ -63,14 +63,14 @@ export class StreamPartNetworkSplitAvoidance {
         this.running = true
         await exponentialRunOff(async () => {
             const discoveredEntrypoints = await this.options.discoverEntryPoints()
-            const filteredEntryPoints = discoveredEntrypoints.filter((peer) => !this.excludedNodes.has(getNodeIdFromPeerDescriptor(peer)))
+            const filteredEntryPoints = discoveredEntrypoints.filter((peer) => !this.excludedNodes.has(toNodeId(peer)))
             await this.options.discoveryLayerNode.joinDht(filteredEntryPoints, false, false)
             if (this.options.discoveryLayerNode.getNeighborCount() < MIN_NEIGHBOR_COUNT) {
                 // Filter out nodes that are not neighbors as those nodes are assumed to be offline
                 const newExcludes = filteredEntryPoints
                     .filter((peer) => !this.options.discoveryLayerNode.getNeighbors()
                         .some((neighbor) => areEqualPeerDescriptors(neighbor, peer)))
-                    .map((peer) => getNodeIdFromPeerDescriptor(peer))
+                    .map((peer) => toNodeId(peer))
                 newExcludes.forEach((node) => this.excludedNodes.add(node))
                 throw new Error(`Network split is still possible`)
             }

--- a/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, toNodeId } from '@streamr/dht'
 import { Handshaker } from './neighbor-discovery/Handshaker'
 import { NeighborFinder } from './neighbor-discovery/NeighborFinder'
 import { NeighborUpdateManager } from './neighbor-discovery/NeighborUpdateManager'
@@ -24,7 +24,7 @@ type ContentDeliveryLayerNodeOptions = MarkOptional<StrictContentDeliveryLayerNo
     }
 
 const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): StrictContentDeliveryLayerNodeOptions => {
-    const ownNodeId = getNodeIdFromPeerDescriptor(options.localPeerDescriptor)
+    const ownNodeId = toNodeId(options.localPeerDescriptor)
     const rpcCommunicator = options.rpcCommunicator ?? new ListeningRpcCommunicator(
         formStreamPartContentDeliveryServiceId(options.streamPartId),
         options.transport

--- a/packages/trackerless-network/src/logic/inspect/Inspector.ts
+++ b/packages/trackerless-network/src/logic/inspect/Inspector.ts
@@ -1,4 +1,4 @@
-import { ConnectionLocker, DhtAddress, ListeningRpcCommunicator, LockID, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, DhtAddress, ListeningRpcCommunicator, LockID, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { Logger, StreamPartID, waitForEvent3 } from '@streamr/utils'
 import { MessageID } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { TemporaryConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
@@ -47,7 +47,7 @@ export class Inspector {
             TemporaryConnectionRpcClient
         )
         await rpcRemote.openConnection()
-        this.connectionLocker.weakLockConnection(getNodeIdFromPeerDescriptor(peerDescriptor), lockId)
+        this.connectionLocker.weakLockConnection(toNodeId(peerDescriptor), lockId)
     }
 
     async defaultCloseInspectConnection(peerDescriptor: PeerDescriptor, lockId: LockID): Promise<void> {
@@ -58,11 +58,11 @@ export class Inspector {
             TemporaryConnectionRpcClient
         )
         await rpcRemote.closeConnection()
-        this.connectionLocker.weakUnlockConnection(getNodeIdFromPeerDescriptor(peerDescriptor), lockId)
+        this.connectionLocker.weakUnlockConnection(toNodeId(peerDescriptor), lockId)
     }
 
     async inspect(peerDescriptor: PeerDescriptor): Promise<boolean> {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         const session = new InspectSession({
             inspectedNode: nodeId
         })

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcLocal.ts
@@ -4,8 +4,8 @@ import {
     DhtAddressRaw,
     DhtCallContext,
     PeerDescriptor,
-    getDhtAddressFromRaw,
-    getNodeIdFromPeerDescriptor
+    toDhtAddress,
+    toNodeId
 } from '@streamr/dht'
 import { Logger, StreamPartID } from '@streamr/utils'
 import {
@@ -46,8 +46,8 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
 
     private handleRequest(request: StreamPartHandshakeRequest, context: ServerCallContext): StreamPartHandshakeResponse {
         const senderDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const getInterleaveNodeIds = () => (request.interleaveNodeId !== undefined) ? [getDhtAddressFromRaw(request.interleaveNodeId)] : []
-        const senderNodeId = getNodeIdFromPeerDescriptor(senderDescriptor)
+        const getInterleaveNodeIds = () => (request.interleaveNodeId !== undefined) ? [toDhtAddress(request.interleaveNodeId)] : []
+        const senderNodeId = toNodeId(senderDescriptor)
         if (this.options.ongoingInterleaves.has(senderNodeId)) {
             return this.rejectHandshake(request)
         } else if (this.options.neighbors.has(senderNodeId)
@@ -88,16 +88,16 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
 
     private acceptHandshakeWithInterleaving(request: StreamPartHandshakeRequest, requester: PeerDescriptor): StreamPartHandshakeResponse {
         const exclude: DhtAddress[] = []
-        request.neighborNodeIds.forEach((id: DhtAddressRaw) => exclude.push(getDhtAddressFromRaw(id)))
+        request.neighborNodeIds.forEach((id: DhtAddressRaw) => exclude.push(toDhtAddress(id)))
         this.options.ongoingInterleaves.forEach((id) => exclude.push(id))
-        exclude.push(getNodeIdFromPeerDescriptor(requester))
+        exclude.push(toNodeId(requester))
         if (request.interleaveNodeId !== undefined) {
-            exclude.push(getDhtAddressFromRaw(request.interleaveNodeId))
+            exclude.push(toDhtAddress(request.interleaveNodeId))
         }
         const last = this.options.neighbors.getLast(exclude)
         const lastPeerDescriptor = last ? last.getPeerDescriptor() : undefined
         if (last) {
-            const nodeId = getNodeIdFromPeerDescriptor(last.getPeerDescriptor())
+            const nodeId = toNodeId(last.getPeerDescriptor())
             const remote = this.options.createRpcRemote(last.getPeerDescriptor())
             this.options.ongoingInterleaves.add(nodeId)
             // Run this with then catch instead of setImmediate to avoid changes in state
@@ -107,7 +107,7 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
                 // and unlock the connection
                 // If response is not accepted, keep the last node as a neighbor
                 if (response.accepted) {
-                    this.options.neighbors.remove(getNodeIdFromPeerDescriptor(lastPeerDescriptor!))
+                    this.options.neighbors.remove(toNodeId(lastPeerDescriptor!))
                 }
             }).catch(() => {
                 // no-op: InterleaveRequest cannot reject
@@ -125,13 +125,13 @@ export class HandshakeRpcLocal implements IHandshakeRpc {
 
     async interleaveRequest(message: InterleaveRequest, context: ServerCallContext): Promise<InterleaveResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const remoteNodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        const remoteNodeId = toNodeId(senderPeerDescriptor)
         try {
             await this.options.handshakeWithInterleaving(message.interleaveTargetDescriptor!, remoteNodeId)
             this.options.neighbors.remove(remoteNodeId)
             return { accepted: true }
         } catch (err) {
-            logger.debug(`interleaveRequest to ${getNodeIdFromPeerDescriptor(message.interleaveTargetDescriptor!)} failed`, { err })
+            logger.debug(`interleaveRequest to ${toNodeId(message.interleaveTargetDescriptor!)} failed`, { err })
             return { accepted: false }
         }
     }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/HandshakeRpcRemote.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, PeerDescriptor, RpcRemote, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '@streamr/dht'
+import { DhtAddress, PeerDescriptor, RpcRemote, toNodeId, toDhtAddressRaw } from '@streamr/dht'
 import { Logger, StreamPartID } from '@streamr/utils'
 import { v4 } from 'uuid'
 import { InterleaveRequest, InterleaveResponse, StreamPartHandshakeRequest } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
@@ -24,9 +24,9 @@ export class HandshakeRpcRemote extends RpcRemote<HandshakeRpcClient> {
         const request: StreamPartHandshakeRequest = {
             streamPartId,
             requestId: v4(),
-            neighborNodeIds: neighborNodeIds.map((id) => getRawFromDhtAddress(id)),
-            concurrentHandshakeNodeId: (concurrentHandshakeNodeId !== undefined) ? getRawFromDhtAddress(concurrentHandshakeNodeId) : undefined,
-            interleaveNodeId: (interleaveNodeId !== undefined) ? getRawFromDhtAddress(interleaveNodeId) : undefined
+            neighborNodeIds: neighborNodeIds.map((id) => toDhtAddressRaw(id)),
+            concurrentHandshakeNodeId: (concurrentHandshakeNodeId !== undefined) ? toDhtAddressRaw(concurrentHandshakeNodeId) : undefined,
+            interleaveNodeId: (interleaveNodeId !== undefined) ? toDhtAddressRaw(interleaveNodeId) : undefined
         }
         try {
             const response = await this.getClient().handshake(request, this.formDhtRpcOptions())
@@ -35,7 +35,7 @@ export class HandshakeRpcRemote extends RpcRemote<HandshakeRpcClient> {
                 interleaveTargetDescriptor: response.interleaveTargetDescriptor
             }
         } catch (err: any) {
-            logger.debug(`handshake to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed`, { err })
+            logger.debug(`handshake to ${toNodeId(this.getPeerDescriptor())} failed`, { err })
             return {
                 accepted: false
             }
@@ -56,7 +56,7 @@ export class HandshakeRpcRemote extends RpcRemote<HandshakeRpcClient> {
                 accepted: res.accepted
             }
         } catch (err) {
-            logger.debug(`interleaveRequest to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed`, { err })
+            logger.debug(`interleaveRequest to ${toNodeId(this.getPeerDescriptor())} failed`, { err })
             return {
                 accepted: false
             }

--- a/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/Handshaker.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { Logger, StreamPartID } from '@streamr/utils'
 import {
     InterleaveRequest,
@@ -70,7 +70,7 @@ export class Handshaker {
     private async selectParallelTargetsAndHandshake(excludedIds: DhtAddress[]): Promise<DhtAddress[]> {
         const exclude = excludedIds.concat(this.options.neighbors.getIds())
         const neighbors = this.selectParallelTargets(exclude)
-        neighbors.forEach((contact) => this.options.ongoingHandshakes.add(getNodeIdFromPeerDescriptor(contact.getPeerDescriptor())))
+        neighbors.forEach((contact) => this.options.ongoingHandshakes.add(toNodeId(contact.getPeerDescriptor())))
         return this.doParallelHandshakes(neighbors, exclude)
     }
 
@@ -83,7 +83,7 @@ export class Handshaker {
                 true
             )
             if (wsNode) {
-                const wsNodeId = getNodeIdFromPeerDescriptor(wsNode.getPeerDescriptor())
+                const wsNodeId = toNodeId(wsNode.getPeerDescriptor())
                 excludedIds.push(wsNodeId)
                 neighbors.set(wsNodeId, wsNode)
             }   
@@ -92,21 +92,21 @@ export class Handshaker {
         const left = this.options.leftNodeView.getFirst([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
         const right = this.options.rightNodeView.getFirst([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
         if (left) {
-            neighbors.set(getNodeIdFromPeerDescriptor(left.getPeerDescriptor()), left)
+            neighbors.set(toNodeId(left.getPeerDescriptor()), left)
         }
         if (right) {
-            neighbors.set(getNodeIdFromPeerDescriptor(right.getPeerDescriptor()), right)
+            neighbors.set(toNodeId(right.getPeerDescriptor()), right)
         }
         // If there is still room add the closest contact based on the kademlia metric
         if (neighbors.size < PARALLEL_HANDSHAKE_COUNT) {
             const first = this.options.nearbyNodeView.getFirst([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
             if (first) {
-                neighbors.set(getNodeIdFromPeerDescriptor(first.getPeerDescriptor()), first)
+                neighbors.set(toNodeId(first.getPeerDescriptor()), first)
             }
         }
         const getExcludedFromRandomView = () => [
             ...excludedIds,
-            ...Array.from(neighbors.values()).map((neighbor) => getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor()))
+            ...Array.from(neighbors.values()).map((neighbor) => toNodeId(neighbor.getPeerDescriptor()))
         ]
         // If there is still room add a random contact until PARALLEL_HANDSHAKE_COUNT is reached
         while (
@@ -115,7 +115,7 @@ export class Handshaker {
         ) {
             const random = this.options.randomNodeView.getRandom([...excludedIds, ...Array.from(neighbors.keys())] as DhtAddress[])
             if (random) {
-                neighbors.set(getNodeIdFromPeerDescriptor(random.getPeerDescriptor()), random)
+                neighbors.set(toNodeId(random.getPeerDescriptor()), random)
             }
         }
         return Array.from(neighbors.values()).map((neighbor) => this.createRpcRemote(neighbor.getPeerDescriptor()))
@@ -126,13 +126,13 @@ export class Handshaker {
             Array.from(targets.values()).map(async (target: HandshakeRpcRemote, i) => {
                 const otherNode = i === 0 ? targets[1] : targets[0]
                 // TODO better check (currently this condition is always true)
-                const otherNodeId = otherNode ? getNodeIdFromPeerDescriptor(otherNode.getPeerDescriptor()) : undefined
+                const otherNodeId = otherNode ? toNodeId(otherNode.getPeerDescriptor()) : undefined
                 return this.handshakeWithTarget(target, otherNodeId)
             })
         )
         results.forEach((res, i) => {
             if (res.status !== 'fulfilled' || !res.value) {
-                excludedIds.push(getNodeIdFromPeerDescriptor(targets[i].getPeerDescriptor()))
+                excludedIds.push(toNodeId(targets[i].getPeerDescriptor()))
             }
         })
         return excludedIds
@@ -147,14 +147,14 @@ export class Handshaker {
         if (neighbor) {
             const accepted = await this.handshakeWithTarget(this.createRpcRemote(neighbor.getPeerDescriptor()))
             if (!accepted) {
-                excludedIds.push(getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor()))
+                excludedIds.push(toNodeId(neighbor.getPeerDescriptor()))
             }
         }
         return excludedIds
     }
 
     private async handshakeWithTarget(neighbor: HandshakeRpcRemote, concurrentNodeId?: DhtAddress): Promise<boolean> {
-        const targetNodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
+        const targetNodeId = toNodeId(neighbor.getPeerDescriptor())
         this.options.ongoingHandshakes.add(targetNodeId)
         const result = await neighbor.handshake(
             this.options.streamPartId,
@@ -173,7 +173,7 @@ export class Handshaker {
 
     private async handshakeWithInterleaving(target: PeerDescriptor, remoteNodeId: DhtAddress): Promise<boolean> {
         const neighbor = this.createRpcRemote(target)
-        const targetNodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
+        const targetNodeId = toNodeId(neighbor.getPeerDescriptor())
         this.options.ongoingHandshakes.add(targetNodeId)
         const result = await neighbor.handshake(
             this.options.streamPartId,

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { Logger, StreamPartID, scheduleAtInterval } from '@streamr/utils'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { NeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
@@ -49,7 +49,7 @@ export class NeighborUpdateManager {
         const startTime = Date.now()
         await Promise.allSettled(this.options.neighbors.getAll().map(async (neighbor) => {
             const res = await this.createRemote(neighbor.getPeerDescriptor()).updateNeighbors(this.options.streamPartId, neighborDescriptors)
-            const nodeId = getNodeIdFromPeerDescriptor(neighbor.getPeerDescriptor())
+            const nodeId = toNodeId(neighbor.getPeerDescriptor())
             this.options.neighbors.get(nodeId)!.setRtt(Date.now() - startTime)
             if (res.removeMe) {
                 this.options.neighbors.remove(nodeId)

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { StreamPartID } from '@streamr/utils'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { ContentDeliveryRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
@@ -28,9 +28,9 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
     }
 
     private updateContacts(neighborDescriptors: PeerDescriptor[]): void {
-        const ownNodeId = getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor)
+        const ownNodeId = toNodeId(this.options.localPeerDescriptor)
         const newPeerDescriptors = neighborDescriptors.filter((peerDescriptor) => {
-            const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+            const nodeId = toNodeId(peerDescriptor)
             return nodeId !== ownNodeId && !this.options.neighbors.getIds().includes(nodeId)
         })
         newPeerDescriptors.forEach((peerDescriptor) => this.options.nearbyNodeView.add(
@@ -54,7 +54,7 @@ export class NeighborUpdateRpcLocal implements INeighborUpdateRpc {
     // INeighborUpdateRpc server method
     async neighborUpdate(message: NeighborUpdate, context: ServerCallContext): Promise<NeighborUpdate> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const remoteNodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        const remoteNodeId = toNodeId(senderPeerDescriptor)
         this.updateContacts(message.neighborDescriptors)
         if (!this.options.neighbors.has(remoteNodeId) && !this.options.ongoingHandshakes.has(remoteNodeId)) {
             return this.createResponse(true)

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateRpcRemote.ts
@@ -1,4 +1,4 @@
-import { PeerDescriptor, RpcRemote, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { PeerDescriptor, RpcRemote, toNodeId } from '@streamr/dht'
 import { Logger, StreamPartID } from '@streamr/utils'
 import { NeighborUpdate } from '../../proto/packages/trackerless-network/protos/NetworkRpc'
 import { NeighborUpdateRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
@@ -25,7 +25,7 @@ export class NeighborUpdateRpcRemote extends RpcRemote<NeighborUpdateRpcClient> 
                 removeMe: response.removeMe
             }
         } catch (err: any) {
-            logger.debug(`updateNeighbors to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed`, { err })
+            logger.debug(`updateNeighbors to ${toNodeId(this.getPeerDescriptor())} failed`, { err })
             return {
                 peerDescriptors: [],
                 removeMe: true

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -4,7 +4,7 @@ import {
     ITransport,
     ListeningRpcCommunicator,
     PeerDescriptor,
-    getNodeIdFromPeerDescriptor
+    toNodeId
 } from '@streamr/dht'
 import { Logger, StreamPartID, UserID, addManagedEventListener, wait } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
@@ -87,7 +87,7 @@ export class ProxyClient extends EventEmitter<Events> {
         this.options = options
         this.rpcCommunicator = new ListeningRpcCommunicator(formStreamPartContentDeliveryServiceId(options.streamPartId), options.transport)
         // TODO use options option or named constant?
-        this.neighbors = new NodeList(getNodeIdFromPeerDescriptor(this.options.localPeerDescriptor), 1000)
+        this.neighbors = new NodeList(toNodeId(this.options.localPeerDescriptor), 1000)
         this.contentDeliveryRpcLocal = new ContentDeliveryRpcLocal({
             localPeerDescriptor: this.options.localPeerDescriptor,
             streamPartId: this.options.streamPartId,
@@ -137,7 +137,7 @@ export class ProxyClient extends EventEmitter<Events> {
         }
         const nodesIds = new Map<DhtAddress, PeerDescriptor>()
         nodes.forEach((peerDescriptor) => {
-            nodesIds.set(getNodeIdFromPeerDescriptor(peerDescriptor), peerDescriptor)
+            nodesIds.set(toNodeId(peerDescriptor), peerDescriptor)
         })
         this.definition = {
             nodes: nodesIds,
@@ -225,7 +225,7 @@ export class ProxyClient extends EventEmitter<Events> {
     }
 
     private removeConnection(peerDescriptor: PeerDescriptor): void {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         this.connections.delete(nodeId)
         this.neighbors.remove(nodeId)
         this.options.connectionLocker.unlockConnection(peerDescriptor, SERVICE_ID)
@@ -248,7 +248,7 @@ export class ProxyClient extends EventEmitter<Events> {
     }
 
     private async onNodeDisconnected(peerDescriptor: PeerDescriptor): Promise<void> {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         if (this.connections.has(nodeId)) {
             this.options.connectionLocker.unlockConnection(peerDescriptor, SERVICE_ID)
             this.removeConnection(peerDescriptor)

--- a/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyConnectionRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, DhtCallContext, ListeningRpcCommunicator, PeerDescriptor, toNodeId } from '@streamr/dht'
 import { Logger, StreamPartID, UserID, binaryToHex, toEthereumAddress } from '@streamr/utils'
 import { EventEmitter } from 'eventemitter3'
 import {
@@ -85,7 +85,7 @@ export class ProxyConnectionRpcLocal extends EventEmitter<Events> implements IPr
     // IProxyConnectionRpc server method
     async requestConnection(request: ProxyConnectionRequest, context: ServerCallContext): Promise<ProxyConnectionResponse> {
         const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
-        const remoteNodeId = getNodeIdFromPeerDescriptor(senderPeerDescriptor)
+        const remoteNodeId = toNodeId(senderPeerDescriptor)
         this.connections.set(remoteNodeId, {
             direction: request.direction,
             userId: toEthereumAddress(binaryToHex(request.userId, true)),

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcLocal.ts
@@ -1,5 +1,5 @@
 import { ServerCallContext } from '@protobuf-ts/runtime-rpc'
-import { ConnectionLocker, DhtAddress, DhtCallContext, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ConnectionLocker, DhtAddress, DhtCallContext, ListeningRpcCommunicator, toNodeId } from '@streamr/dht'
 import { StreamPartID } from '@streamr/utils'
 import { Empty } from '../../proto/google/protobuf/empty'
 import { PeerDescriptor } from '../../proto/packages/dht/protos/DhtRpc'
@@ -30,7 +30,7 @@ export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
     constructor(options: TemporaryConnectionRpcLocalOptions) {
         this.options = options
         // TODO use options option or named constant?
-        this.temporaryNodes = new NodeList(getNodeIdFromPeerDescriptor(options.localPeerDescriptor), 10)
+        this.temporaryNodes = new NodeList(toNodeId(options.localPeerDescriptor), 10)
         this.lockId = LOCK_ID_BASE + options.streamPartId
     }
 
@@ -59,14 +59,14 @@ export class TemporaryConnectionRpcLocal implements ITemporaryConnectionRpc {
             ContentDeliveryRpcClient
         )
         this.temporaryNodes.add(remote)
-        this.options.connectionLocker.weakLockConnection(getNodeIdFromPeerDescriptor(sender), this.lockId)
+        this.options.connectionLocker.weakLockConnection(toNodeId(sender), this.lockId)
         return {
             accepted: true
         }
     }
 
     async closeConnection(_request: CloseTemporaryConnection, context: ServerCallContext): Promise<Empty> {
-        const remoteNodeId = getNodeIdFromPeerDescriptor((context as DhtCallContext).incomingSourceDescriptor!)
+        const remoteNodeId = toNodeId((context as DhtCallContext).incomingSourceDescriptor!)
         this.removeNode(remoteNodeId)
         return {}
     }

--- a/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/temporary-connection/TemporaryConnectionRpcRemote.ts
@@ -1,4 +1,4 @@
-import { RpcRemote, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { RpcRemote, toNodeId } from '@streamr/dht'
 import { Logger } from '@streamr/utils'
 import { TemporaryConnectionRpcClient } from '../../proto/packages/trackerless-network/protos/NetworkRpc.client'
 
@@ -11,7 +11,7 @@ export class TemporaryConnectionRpcRemote extends RpcRemote<TemporaryConnectionR
             const response = await this.getClient().openConnection({}, this.formDhtRpcOptions())
             return response.accepted
         } catch (err: any) {
-            logger.debug(`temporaryConnection to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed`, { err })
+            logger.debug(`temporaryConnection to ${toNodeId(this.getPeerDescriptor())} failed`, { err })
             return false
         }
     }
@@ -23,7 +23,7 @@ export class TemporaryConnectionRpcRemote extends RpcRemote<TemporaryConnectionR
                 notification: true
             }))
         } catch (err) {
-            logger.trace(`closeConnection to ${getNodeIdFromPeerDescriptor(this.getPeerDescriptor())} failed`, { err })
+            logger.trace(`closeConnection to ${toNodeId(this.getPeerDescriptor())} failed`, { err })
         }
     }
 }

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -2,7 +2,7 @@
 
 import {
     DhtNode,
-    getNodeIdFromPeerDescriptor,
+    toNodeId,
     getRandomRegion,
     LatencyType,
     PeerDescriptor,
@@ -75,7 +75,7 @@ const measureJoiningTime = async () => {
     const peerDescriptor = createMockPeerDescriptor({
         region: getRandomRegion()
     })
-    console.log('starting node with id ', getNodeIdFromPeerDescriptor(peerDescriptor))
+    console.log('starting node with id ', toNodeId(peerDescriptor))
 
     // start publishing ons stream
     const stream = Array.from(streamParts.keys())[Math.floor(Math.random() * streamParts.size)]

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -1,4 +1,4 @@
-import { getNodeIdFromPeerDescriptor, getRandomRegion } from '@streamr/dht'
+import { toNodeId, getRandomRegion } from '@streamr/dht'
 import { StreamPartIDUtils, waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { NetworkStack } from '../../src/NetworkStack'
@@ -69,7 +69,7 @@ describe('Full node network with WebRTC connections', () => {
         const successIds: string[] = []
         nodes.forEach((node) => {
             node.getContentDeliveryManager().on('newMessage', () => {
-                successIds.push(getNodeIdFromPeerDescriptor(node.getContentDeliveryManager().getPeerDescriptor()))
+                successIds.push(toNodeId(node.getContentDeliveryManager().getPeerDescriptor()))
                 receivedMessageCount += 1
             })
         })

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -1,4 +1,4 @@
-import { getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils, waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { NetworkStack } from '../../src/NetworkStack'
@@ -67,7 +67,7 @@ describe('Full node network with WebSocket connections only', () => {
         const successIds: string[] = []
         nodes.forEach((node) => {
             node.getContentDeliveryManager().on('newMessage', () => {
-                successIds.push(getNodeIdFromPeerDescriptor(node.getContentDeliveryManager().getPeerDescriptor()))
+                successIds.push(toNodeId(node.getContentDeliveryManager().getPeerDescriptor()))
                 receivedMessageCount += 1
             })
         })

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node-Latencies.test.ts
@@ -1,4 +1,4 @@
-import { DhtNode, LatencyType, PeerDescriptor, Simulator, SimulatorTransport, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtNode, LatencyType, PeerDescriptor, Simulator, SimulatorTransport, toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils, waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
@@ -98,7 +98,7 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
                 const neighbor = allNodes.find((node) => {
                     return node.getOwnNodeId() === ownNodeId
                 })
-                const neighborNodeIds = neighbor!.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+                const neighborNodeIds = neighbor!.getNeighbors().map((n) => toNodeId(n))
                 expect(neighborNodeIds).toContain(nodeId)
             })
         })
@@ -122,10 +122,10 @@ describe('ContentDeliveryLayerNode-DhtNode-Latencies', () => {
             otherContentDeliveryLayerNodes.forEach((node) => {
                 const nodeId = node.getOwnNodeId()
                 node.getNeighbors().forEach((neighbor) => {
-                    const neighborId = getNodeIdFromPeerDescriptor(neighbor)
+                    const neighborId = toNodeId(neighbor)
                     if (neighborId !== entryPointContentDeliveryLayerNode.getOwnNodeId()) {
                         const neighbor = otherContentDeliveryLayerNodes.find((n) => n.getOwnNodeId() === neighborId)
-                        const neighborNodeIds = neighbor!.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+                        const neighborNodeIds = neighbor!.getNeighbors().map((n) => toNodeId(n))
                         if (!neighborNodeIds.includes(nodeId)) {
                             mismatchCounter += 1
                         }

--- a/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryLayerNode-Layer1Node.test.ts
@@ -1,4 +1,4 @@
-import { ConnectionManager, DhtNode, PeerDescriptor, Simulator, SimulatorTransport, getNodeIdFromPeerDescriptor, getRandomRegion } from '@streamr/dht'
+import { ConnectionManager, DhtNode, PeerDescriptor, Simulator, SimulatorTransport, toNodeId, getRandomRegion } from '@streamr/dht'
 import { Logger, StreamPartIDUtils, waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
@@ -117,7 +117,7 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
                 const neighbor = allNodes.find((node) => {
                     return node.getOwnNodeId() === nodeId
                 })
-                const neighborNodeIds = neighbor!.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+                const neighborNodeIds = neighbor!.getNeighbors().map((n) => toNodeId(n))
                 expect(neighborNodeIds.includes(allNodes[i].getOwnNodeId())).toEqual(true)
             })
         })
@@ -145,10 +145,10 @@ describe('ContentDeliveryLayerNode-DhtNode', () => {
             otherContentDeliveryLayerNodes.forEach((node) => {
                 const nodeId = node.getOwnNodeId()
                 node.getNeighbors().forEach((neighbor) => {
-                    const neighborId = getNodeIdFromPeerDescriptor(neighbor)
+                    const neighborId = toNodeId(neighbor)
                     if (neighborId !== entryPointContentDeliveryLayerNode.getOwnNodeId()) {
                         const neighbor = otherContentDeliveryLayerNodes.find((n) => n.getOwnNodeId() === neighborId)
-                        const neighborNodeIds = neighbor!.getNeighbors().map((n) => getNodeIdFromPeerDescriptor(n))
+                        const neighborNodeIds = neighbor!.getNeighbors().map((n) => toNodeId(n))
                         if (!neighborNodeIds.includes(nodeId)) {
                             mismatchCounter += 1
                         }

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -4,7 +4,7 @@ import {
     PeerDescriptor,
     Simulator,
     SimulatorTransport,
-    getNodeIdFromPeerDescriptor
+    toNodeId
 } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { NodeList } from '../../src/logic/NodeList'
@@ -82,7 +82,7 @@ describe('Handshakes', () => {
         rpcCommunicator2 = new ListeningRpcCommunicator(streamPartId, simulatorTransport2)
         rpcCommunicator3 = new ListeningRpcCommunicator(streamPartId, simulatorTransport3)
 
-        const handshakerNodeId = getNodeIdFromPeerDescriptor(peerDescriptor2)
+        const handshakerNodeId = toNodeId(peerDescriptor2)
         leftNodeView = new NodeList(handshakerNodeId, 10)
         rightNodeView = new NodeList(handshakerNodeId, 10)
         nodeView = new NodeList(handshakerNodeId, 10)
@@ -124,7 +124,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(neighbors.has(toNodeId(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake accepted', async () => {
@@ -139,7 +139,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
+        expect(neighbors.has(toNodeId(peerDescriptor1))).toEqual(true)
     })
 
     it('Handshake rejected', async () => {
@@ -154,7 +154,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(false)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(false)
+        expect(neighbors.has(toNodeId(peerDescriptor1))).toEqual(false)
     })
 
     it('Handshake with Interleaving', async () => {
@@ -170,7 +170,7 @@ describe('Handshakes', () => {
             )
         )
         expect(res).toEqual(true)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor1))).toEqual(true)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(peerDescriptor3))).toEqual(true)
+        expect(neighbors.has(toNodeId(peerDescriptor1))).toEqual(true)
+        expect(neighbors.has(toNodeId(peerDescriptor3))).toEqual(true)
     })
 })

--- a/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
+++ b/packages/trackerless-network/test/unit/ContentDeliveryLayerNode.test.ts
@@ -1,4 +1,4 @@
-import { getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils, waitForCondition } from '@streamr/utils'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
 import { NodeList } from '../../src/logic/NodeList'
@@ -22,7 +22,7 @@ describe('ContentDeliveryLayerNode', () => {
     let discoveryLayerNode: MockDiscoveryLayerNode
 
     beforeEach(async () => {
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
 
         neighbors = new NodeList(nodeId, 10)
         randomNodeView = new NodeList(nodeId, 10)
@@ -54,14 +54,14 @@ describe('ContentDeliveryLayerNode', () => {
         const mockRemote = createMockContentDeliveryRpcRemote()
         neighbors.add(mockRemote)
         const result = contentDeliveryLayerNode.getNeighbors()
-        expect(getNodeIdFromPeerDescriptor(result[0])).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))
+        expect(toNodeId(result[0])).toEqual(toNodeId(mockRemote.getPeerDescriptor()))
     })
 
     it('getNearbyNodeView', () => {
         const mockRemote = createMockContentDeliveryRpcRemote()
         nearbyNodeView.add(mockRemote)
         const ids = contentDeliveryLayerNode.getNearbyNodeView().getIds()
-        expect(ids[0]).toEqual(getNodeIdFromPeerDescriptor(mockRemote.getPeerDescriptor()))
+        expect(ids[0]).toEqual(toNodeId(mockRemote.getPeerDescriptor()))
     })
 
     it('Adds Closest Nodes from layer1 nearbyContactAdded event to nearbyNodeView', async () => {
@@ -70,8 +70,8 @@ describe('ContentDeliveryLayerNode', () => {
         discoveryLayerNode.setClosestContacts([peerDescriptor1, peerDescriptor2])
         discoveryLayerNode.emit('nearbyContactAdded', peerDescriptor1)
         await waitForCondition(() => nearbyNodeView.size() === 2)
-        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(nearbyNodeView.get(toNodeId(peerDescriptor1))).toBeTruthy()
+        expect(nearbyNodeView.get(toNodeId(peerDescriptor2))).toBeTruthy()
     })
 
     it('Adds Random Nodes from layer1 randomContactAdded event to randomNodeView', async () => {
@@ -80,8 +80,8 @@ describe('ContentDeliveryLayerNode', () => {
         discoveryLayerNode.setRandomContacts([peerDescriptor1, peerDescriptor2])
         discoveryLayerNode.emit('randomContactAdded', peerDescriptor1)
         await waitForCondition(() => randomNodeView.size() === 2)
-        expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(randomNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(randomNodeView.get(toNodeId(peerDescriptor1))).toBeTruthy()
+        expect(randomNodeView.get(toNodeId(peerDescriptor2))).toBeTruthy()
     })
 
     it('Adds Nodes from layer1 neighbors to nearbyNodeView if its size is below nodeViewSize', async () => {
@@ -93,8 +93,8 @@ describe('ContentDeliveryLayerNode', () => {
         await waitForCondition(() => {
             return nearbyNodeView.size() === 3
         }, 20000)
-        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor1))).toBeTruthy()
-        expect(nearbyNodeView.get(getNodeIdFromPeerDescriptor(peerDescriptor2))).toBeTruthy()
+        expect(nearbyNodeView.get(toNodeId(peerDescriptor1))).toBeTruthy()
+        expect(nearbyNodeView.get(toNodeId(peerDescriptor2))).toBeTruthy()
     }, 25000)
 
     it('getInfo', () => {

--- a/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, NodeType, getNodeIdFromPeerDescriptor, getRawFromDhtAddress } from '@streamr/dht'
+import { DhtAddress, NodeType, toNodeId, toDhtAddressRaw } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { NodeList } from '../../src/logic/NodeList'
 import { HandshakeRpcLocal } from '../../src/logic/neighbor-discovery/HandshakeRpcLocal'
@@ -19,7 +19,7 @@ describe('HandshakeRpcLocal', () => {
     let handshakeWithInterleaving: jest.Mock
 
     beforeEach(() => {
-        neighbors = new NodeList(getNodeIdFromPeerDescriptor(localPeerDescriptor), 10)
+        neighbors = new NodeList(toNodeId(localPeerDescriptor), 10)
         ongoingHandshakes = new Set()
         ongoingInterleaves = new Set()
         handshakeWithInterleaving = jest.fn()
@@ -86,7 +86,7 @@ describe('HandshakeRpcLocal', () => {
     it('handshakeWithInterleaving success', async () => {
         const req: InterleaveRequest = {
             interleaveTargetDescriptor: {
-                nodeId: getRawFromDhtAddress('0x2222' as DhtAddress),
+                nodeId: toDhtAddressRaw('0x2222' as DhtAddress),
                 type: NodeType.NODEJS
             }
         }
@@ -99,7 +99,7 @@ describe('HandshakeRpcLocal', () => {
     it('handshakeWithInterleaving success', async () => {
         const req: InterleaveRequest = {
             interleaveTargetDescriptor: {
-                nodeId: getRawFromDhtAddress('0x2222' as DhtAddress),
+                nodeId: toDhtAddressRaw('0x2222' as DhtAddress),
                 type: NodeType.NODEJS
             }
         }
@@ -115,7 +115,7 @@ describe('HandshakeRpcLocal', () => {
         neighbors.add(createMockContentDeliveryRpcRemote())
         neighbors.add(createMockContentDeliveryRpcRemote())
         const requestor = createMockPeerDescriptor()
-        ongoingInterleaves.add(getNodeIdFromPeerDescriptor(requestor))
+        ongoingInterleaves.add(toNodeId(requestor))
         const req = StreamPartHandshakeRequest.create({
             streamPartId: STREAM_PART_ID,
             requestId: 'requestId'
@@ -134,9 +134,9 @@ describe('HandshakeRpcLocal', () => {
         neighbors.add(createMockContentDeliveryRpcRemote(interleavingPeer2))
         neighbors.add(createMockContentDeliveryRpcRemote(interleavingPeer3))
         neighbors.add(createMockContentDeliveryRpcRemote())
-        ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer1))
-        ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer2))
-        ongoingInterleaves.add(getNodeIdFromPeerDescriptor(interleavingPeer3))
+        ongoingInterleaves.add(toNodeId(interleavingPeer1))
+        ongoingInterleaves.add(toNodeId(interleavingPeer2))
+        ongoingInterleaves.add(toNodeId(interleavingPeer3))
         const req = StreamPartHandshakeRequest.create({
             streamPartId: STREAM_PART_ID,
             requestId: 'requestId'

--- a/packages/trackerless-network/test/unit/Handshaker.test.ts
+++ b/packages/trackerless-network/test/unit/Handshaker.test.ts
@@ -1,4 +1,4 @@
-import { ListeningRpcCommunicator, Simulator, SimulatorTransport, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ListeningRpcCommunicator, Simulator, SimulatorTransport, toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { range } from 'lodash'
 import { NodeList } from '../../src/logic/NodeList'
@@ -28,7 +28,7 @@ describe('Handshaker', () => {
         await simulatorTransport.start()
         const rpcCommunicator = new ListeningRpcCommunicator(streamPartId, simulatorTransport)
 
-        const nodeId = getNodeIdFromPeerDescriptor(peerDescriptor)
+        const nodeId = toNodeId(peerDescriptor)
         neighbors = new NodeList(nodeId, 10)
         leftNodeView = new NodeList(nodeId, 20)
         rightNodeView = new NodeList(nodeId, 20)

--- a/packages/trackerless-network/test/unit/InspectSession.test.ts
+++ b/packages/trackerless-network/test/unit/InspectSession.test.ts
@@ -2,7 +2,7 @@ import { InspectSession, Events } from '../../src/logic/inspect/InspectSession'
 import { MessageID } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { waitForEvent3 } from '../../../utils/dist/src/waitForEvent3'
 import { utf8ToBinary } from '@streamr/utils'
-import { DhtAddress, createRandomDhtAddress } from '@streamr/dht'
+import { DhtAddress, randomDhtAddress } from '@streamr/dht'
 
 describe('InspectSession', () => {
 
@@ -30,8 +30,8 @@ describe('InspectSession', () => {
     }
 
     beforeEach(() => {
-        inspectedNode = createRandomDhtAddress()
-        anotherNode = createRandomDhtAddress()
+        inspectedNode = randomDhtAddress()
+        anotherNode = randomDhtAddress()
         inspectSession = new InspectSession({
             inspectedNode
         })

--- a/packages/trackerless-network/test/unit/Inspector.test.ts
+++ b/packages/trackerless-network/test/unit/Inspector.test.ts
@@ -1,4 +1,4 @@
-import { ListeningRpcCommunicator, createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { ListeningRpcCommunicator, randomDhtAddress, toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils, utf8ToBinary } from '@streamr/utils'
 import { Inspector } from '../../src/logic/inspect/Inspector'
 import { MockTransport } from '../utils/mock/MockTransport'
@@ -11,7 +11,7 @@ describe('Inspector', () => {
 
     const inspectedDescriptor = createMockPeerDescriptor()
 
-    const nodeId = createRandomDhtAddress()
+    const nodeId = randomDhtAddress()
     let mockConnect: jest.Mock
 
     const messageRef = {
@@ -40,11 +40,11 @@ describe('Inspector', () => {
 
     it('Opens inspection connection and runs successfully', async () => {
         setTimeout(() => {
-            inspector.markMessage(getNodeIdFromPeerDescriptor(inspectedDescriptor), messageRef)
+            inspector.markMessage(toNodeId(inspectedDescriptor), messageRef)
             inspector.markMessage(nodeId, messageRef)
         }, 250)
         await inspector.inspect(inspectedDescriptor)
-        expect(inspector.isInspected(getNodeIdFromPeerDescriptor(inspectedDescriptor))).toBe(false)
+        expect(inspector.isInspected(toNodeId(inspectedDescriptor))).toBe(false)
         expect(mockConnect).toBeCalledTimes(1)
     })
 

--- a/packages/trackerless-network/test/unit/NeighborFinder.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborFinder.test.ts
@@ -4,11 +4,11 @@ import { waitForCondition } from '@streamr/utils'
 import { range } from 'lodash'
 import { expect } from 'expect'
 import { createMockContentDeliveryRpcRemote } from '../utils/utils'
-import { DhtAddress, createRandomDhtAddress, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, randomDhtAddress, toNodeId } from '@streamr/dht'
 
 describe('NeighborFinder', () => {
 
-    const nodeId = createRandomDhtAddress()
+    const nodeId = randomDhtAddress()
     let neighbors: NodeList
     let nearbyNodeView: NodeList
     let neighborFinder: NeighborFinder
@@ -24,7 +24,7 @@ describe('NeighborFinder', () => {
             if (Math.random() < 0.5) {
                 neighbors.add(target!)
             } else {
-                excluded.push(getNodeIdFromPeerDescriptor(target!.getPeerDescriptor()))
+                excluded.push(toNodeId(target!.getPeerDescriptor()))
             }
             return excluded
         }

--- a/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/NeighborUpdateRpcLocal.test.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, ListeningRpcCommunicator, getNodeIdFromPeerDescriptor } from '@streamr/dht'
+import { DhtAddress, ListeningRpcCommunicator, toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { range } from 'lodash'
 import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
@@ -35,8 +35,8 @@ describe('NeighborUpdateRpcLocal', () => {
 
     beforeEach(() => {
         rpcCommunicator = new ListeningRpcCommunicator('mock', new MockTransport())
-        neighbors = new NodeList(getNodeIdFromPeerDescriptor(localPeerDescriptor), neighborTargetCount + 1)
-        nearbyNodeView = new NodeList(getNodeIdFromPeerDescriptor(localPeerDescriptor), neighborTargetCount)
+        neighbors = new NodeList(toNodeId(localPeerDescriptor), neighborTargetCount + 1)
+        nearbyNodeView = new NodeList(toNodeId(localPeerDescriptor), neighborTargetCount)
         neighborFinder = {
             start: jest.fn()
         } as any
@@ -122,12 +122,12 @@ describe('NeighborUpdateRpcLocal', () => {
             removeMe: false
         }, { incomingSourceDescriptor: caller } as any)
         expect(res.removeMe).toEqual(true)
-        expect(neighbors.has(getNodeIdFromPeerDescriptor(caller))).toEqual(false)
+        expect(neighbors.has(toNodeId(caller))).toEqual(false)
     })
 
     it('does not ask to be removed if there is an ongoing handshake to the caller', async () => {
         const caller = createMockPeerDescriptor()
-        ongoingHandshakes.add(getNodeIdFromPeerDescriptor(caller))
+        ongoingHandshakes.add(toNodeId(caller))
         const res = await rpcLocal.neighborUpdate({
             streamPartId,
             neighborDescriptors: [localPeerDescriptor],

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -2,9 +2,9 @@ import {
     ListeningRpcCommunicator,
     NodeType,
     PeerDescriptor,
-    createRandomDhtAddress,
-    getDhtAddressFromRaw,
-    getNodeIdFromPeerDescriptor,
+    randomDhtAddress,
+    toDhtAddress,
+    toNodeId,
 } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { expect } from 'expect'
@@ -26,7 +26,7 @@ describe('NodeList', () => {
         new Uint8Array([1, 1, 4]),
         new Uint8Array([1, 1, 5])
     ]
-    const ownId = createRandomDhtAddress()
+    const ownId = randomDhtAddress()
     let nodeList: NodeList
 
     const createRemoteGraphNode = (peerDescriptor: PeerDescriptor) => {
@@ -57,7 +57,7 @@ describe('NodeList', () => {
         }
         const newNode = createRemoteGraphNode(newDescriptor)
         nodeList.add(newNode)
-        expect(nodeList.has(getNodeIdFromPeerDescriptor(newDescriptor))).toEqual(true)
+        expect(nodeList.has(toNodeId(newDescriptor))).toEqual(true)
 
         const newDescriptor2 = {
             nodeId: new Uint8Array([1, 2, 4]),
@@ -65,26 +65,26 @@ describe('NodeList', () => {
         }
         const newNode2 = createRemoteGraphNode(newDescriptor2)
         nodeList.add(newNode2)
-        expect(nodeList.has(getNodeIdFromPeerDescriptor(newDescriptor2))).toEqual(false)
+        expect(nodeList.has(toNodeId(newDescriptor2))).toEqual(false)
     })
 
     it('remove', () => {
         const toRemove = nodeList.getFirst([])
-        const nodeId = getNodeIdFromPeerDescriptor(toRemove!.getPeerDescriptor())
+        const nodeId = toNodeId(toRemove!.getPeerDescriptor())
         nodeList.remove(nodeId)
         expect(nodeList.has(nodeId)).toEqual(false)
     })
 
     it('getFirst', () => {
         const closest = nodeList.getFirst([])
-        expect(getNodeIdFromPeerDescriptor(closest!.getPeerDescriptor()))
-            .toEqual(getDhtAddressFromRaw(new Uint8Array([1, 1, 1])))
+        expect(toNodeId(closest!.getPeerDescriptor()))
+            .toEqual(toDhtAddress(new Uint8Array([1, 1, 1])))
     })
 
     it('getFirst with exclude', () => {
-        const closest = nodeList.getFirst([getDhtAddressFromRaw(new Uint8Array([1, 1, 1]))])
-        expect(getNodeIdFromPeerDescriptor(closest!.getPeerDescriptor()))
-            .toEqual(getDhtAddressFromRaw(new Uint8Array([1, 1, 2])))
+        const closest = nodeList.getFirst([toDhtAddress(new Uint8Array([1, 1, 1]))])
+        expect(toNodeId(closest!.getPeerDescriptor()))
+            .toEqual(toDhtAddress(new Uint8Array([1, 1, 2])))
     })
 
     it('getFirst wsOnly', () => {
@@ -95,14 +95,14 @@ describe('NodeList', () => {
 
     it('getLast', () => {
         const closest = nodeList.getLast([])
-        expect(getNodeIdFromPeerDescriptor(closest!.getPeerDescriptor()))
-            .toEqual(getDhtAddressFromRaw(new Uint8Array([1, 1, 5])))
+        expect(toNodeId(closest!.getPeerDescriptor()))
+            .toEqual(toDhtAddress(new Uint8Array([1, 1, 5])))
     })
 
     it('getLast with exclude', () => {
-        const closest = nodeList.getLast([getDhtAddressFromRaw(new Uint8Array([1, 1, 5]))])
-        expect(getNodeIdFromPeerDescriptor(closest!.getPeerDescriptor()))
-            .toEqual(getDhtAddressFromRaw(new Uint8Array([1, 1, 4])))
+        const closest = nodeList.getLast([toDhtAddress(new Uint8Array([1, 1, 5]))])
+        expect(toNodeId(closest!.getPeerDescriptor()))
+            .toEqual(toDhtAddress(new Uint8Array([1, 1, 4])))
     })
 
     it('getFirstAndLast', () => {
@@ -132,17 +132,17 @@ describe('NodeList', () => {
 
     it('getFirstAndLast with exclude', () => {
         const results = nodeList.getFirstAndLast([
-            getDhtAddressFromRaw(new Uint8Array([1, 1, 1])),
-            getDhtAddressFromRaw(new Uint8Array([1, 1, 5]))
+            toDhtAddress(new Uint8Array([1, 1, 1])),
+            toDhtAddress(new Uint8Array([1, 1, 5]))
         ])
         expect(results).toEqual([
-            nodeList.getFirst([getDhtAddressFromRaw(new Uint8Array([1, 1, 1]))]),
-            nodeList.getLast([getDhtAddressFromRaw(new Uint8Array([1, 1, 5]))])
+            nodeList.getFirst([toDhtAddress(new Uint8Array([1, 1, 1]))]),
+            nodeList.getLast([toDhtAddress(new Uint8Array([1, 1, 5]))])
         ])
     })
 
     it('items are in insertion order', () => {
-        const list = new NodeList(createRandomDhtAddress(), 100)
+        const list = new NodeList(randomDhtAddress(), 100)
         const item1 = createRemoteGraphNode(createMockPeerDescriptor())
         const item2 = createRemoteGraphNode(createMockPeerDescriptor())
         const item3 = createRemoteGraphNode(createMockPeerDescriptor())

--- a/packages/trackerless-network/test/unit/PeerDescriptorStoreManager.test.ts
+++ b/packages/trackerless-network/test/unit/PeerDescriptorStoreManager.test.ts
@@ -1,11 +1,11 @@
-import { PeerDescriptor, areEqualPeerDescriptors, createRandomDhtAddress } from '@streamr/dht'
+import { PeerDescriptor, areEqualPeerDescriptors, randomDhtAddress } from '@streamr/dht'
 import { wait } from '@streamr/utils'
 import { PeerDescriptorStoreManager } from '../../src/logic/PeerDescriptorStoreManager'
 import { Any } from '../../src/proto/google/protobuf/any'
 import { DataEntry } from '../../src/proto/packages/dht/protos/DhtRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
 
-const KEY = createRandomDhtAddress()
+const KEY = randomDhtAddress()
 
 describe('PeerDescriptorStoreManager', () => {
 

--- a/packages/trackerless-network/test/unit/TemporaryConnectionRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/TemporaryConnectionRpcLocal.test.ts
@@ -1,4 +1,4 @@
-import { ListeningRpcCommunicator, getDhtAddressFromRaw } from '@streamr/dht'
+import { ListeningRpcCommunicator, toDhtAddress } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { TemporaryConnectionRpcLocal } from '../../src/logic/temporary-connection/TemporaryConnectionRpcLocal'
 import { MockTransport } from '../utils/mock/MockTransport'
@@ -30,9 +30,9 @@ describe('TemporaryConnectionRpcLocal', () => {
     it('Open and Close Connection', async () => {
         const caller = createMockPeerDescriptor()
         await rpcLocal.openConnection({}, { incomingSourceDescriptor: caller } as any)
-        expect(rpcLocal.getNodes().get(getDhtAddressFromRaw(caller.nodeId))).toBeDefined()
+        expect(rpcLocal.getNodes().get(toDhtAddress(caller.nodeId))).toBeDefined()
         await rpcLocal.closeConnection({}, { incomingSourceDescriptor: caller } as any)
-        expect(rpcLocal.getNodes().get(getDhtAddressFromRaw(caller.nodeId))).toBeUndefined()
+        expect(rpcLocal.getNodes().get(toDhtAddress(caller.nodeId))).toBeUndefined()
     })
 
 })

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -5,9 +5,9 @@ import {
     PeerDescriptor,
     Simulator,
     SimulatorTransport,
-    createRandomDhtAddress,
+    randomDhtAddress,
     getRandomRegion,
-    getRawFromDhtAddress
+    toDhtAddressRaw
 } from '@streamr/dht'
 import { RpcCommunicator } from '@streamr/proto-rpc'
 import { StreamPartID, StreamPartIDUtils, UserID, hexToBinary, utf8ToBinary } from '@streamr/utils'
@@ -98,7 +98,7 @@ export const createStreamMessage = (
 export const createMockPeerDescriptor = (opts?: Omit<Partial<PeerDescriptor>, 'nodeId' | 'type'>): PeerDescriptor => {
     return {
         ...opts,
-        nodeId: getRawFromDhtAddress(createRandomDhtAddress()),
+        nodeId: toDhtAddressRaw(randomDhtAddress()),
         type: NodeType.NODEJS,
         region: getRandomRegion()
     }


### PR DESCRIPTION
Renamed:
- `getDhtAddressFromRaw` -> `toDhtAddress`
- `getRawFromDhtAddress` -> `toDhtAddressRaw`
- `getNodeIdFromPeerDescriptor` -> `toNodeId`
- `createRandomDhtAddress` -> `randomDhtAddress`

This way we adapt the same naming style, which is already used in the utils package `toEthereumAddress()`. We'll soon add also more functions with that naming style: `toUserId()` and `toUserIdRaw()` (https://github.com/streamr-dev/network/pull/2774).

This PR doesn't contain functionality changes, only the four renames mentioned above.