### PR TITLE
test(trackerless-network): Use `toEqualBinary()` custom matcher

### DIFF
--- a/packages/trackerless-network/jest.config.js
+++ b/packages/trackerless-network/jest.config.js
@@ -1,5 +1,8 @@
 const rootConfig = require('../../jest.config')
 module.exports = {
     ...rootConfig,
+    setupFilesAfterEnv: rootConfig.setupFilesAfterEnv.concat(
+        '@streamr/test-utils/setupCustomMatchers'
+    ),
     testTimeout: 15000
 }

--- a/packages/trackerless-network/karma-setup.js
+++ b/packages/trackerless-network/karma-setup.js
@@ -1,0 +1,7 @@
+/**
+ * This setup script is executed indirectly by Karma via the `browser-test-runner`
+ * package. See karma-config.js in that package for more details.
+ */
+
+const { customMatchers } = require('@streamr/test-utils')
+expect.extend(customMatchers)

--- a/packages/trackerless-network/karma.config.js
+++ b/packages/trackerless-network/karma.config.js
@@ -19,4 +19,4 @@ module.exports = createKarmaConfig(TEST_PATHS, createWebpackConfig({
         '@streamr/dht': path.resolve('../dht/src/exports.ts'),
         '@streamr/proto-rpc': path.resolve('../proto-rpc/src/exports.ts'),
     }
-}))
+}), __dirname)

--- a/packages/trackerless-network/test/types/global.d.ts
+++ b/packages/trackerless-network/test/types/global.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-unresolved
+import '@streamr/test-utils/customMatcherTypes'

--- a/packages/trackerless-network/test/unit/ProxyConnectionRpcRemote.test.ts
+++ b/packages/trackerless-network/test/unit/ProxyConnectionRpcRemote.test.ts
@@ -1,10 +1,10 @@
 import { RpcCommunicator } from '@streamr/proto-rpc'
+import { randomUserId } from '@streamr/test-utils'
+import { hexToBinary } from '@streamr/utils'
 import { ProxyConnectionRpcRemote } from '../../src/logic/proxy/ProxyConnectionRpcRemote'
 import { ProxyConnectionRequest, ProxyDirection } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc'
 import { ProxyConnectionRpcClient } from '../../src/proto/packages/trackerless-network/protos/NetworkRpc.client'
 import { createMockPeerDescriptor } from '../utils/utils'
-import { hexToBinary } from '@streamr/utils'
-import { randomUserId } from '@streamr/test-utils'
 
 describe('ProxyConnectionRpcRemote', () => {
 
@@ -28,7 +28,7 @@ describe('ProxyConnectionRpcRemote', () => {
         const request = ProxyConnectionRequest.fromBinary(rpcMessage.body.value)
         expect(request).toEqual({
             direction: ProxyDirection.PUBLISH,
-            userId: Uint8Array.from(hexToBinary(userId))
+            userId: expect.toEqualBinary(hexToBinary(userId))
         })
         expect(callContext).toMatchObject({
             sourceDescriptor: clientPeerDescriptor,

--- a/packages/trackerless-network/tsconfig.json
+++ b/packages/trackerless-network/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.jest.json"
+}


### PR DESCRIPTION
The `tsconfig.json` was added because without the file there were these kinds of errors e.g. when `trackerless-network` unit tests were run:
```
ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
...
src/logic/ContentDeliveryManager.ts:128:66 - error TS2339: Property 'contentMessage' does not exist on type '{ oneofKind: "contentMessage"; contentMessage: ContentMessage; } | { oneofKind: undefined; }'.
      Property 'contentMessage' does not exist on type '{ oneofKind: undefined; }'.
...
src/NetworkStack.ts:12:47 - error TS2732: Cannot find module '../package.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
``` 

## Future improvements

- Maybe we could tweak some configuration so that the `tsconfig.json` file is not needed? The root level `jest.config.js` already defines that `tsconfig.jest.json` should be used.