### PR TITLE
feat(utils): `merge()` does deep merge

### DIFF
--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -445,27 +445,23 @@ export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStrea
 
 const applyEnvironmentDefaults = (environmentId: EnvironmentId, data: StreamrClientConfig): StreamrClientConfig => {
     const defaults = CHAIN_CONFIG[environmentId]
-    const config = merge(data, {
+    const config = merge({
         network: {
-            ...data.network,
             controlLayer: {
-                entryPoints: defaults.entryPoints,
-                ...data.network?.controlLayer,
+                entryPoints: defaults.entryPoints
             }
         } as any,
         contracts: {
             ethereumNetwork: {
-                chainId: defaults.id,
-                ...data.contracts?.ethereumNetwork
+                chainId: defaults.id
             },
             streamRegistryChainAddress: defaults.contracts.StreamRegistry,
             streamStorageRegistryChainAddress: defaults.contracts.StreamStorageRegistry,
             storageNodeRegistryChainAddress: defaults.contracts.StorageNodeRegistry,
             rpcs: defaults.rpcEndpoints,
-            theGraphUrl: defaults.theGraphUrl,
-            ...data.contracts,
+            theGraphUrl: defaults.theGraphUrl
         } as any
-    }) as any
+    }, data) as any
     if (environmentId === 'polygon') {
         config.contracts.ethereumNetwork = { 
             highGasPriceStrategy: true,

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -83,6 +83,20 @@ function getFieldType(value: any): (Field['type'] | undefined) {
     }
 }
 
+export const flatMerge = <TTarget>(...sources: (Partial<TTarget> | undefined)[]): TTarget => {
+    const result: Record<string, unknown> = {}
+    for (const source of sources) {
+        if (source !== undefined) {
+            for (const [key, value] of Object.entries(source)) {
+                if (value !== undefined) {
+                    result[key] = value
+                }
+            }
+        }
+    }
+    return result as TTarget
+}
+
 /**
  * A convenience API for managing and accessing an individual stream.
  *
@@ -139,7 +153,10 @@ export class Stream {
      * Updates the metadata of the stream by merging with the existing metadata.
      */
     async update(metadata: Partial<StreamMetadata>): Promise<void> {
-        const merged = merge(this.getMetadata(), metadata)
+        // TODO maybe should use deep merge, i.e. merge() from @streamr/utils as that corresponds
+        // the implicit intention of the method description. But we'll harmonize this method soon in NET-1364,
+        // so we don't change the behavior now.
+        const merged = flatMerge(this.getMetadata(), metadata)
         try {
             await this._streamRegistry.updateStream(this.id, merged)
         } finally {

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -2,7 +2,7 @@ import { isArray, mergeWith } from 'lodash'
 
 /*
  * Does deep merge. This is similar to `lodash` merge, but handles arrays differently:
- * `lodash` merges elements of arrays by their indices, this overrites the existing
+ * `lodash` merges elements of arrays by their indices, this overwrites the existing
  * value with the array
  */
 export const merge = <TTarget>(...sources: (Partial<TTarget> | undefined)[]): TTarget => {

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -9,7 +9,7 @@ export const merge = <TTarget>(...sources: (Partial<TTarget> | undefined)[]): TT
     const result: Record<string, unknown> = {}
     mergeWith(result, ...sources, (_: any, srcValue: any) => {
         if (isArray(srcValue)) {
-            return srcValue
+            return [...srcValue]
         } else {
             return undefined  // no customization: does the default merging for this field
         }

--- a/packages/utils/src/merge.ts
+++ b/packages/utils/src/merge.ts
@@ -1,13 +1,18 @@
+import { isArray, mergeWith } from 'lodash'
+
+/*
+ * Does deep merge. This is similar to `lodash` merge, but handles arrays differently:
+ * `lodash` merges elements of arrays by their indices, this overrites the existing
+ * value with the array
+ */
 export const merge = <TTarget>(...sources: (Partial<TTarget> | undefined)[]): TTarget => {
     const result: Record<string, unknown> = {}
-    for (const source of sources) {
-        if (source !== undefined) {
-            for (const [key, value] of Object.entries(source)) {
-                if (value !== undefined) {
-                    result[key] = value
-                }
-            }
+    mergeWith(result, ...sources, (_: any, srcValue: any) => {
+        if (isArray(srcValue)) {
+            return srcValue
+        } else {
+            return undefined  // no customization: does the default merging for this field
         }
-    }
+    })
     return result as TTarget
 }

--- a/packages/utils/test/merge.test.ts
+++ b/packages/utils/test/merge.test.ts
@@ -118,15 +118,31 @@ describe('merge', () => {
 
     it('class instances are handled as object references', () => {
         // eslint-disable-next-line @typescript-eslint/no-extraneous-class
-        class Foo {}
+        class Foo {
+            values: Record<string, unknown> = {}
+        }
+        const foo1 = new Foo()
+        foo1.values = {
+            x: 5,
+            y: 6
+        }
+        const foo2 = new Foo()
+        foo2.values = {
+            y: 7,
+            z: 8
+        }
         const o1 = {
-            foo: 1
+            foo: foo1
         }
-        const foo = new Foo()
         const o2 = {
-            foo
+            foo: foo2
         }
-        expect(merge(o1, o2).foo).toBe(foo)
+        const result = merge(o1, o2)
+        expect(result.foo).toBe(foo2)
+        expect(result.foo.values).toEqual({
+            y: 7,
+            z: 8
+        })
     })
 
     it('arrays are overwritten', () => {

--- a/packages/utils/test/merge.test.ts
+++ b/packages/utils/test/merge.test.ts
@@ -62,30 +62,44 @@ describe('merge', () => {
         })
     })
 
-    it('not deeply', () => {
+    it('deeply', () => {
         interface Bar {
             lorem: number | undefined
             ipsum: number | undefined
+            dolor: Record<string, number>
         }
         const o1 = {
             foo: 1,
             bar: {
                 lorem: undefined,
-                ipsum: 1
+                ipsum: 1,
+                dolor: {
+                    x: 1,
+                    y: 2
+                }
             } as Bar
         }
         const o2 = {
             foo: 2,
             bar: {
                 lorem: 2,
-                ipsum: undefined
+                ipsum: undefined,
+                dolor: {
+                    y: 3,
+                    z: 4
+                }
             } as Bar
         }
         expect(merge(o1, o2)).toEqual({
             foo: 2,
             bar: {
                 lorem: 2,
-                ipsum: undefined
+                ipsum: 1,
+                dolor: {
+                    x: 1,
+                    y: 3,
+                    z: 4
+                }
             }
         })
     })
@@ -99,6 +113,31 @@ describe('merge', () => {
         }
         expect(merge(undefined, o1, undefined, o2, undefined)).toEqual({
             foo: 2
+        })
+    })
+
+    it('class instances are handled as object references', () => {
+        // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+        class Foo {}
+        const o1 = {
+            foo: 1
+        }
+        const foo = new Foo()
+        const o2 = {
+            foo
+        }
+        expect(merge(o1, o2).foo).toBe(foo)
+    })
+
+    it('arrays are overwritten', () => {
+        const o1 = {
+            foo: [1, 2, 3, { x: 1 }]
+        }
+        const o2 = {
+            foo: [4, 5, 6, { y: 2 }]
+        }
+        expect(merge<any>(o1, o2)).toEqual({
+            foo: [4, 5, 6, { y: 2 }]
         })
     })
 })


### PR DESCRIPTION
Changed the `merge()` utility function to perform a deep merge instead of a flat merge. In most cases, it doesn't matter whether we use flat or deep merging, so the flat behavior may not have been explicitly required. When merging objects, we could implicitly assume that the merge is deep. So maybe this is better this way?

This is part of a preparation for NET-1363, where a deep merge is needed.

Also simplified `applyEnvironmentDefaults()`.

## Usage in Stream#update

The `Streamr#update` is one of the callers of `merge()`. The  API documentation says it "merges metadata with the existing metadata.". It is not clear whether that means a deep or a flat merge?

We'll harmonize the `Stream#update` method soonish so that it matches the functionality of `StreamrClient#updateStream` (NET-1364). That's why we don't change the behavior in this PR. If we'd keep the merging functionality, it should most likely do deep merge.