### PR TITLE
test(trackerless-network): NET-1195 remove setStreamPartEntryPoints calls from e2e tests

### DIFF
--- a/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-connections.test.ts
@@ -79,7 +79,6 @@ describe('Proxy connections', () => {
             }
         })
         await proxyNode1.start()
-        proxyNode1.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
         proxyNode1.stack.getContentDeliveryManager().joinStreamPart(STREAM_PART_ID)
         proxyNode2 = createNetworkNode({
             layer0: {
@@ -92,7 +91,6 @@ describe('Proxy connections', () => {
             }
         })
         await proxyNode2.start()
-        proxyNode2.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor1])
         proxyNode2.stack.getContentDeliveryManager().joinStreamPart(STREAM_PART_ID)
         proxiedNode = createNetworkNode({
             layer0: {

--- a/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
+++ b/packages/trackerless-network/test/end-to-end/proxy-key-exchange.test.ts
@@ -36,7 +36,6 @@ describe('proxy group key exchange', () => {
             }
         })
         await proxyNode.start()
-        proxyNode.setStreamPartEntryPoints(STREAM_PART_ID, [proxyNodeDescriptor])
         proxyNode.stack.getContentDeliveryManager().joinStreamPart(STREAM_PART_ID)
         publisher = createNetworkNode({
             layer0: {

--- a/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/webrtc-full-node-network.test.ts
@@ -32,7 +32,6 @@ describe('Full node network with WebRTC connections', () => {
             }
         })
         await entryPoint.start()
-        entryPoint.getContentDeliveryManager().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
         entryPoint.getContentDeliveryManager().joinStreamPart(streamPartId)
 
         await Promise.all(range(NUM_OF_NODES).map(async () => {
@@ -45,7 +44,6 @@ describe('Full node network with WebRTC connections', () => {
             })
             nodes.push(node)
             await node.start()
-            node.getContentDeliveryManager().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
             node.getContentDeliveryManager().joinStreamPart(streamPartId)
         }))
 

--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -29,7 +29,6 @@ describe('Full node network with WebSocket connections only', () => {
             }
         })
         await entryPoint.start()
-        entryPoint.getContentDeliveryManager().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
         entryPoint.getContentDeliveryManager().joinStreamPart(streamPartId)
 
         await Promise.all(range(NUM_OF_NODES).map(async (i) => {
@@ -43,7 +42,6 @@ describe('Full node network with WebSocket connections only', () => {
             })
             nodes.push(node)
             await node.start()
-            node.getContentDeliveryManager().setStreamPartEntryPoints(streamPartId, [epPeerDescriptor])
             node.getContentDeliveryManager().joinStreamPart(streamPartId)
         }))
 


### PR DESCRIPTION
## Summary

Remove `setStreamPartEntryPoints` calls from E2E tests to test the production setup 