### PR TITLE
feat(sdk)!: `StreamMetadata#partitions` is nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ Changes before Tatum release are not documented in this file.
 #### Added
 
 - Method `StreamrClient#getDiagnosticInfo()` provides diagnostic info about network (https://github.com/streamr-dev/network/pull/2740, https://github.com/streamr-dev/network/pull/2741)
-- Add `Stream#getPartitionCount()` method
+- Add `Stream#getPartitionCount()` method (https://github.com/streamr-dev/network/pull/2825)
 
 #### Changed
 
-- **BREAKING CHANGE:** Field `StreamMetadata#partitions` is nullable
+- **BREAKING CHANGE:** Field `StreamMetadata#partitions` is nullable (https://github.com/streamr-dev/network/pull/2825)
 - Network-level changes
   - Avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 
   - Internal record `StreamPartitionInfo` format changed (https://github.com/streamr-dev/network/pull/2738, https://github.com/streamr-dev/network/pull/2790)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ Changes before Tatum release are not documented in this file.
 #### Added
 
 - Method `StreamrClient#getDiagnosticInfo()` provides diagnostic info about network (https://github.com/streamr-dev/network/pull/2740, https://github.com/streamr-dev/network/pull/2741)
+- Add `Stream#getPartitionCount()` method
 
 #### Changed
 
+- **BREAKING CHANGE:** Field `StreamMetadata#partitions` is nullable
 - Network-level changes
   - Avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 
   - Internal record `StreamPartitionInfo` format changed (https://github.com/streamr-dev/network/pull/2738, https://github.com/streamr-dev/network/pull/2790)

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -314,7 +314,7 @@ export class Stream {
         // object can't contain extra fields
         if (metadata === '') {
             return {
-                partitions: 1
+                partitions: DEFAULT_PARTITION_COUNT
             }
         }
         const err = new StreamrClientError(`Invalid stream metadata: ${metadata}`, 'INVALID_STREAM_METADATA')
@@ -334,7 +334,7 @@ export class Stream {
         } else {
             return {
                 ...json,
-                partitions: 1
+                partitions: DEFAULT_PARTITION_COUNT
             }
         }
     }

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -170,7 +170,11 @@ export class Stream {
      * Returns the partitions of the stream.
      */
     getStreamParts(): StreamPartID[] {
-        return range(0, this.getMetadata().partitions).map((p) => toStreamPartID(this.id, p))
+        return range(0, this.getPartitionCount()).map((p) => toStreamPartID(this.id, p))
+    }
+
+    getPartitionCount(): number {
+        return this.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
     }
 
     /**

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -1,4 +1,5 @@
 import {
+    DEFAULT_PARTITION_COUNT,
     StreamID,
     StreamPartID,
     collect,
@@ -29,7 +30,7 @@ export interface StreamMetadata {
     /**
      * Determines how many partitions this stream consist of.
      */
-    partitions: number
+    partitions?: number
 
     /**
      * Human-readable description of this stream.
@@ -264,7 +265,7 @@ export class Stream {
             await this._subscriber.add(assignmentSubscription)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
                 id: this.id,
-                partitions: this.getMetadata().partitions
+                partitions: this.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
             }, this._loggerFactory)
             await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -174,7 +174,11 @@ export class Stream {
     }
 
     getPartitionCount(): number {
-        return this.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
+        const metadataValue = this.getMetadata().partitions
+        if (metadataValue !== undefined) {
+            ensureValidStreamPartitionCount(metadataValue)
+        }
+        return metadataValue ?? DEFAULT_PARTITION_COUNT
     }
 
     /**

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -132,7 +132,7 @@ export class Stream {
         this.id = id
         this.metadata = merge(
             {
-                partitions: 1,
+                partitions: DEFAULT_PARTITION_COUNT,
                 // TODO should we remove this default or make config as a required StreamMetadata field?
                 config: {
                     fields: []

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -3,7 +3,7 @@ import './utils/PatchTsyringe'
 
 import { DhtAddress } from '@streamr/dht'
 import { ProxyDirection } from '@streamr/trackerless-network'
-import { EthereumAddress, StreamID, TheGraphClient, toEthereumAddress, UserID } from '@streamr/utils'
+import { DEFAULT_PARTITION_COUNT, EthereumAddress, StreamID, TheGraphClient, toEthereumAddress, UserID } from '@streamr/utils'
 import type { Overrides } from 'ethers'
 import EventEmitter from 'eventemitter3'
 import merge from 'lodash/merge'
@@ -371,7 +371,7 @@ export class StreamrClient {
     async createStream(propsOrStreamIdOrPath: Partial<StreamMetadata> & { id: string } | string): Promise<Stream> {
         const props = typeof propsOrStreamIdOrPath === 'object' ? propsOrStreamIdOrPath : { id: propsOrStreamIdOrPath }
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
-        return this.streamRegistry.createStream(streamId, merge({ partitions: 1 }, omit(props, 'id') ))
+        return this.streamRegistry.createStream(streamId, merge({ partitions: DEFAULT_PARTITION_COUNT }, omit(props, 'id') ))
     }
 
     /**

--- a/packages/sdk/src/publish/MessageFactory.ts
+++ b/packages/sdk/src/publish/MessageFactory.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PARTITION_COUNT, StreamID, UserID, keyToArrayIndex, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
+import { StreamID, UserID, keyToArrayIndex, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
 import random from 'lodash/random'
 import { Authentication } from '../Authentication'
 import { StreamrClientError } from '../StreamrClientError'
@@ -68,7 +68,7 @@ export class MessageFactory {
             throw new StreamrClientError(`You don't have permission to publish to this stream. Using address: ${publisherId}`, 'MISSING_PERMISSION')
         }
 
-        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
+        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getPartitionCount()
         let partition
         if (explicitPartition !== undefined) {
             if ((explicitPartition < 0 || explicitPartition >= partitionCount)) {

--- a/packages/sdk/src/publish/MessageFactory.ts
+++ b/packages/sdk/src/publish/MessageFactory.ts
@@ -1,4 +1,4 @@
-import { StreamID, UserID, keyToArrayIndex, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
+import { DEFAULT_PARTITION_COUNT, StreamID, UserID, keyToArrayIndex, toEthereumAddress, utf8ToBinary } from '@streamr/utils'
 import random from 'lodash/random'
 import { Authentication } from '../Authentication'
 import { StreamrClientError } from '../StreamrClientError'
@@ -68,7 +68,7 @@ export class MessageFactory {
             throw new StreamrClientError(`You don't have permission to publish to this stream. Using address: ${publisherId}`, 'MISSING_PERMISSION')
         }
 
-        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions
+        const partitionCount = (await this.streamRegistry.getStream(this.streamId)).getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
         let partition
         if (explicitPartition !== undefined) {
             if ((explicitPartition < 0 || explicitPartition >= partitionCount)) {

--- a/packages/sdk/src/utils/validateStreamMessage.ts
+++ b/packages/sdk/src/utils/validateStreamMessage.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PARTITION_COUNT, UserID } from '@streamr/utils'
+import { UserID } from '@streamr/utils'
 import { StreamRegistry } from '../contracts/StreamRegistry'
 import { StreamMessage, StreamMessageType } from '../protocol/StreamMessage'
 import { StreamMessageError } from '../protocol/StreamMessageError'
@@ -65,7 +65,7 @@ const validateMessage = async (
 ): Promise<void> => {
     const streamId = streamMessage.getStreamId()
     const stream = await streamRegistry.getStream(streamId)
-    const partitionCount = stream.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
+    const partitionCount = stream.getPartitionCount()
     if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= partitionCount) {
         throw new StreamMessageError(`Partition ${streamMessage.getStreamPartition()} is out of range (0..${partitionCount - 1})`, streamMessage)
     }

--- a/packages/sdk/src/utils/validateStreamMessage.ts
+++ b/packages/sdk/src/utils/validateStreamMessage.ts
@@ -1,4 +1,4 @@
-import { UserID } from '@streamr/utils'
+import { DEFAULT_PARTITION_COUNT, UserID } from '@streamr/utils'
 import { StreamRegistry } from '../contracts/StreamRegistry'
 import { StreamMessage, StreamMessageType } from '../protocol/StreamMessage'
 import { StreamMessageError } from '../protocol/StreamMessageError'
@@ -65,7 +65,7 @@ const validateMessage = async (
 ): Promise<void> => {
     const streamId = streamMessage.getStreamId()
     const stream = await streamRegistry.getStream(streamId)
-    const partitionCount = stream.getMetadata().partitions
+    const partitionCount = stream.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
     if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= partitionCount) {
         throw new StreamMessageError(`Partition ${streamMessage.getStreamPartition()} is out of range (0..${partitionCount - 1})`, streamMessage)
     }

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
 import {
+    DEFAULT_PARTITION_COUNT,
     Logger,
     MAX_PARTITION_COUNT,
     StreamPartID,
@@ -186,9 +187,7 @@ export const createStreamRegistry = (opts?: {
 }): StreamRegistry => {
     return {
         getStream: async () => ({
-            getMetadata: () => ({
-                partitions: opts?.partitionCount ?? 1
-            })
+            getPartitionCount: () => opts?.partitionCount ?? DEFAULT_PARTITION_COUNT
         }),
         hasPublicSubscribePermission: async () => {
             return opts?.isPublicStream ?? false

--- a/packages/sdk/test/unit/validateStreamMessage.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage.test.ts
@@ -34,9 +34,7 @@ const validate = async (messageOptions: MessageOptions) => {
     }
     const streamRegistry: Pick<StreamRegistry, 'getStream' | 'isStreamPublisher'> = {
         getStream: async (): Promise<Stream> => ({
-            getMetadata: () => ({
-                partitions: PARTITION_COUNT
-            })
+            getPartitionCount: () => PARTITION_COUNT
         } as any),
         isStreamPublisher: async (_streamIdOrPath: string, userId: UserID) => {
             return userId === toEthereumAddress(publisherWallet.address)

--- a/packages/sdk/test/unit/validateStreamMessage2.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage2.test.ts
@@ -72,9 +72,7 @@ describe('Validator2', () => {
         // Default stubs
         getStream = async () => {
             return {
-                getMetadata: () => ({
-                    partitions: 10
-                })
+                getPartitionCount: () => 10
             } as any
         }
         isPublisher = async (userId: UserID, streamId: string) => {

--- a/packages/utils/src/exports.ts
+++ b/packages/utils/src/exports.ts
@@ -123,6 +123,6 @@ export {
 }
 
 export { StreamID, toStreamID, StreamIDUtils } from './StreamID'
-export { MAX_PARTITION_COUNT, ensureValidStreamPartitionCount, ensureValidStreamPartitionIndex } from './partition'
+export { DEFAULT_PARTITION_COUNT, MAX_PARTITION_COUNT, ensureValidStreamPartitionCount, ensureValidStreamPartitionIndex } from './partition'
 export { StreamPartID, toStreamPartID, StreamPartIDUtils } from './StreamPartID'
 export { UserID, toUserId, isValidUserId } from './UserID'

--- a/packages/utils/src/partition.ts
+++ b/packages/utils/src/partition.ts
@@ -1,3 +1,4 @@
+export const DEFAULT_PARTITION_COUNT = 1
 export const MAX_PARTITION_COUNT = 100
 
 export function ensureValidStreamPartitionIndex(streamPartition: number | undefined): void | never {


### PR DESCRIPTION
**This is a breaking change** as this changes the API

Changed `StreamMetadata` field type: the `partitions` field now nullable.

We can't ensure that the data contains some values (or even that metadata is a JSON). Therefore it is better that the type system doesn't assert anything about the content of the metadata.

Also added `Stream#getPartititionCount()` method. It reads the info from the metadata and defaults to 1 if there is no data available. It also validates that the partition count is valid (between 1 and 100).

Also added `DEFAULT_PARTITITION_COUNT` constant to `@streamr/utils`.

## Future improvements

Maybe the best type for metadata would be just `Record<string, any>`?
- also maybe the `Stream` constructor and `Stream#parseMetadata` shouldn't inject any default value for the `partitions` field