### PR TITLE
test: Random user ids

### DIFF
--- a/packages/node/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/node/test/integration/plugins/storage/Storage.test.ts
@@ -7,23 +7,24 @@ import {
     convertBytesToStreamMessage,
     convertStreamMessageToBytes
 } from '@streamr/sdk'
-import { EthereumAddress, UserID, hexToBinary, toEthereumAddress, toStreamID, utf8ToBinary } from '@streamr/utils'
+import { hexToBinary, toStreamID, UserID, utf8ToBinary } from '@streamr/utils'
 import { Client } from 'cassandra-driver'
 import { randomFillSync } from 'crypto'
 import { Readable } from 'stream'
 import toArray from 'stream-to-array'
 import { Storage, startCassandraStorage } from '../../../../src/plugins/storage/Storage'
 import { STREAMR_DOCKER_DEV_HOST } from '../../../utils'
+import { randomUserId } from '@streamr/test-utils'
 
 const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 const MAX_BUCKET_MESSAGE_COUNT = 20
 
-const publisherZero = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-const publisherOne = toEthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
-const publisherTwo = toEthereumAddress('0xcccccccccccccccccccccccccccccccccccccccc')
-const publisherThree = toEthereumAddress('0xdddddddddddddddddddddddddddddddddddddddd')
+const publisherZero = randomUserId()
+const publisherOne = randomUserId()
+const publisherTwo = randomUserId()
+const publisherThree = randomUserId()
 
 export function buildMsg({
     streamId,
@@ -64,7 +65,7 @@ function buildEncryptedMsg({
     streamPartition: number
     timestamp: number
     sequenceNumber: number
-    publisherId?: EthereumAddress
+    publisherId?: UserID
     msgChainId?: string
 }) {
     return new StreamMessage({

--- a/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -1,6 +1,6 @@
 import { ContentType, EncryptionType, MessageID, SignatureType, StreamMessage, convertBytesToStreamMessage } from '@streamr/sdk'
-import { waitForStreamToEnd } from '@streamr/test-utils'
-import { hexToBinary, toEthereumAddress, toStreamID, utf8ToBinary, waitForCondition, waitForEvent } from '@streamr/utils'
+import { randomUserId, waitForStreamToEnd } from '@streamr/test-utils'
+import { hexToBinary, toStreamID, utf8ToBinary, waitForCondition, waitForEvent } from '@streamr/utils'
 import { Client } from 'cassandra-driver'
 import { PassThrough, Readable } from 'stream'
 import { Storage, startCassandraStorage } from '../../../../src/plugins/storage/Storage'
@@ -11,7 +11,7 @@ const localDataCenter = 'datacenter1'
 const keyspace = 'streamr_dev_v2'
 
 const MOCK_STREAM_ID = `mock-stream-id-${Date.now()}`
-const MOCK_PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+const MOCK_PUBLISHER_ID = randomUserId()
 const MOCK_MSG_CHAIN_ID = 'msgChainId'
 const createMockMessage = (i: number) => {
     return new StreamMessage({

--- a/packages/node/test/integration/plugins/storage/storage-lots-of-data.test.ts
+++ b/packages/node/test/integration/plugins/storage/storage-lots-of-data.test.ts
@@ -1,9 +1,10 @@
+import { randomUserId } from '@streamr/test-utils'
+import { Logger } from '@streamr/utils'
 import { randomFillSync } from 'crypto'
 import toArray from 'stream-to-array'
-import { Storage, startCassandraStorage } from '../../../../src/plugins/storage/Storage'
+import { startCassandraStorage, Storage } from '../../../../src/plugins/storage/Storage'
 import { getTestName, STREAMR_DOCKER_DEV_HOST } from '../../../utils'
 import { buildMsg } from './Storage.test'
-import { Logger, toEthereumAddress } from '@streamr/utils'
 
 const contactPoints = [STREAMR_DOCKER_DEV_HOST]
 const localDataCenter = 'datacenter1'
@@ -61,6 +62,7 @@ describe('Storage: lots of data', () => {
     beforeAll(async () => {
         const storePromises = []
         const randomBuffer = Buffer.alloc(MESSAGE_SIZE)
+        const publisherId = randomUserId()
         for (let i = 0; i < NUM_MESSAGES; i++) {
             randomFillSync(randomBuffer)
             const msg = buildMsg({
@@ -68,7 +70,7 @@ describe('Storage: lots of data', () => {
                 streamPartition: 0,
                 timestamp: 1000000 + (i + 1),
                 sequenceNumber: 0,
-                publisherId: toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                publisherId,
                 content: randomBuffer.toString('hex'),
             })
             storePromises.push(() => storage.store(msg))

--- a/packages/node/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
+++ b/packages/node/test/sequential/plugins/storage/CassandraNullPayloads.test.ts
@@ -1,6 +1,6 @@
 import { ContentType, EncryptionType, MessageID, SignatureType, StreamMessage } from '@streamr/sdk'
-import { randomEthereumAddress } from '@streamr/test-utils'
-import { hexToBinary, toEthereumAddress, toStreamID, utf8ToBinary } from '@streamr/utils'
+import { randomEthereumAddress, randomUserId } from '@streamr/test-utils'
+import { hexToBinary, toStreamID, utf8ToBinary } from '@streamr/utils'
 import { Client, types as cassandraTypes } from 'cassandra-driver'
 import toArray from 'stream-to-array'
 import { BucketId } from '../../../../src/plugins/storage/Bucket'
@@ -51,6 +51,7 @@ async function storeMockMessages({
     storage: Storage
 }) {
     const storePromises = []
+    const publisherId = randomUserId()
     for (let i = 0; i < count; i++) {
         const timestamp = Math.floor((i / (count - 1)) * (1E10))
         const msg = new StreamMessage({
@@ -59,7 +60,7 @@ async function storeMockMessages({
                 0,
                 timestamp,
                 0,
-                toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                publisherId,
                 ''
             ),
             content: utf8ToBinary(JSON.stringify({})),

--- a/packages/node/test/unit/helpers/PayloadFormat.test.ts
+++ b/packages/node/test/unit/helpers/PayloadFormat.test.ts
@@ -1,4 +1,4 @@
-import { randomEthereumAddress } from '@streamr/test-utils'
+import { randomUserId } from '@streamr/test-utils'
 import { MetadataPayloadFormat, PlainPayloadFormat } from '../../../src/helpers/PayloadFormat'
 
 const MOCK_CONTENT = {
@@ -7,7 +7,7 @@ const MOCK_CONTENT = {
 const MOCK_METADATA = {
     timestamp: 123,
     sequenceNumber: 456,
-    publisherId: randomEthereumAddress(),
+    publisherId: randomUserId(),
     msgChainId: 'm'
 }
 

--- a/packages/node/test/unit/plugins/storage/dataQueryEndpoint.test.ts
+++ b/packages/node/test/unit/plugins/storage/dataQueryEndpoint.test.ts
@@ -1,6 +1,6 @@
 import { ContentType, EncryptionType, MessageID, SignatureType, StreamMessage, convertStreamMessageToBytes } from '@streamr/sdk'
-import { toReadableStream } from '@streamr/test-utils'
-import { MetricsContext, hexToBinary, toEthereumAddress, toLengthPrefixedFrame, toStreamID, utf8ToBinary } from '@streamr/utils'
+import { randomUserId, toReadableStream } from '@streamr/test-utils'
+import { MetricsContext, hexToBinary, toLengthPrefixedFrame, toStreamID, utf8ToBinary } from '@streamr/utils'
 import express from 'express'
 import { Readable } from 'stream'
 import request from 'supertest'
@@ -11,6 +11,8 @@ import {
     MIN_SEQUENCE_NUMBER_VALUE,
     createDataQueryEndpoint
 } from '../../../../src/plugins/storage/dataQueryEndpoint'
+
+const PUBLISHER_ID = randomUserId()
 
 const createOutputStream = (msg: StreamMessage[]): Readable => {
     return toReadableStream(...msg.map(convertStreamMessageToBytes))
@@ -33,7 +35,7 @@ describe('dataQueryEndpoint', () => {
                 0,
                 new Date(2017, 3, 1, 12, 0, 0).getTime(),
                 0,
-                toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                PUBLISHER_ID,
                 'msgChainId'
             ),
             content: utf8ToBinary(JSON.stringify(content)),
@@ -93,7 +95,7 @@ describe('dataQueryEndpoint', () => {
 
             it('responds 400 and error message if publisherId+msgChainId combination is invalid in range request', async () => {
                 const base = '/streams/streamId/data/partitions/0/range?fromTimestamp=1000&toTimestamp=2000&fromSequenceNumber=1&toSequenceNumber=2'
-                const suffixes = ['publisherId=foo', 'msgChainId=bar']
+                const suffixes = [`publisherId=${PUBLISHER_ID}`, 'msgChainId=bar']
                 for (const suffix of suffixes) {
                     await testGetRequest(`${base}&${suffix}`)
                         .expect('Content-Type', /json/)
@@ -207,8 +209,8 @@ describe('dataQueryEndpoint', () => {
             })
         })
 
-        describe('?fromTimestamp=1496408255672&fromSequenceNumber=1&publisherId=publisherId', () => {
-            const query = 'fromTimestamp=1496408255672&fromSequenceNumber=1&publisherId=publisherId'
+        describe(`?fromTimestamp=1496408255672&fromSequenceNumber=1&publisherId=${PUBLISHER_ID}`, () => {
+            const query = `fromTimestamp=1496408255672&fromSequenceNumber=1&publisherId=${PUBLISHER_ID}`
 
             it('responds 200 and Content-Type JSON', (done) => {
                 testGetRequest(`/streams/streamId/data/partitions/0/from?${query}`)
@@ -232,7 +234,7 @@ describe('dataQueryEndpoint', () => {
                     0,
                     1496408255672,
                     1,
-                    'publisherId'
+                    PUBLISHER_ID
                 )
             })
 
@@ -364,9 +366,9 @@ describe('dataQueryEndpoint', () => {
         })
 
         // eslint-disable-next-line max-len
-        describe('?fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId&msgChainId=msgChainId', () => {
+        describe(`?fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=${PUBLISHER_ID}&msgChainId=msgChainId`, () => {
             // eslint-disable-next-line max-len
-            const query = 'fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=publisherId&msgChainId=msgChainId'
+            const query = `fromTimestamp=1496408255672&toTimestamp=1496415670909&fromSequenceNumber=1&toSequenceNumber=2&publisherId=${PUBLISHER_ID}&&msgChainId=msgChainId`
 
             let streamMessages: StreamMessage[]
             beforeEach(() => {
@@ -402,7 +404,7 @@ describe('dataQueryEndpoint', () => {
                     1,
                     1496415670909,
                     2,
-                    'publisherId',
+                    PUBLISHER_ID,
                     'msgChainId',
                 )
             })

--- a/packages/node/test/utils.ts
+++ b/packages/node/test/utils.ts
@@ -1,13 +1,14 @@
-import { EthereumAddress, merge, toEthereumAddress } from '@streamr/utils'
-import padEnd from 'lodash/padEnd'
-import { StreamrClient,
+import {
     CONFIG_TEST,
     NetworkPeerDescriptor,
     Stream,
     StreamMetadata,
     StreamPermission,
+    StreamrClient,
     StreamrClientConfig
 } from '@streamr/sdk'
+import { EthereumAddress, merge, toEthereumAddress } from '@streamr/utils'
+import padEnd from 'lodash/padEnd'
 import { Broker, createBroker } from '../src/broker'
 import { Config } from '../src/config/config'
 
@@ -109,7 +110,7 @@ export const createTestStream = async (
     module: NodeModule,
     props?: Partial<StreamMetadata>
 ): Promise<Stream> => {
-    const id = `${await streamrClient.getAddress()}/test/${getTestName(module)}/${Date.now()}`
+    const id = `/test/${getTestName(module)}/${Date.now()}`
     const stream = await streamrClient.createStream({
         id,
         ...props

--- a/packages/sdk/test/unit/StreamMessage.test.ts
+++ b/packages/sdk/test/unit/StreamMessage.test.ts
@@ -1,4 +1,5 @@
-import { StreamPartIDUtils, hexToBinary, toEthereumAddress, toStreamID, utf8ToBinary } from '@streamr/utils'
+import { randomUserId } from '@streamr/test-utils'
+import { StreamPartIDUtils, hexToBinary, toStreamID, utf8ToBinary } from '@streamr/utils'
 import assert from 'assert'
 import { EncryptedGroupKey } from '../../src/protocol/EncryptedGroupKey'
 import { MessageID } from '../../src/protocol/MessageID'
@@ -34,7 +35,7 @@ const msg = ({ timestamp = 1564046332168, sequenceNumber = 10, ...overrides } = 
     })
 }
 
-const PUBLISHER_ID = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+const PUBLISHER_ID = randomUserId()
 
 describe('StreamMessage', () => {
     describe('constructor', () => {

--- a/packages/trackerless-network/test/end-to-end/inspect.test.ts
+++ b/packages/trackerless-network/test/end-to-end/inspect.test.ts
@@ -1,4 +1,4 @@
-import { randomEthereumAddress } from '@streamr/test-utils'
+import { randomUserId } from '@streamr/test-utils'
 import { StreamPartIDUtils, hexToBinary, utf8ToBinary, waitForCondition } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { ContentType, EncryptionType, SignatureType, StreamMessage } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
@@ -44,7 +44,7 @@ describe('inspect', () => {
             streamPartition: StreamPartIDUtils.getStreamPartition(STREAM_PART_ID),
             timestamp: 666,
             sequenceNumber: 0,
-            publisherId: hexToBinary(randomEthereumAddress()),
+            publisherId: hexToBinary(randomUserId()),
             messageChainId: 'msgChainId'
         },
         previousMessageRef: {

--- a/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-and-full-node.test.ts
@@ -1,4 +1,4 @@
-import { randomEthereumAddress, randomUserId } from '@streamr/test-utils'
+import { randomUserId } from '@streamr/test-utils'
 import { StreamPartID, StreamPartIDUtils, hexToBinary, utf8ToBinary, waitForEvent3 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import {
@@ -19,7 +19,7 @@ const createMessage = (streamPartId: StreamPartID): StreamMessage => {
             streamPartition: StreamPartIDUtils.getStreamPartition(streamPartId),
             timestamp: 666,
             sequenceNumber: 0,
-            publisherId: hexToBinary(randomEthereumAddress()),
+            publisherId: hexToBinary(randomUserId()),
             messageChainId: 'msgChainId'
         },
         previousMessageRef: {

--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -1,5 +1,5 @@
 import { DhtAddress } from '@streamr/dht'
-import { randomEthereumAddress, randomUserId } from '@streamr/test-utils'
+import { randomUserId } from '@streamr/test-utils'
 import { StreamPartIDUtils, hexToBinary, utf8ToBinary, wait, waitForCondition, waitForEvent3 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
@@ -21,7 +21,7 @@ const MESSAGE: StreamMessage = {
         streamPartition: StreamPartIDUtils.getStreamPartition(STREAM_PART_ID),
         timestamp: 666,
         sequenceNumber: 0,
-        publisherId: hexToBinary(randomEthereumAddress()),
+        publisherId: hexToBinary(randomUserId()),
         messageChainId: 'msgChainId'
     },
     previousMessageRef: {

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -1,6 +1,8 @@
+import { randomUserId } from '@streamr/test-utils'
 import {
     StreamPartIDUtils,
-    hexToBinary, toEthereumAddress, waitForEvent3
+    hexToBinary,
+    waitForEvent3
 } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { ProxyDirection, SignatureType, StreamMessage } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
@@ -15,8 +17,8 @@ describe('proxy group key exchange', () => {
     const publisherDescriptor = createMockPeerDescriptor()
     const subscriberDescriptor = createMockPeerDescriptor()
 
-    const publisherUserId = toEthereumAddress('0x823A026e226EB47980c88616e01E1D3305Ef8Ecb')
-    const subscriberUserId = toEthereumAddress('0x73E6183bf9b79D30533bEC7B28e982e9Af649B23')
+    const publisherUserId = randomUserId()
+    const subscriberUserId = randomUserId()
 
     let proxyNode: NetworkNode
     let publisher: NetworkNode

--- a/packages/trackerless-network/test/integration/NetworkNode.test.ts
+++ b/packages/trackerless-network/test/integration/NetworkNode.test.ts
@@ -3,6 +3,7 @@ import { StreamPartIDUtils, hexToBinary, utf8ToBinary, waitForCondition } from '
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { ContentType, EncryptionType, SignatureType, StreamMessage } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
+import { randomUserId } from '@streamr/test-utils'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('test#0')
 
@@ -62,7 +63,7 @@ describe('NetworkNode', () => {
                 streamPartition: StreamPartIDUtils.getStreamPartition(STREAM_PART_ID),
                 timestamp: 666,
                 sequenceNumber: 0,
-                publisherId: hexToBinary('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+                publisherId: hexToBinary(randomUserId()),
                 messageChainId: 'msgChainId'
             },
             previousMessageRef: {

--- a/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
+++ b/packages/trackerless-network/test/integration/stream-without-default-entrypoints.test.ts
@@ -5,6 +5,7 @@ import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { streamPartIdToDataKey } from '../../src/logic/ContentDeliveryManager'
 import { ContentType, EncryptionType, SignatureType, StreamMessage } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { createMockPeerDescriptor } from '../utils/utils'
+import { randomUserId } from '@streamr/test-utils'
 
 const STREAM_PART_ID = StreamPartIDUtils.parse('test#0')
 
@@ -21,7 +22,7 @@ describe('stream without default entrypoints', () => {
             streamPartition: StreamPartIDUtils.getStreamPartition(STREAM_PART_ID),
             timestamp: 666,
             sequenceNumber: 0,
-            publisherId: hexToBinary('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+            publisherId: hexToBinary(randomUserId()),
             messageChainId: 'msgChainId'
         },
         previousMessageRef: {

--- a/packages/utils/src/UserID.ts
+++ b/packages/utils/src/UserID.ts
@@ -1,3 +1,7 @@
-import { EthereumAddress } from './EthereumAddress'
+import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
 
 export type UserID = EthereumAddress
+
+export const toUserId = (value: string): UserID => {
+    return toEthereumAddress(value)
+}

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -125,4 +125,4 @@ export {
 export { StreamID, toStreamID, StreamIDUtils } from './StreamID'
 export { MAX_PARTITION_COUNT, ensureValidStreamPartitionCount, ensureValidStreamPartitionIndex } from './partition'
 export { StreamPartID, toStreamPartID, StreamPartIDUtils } from './StreamPartID'
-export { UserID } from './UserID'
+export { UserID, toUserId } from './UserID'


### PR DESCRIPTION
Use `randomUserId()` instead of random / hardcoded Ethereum addresses.

Also use relative path in `createTestStream()` test utility.
