### PR TITLE
fix(trackerless-network): `NodeInfoResponse#controlLayer` optionality

### DIFF
--- a/packages/trackerless-network/generated/packages/trackerless-network/protos/NetworkRpc.ts
+++ b/packages/trackerless-network/generated/packages/trackerless-network/protos/NetworkRpc.ts
@@ -368,7 +368,7 @@ export interface NodeInfoResponse {
      */
     streamPartitions: StreamPartitionInfo[];
     /**
-     * @generated from protobuf field: optional ControlLayerInfo controlLayer = 3;
+     * @generated from protobuf field: ControlLayerInfo controlLayer = 3;
      */
     controlLayer?: ControlLayerInfo;
     /**

--- a/packages/trackerless-network/protos/NetworkRpc.proto
+++ b/packages/trackerless-network/protos/NetworkRpc.proto
@@ -182,6 +182,6 @@ message NodeInfoRequest {}
 message NodeInfoResponse {
   dht.PeerDescriptor peerDescriptor = 1;
   repeated StreamPartitionInfo streamPartitions = 2;
-  optional ControlLayerInfo controlLayer = 3;
+  ControlLayerInfo controlLayer = 3;
   string version = 4;
 }


### PR DESCRIPTION
Remove `optional` annotation from the field as the field is required in practice. 