### PR TITLE
chore(cli-tools): Import group for `logLevel`

### DIFF
--- a/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-add-stream.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 

--- a/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import EasyTable from 'easy-table'
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'

--- a/packages/cli-tools/bin/streamr-storage-node-list.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import EasyTable from 'easy-table'
 import { createClientCommand, Options as BaseOptions } from '../src/command'

--- a/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-remove-stream.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 

--- a/packages/cli-tools/bin/streamr-stream-create.ts
+++ b/packages/cli-tools/bin/streamr-stream-create.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createFnParseInt } from '../src/common'
 import { createClientCommand, Options as BaseOptions } from '../src/command'

--- a/packages/cli-tools/bin/streamr-stream-grant-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-grant-permission.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { PermissionAssignment, Stream } from '@streamr/sdk'
 import { runModifyPermissionsCommand } from '../src/permission'
 

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { Writable } from 'stream'
 import { StreamrClient } from '@streamr/sdk'
 import { wait } from '@streamr/utils'

--- a/packages/cli-tools/bin/streamr-stream-resend-from.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-from.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { resend } from '../src/resend'

--- a/packages/cli-tools/bin/streamr-stream-resend-last.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-last.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { resend } from '../src/resend'

--- a/packages/cli-tools/bin/streamr-stream-resend-range.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend-range.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { assertBothOrNoneDefined, resend } from '../src/resend'

--- a/packages/cli-tools/bin/streamr-stream-resend.ts
+++ b/packages/cli-tools/bin/streamr-stream-resend.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { createCommand } from '../src/command'
 
 createCommand()

--- a/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
+++ b/packages/cli-tools/bin/streamr-stream-revoke-permission.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { PermissionAssignment, Stream } from '@streamr/sdk'
 import { runModifyPermissionsCommand } from '../src/permission'
 

--- a/packages/cli-tools/bin/streamr-stream-search.ts
+++ b/packages/cli-tools/bin/streamr-stream-search.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient, SearchStreamsPermissionFilter, StreamPermission } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { Option } from 'commander'

--- a/packages/cli-tools/bin/streamr-stream-show.ts
+++ b/packages/cli-tools/bin/streamr-stream-show.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { getPermissionId } from '../src/permission'

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import omit from 'lodash/omit'
 import isString from 'lodash/isString'
 import { StreamrClient, MessageMetadata } from '@streamr/sdk'

--- a/packages/cli-tools/bin/streamr-wallet-whoami.ts
+++ b/packages/cli-tools/bin/streamr-wallet-whoami.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import '../src/logLevel'
+
 import { StreamrClient } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 


### PR DESCRIPTION
Added a blank line after the `logLevel` import so that it forms a separate _import group_. That way e.g. VS Code's "Organize importa" doesn't change the ordering of that import statement.

## Background

We need to import `logLevel` e.g. before `createClientCommand` so that it affects the logger creation correctly.