### PR TITLE
feat(DHT): NET-1358: time out webrtc connections early if signalling fails

### DIFF
--- a/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/BrowserWebrtcConnection.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'eventemitter3'
 import { WebrtcConnectionEvents, IWebrtcConnection, RtcDescription } from './IWebrtcConnection'
 import { IConnection, ConnectionID, ConnectionEvents, ConnectionType } from '../IConnection'
 import { Logger } from '@streamr/utils'
-import { IceServer } from './WebrtcConnector'
+import { EARLY_TIMEOUT, IceServer } from './WebrtcConnector'
 import { createRandomConnectionId } from '../Connection'
 
 enum DisconnectedRtcPeerConnectionStateEnum {
@@ -32,11 +32,15 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
     private makingOffer = false
     private isOffering = false
     private closed = false
+    private earlyTimeout: NodeJS.Timeout
 
     constructor(params: Params) {
         super()
         this.connectionId = createRandomConnectionId()
         this.iceServers = params.iceServers ?? []
+        this.earlyTimeout = setTimeout(() => {
+            this.doClose(false, 'timed out due to remote descriptor not being set')
+        }, EARLY_TIMEOUT)
     }
 
     public start(isOffering: boolean): void {
@@ -96,6 +100,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
         }
         try {
             await this.peerConnection?.setRemoteDescription({ sdp: description, type: type.toLowerCase() as RTCSdpType })
+            clearTimeout(this.earlyTimeout)
         } catch (err) {
             logger.warn('Failed to set remote description', { err })
         }
@@ -133,6 +138,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IWebrt
         if (!this.closed) {
             this.closed = true
             this.lastState = 'closed'
+            clearTimeout(this.earlyTimeout)
 
             this.stopListening()
             this.emit('disconnected', gracefulLeave, undefined, reason)

--- a/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
+++ b/packages/dht/src/connection/webrtc/NodeWebrtcConnection.ts
@@ -8,7 +8,7 @@ import { DataChannel, DescriptionType, PeerConnection, initLogger } from 'node-d
 import { Logger } from '@streamr/utils'
 import { IllegalRtcPeerConnectionState } from '../../helpers/errors'
 import { iceServerAsString } from './iceServerAsString'
-import { IceServer } from './WebrtcConnector'
+import { IceServer, EARLY_TIMEOUT } from './WebrtcConnector'
 import { PortRange } from '../ConnectionManager'
 import { toNodeId } from '../../identifiers'
 import { createRandomConnectionId } from '../Connection'
@@ -58,6 +58,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
     private readonly maxMessageSize?: number
     private closed = false
     private offering?: boolean
+    private readonly earlyTimeout: NodeJS.Timeout
 
     constructor(params: Params) {
         super()
@@ -69,6 +70,9 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
         this.remotePeerDescriptor = params.remotePeerDescriptor
         this.maxMessageSize = params.maxMessageSize ?? 1048576
         this.portRange = params.portRange
+        this.earlyTimeout = setTimeout(() => {
+            this.doClose(false, 'timed out due to remote descriptor not being set')
+        }, EARLY_TIMEOUT)
     }
 
     public start(isOffering: boolean): void {
@@ -101,6 +105,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     public async setRemoteDescription(description: string, type: string): Promise<void> {
         if (this.connection) {
+            clearTimeout(this.earlyTimeout)
             const remoteNodeId = toNodeId(this.remotePeerDescriptor)
             try {
                 logger.trace(`Setting remote descriptor for peer: ${remoteNodeId}`)
@@ -150,6 +155,7 @@ export class NodeWebrtcConnection extends EventEmitter<Events> implements IConne
 
     private doClose(gracefulLeave: boolean, reason?: string): void {
         if (!this.closed) {
+            clearTimeout(this.earlyTimeout)
             const remoteNodeId = toNodeId(this.remotePeerDescriptor)
             logger.trace(`Closing Node WebRTC Connection to ${remoteNodeId}` + `${(reason !== undefined) ? `, reason: ${reason}` : ''}`)
 

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -32,6 +32,8 @@ export const replaceInternalIpWithExternalIp = (candidate: string, ip: string): 
     return parsed.join(' ')
 }
 
+export const EARLY_TIMEOUT = 5000
+
 export interface WebrtcConnectorOptions {
     onNewConnection: (connection: PendingConnection) => boolean
     transport: ITransport

--- a/packages/dht/test/unit/WebrtcConnection.test.ts
+++ b/packages/dht/test/unit/WebrtcConnection.test.ts
@@ -1,0 +1,29 @@
+import { waitForEvent3 } from '@streamr/utils'
+import { NodeWebrtcConnection } from '../../src/connection/webrtc/NodeWebrtcConnection'
+import { createMockPeerDescriptor } from '../utils/utils'
+import { ConnectionEvents } from '../../src/connection/IConnection'
+
+describe('WebrtcConnection', () => {
+
+    let connection: NodeWebrtcConnection
+
+    beforeEach(() => {
+        const peerDescriptor = createMockPeerDescriptor()
+        connection = new NodeWebrtcConnection({
+            remotePeerDescriptor: peerDescriptor
+        })
+    })
+
+    afterEach(() => {
+        connection.close(true)
+    })
+
+    it('Disconnects early if remote descriptor is not set', async () => {
+        connection.start(true)
+        await waitForEvent3<ConnectionEvents>(connection as any, 'disconnected', 5001, (_graceful: boolean, _code: number, reason: string) => {
+            expect(reason).toBe('timed out due to remote descriptor not being set')
+            return true
+        })
+    })
+
+})


### PR DESCRIPTION
## Summary

Close webrtc connections if remote description does not arrive within 5 seconds. This is an improvement for some worst case time-to-data spikes.

If the description does not arrive it indicates that the other end is not online or routing has failed and a new connection should be eventually attempted.
