### PR TITLE
feat(network): Improve `StreamPartitionInfo` compatibility

### DIFF
--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -163,7 +163,8 @@ enum ProxyDirection {
 message StreamPartitionInfo {
   string id = 1;
   repeated dht.PeerDescriptor controlLayerNeighbors = 2;
-  repeated ContentDeliveryLayerNeighborInfo contentDeliveryLayerNeighbors = 3;
+  repeated dht.PeerDescriptor deprecatedContentDeliveryLayerNeighbors = 3;
+  repeated ContentDeliveryLayerNeighborInfo contentDeliveryLayerNeighbors = 4;
 }
 
 message ContentDeliveryLayerNeighborInfo {

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -334,6 +334,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             return {
                 id: streamPartId,
                 controlLayerNeighbors: stream.discoveryLayerNode.getNeighbors(),
+                deprecatedContentDeliveryLayerNeighbors: [],
                 contentDeliveryLayerNeighbors: stream.node.getInfos()
             }
         })

--- a/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/src/proto/packages/trackerless-network/protos/NetworkRpc.ts
@@ -316,7 +316,11 @@ export interface StreamPartitionInfo {
      */
     controlLayerNeighbors: PeerDescriptor[];
     /**
-     * @generated from protobuf field: repeated ContentDeliveryLayerNeighborInfo contentDeliveryLayerNeighbors = 3;
+     * @generated from protobuf field: repeated dht.PeerDescriptor deprecatedContentDeliveryLayerNeighbors = 3;
+     */
+    deprecatedContentDeliveryLayerNeighbors: PeerDescriptor[];
+    /**
+     * @generated from protobuf field: repeated ContentDeliveryLayerNeighborInfo contentDeliveryLayerNeighbors = 4;
      */
     contentDeliveryLayerNeighbors: ContentDeliveryLayerNeighborInfo[];
 }
@@ -678,7 +682,8 @@ class StreamPartitionInfo$Type extends MessageType<StreamPartitionInfo> {
         super("StreamPartitionInfo", [
             { no: 1, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "controlLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
-            { no: 3, name: "contentDeliveryLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => ContentDeliveryLayerNeighborInfo }
+            { no: 3, name: "deprecatedContentDeliveryLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => PeerDescriptor },
+            { no: 4, name: "contentDeliveryLayerNeighbors", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => ContentDeliveryLayerNeighborInfo }
         ]);
     }
 }


### PR DESCRIPTION
Improve backwards compatibility for `StreamPartitionInfo`. The format for `contentDeliveryLayerNeighbors` field was changed in https://github.com/streamr-dev/network/pull/2738.

## Open questions

- Should we populate real data to the `deprecatedContentDeliveryLayerNeighbors` field to achieve better compatibility? With the current approach caller checks the version number and decides which field to read.