### PR TITLE
feat(network): NET-1346 avoid routing through proxy connections

### DIFF
--- a/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
+++ b/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
@@ -52,7 +52,8 @@ describe('StreamrChallenger', () => {
                 websocketPortRange: { min: 12323, max: 12323 },
                 createLocalPeerDescriptor: async () => mockPeerDescriptor1
             }),
-            metricsContext: new MetricsContext()
+            metricsContext: new MetricsContext(),
+            allowPrivateConnections: false
         })
         await challengedClientTransport.start()
         challengedClient = new ListeningRpcCommunicator(SERVICE_ID, challengedClientTransport)

--- a/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
+++ b/packages/autocertifier-server/test/integration/StreamrChallenger.test.ts
@@ -53,7 +53,7 @@ describe('StreamrChallenger', () => {
                 createLocalPeerDescriptor: async () => mockPeerDescriptor1
             }),
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: false
+            allowIncomingPrivateConnections: false
         })
         await challengedClientTransport.start()
         challengedClient = new ListeningRpcCommunicator(SERVICE_ID, challengedClientTransport)

--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -50,6 +50,7 @@ service ConnectionLockRpc {
   rpc lockRequest (LockRequest) returns (LockResponse);
   rpc unlockRequest (UnlockRequest) returns (google.protobuf.Empty);
   rpc gracefulDisconnect (DisconnectNotice) returns (google.protobuf.Empty);
+  rpc setPrivate (SetPrivateRequest) returns (google.protobuf.Empty);
 }
 
 service ExternalApiRpc {
@@ -299,6 +300,10 @@ enum DisconnectMode {
 
 message DisconnectNotice {
   DisconnectMode disconnectMode = 1;
+}
+
+message SetPrivateRequest {
+  bool isPrivate = 1;
 }
 
 message ExternalFetchDataRequest {

--- a/packages/dht/src/connection/ConnectionLockRpcLocal.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcLocal.ts
@@ -7,7 +7,8 @@ import {
     LockRequest,
     LockResponse,
     PeerDescriptor,
-    UnlockRequest
+    UnlockRequest,
+    SetPrivateRequest
 } from '../proto/packages/dht/protos/DhtRpc'
 import { IConnectionLockRpc } from '../proto/packages/dht/protos/DhtRpc.server'
 import { DhtCallContext } from '../rpc-protocol/DhtCallContext'
@@ -20,6 +21,7 @@ interface ConnectionLockRpcLocalOptions {
     removeRemoteLocked: (id: DhtAddress, lockId: LockID) => void
     closeConnection: (peerDescriptor: PeerDescriptor, gracefulLeave: boolean, reason?: string) => Promise<void>
     getLocalPeerDescriptor: () => PeerDescriptor
+    setPrivate: (id: DhtAddress, isPrivate: boolean) => void
 }
 
 const logger = new Logger(module)
@@ -64,6 +66,13 @@ export class ConnectionLockRpcLocal implements IConnectionLockRpc {
         } else {
             await this.options.closeConnection(senderPeerDescriptor, false, 'graceful disconnect notified')
         }
+        return {}
+    }
+
+    async setPrivate(request: SetPrivateRequest, context: ServerCallContext): Promise<Empty> {
+        const senderPeerDescriptor = (context as DhtCallContext).incomingSourceDescriptor!
+        const senderId = toNodeId(senderPeerDescriptor)            
+        this.options.setPrivate(senderId, request.isPrivate)
         return {}
     }
 }

--- a/packages/dht/src/connection/ConnectionLockRpcRemote.ts
+++ b/packages/dht/src/connection/ConnectionLockRpcRemote.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@streamr/utils'
 import { RpcRemote } from '../dht/contact/RpcRemote'
-import { DisconnectMode, DisconnectNotice, LockRequest, UnlockRequest } from '../proto/packages/dht/protos/DhtRpc'
+import { DisconnectMode, DisconnectNotice, LockRequest, UnlockRequest, SetPrivateRequest } from '../proto/packages/dht/protos/DhtRpc'
 import { ConnectionLockRpcClient } from '../proto/packages/dht/protos/DhtRpc.client'
 import { LockID } from './ConnectionLockStates'
 import { toNodeId } from '../identifiers'
@@ -48,5 +48,17 @@ export class ConnectionLockRpcRemote extends RpcRemote<ConnectionLockRpcClient> 
             timeout: 2000  // TODO use options option or named constant?
         })
         await this.getClient().gracefulDisconnect(request, options)
+    }
+
+    public async setPrivate(isPrivate: boolean): Promise<void> {
+        logger.trace(`Setting isPrivate: ${isPrivate} for ${toNodeId(this.getPeerDescriptor())}`)
+        const request: SetPrivateRequest = {
+            isPrivate
+        }
+        const options = this.formDhtRpcOptions({
+            connect: false,
+            notification: true
+        })
+        await this.getClient().setPrivate(request, options)
     }
 }

--- a/packages/dht/src/connection/ConnectionLockStates.ts
+++ b/packages/dht/src/connection/ConnectionLockStates.ts
@@ -12,6 +12,8 @@ export class ConnectionLockStates {
     // TODO: remove weakLocks use localLocks instead. When opening weakLocks from the ConnectioManager,
     // simply do not send lock requests.
     private weakLocks: Map<DhtAddress, Set<LockID>> = new Map()
+    // Used to filter proxy connections from the connections view
+    private remotePrivateConnections: Set<DhtAddress> = new Set()
 
     public getLocalLockedConnectionCount(): number {
         return this.localLocks.size
@@ -97,6 +99,22 @@ export class ConnectionLockStates {
                 this.weakLocks.delete(id)
             }
         }
+    }
+
+    public addPrivate(id: DhtAddress): void {
+        this.remotePrivateConnections.add(id)
+    }
+
+    public removePrivate(id: DhtAddress): void {
+        this.remotePrivateConnections.delete(id)
+    }
+
+    public getPrivateConnections(): Set<DhtAddress> {
+        return this.remotePrivateConnections
+    }
+
+    public isPrivate(id: DhtAddress): boolean {
+        return this.remotePrivateConnections.has(id)
     }
 
     public clearAllLocks(id: DhtAddress): void {

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -191,7 +191,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         this.endpoints.forEach((endpoint) => {
             if (endpoint.connected) {
                 const connection = endpoint.connection
-                if (!this.locks.isLocked(connection.getNodeId()) && Date.now() - connection.getLastUsedTimestamp() > maxIdleTime) {
+                const nodeId = connection.getNodeId()
+                if (!this.locks.isLocked(nodeId) && !this.locks.isPrivate(nodeId) && Date.now() - connection.getLastUsedTimestamp() > maxIdleTime) {
                     logger.trace('disconnecting in timeout interval: ' + getNodeIdOrUnknownFromPeerDescriptor(connection.getPeerDescriptor()))
                     disconnectionCandidates.addContact(connection)
                 }
@@ -561,6 +562,10 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 return this.setPrivateForConnection(peerDescription!, false)
             }
         }))
+    }
+
+    public getIsPrivate(): boolean {
+        return this.isPrivate
     }
 
     private async setPrivateForConnection(targetDescriptor: PeerDescriptor, isPrivate: boolean): Promise<void> {

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -32,6 +32,7 @@ import { PendingConnection } from './PendingConnection'
 export interface ConnectionManagerOptions {
     maxConnections?: number
     metricsContext: MetricsContext
+    allowPrivateConnections: boolean
     createConnectorFacade: () => ConnectorFacade
 }
 
@@ -158,6 +159,10 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
                 this.closeConnection(peerDescriptor, gracefulLeave, reason),
             getLocalPeerDescriptor: () => this.getLocalPeerDescriptor(),
             setPrivate: (id: DhtAddress, isPrivate: boolean) => {
+                if (!this.options.allowPrivateConnections) {
+                    logger.debug(`node ${id} attemted to set a connection as private, but it is not allowed`)
+                    return
+                }
                 if (isPrivate) {
                     this.locks.addPrivate(id)
                 } else {

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -128,7 +128,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
     private rpcCommunicator?: RoutingRpcCommunicator
     private disconnectorIntervalRef?: NodeJS.Timeout
     private state = ConnectionManagerState.IDLE
-    private isPrivate = false
+    private privateMode = false
 
     constructor(options: ConnectionManagerOptions) {
         super()
@@ -410,8 +410,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
             connected: true,
             connection: managedConnection
         })
-        if (this.isPrivate) {
-            this.setPrivateForConnection(peerDescriptor, this.isPrivate).catch(() => {})
+        if (this.privateMode) {
+            this.setPrivateForConnection(peerDescriptor, this.privateMode).catch(() => {})
         }
         this.emit('connected', peerDescriptor)
         this.onConnectionCountChange()
@@ -544,8 +544,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         this.locks.removeWeakLocked(nodeId, lockId)
     }
 
-    public async setPrivate(): Promise<void> {
-        this.isPrivate = true
+    public async enablePrivateMode(): Promise<void> {
+        this.privateMode = true
         await Promise.all(Array.from(this.endpoints.values()).map((endpoint) => {
             if (endpoint.connected) {
                 const peerDescription = endpoint.connection.getPeerDescriptor()
@@ -554,8 +554,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }))
     }
 
-    public async setPublic(): Promise<void> {
-        this.isPrivate = false
+    public async disablePrivateMode(): Promise<void> {
+        this.privateMode = false
         await Promise.all(Array.from(this.endpoints.values()).map((endpoint) => {
             if (endpoint.connected) {
                 const peerDescription = endpoint.connection.getPeerDescriptor()
@@ -564,8 +564,8 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         }))
     }
 
-    public getIsPrivate(): boolean {
-        return this.isPrivate
+    public isPrivateMode(): boolean {
+        return this.privateMode
     }
 
     private async setPrivateForConnection(targetDescriptor: PeerDescriptor, isPrivate: boolean): Promise<void> {

--- a/packages/dht/src/connection/simulator/SimulatorTransport.ts
+++ b/packages/dht/src/connection/simulator/SimulatorTransport.ts
@@ -9,7 +9,7 @@ export class SimulatorTransport extends ConnectionManager {
         super({
             createConnectorFacade: () => new SimulatorConnectorFacade(localPeerDescriptor, simulator),
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: false
+            allowIncomingPrivateConnections: false
         })
     }
 }

--- a/packages/dht/src/connection/simulator/SimulatorTransport.ts
+++ b/packages/dht/src/connection/simulator/SimulatorTransport.ts
@@ -8,7 +8,8 @@ export class SimulatorTransport extends ConnectionManager {
     constructor(localPeerDescriptor: PeerDescriptor, simulator: Simulator) {
         super({
             createConnectorFacade: () => new SimulatorConnectorFacade(localPeerDescriptor, simulator),
-            metricsContext: new MetricsContext()
+            metricsContext: new MetricsContext(),
+            allowPrivateConnections: false
         })
     }
 }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -104,7 +104,7 @@ export interface DhtNodeOptions {
     autoCertifierUrl?: string
     autoCertifierConfigFile?: string
     geoIpDatabaseFolder?: string
-    allowPrivateConnections?: boolean
+    allowIncomingPrivateConnections?: boolean
 }
 
 type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
@@ -244,7 +244,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 createConnectorFacade: () => new DefaultConnectorFacade(connectorFacadeOptions),
                 maxConnections: this.options.maxConnections,
                 metricsContext: this.options.metricsContext,
-                allowPrivateConnections: this.options.allowPrivateConnections ?? false
+                allowIncomingPrivateConnections: this.options.allowIncomingPrivateConnections ?? false
             })
             await connectionManager.start()
             this.connectionsView = connectionManager

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -104,6 +104,7 @@ export interface DhtNodeOptions {
     autoCertifierUrl?: string
     autoCertifierConfigFile?: string
     geoIpDatabaseFolder?: string
+    allowPrivateConnections?: boolean
 }
 
 type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
@@ -242,7 +243,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             const connectionManager = new ConnectionManager({
                 createConnectorFacade: () => new DefaultConnectorFacade(connectorFacadeOptions),
                 maxConnections: this.options.maxConnections,
-                metricsContext: this.options.metricsContext
+                metricsContext: this.options.metricsContext,
+                allowPrivateConnections: this.options.allowPrivateConnections ?? false
             })
             await connectionManager.start()
             this.connectionsView = connectionManager

--- a/packages/dht/src/proto/google/protobuf/any.ts
+++ b/packages/dht/src/proto/google/protobuf/any.ts
@@ -73,6 +73,10 @@ import { MessageType } from "@protobuf-ts/runtime";
  *     if (any.is(Foo.class)) {
  *       foo = any.unpack(Foo.class);
  *     }
+ *     // or ...
+ *     if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+ *       foo = any.unpack(Foo.getDefaultInstance());
+ *     }
  *
  *  Example 3: Pack and unpack a message in Python.
  *
@@ -87,10 +91,13 @@ import { MessageType } from "@protobuf-ts/runtime";
  *  Example 4: Pack and unpack a message in Go
  *
  *      foo := &pb.Foo{...}
- *      any, err := ptypes.MarshalAny(foo)
+ *      any, err := anypb.New(foo)
+ *      if err != nil {
+ *        ...
+ *      }
  *      ...
  *      foo := &pb.Foo{}
- *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *      if err := any.UnmarshalTo(foo); err != nil {
  *        ...
  *      }
  *
@@ -99,7 +106,6 @@ import { MessageType } from "@protobuf-ts/runtime";
  * methods only use the fully qualified type name after the last '/'
  * in the type URL, for example "foo.bar.com/x/y.z" will yield type
  * name "y.z".
- *
  *
  * JSON
  * ====
@@ -157,7 +163,8 @@ export interface Any {
      *
      * Note: this functionality is not currently available in the official
      * protobuf release, and it is not used for type URLs beginning with
-     * type.googleapis.com.
+     * type.googleapis.com. As of May 2023, there are no widely used type server
+     * implementations and no plans to implement one.
      *
      * Schemes other than `http`, `https` (or the empty scheme) might be
      * used with implementation specific semantics.

--- a/packages/dht/src/proto/google/protobuf/empty.ts
+++ b/packages/dht/src/proto/google/protobuf/empty.ts
@@ -49,7 +49,6 @@ import { MessageType } from "@protobuf-ts/runtime";
  *       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
  *     }
  *
- * The JSON representation for `Empty` is empty JSON object `{}`.
  *
  * @generated from protobuf message google.protobuf.Empty
  */

--- a/packages/dht/src/proto/google/protobuf/timestamp.ts
+++ b/packages/dht/src/proto/google/protobuf/timestamp.ts
@@ -97,8 +97,15 @@ import { MessageType } from "@protobuf-ts/runtime";
  *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
+ * Example 5: Compute Timestamp from Java `Instant.now()`.
  *
- * Example 5: Compute Timestamp from current time in Python.
+ *     Instant now = Instant.now();
+ *
+ *     Timestamp timestamp =
+ *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+ *             .setNanos(now.getNano()).build();
+ *
+ * Example 6: Compute Timestamp from current time in Python.
  *
  *     timestamp = Timestamp()
  *     timestamp.GetCurrentTime()
@@ -127,9 +134,8 @@ import { MessageType } from "@protobuf-ts/runtime";
  * [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
  * the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
  * the Joda Time's [`ISODateTimeFormat.dateTime()`](
- * http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+ * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
  * ) to obtain a formatter capable of generating timestamps in this format.
- *
  *
  *
  * @generated from protobuf message google.protobuf.Timestamp

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.client.ts
@@ -7,6 +7,7 @@ import type { ExternalStoreDataRequest } from "./DhtRpc";
 import type { ExternalFetchDataResponse } from "./DhtRpc";
 import type { ExternalFetchDataRequest } from "./DhtRpc";
 import { ConnectionLockRpc } from "./DhtRpc";
+import type { SetPrivateRequest } from "./DhtRpc";
 import type { DisconnectNotice } from "./DhtRpc";
 import type { UnlockRequest } from "./DhtRpc";
 import type { LockResponse } from "./DhtRpc";
@@ -336,6 +337,10 @@ export interface IConnectionLockRpcClient {
      * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
     gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty>;
+    /**
+     * @generated from protobuf rpc: setPrivate(dht.SetPrivateRequest) returns (google.protobuf.Empty);
+     */
+    setPrivate(input: SetPrivateRequest, options?: RpcOptions): UnaryCall<SetPrivateRequest, Empty>;
 }
 /**
  * @generated from protobuf service dht.ConnectionLockRpc
@@ -366,6 +371,13 @@ export class ConnectionLockRpcClient implements IConnectionLockRpcClient, Servic
     gracefulDisconnect(input: DisconnectNotice, options?: RpcOptions): UnaryCall<DisconnectNotice, Empty> {
         const method = this.methods[2], opt = this._transport.mergeOptions(options);
         return stackIntercept<DisconnectNotice, Empty>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * @generated from protobuf rpc: setPrivate(dht.SetPrivateRequest) returns (google.protobuf.Empty);
+     */
+    setPrivate(input: SetPrivateRequest, options?: RpcOptions): UnaryCall<SetPrivateRequest, Empty> {
+        const method = this.methods[3], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SetPrivateRequest, Empty>("unary", this._transport, method, opt, input);
     }
 }
 /**

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.server.ts
@@ -5,6 +5,7 @@ import { ExternalStoreDataResponse } from "./DhtRpc";
 import { ExternalStoreDataRequest } from "./DhtRpc";
 import { ExternalFetchDataResponse } from "./DhtRpc";
 import { ExternalFetchDataRequest } from "./DhtRpc";
+import { SetPrivateRequest } from "./DhtRpc";
 import { DisconnectNotice } from "./DhtRpc";
 import { UnlockRequest } from "./DhtRpc";
 import { LockResponse } from "./DhtRpc";
@@ -144,6 +145,10 @@ export interface IConnectionLockRpc<T = ServerCallContext> {
      * @generated from protobuf rpc: gracefulDisconnect(dht.DisconnectNotice) returns (google.protobuf.Empty);
      */
     gracefulDisconnect(request: DisconnectNotice, context: T): Promise<Empty>;
+    /**
+     * @generated from protobuf rpc: setPrivate(dht.SetPrivateRequest) returns (google.protobuf.Empty);
+     */
+    setPrivate(request: SetPrivateRequest, context: T): Promise<Empty>;
 }
 /**
  * @generated from protobuf service dht.ExternalApiRpc

--- a/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
+++ b/packages/dht/src/proto/packages/dht/protos/DhtRpc.ts
@@ -583,6 +583,15 @@ export interface DisconnectNotice {
     disconnectMode: DisconnectMode;
 }
 /**
+ * @generated from protobuf message dht.SetPrivateRequest
+ */
+export interface SetPrivateRequest {
+    /**
+     * @generated from protobuf field: bool isPrivate = 1;
+     */
+    isPrivate: boolean;
+}
+/**
  * @generated from protobuf message dht.ExternalFetchDataRequest
  */
 export interface ExternalFetchDataRequest {
@@ -1154,6 +1163,18 @@ class DisconnectNotice$Type extends MessageType<DisconnectNotice> {
  */
 export const DisconnectNotice = new DisconnectNotice$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class SetPrivateRequest$Type extends MessageType<SetPrivateRequest> {
+    constructor() {
+        super("dht.SetPrivateRequest", [
+            { no: 1, name: "isPrivate", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+}
+/**
+ * @generated MessageType for protobuf message dht.SetPrivateRequest
+ */
+export const SetPrivateRequest = new SetPrivateRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class ExternalFetchDataRequest$Type extends MessageType<ExternalFetchDataRequest> {
     constructor() {
         super("dht.ExternalFetchDataRequest", [
@@ -1233,7 +1254,8 @@ export const WebrtcConnectorRpc = new ServiceType("dht.WebrtcConnectorRpc", [
 export const ConnectionLockRpc = new ServiceType("dht.ConnectionLockRpc", [
     { name: "lockRequest", options: {}, I: LockRequest, O: LockResponse },
     { name: "unlockRequest", options: {}, I: UnlockRequest, O: Empty },
-    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: Empty }
+    { name: "gracefulDisconnect", options: {}, I: DisconnectNotice, O: Empty },
+    { name: "setPrivate", options: {}, I: SetPrivateRequest, O: Empty }
 ]);
 /**
  * @generated ServiceType for protobuf service dht.ExternalApiRpc

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -16,7 +16,7 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
         metricsContext: new MetricsContext(),
-        allowPrivateConnections: true
+        allowIncomingPrivateConnections: true
     })
 }
 

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -15,7 +15,8 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             transport,
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
-        metricsContext: new MetricsContext()
+        metricsContext: new MetricsContext(),
+        allowPrivateConnections: true
     })
 }
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -1,4 +1,4 @@
-import { Logger, MetricsContext, waitForEvent3 } from '@streamr/utils'
+import { Logger, MetricsContext, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { MarkOptional } from 'ts-essentials'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'
@@ -467,6 +467,60 @@ describe('ConnectionManager', () => {
         expect(connectionManager2.getConnections().length).toEqual(0)
 
         await connectionManager2.stop()
+    })
+
+    it('private connections', async () => {
+        const connectionManager1 = createConnectionManager({
+            transport: mockTransport,
+            websocketHost: '127.0.0.1',
+            websocketServerEnableTls: false,
+            websocketPortRange: { min: 10009, max: 10009 }
+        })
+
+        await connectionManager1.start()
+
+        const connectionManager2 = createConnectionManager({
+            transport: mockTransport,
+            websocketHost: '127.0.0.1',
+            websocketServerEnableTls: false,
+            websocketPortRange: { min: 10010, max: 100010 }
+        })
+
+        await connectionManager2.start()
+
+        const msg: Message = {
+            serviceId: SERVICE_ID,
+            messageId: '1',
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            },
+            targetDescriptor: connectionManager1.getLocalPeerDescriptor()
+        }
+
+        const connectedPromise1 = new Promise<void>((resolve, _reject) => {
+            connectionManager1.on('connected', () => {
+                resolve()
+            })
+        })
+
+        const connectedPromise2 = new Promise<void>((resolve, _reject) => {
+            connectionManager2.on('connected', () => {
+                resolve()
+            })
+        })
+        await Promise.all([connectedPromise1, connectedPromise2, connectionManager2.send(msg)])
+
+        await connectionManager1.setPrivate()
+        await waitForCondition(() => connectionManager2.getConnections().length === 0)
+        expect(connectionManager1.getConnections().length).toEqual(1)
+        await connectionManager1.setPublic()
+        await waitForCondition(() => connectionManager2.getConnections().length === 1)
+        expect(connectionManager1.getConnections().length).toEqual(1)
+
+        await connectionManager1.stop()
+        await connectionManager2.stop()
+ 
     })
 
 })

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -511,11 +511,11 @@ describe('ConnectionManager', () => {
         })
         await Promise.all([connectedPromise1, connectedPromise2, connectionManager2.send(msg)])
 
-        await connectionManager1.setPrivate()
+        await connectionManager1.enablePrivateMode()
         await waitForCondition(() => connectionManager2.getConnections().length === 0)
         expect(connectionManager1.getConnections().length).toEqual(1)
 
-        await connectionManager1.setPublic()
+        await connectionManager1.disablePrivateMode()
         await waitForCondition(() => connectionManager2.getConnections().length === 1)
         expect(connectionManager1.getConnections().length).toEqual(1)
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -514,6 +514,7 @@ describe('ConnectionManager', () => {
         await connectionManager1.setPrivate()
         await waitForCondition(() => connectionManager2.getConnections().length === 0)
         expect(connectionManager1.getConnections().length).toEqual(1)
+
         await connectionManager1.setPublic()
         await waitForCondition(() => connectionManager2.getConnections().length === 1)
         expect(connectionManager1.getConnections().length).toEqual(1)

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -37,7 +37,8 @@ describe('ConnectionManager', () => {
                 websocketServerEnableTls: false,
                 ...opts
             }),
-            metricsContext: new MetricsContext()
+            metricsContext: new MetricsContext(),
+            allowPrivateConnections: true
         })
     }
 

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -38,7 +38,7 @@ describe('ConnectionManager', () => {
                 ...opts
             }),
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: true
+            allowIncomingPrivateConnections: true
         })
     }
 
@@ -512,11 +512,11 @@ describe('ConnectionManager', () => {
         })
         await Promise.all([connectedPromise1, connectedPromise2, connectionManager2.send(msg)])
 
-        await connectionManager1.enablePrivateMode()
+        await connectionManager1.enablePrivateClientMode()
         await waitForCondition(() => connectionManager2.getConnections().length === 0)
         expect(connectionManager1.getConnections().length).toEqual(1)
 
-        await connectionManager1.disablePrivateMode()
+        await connectionManager1.disablePrivateClientMode()
         await waitForCondition(() => connectionManager2.getConnections().length === 1)
         expect(connectionManager1.getConnections().length).toEqual(1)
 

--- a/packages/dht/test/integration/ConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/ConnectivityChecking.test.ts
@@ -30,7 +30,8 @@ describe('ConnectivityChecking', () => {
                 websocketServerEnableTls: false,
                 transport: new MockTransport()
             }),
-            metricsContext: new MetricsContext()
+            metricsContext: new MetricsContext(),
+            allowPrivateConnections: false
         })
         await server.start()
     })

--- a/packages/dht/test/integration/ConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/ConnectivityChecking.test.ts
@@ -31,7 +31,7 @@ describe('ConnectivityChecking', () => {
                 transport: new MockTransport()
             }),
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: false
+            allowIncomingPrivateConnections: false
         })
         await server.start()
     })

--- a/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
@@ -44,7 +44,7 @@ describe('ConnectivityChecking', () => {
                 geoIpDatabaseFolder: dbPath
             }),
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: false
+            allowIncomingPrivateConnections: false
         })
         await server.start()
         mock = jest.spyOn(WebsocketServerConnection.prototype, 'getRemoteIpAddress').mockImplementation(() => testIp)

--- a/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
@@ -43,7 +43,8 @@ describe('ConnectivityChecking', () => {
                 transport: new MockTransport(),
                 geoIpDatabaseFolder: dbPath
             }),
-            metricsContext: new MetricsContext()
+            metricsContext: new MetricsContext(),
+            allowPrivateConnections: false
         })
         await server.start()
         mock = jest.spyOn(WebsocketServerConnection.prototype, 'getRemoteIpAddress').mockImplementation(() => testIp)

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -25,7 +25,8 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, opts: Omit
             createLocalPeerDescriptor: async () => localPeerDescriptor,
             ...opts
         }),
-        metricsContext: new MetricsContext()
+        metricsContext: new MetricsContext(),
+        allowPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/integration/SimultaneousConnections.test.ts
+++ b/packages/dht/test/integration/SimultaneousConnections.test.ts
@@ -26,7 +26,7 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, opts: Omit
             ...opts
         }),
         metricsContext: new MetricsContext(),
-        allowPrivateConnections: false
+        allowIncomingPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
@@ -16,7 +16,7 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
         metricsContext: new MetricsContext(),
-        allowPrivateConnections: false
+        allowIncomingPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
@@ -15,7 +15,8 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             transport,
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
-        metricsContext: new MetricsContext()
+        metricsContext: new MetricsContext(),
+        allowPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -17,7 +17,8 @@ const createOptions = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultCo
             createLocalPeerDescriptor: async () => localPeerDescriptor,
             ...opts
         }),
-        metricsContext: new MetricsContext()
+        metricsContext: new MetricsContext(),
+        allowPrivateConnections: false
     }
 }
 

--- a/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebsocketConnectionManagement.test.ts
@@ -18,7 +18,7 @@ const createOptions = (localPeerDescriptor: PeerDescriptor, opts: Omit<DefaultCo
             ...opts
         }),
         metricsContext: new MetricsContext(),
-        allowPrivateConnections: false
+        allowIncomingPrivateConnections: false
     }
 }
 

--- a/packages/dht/test/integration/rpc-connections-over-webrtc.test.ts
+++ b/packages/dht/test/integration/rpc-connections-over-webrtc.test.ts
@@ -21,7 +21,7 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
         metricsContext: new MetricsContext(),
-        allowPrivateConnections: false
+        allowIncomingPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/integration/rpc-connections-over-webrtc.test.ts
+++ b/packages/dht/test/integration/rpc-connections-over-webrtc.test.ts
@@ -20,7 +20,8 @@ const createConnectionManager = (localPeerDescriptor: PeerDescriptor, transport:
             transport,
             createLocalPeerDescriptor: async () => localPeerDescriptor
         }),
-        metricsContext: new MetricsContext()
+        metricsContext: new MetricsContext(),
+        allowPrivateConnections: false
     })
 }
 

--- a/packages/dht/test/unit/ConnectionManager.test.ts
+++ b/packages/dht/test/unit/ConnectionManager.test.ts
@@ -15,6 +15,7 @@ describe('ConnetionManager', () => {
     beforeEach(async () => {
         connectionManager = new ConnectionManager({
             metricsContext: new MetricsContext(),
+            allowPrivateConnections: false,
             createConnectorFacade: () => { 
                 fakeConnectorFacade = new FakeConnectorFacade(localPeerDescriptor)
                 return fakeConnectorFacade

--- a/packages/dht/test/unit/ConnectionManager.test.ts
+++ b/packages/dht/test/unit/ConnectionManager.test.ts
@@ -15,7 +15,7 @@ describe('ConnetionManager', () => {
     beforeEach(async () => {
         connectionManager = new ConnectionManager({
             metricsContext: new MetricsContext(),
-            allowPrivateConnections: false,
+            allowIncomingPrivateConnections: false,
             createConnectorFacade: () => { 
                 fakeConnectorFacade = new FakeConnectorFacade(localPeerDescriptor)
                 return fakeConnectorFacade

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -66,7 +66,8 @@ export class NetworkStack {
         this.metricsContext = options.metricsContext ?? new MetricsContext()
         this.controlLayerNode = new DhtNode({
             ...options.layer0,
-            metricsContext: this.metricsContext
+            metricsContext: this.metricsContext,
+            allowPrivateConnections: options.networkNode?.acceptProxyConnections
         })
         this.contentDeliveryManager = new ContentDeliveryManager({
             ...options.networkNode,

--- a/packages/trackerless-network/src/NetworkStack.ts
+++ b/packages/trackerless-network/src/NetworkStack.ts
@@ -67,7 +67,7 @@ export class NetworkStack {
         this.controlLayerNode = new DhtNode({
             ...options.layer0,
             metricsContext: this.metricsContext,
-            allowPrivateConnections: options.networkNode?.acceptProxyConnections
+            allowIncomingPrivateConnections: options.networkNode?.acceptProxyConnections
         })
         this.contentDeliveryManager = new ContentDeliveryManager({
             ...options.networkNode,

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -213,8 +213,8 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             // leaveStreamPart has been called (or leaveStreamPart called, and then setProxies called)
             return
         }
-        if ((this.transport! as ConnectionManager).getIsPrivate()) {
-            await (this.transport! as ConnectionManager).setPublic()
+        if ((this.transport! as ConnectionManager).isPrivateMode()) {
+            await (this.transport! as ConnectionManager).disablePrivateMode()
         }
         await streamPart.discoveryLayerNode.start()
         await streamPart.node.start()
@@ -304,7 +304,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                     this.emit('newMessage', message)
                 })
                 if (Array.from(this.streamParts.values()).every((streamPart) => streamPart.proxied)) {
-                    await (this.transport! as ConnectionManager).setPrivate()
+                    await (this.transport! as ConnectionManager).enablePrivateMode()
                 }
                 await client.start()
             }

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -29,6 +29,7 @@ import { MIN_NEIGHBOR_COUNT as NETWORK_SPLIT_AVOIDANCE_MIN_NEIGHBOR_COUNT, Strea
 import { StreamPartReconnect } from './StreamPartReconnect'
 import { createContentDeliveryLayerNode } from './createContentDeliveryLayerNode'
 import { ProxyClient } from './proxy/ProxyClient'
+import { ConnectionManager } from '@streamr/dht/src/exports'
 
 export type StreamPartDelivery = {
     broadcast: (msg: StreamMessage) => void
@@ -299,6 +300,9 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                 client.on('message', (message: StreamMessage) => {
                     this.emit('newMessage', message)
                 })
+                if (Array.from(this.streamParts.values()).every((streamPart) => streamPart.proxied)) {
+                    await (this.transport! as ConnectionManager).setPrivate()
+                }
                 await client.start()
             }
             await client.setProxies(nodes, direction, userId, connectionCount)

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -213,6 +213,9 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             // leaveStreamPart has been called (or leaveStreamPart called, and then setProxies called)
             return
         }
+        if ((this.transport! as ConnectionManager).getIsPrivate()) {
+            await (this.transport! as ConnectionManager).setPublic()
+        }
         await streamPart.discoveryLayerNode.start()
         await streamPart.node.start()
         const knownEntryPoints = this.knownStreamPartEntryPoints.get(streamPartId)

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -213,8 +213,8 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             // leaveStreamPart has been called (or leaveStreamPart called, and then setProxies called)
             return
         }
-        if ((this.transport! as ConnectionManager).isPrivateMode()) {
-            await (this.transport! as ConnectionManager).disablePrivateMode()
+        if ((this.transport! as ConnectionManager).isPrivateClientMode()) {
+            await (this.transport! as ConnectionManager).disablePrivateClientMode()
         }
         await streamPart.discoveryLayerNode.start()
         await streamPart.node.start()
@@ -304,7 +304,7 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
                     this.emit('newMessage', message)
                 })
                 if (Array.from(this.streamParts.values()).every((streamPart) => streamPart.proxied)) {
-                    await (this.transport! as ConnectionManager).enablePrivateMode()
+                    await (this.transport! as ConnectionManager).enablePrivateClientMode()
                 }
                 await client.start()
             }

--- a/packages/trackerless-network/test/utils/mock/MockTransport.ts
+++ b/packages/trackerless-network/test/utils/mock/MockTransport.ts
@@ -23,7 +23,7 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     }
 
     // eslint-disable-next-line class-methods-use-this
-    enablePrivateMode(): void {
+    enablePrivateClientMode(): void {
 
     }
 

--- a/packages/trackerless-network/test/utils/mock/MockTransport.ts
+++ b/packages/trackerless-network/test/utils/mock/MockTransport.ts
@@ -23,7 +23,7 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     }
 
     // eslint-disable-next-line class-methods-use-this
-    setPrivate(): void {
+    enablePrivateMode(): void {
 
     }
 

--- a/packages/trackerless-network/test/utils/mock/MockTransport.ts
+++ b/packages/trackerless-network/test/utils/mock/MockTransport.ts
@@ -26,4 +26,5 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     setPrivate(): void {
 
     }
+
 }

--- a/packages/trackerless-network/test/utils/mock/MockTransport.ts
+++ b/packages/trackerless-network/test/utils/mock/MockTransport.ts
@@ -21,4 +21,9 @@ export class MockTransport extends EventEmitter<TransportEvents> implements ITra
     getDiagnosticInfo(): Record<string, unknown> {
         return {}
     }
+
+    // eslint-disable-next-line class-methods-use-this
+    setPrivate(): void {
+
+    }
 }


### PR DESCRIPTION
## Summary

Added new functionality in the connection manager to set the manager in private mode. In private mode the node will inform all peers that the connection is private. This way the peers will know not to use the connections during routing. 

This fixes a known issue with routing where routing is attempted through pure proxy client nodes.

Allowing private connections has to be explicitly allowed. This is required to not allow free riding. Private connections are allowed if the `acceptProxyConnections` flag is set true in the SDK. There is currently no need to have an option to only set the `acceptIncomingPrivateConnections` as true since the feature is only used for proxies.
