### PR TITLE
chore(eslint): Remove unnecessary ignores

### DIFF
--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -188,7 +188,6 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
     }
 
     // ChallengeManager implementation
-    // eslint-disable-next-line class-methods-use-this
     public async deleteChallenge(fqdn: string, value: string): Promise<void> {
         if (this.route53Api !== undefined) {
             logger.trace(`Deleting acme challenge for ${fqdn} with value ${value} to Route53`)

--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/parameter-properties, quotes */
+/* eslint-disable quotes */
 
 import sqlite3 from 'sqlite3'
 import { open, Statement, Database as SqliteDatabase } from 'sqlite'

--- a/packages/dht/src/dht/routing/Router.ts
+++ b/packages/dht/src/dht/routing/Router.ts
@@ -122,10 +122,8 @@ export class Router {
         const contacts = session.updateAndGetRoutablePeers()
         if (contacts.length > 0) {
             this.addRoutingSession(session)
-            // eslint-disable-next-line promise/catch-or-return
             logger.trace('starting to raceEvents from routingSession: ' + session.sessionId)
             let eventReceived: Promise<unknown>
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             executeSafePromise(async () => {
                 eventReceived = raceEvents3<RoutingSessionEvents>(
                     session,

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -196,7 +196,6 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         }
         while ((this.ongoingRequests.size < this.options.parallelism) && (uncontacted.length > 0) && !this.stopped) {
             const nextPeer = uncontacted.shift()
-            // eslint-disable-next-line max-len
             logger.trace(`Sending routeMessage request to contact: ${toNodeId(nextPeer!.getPeerDescriptor())} (sessionId=${this.sessionId})`)
             this.contactedPeers.add(nextPeer!.getNodeId())
             this.ongoingRequests.add(nextPeer!.getNodeId())

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'

--- a/packages/dht/test/integration/Websocket.test.ts
+++ b/packages/dht/test/integration/Websocket.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import { WebsocketServer } from '../../src/connection/websocket/WebsocketServer'
 import { IConnection } from '../../src/connection/IConnection'
 import { WebsocketClientConnection } from '../../src/connection/websocket/NodeWebsocketClientConnection'

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable promise/no-nesting */
-
 import { MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'

--- a/packages/dht/test/utils/FakeTransport.ts
+++ b/packages/dht/test/utils/FakeTransport.ts
@@ -43,12 +43,10 @@ class FakeTransport extends EventEmitter<TransportEvents> implements ITransport,
         return this.connections
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getConnectionCount(): number {
         return this.connections.length
     }
 
-    // eslint-disable-next-line class-methods-use-this
     hasConnection(nodeId: DhtAddress): boolean {
         return this.connections.some((c) => toNodeId(c) === nodeId)
     }

--- a/packages/node/src/plugins/mqtt/MqttPlugin.ts
+++ b/packages/node/src/plugins/mqtt/MqttPlugin.ts
@@ -28,7 +28,6 @@ export class MqttPlugin extends Plugin<MqttPluginConfig> {
         return this.server.start()
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async stop(): Promise<void> {
         await this.server!.stop()
     }

--- a/packages/node/src/plugins/storage/BucketManager.ts
+++ b/packages/node/src/plugins/storage/BucketManager.ts
@@ -150,7 +150,6 @@ export class BucketManager {
 
             // minTimestamp is undefined if all buckets are found
             if (minTimestamp === undefined) {
-                // eslint-disable-next-line no-continue
                 continue
             }
 
@@ -179,14 +178,12 @@ export class BucketManager {
 
             // if latest is not found or it's full => try to find latest in database
             if (!latestBucket || latestBucket.isAlmostFull()) {
-                // eslint-disable-next-line no-await-in-loop
                 const foundBuckets = await this.getLastBuckets(streamId, partition, 1)
                 checkFoundBuckets(foundBuckets)
             }
 
             // check in database that we have bucket for minTimestamp
             if (!insertNewBucket && !this.findBucketId(key, minTimestamp)) {
-                // eslint-disable-next-line no-await-in-loop
                 const foundBuckets = await this.getLastBuckets(streamId, partition, 1, minTimestamp)
                 checkFoundBuckets(foundBuckets)
             }
@@ -202,11 +199,9 @@ export class BucketManager {
 
                 stream.buckets.push(newBucket)
                 this.buckets[newBucket.getId()] = newBucket
-                // eslint-disable-next-line require-atomic-updates
                 stream.minTimestamp = undefined
             }
         }
-
         this.checkFullBucketsTimeout = setTimeout(() => this.checkFullBuckets(), this.opts.checkFullBucketsTimeout)
     }
 
@@ -258,7 +253,7 @@ export class BucketManager {
         if (fromTimestamp !== undefined) {
             return Promise.all([getExplicitFirst(), getRest()])
                 .then(([first, rest]) => rest.concat(first))
-        } else { // eslint-disable-line no-else-return
+        } else {
             return getRest()
         }
     }

--- a/packages/node/src/plugins/storage/Storage.ts
+++ b/packages/node/src/plugins/storage/Storage.ts
@@ -118,7 +118,6 @@ export class Storage extends EventEmitter {
 
     requestLast(streamId: string, partition: number, limit: number): Readable {
         if (limit > MAX_RESEND_LAST) {
-            // eslint-disable-next-line no-param-reassign
             limit = MAX_RESEND_LAST
         }
 
@@ -561,7 +560,6 @@ export const startCassandraStorage = async ({
     let retryCount = nbTrials
     let lastError = ''
     while (retryCount > 0) {
-        /* eslint-disable no-await-in-loop */
         try {
             await cassandraClient.connect().catch((err) => { throw err })
             return new Storage(cassandraClient, opts || {})
@@ -572,7 +570,6 @@ export const startCassandraStorage = async ({
             await sleep(5000)
             lastError = err
         }
-        /* eslint-enable no-await-in-loop */
     }
     throw new Error(`Failed to connect to Cassandra after ${nbTrials} trials: ${lastError.toString()}`)
 }

--- a/packages/node/test/integration/plugins/storage/BucketManager.test.ts
+++ b/packages/node/test/integration/plugins/storage/BucketManager.test.ts
@@ -17,7 +17,6 @@ describe('BucketManager', () => {
     const insertBuckets = async (startTimestamp: Date) => {
         for (let i = 0; i < 100; i++) {
             const currentTimestamp = new Date(startTimestamp.getTime() + i * 60 * 1000) // + "i" minutes
-            // eslint-disable-next-line no-await-in-loop
             await cassandraClient.execute('INSERT INTO bucket (stream_id, partition, date_create, id, records, size) '
                 + 'VALUES (?, 0, ?, ?, 5, 5)', [
                 streamId,

--- a/packages/node/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/node/test/integration/plugins/storage/Storage.test.ts
@@ -171,7 +171,6 @@ describe('Storage', () => {
         ])
 
         const {
-            // eslint-disable-next-line camelcase
             stream_id, partition, ts, sequence_no, publisher_id, msg_chain_id, payload
         } = result.first()
 

--- a/packages/node/test/unit/plugins/storage/Batch.test.ts
+++ b/packages/node/test/unit/plugins/storage/Batch.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import { Batch, InsertRecord, State } from '../../../../src/plugins/storage/Batch'
 import { BucketId } from '../../../../src/plugins/storage/Bucket'
 

--- a/packages/node/test/unit/plugins/storage/Bucket.test.ts
+++ b/packages/node/test/unit/plugins/storage/Bucket.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import { Bucket } from '../../../../src/plugins/storage/Bucket'
 
 describe('Bucket', () => {

--- a/packages/node/test/unit/plugins/storage/dataQueryEndpoint.test.ts
+++ b/packages/node/test/unit/plugins/storage/dataQueryEndpoint.test.ts
@@ -92,7 +92,6 @@ describe('dataQueryEndpoint', () => {
             })
 
             it('responds 400 and error message if publisherId+msgChainId combination is invalid in range request', async () => {
-                // eslint-disable-next-line max-len
                 const base = '/streams/streamId/data/partitions/0/range?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
                 const suffixes = ['publisherId=foo', 'msgChainId=bar']
                 for (const suffix of suffixes) {
@@ -303,14 +302,12 @@ describe('dataQueryEndpoint', () => {
             })
 
             it('responds 200 and Content-Type JSON', (done) => {
-                // eslint-disable-next-line max-len
                 testGetRequest('/streams/streamId/data/partitions/0/range?fromTimestamp=1496408255672&toTimestamp=1496415670909')
                     .expect('Content-Type', /json/)
                     .expect(200, done)
             })
 
             it('responds with data points as body', (done) => {
-                // eslint-disable-next-line max-len
                 testGetRequest('/streams/streamId/data/partitions/0/range?fromTimestamp=1496408255672&toTimestamp=1496415670909')
                     .expect(streamMessages.map((msg) => toObject(msg)), done)
             })
@@ -318,7 +315,6 @@ describe('dataQueryEndpoint', () => {
             it('invokes storage#requestRange once with correct arguments', async () => {
                 storage.requestRange = jest.fn().mockReturnValue(createOutputStream([]))
 
-                // eslint-disable-next-line max-len
                 await testGetRequest('/streams/streamId/data/partitions/0/range?fromTimestamp=1496408255672&toTimestamp=1496415670909')
 
                 expect(storage.requestRange).toHaveBeenCalledTimes(1)
@@ -337,7 +333,6 @@ describe('dataQueryEndpoint', () => {
             it('responds 500 and error message if storage signals error', (done) => {
                 storage.requestRange = () => toReadableStream(new Error('error'))
 
-                // eslint-disable-next-line max-len
                 testGetRequest('/streams/streamId/data/partitions/0/range?fromTimestamp=1496408255672&toTimestamp=1496415670909')
                     .expect('Content-Type', /json/)
                     .expect(500, {

--- a/packages/proto-rpc/src/errors.ts
+++ b/packages/proto-rpc/src/errors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable max-len */
 
 export enum ErrorCode {

--- a/packages/proto-rpc/src/toProtoRpcClient.ts
+++ b/packages/proto-rpc/src/toProtoRpcClient.ts
@@ -1,5 +1,4 @@
-/* eslint-disable prefer-spread, @typescript-eslint/consistent-indexed-object-style, 
-@typescript-eslint/no-invalid-void-type */
+/* eslint-disable prefer-spread, @typescript-eslint/consistent-indexed-object-style */
 
 import type { ServiceInfo } from '@protobuf-ts/runtime-rpc'
 import { Empty } from './proto/google/protobuf/empty'

--- a/packages/sdk/src/Authentication.ts
+++ b/packages/sdk/src/Authentication.ts
@@ -58,7 +58,6 @@ export const createAuthentication = (config: Pick<StrictStreamrClientConfig, 'au
                 const actualChainId = (await provider.getNetwork()).chainId
                 if (actualChainId !== BigInt(expectedChainId)) {
                     throw new Error(
-                        // eslint-disable-next-line max-len
                         `Please connect the custom authentication provider with chainId ${expectedChainId} (current chainId is ${actualChainId})`
                     )
                 }

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -252,7 +252,6 @@ export class Stream {
             await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(
                 propagationPromise,
-                // eslint-disable-next-line no-underscore-dangle
                 waitOptions.timeout ?? this._config._timeouts.storageNode.timeout,
                 'storage node did not respond'
             )

--- a/packages/sdk/src/contracts/StreamRegistry.ts
+++ b/packages/sdk/src/contracts/StreamRegistry.ts
@@ -95,8 +95,7 @@ export class StreamRegistry {
     private readonly isStreamPublisher_cached: CacheAsyncFnType<[StreamID, UserID], boolean, string>
     private readonly isStreamSubscriber_cached: CacheAsyncFnType<[StreamID, UserID], boolean, string>
     private readonly hasPublicSubscribePermission_cached: CacheAsyncFnType<[StreamID], boolean, string>
-    
-    /* eslint-disable indent */
+
     /** @internal */
     constructor(
         streamFactory: StreamFactory,
@@ -125,7 +124,6 @@ export class StreamRegistry {
         )
         const chainEventPoller = new ChainEventPoller(this.rpcProviderSource.getSubProviders().map((p) => {
             return contractFactory.createEventContract(toEthereumAddress(this.config.contracts.streamRegistryChainAddress), StreamRegistryArtifact, p)
-        // eslint-disable-next-line no-underscore-dangle
         }), config.contracts.pollInterval)
         initContractEventGateway({
             sourceName: 'StreamCreated', 
@@ -349,7 +347,6 @@ export class StreamRegistry {
     // Permissions
     // --------------------------------------------------------------------------------------------
 
-    /* eslint-disable no-else-return */
     async hasPermission(query: PermissionQuery): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(query.streamId)
         const permissionType = streamPermissionToSolidityType(query.permission)
@@ -449,7 +446,6 @@ export class StreamRegistry {
                 const solidityType = streamPermissionToSolidityType(permission)
                 const user = isPublicPermissionAssignment(assignment) ? undefined : toEthereumAddress(assignment.user)
                 const txToSubmit = createTransaction(streamId, user, solidityType)
-                // eslint-disable-next-line no-await-in-loop
                 await waitForTx(txToSubmit)
             }
         }
@@ -463,7 +459,6 @@ export class StreamRegistry {
         const targets: string[][] = []
         const chainPermissions: ChainPermissions[][] = []
         for (const item of items) {
-            // eslint-disable-next-line no-await-in-loop
             const streamId = await this.streamIdBuilder.toStreamID(item.streamId)
             this.clearStreamCache(streamId)
             streamIds.push(streamId)

--- a/packages/sdk/src/contracts/StreamStorageRegistry.ts
+++ b/packages/sdk/src/contracts/StreamStorageRegistry.ts
@@ -77,7 +77,6 @@ export class StreamStorageRegistry {
                 StreamStorageRegistryArtifact,
                 p
             )
-        // eslint-disable-next-line no-underscore-dangle
         }), config.contracts.pollInterval)
         this.initStreamAssignmentEventListeners(eventEmitter, chainEventPoller, loggerFactory)
     }

--- a/packages/sdk/src/contracts/searchStreams.ts
+++ b/packages/sdk/src/contracts/searchStreams.ts
@@ -1,4 +1,3 @@
-/* eslint-disable padding-line-between-statements */
 import { GraphQLQuery, Logger, StreamID, TheGraphClient, UserID, toEthereumAddress, toStreamID } from '@streamr/utils'
 import { Stream } from '../Stream'
 import { ChainPermissions, PUBLIC_PERMISSION_ADDRESS, StreamPermission, convertChainPermissionsToStreamPermissions } from '../permission'

--- a/packages/sdk/src/encryption/SubscriberKeyExchange.ts
+++ b/packages/sdk/src/encryption/SubscriberKeyExchange.ts
@@ -64,7 +64,6 @@ export class SubscriberKeyExchange {
         this.authentication = authentication
         this.logger = loggerFactory.createLogger(module)
         this.ensureStarted = pOnce(async () => {
-            // eslint-disable-next-line no-underscore-dangle
             this.rsaKeyPair = await RSAKeyPair.create(config.encryption.rsaKeyLength)
             networkNodeFacade.addMessageListener((msg: StreamMessage) => this.onMessage(msg))
             this.logger.debug('Started')

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -127,7 +127,6 @@ const _operatorContractUtils = {
     getTestAdminWallet,
     getOperatorContract
 }
-// eslint-disable-next-line no-underscore-dangle
 export { _operatorContractUtils }
 export type { SetupOperatorContractOpts, SetupOperatorContractReturnType, DeployOperatorContractOpts, DeploySponsorshipContractOpts }
 

--- a/packages/sdk/src/protocol/StreamMessage.ts
+++ b/packages/sdk/src/protocol/StreamMessage.ts
@@ -68,7 +68,6 @@ function validateSequence(messageId: MessageID, prevMsgRef: MessageRef | undefin
     }
     if (comparison < 0) {
         throw new ValidationError(
-            // eslint-disable-next-line max-len
             `prevMessageRef must come before current. Current: ${JSON.stringify(messageId.toMessageRef())} Previous: ${JSON.stringify(prevMsgRef)}`
         )
     }

--- a/packages/sdk/src/publish/MessageFactory.ts
+++ b/packages/sdk/src/publish/MessageFactory.ts
@@ -56,7 +56,6 @@ export class MessageFactory {
         })
     }
 
-    /* eslint-disable padding-line-between-statements */
     async createMessage(
         content: unknown,
         metadata: PublishMetadata & { timestamp: number },

--- a/packages/sdk/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/sdk/src/subscribe/MessagePipelineFactory.ts
@@ -56,7 +56,6 @@ export class MessagePipelineFactory {
         this.loggerFactory = loggerFactory
     }
 
-    // eslint-disable-next-line max-len
     createMessagePipeline(opts: MessagePipelineFactoryOptions): PushPipeline<StreamMessage, StreamMessage> {
         return _createMessagePipeline({
             ...opts,

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -34,8 +34,6 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): PushPipelin
 
     const logger = opts.loggerFactory.createLogger(module)
 
-    /* eslint-enable object-curly-newline */
-
     const onError = (error: Error | StreamMessageError, streamMessage?: StreamMessage) => {
         if (streamMessage) {
             ignoreMessages.add(streamMessage)

--- a/packages/sdk/src/subscribe/waitForStorage.ts
+++ b/packages/sdk/src/subscribe/waitForStorage.ts
@@ -51,5 +51,4 @@ export const waitForStorage = async (
         })
         await wait(opts.interval)
     }
-    /* eslint-enable no-await-in-loop */
 }

--- a/packages/sdk/src/utils/WebStreamToNodeStream.ts
+++ b/packages/sdk/src/utils/WebStreamToNodeStream.ts
@@ -54,7 +54,6 @@ async function pull(fromBrowserStream: ReadableStream | WebStream.ReadableStream
         reader.cancel()
         toNodeStream.end()
     }
-    /* eslint-enable no-constant-condition, no-await-in-loop */
 }
 
 /**

--- a/packages/sdk/src/utils/promises.ts
+++ b/packages/sdk/src/utils/promises.ts
@@ -205,10 +205,10 @@ export async function until(
     try {
         // Promise wrapped condition function works for normal functions just the same as Promises
         let wasDone = false
-        while (!wasDone && !isTimedOut) { // eslint-disable-line no-await-in-loop
-            wasDone = await Promise.resolve().then(condition) // eslint-disable-line no-await-in-loop
+        while (!wasDone && !isTimedOut) {
+            wasDone = await Promise.resolve().then(condition)
             if (!wasDone && !isTimedOut) {
-                await wait(pollingIntervalMs) // eslint-disable-line no-await-in-loop
+                await wait(pollingIntervalMs)
             }
         }
 

--- a/packages/sdk/test/end-to-end/contract-call-error.test.ts
+++ b/packages/sdk/test/end-to-end/contract-call-error.test.ts
@@ -13,7 +13,6 @@ describe('contract call error', () => {
             }
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
-            // eslint-disable-next-line max-len
             'Error while executing contract call "streamRegistry.createStream", code=UNKNOWN_ERROR'
         )
     })
@@ -43,7 +42,6 @@ describe('contract call error', () => {
         await expect(() => Promise.all([
             client.createStream('/path1' + Date.now()),
             client.createStream('/path2' + Date.now())
-            // eslint-disable-next-line max-len
         ])).rejects.toThrow('Error while executing contract call "streamRegistry.createStream", code=NONCE_EXPIRED')
     })
 })

--- a/packages/sdk/test/integration/multiple-clients.test.ts
+++ b/packages/sdk/test/integration/multiple-clients.test.ts
@@ -192,13 +192,11 @@ describe('PubSub with multiple clients', () => {
                 }
             })
 
-            /* eslint-disable no-await-in-loop */
             const publishers: StreamrClient[] = []
             for (let i = 0; i < 3; i++) {
                 publishers.push(await createPublisher(i))
             }
 
-            /* eslint-enable no-await-in-loop */
             let counter = 0
             const published: Record<string, Message[]> = {}
             await Promise.all(publishers.map(async (pubClient) => {

--- a/packages/sdk/test/test-utils/fake/FakeERC1271ContractFacade.ts
+++ b/packages/sdk/test/test-utils/fake/FakeERC1271ContractFacade.ts
@@ -15,7 +15,6 @@ export class FakeERC1271ContractFacade implements Methods<ERC1271ContractFacade>
         this.chain = chain
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async isValidSignature(contractAddress: EthereumAddress, payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
         const recoveredSignerUserId = toEthereumAddress(binaryToHex(recoverSignerUserId(signature, payload), true))
         return this.chain.hasErc1271AllowedAddress(contractAddress, recoveredSignerUserId)

--- a/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
@@ -88,7 +88,6 @@ export class FakeNetworkNode implements NetworkNodeStub {
         throw new Error('not implemented')
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getOptions(): NetworkOptions {
         return this.options
     }

--- a/packages/sdk/test/test-utils/fake/FakeStorageNodeRegistry.ts
+++ b/packages/sdk/test/test-utils/fake/FakeStorageNodeRegistry.ts
@@ -18,7 +18,6 @@ export class FakeStorageNodeRegistry implements Methods<StorageNodeRegistry> {
         throw new Error('not implemented')
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async getStorageNodeMetadata(nodeAddress: EthereumAddress): Promise<StorageNodeMetadata> {
         const metadata = this.chain.getStorageNodeMetadata(nodeAddress)
         if (metadata !== undefined) {

--- a/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
@@ -60,7 +60,6 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async updateStream(streamId: StreamID, metadata: StreamMetadata): Promise<Stream> {
         const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -217,7 +217,6 @@ export const createGroupKeyManager = (
                 litProtocolLogging: false,
                 maxKeyRequestsPerSecond: 10,
                 keyRequestTimeout: 50,
-                // eslint-disable-next-line no-underscore-dangle
                 rsaKeyLength: CONFIG_TEST.encryption!.rsaKeyLength!
             }
         },

--- a/packages/sdk/test/unit/LocalGroupKeyStore.test.ts
+++ b/packages/sdk/test/unit/LocalGroupKeyStore.test.ts
@@ -22,9 +22,9 @@ describe('LocalGroupKeyStore', () => {
 
     afterEach(async () => {
         // @ts-expect-error doesn't want us to unassign, but it's ok
-        store = undefined // eslint-disable-line require-atomic-updates
+        store = undefined
         // @ts-expect-error doesn't want us to unassign, but it's ok
-        store2 = undefined // eslint-disable-line require-atomic-updates
+        store2 = undefined
     })
 
     it('can get and set', async () => {

--- a/packages/sdk/test/unit/SignatureValidator.test.ts
+++ b/packages/sdk/test/unit/SignatureValidator.test.ts
@@ -155,7 +155,6 @@ describe('SignatureValidator', () => {
                 messageType: StreamMessageType.MESSAGE,
                 contentType: ContentType.JSON,
                 encryptionType: EncryptionType.NONE,
-                // eslint-disable-next-line max-len
                 signature: hexToBinary('aaaaaaaaaaaaaaaaaaaa'),
                 signatureType: SignatureType.ERC_1271
             })

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -196,7 +196,6 @@ export const randomUserId = (): UserID => {
 // eslint-disable-next-line no-underscore-dangle
 declare let _streamr_electron_test: any
 export function isRunningInElectron(): boolean {
-    // eslint-disable-next-line no-underscore-dangle
     return typeof _streamr_electron_test !== 'undefined'
 }
 
@@ -212,7 +211,6 @@ export function describeOnlyInNodeJs(...args: Parameters<typeof describe>): void
  * Used to spin up an HTTP server used by integration tests to fetch private keys having non-zero ERC-20 token
  * balances in streamr-docker-dev environment.
  */
-/* eslint-disable no-console */
 export class KeyServer {
     public static readonly KEY_SERVER_PORT = 45454
     private static singleton: KeyServer | undefined

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -113,7 +113,6 @@ export class NetworkNode {
         return this.stack.fetchNodeInfo(node)
     }
 
-    // eslint-disable-next-line class-methods-use-this
     getDiagnosticInfo(): Record<string, unknown> {
         return {
             controlLayer: this.stack.getControlLayerNode().getDiagnosticInfo(),

--- a/packages/trackerless-network/src/logic/ExternalNetworkRpc.ts
+++ b/packages/trackerless-network/src/logic/ExternalNetworkRpc.ts
@@ -5,7 +5,6 @@ import { ClassType, ClientTransport, ProtoRpcClient, toProtoRpcClient } from '@s
 
 export const SERVICE_ID = 'external-network-service'
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ExternalRpcClient = ServiceInfo & ClassType
 // eslint-disable-next-line @typescript-eslint/prefer-function-type, @typescript-eslint/consistent-type-definitions
 export type ExternalRpcClientClass<T extends ExternalRpcClient> = { new (clientTransport: ClientTransport): T }

--- a/packages/trackerless-network/src/logic/PeerDescriptorStoreManager.ts
+++ b/packages/trackerless-network/src/logic/PeerDescriptorStoreManager.ts
@@ -32,7 +32,6 @@ export class PeerDescriptorStoreManager {
 
     private readonly abortController: AbortController
     private readonly options: PeerDescriptorStoreManagerOptions
-    // eslint-disable-next-line no-underscore-dangle
     private isLocalNodeStored_ = false
 
     constructor(options: PeerDescriptorStoreManagerOptions) {

--- a/packages/trackerless-network/src/logic/propagation/Propagation.ts
+++ b/packages/trackerless-network/src/logic/propagation/Propagation.ts
@@ -65,7 +65,6 @@ export class Propagation {
 
     private sendAndAwaitThenMark({ message, source, handledNeighbors }: PropagationTask, neighborId: DhtAddress): void {
         if (!handledNeighbors.has(neighborId) && neighborId !== source) {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             (async () => {
                 try {
                     await this.sendToNeighbor(neighborId, message)

--- a/packages/trackerless-network/test/benchmark/first-message.ts
+++ b/packages/trackerless-network/test/benchmark/first-message.ts
@@ -147,7 +147,6 @@ const run = async () => {
     await shutdownNetwork()
 } 
 
-// eslint-disable-next-line promise/catch-or-return
 run().then(() => {
     console.log('done')
 }).catch((err) => {

--- a/packages/utils/src/Multimap.ts
+++ b/packages/utils/src/Multimap.ts
@@ -17,7 +17,6 @@ export class Multimap<K, V> {
         const items = this.delegatee.get(key)
         if (items !== undefined) {
             return items.includes(value)
-            // eslint-disable-next-line no-else-return
         } else {
             return false
         }

--- a/packages/utils/src/waitForEvent.ts
+++ b/packages/utils/src/waitForEvent.ts
@@ -19,7 +19,6 @@ export async function waitForEvent(
     abortSignal?: AbortSignal
 ): Promise<unknown[]> {
     let listener: (eventArgs: any[]) => void
-    // eslint-disable-next-line no-async-promise-executor
     const task: Promise<unknown[]> = new Promise((resolve) => {
         listener = (...eventArgs: any[]) => {
             if (predicate(...eventArgs)) {

--- a/packages/utils/test/lengthPrefixFrameUtils.test.ts
+++ b/packages/utils/test/lengthPrefixFrameUtils.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import { binaryToHex } from '../src/binaryUtils'
 import { LengthPrefixedFrameDecoder, toLengthPrefixedFrame } from '../src/lengthPrefixedFrameUtils'
 


### PR DESCRIPTION
Remove `eslint-disable`/`eslint-enable` annotations, which don't have any effect. 

## Rules

| Rule  | Count  |
|:------|:-----|
| `no-await-in-loop` | 14 |
| `max-len` | 12 |
| `no-underscore-dangle` | 9 |
| `class-methods-use-this` | 9 |
| `require-atomic-updates` | 3 |
| `no-else-return` | 3 |
| `no-console` | 3 |
| `quotes` | 2 |
| `promise/catch-or-return` | 2 |
| `prefer-spread` | 2 |
| `padding-line-between-statements` | 2 |
| `no-new` | 2 |
| `@typescript-eslint/no-floating-promises` | 2 |
| `@typescript-eslint/consistent-indexed-object-style` | 2 |
| `promise/no-nesting` | 1 |
| `object-curly-newline` | 1 |
| `no-param-reassign` | 1 |
| `no-continue` | 1 |
| `no-constant-condition` | 1 |
| `no-async-promise-executor` | 1 |
| `indent` | 1 |
| `eslint/no-invalid-void-type` | 1 |
| `camelcase` | 1 |
| `@typescript-eslint/parameter-properties` | 1 |
| `@typescript-eslint/no-namespace` | 1 |
| `@typescript-eslint/consistent-type-definitions` | 1 |