### PR TITLE
perf(utils): Optimize `toEthereumAddress`

### DIFF
--- a/packages/utils/src/EthereumAddress.ts
+++ b/packages/utils/src/EthereumAddress.ts
@@ -5,7 +5,7 @@ const REGEX = /^0x[a-fA-F0-9]{40}$/
 export type EthereumAddress = BrandedString<'EthereumAddress'>
 
 export function toEthereumAddress(str: string): EthereumAddress | never {
-    if (str.match(REGEX)) {
+    if (REGEX.test(str)) {
         return str.toLowerCase() as EthereumAddress
     }
     throw new Error(`not a valid Ethereum address: "${str}"`)


### PR DESCRIPTION
Changed the validation check in `EthereumAddress` to use `regexp.test()` instead of `str.match()` as we care only about the boolean result (not the matching groups returned by `str.match()`).

## Optimization

Both usages are very efficient. For 1M `toEthereumAddress()` calls:
- before: 435 ms
- after: 405 ms
- i.e. ~7% faster