### PR TITLE
chore(node): Express v5 compatibility in `publishEndpoint`

### DIFF
--- a/packages/node/src/plugins/http/publishEndpoint.ts
+++ b/packages/node/src/plugins/http/publishEndpoint.ts
@@ -43,10 +43,10 @@ const createHandler = (msgChainId: string, streamrClient: StreamrClient): Reques
                 partitionKey,
                 msgChainId
             })
-            return res.sendStatus(200)
+            res.sendStatus(200)
         } catch (err) {
             logger.error('Unable to publish to message', { streamId, err })
-            return res.sendStatus(500)
+            res.sendStatus(500)
         }
     }
 }


### PR DESCRIPTION
## Changes

Fixed return values in `express` request handler.  

## Background

The request handler should return `void` in `express` v4, which we are currently using:

```ts
export interface RequestHandler<
    P = ParamsDictionary,
    ResBody = any,
    ReqBody = any,
    ReqQuery = ParsedQs,
    LocalsObj extends Record<string, any> = Record<string, any>,
> {
    (
        req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
        res: Response<ResBody, LocalsObj>,
        next: NextFunction,
    ): void;
}
```

This is also a good return value for `express` v5. The previous return type would cause a build error in v5 (see e.g. build in https://github.com/streamr-dev/network/pull/2787). The type definition in v5 is:

```ts
export interface RequestHandler<
    P = ParamsDictionary,
    ResBody = any,
    ReqBody = any,
    ReqQuery = ParsedQs,
    LocalsObj extends Record<string, any> = Record<string, any>,
> {
    (
        req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
        res: Response<ResBody, LocalsObj>,
        next: NextFunction,
    ): void | Promise<void>;
}
```
