### PR TITLE
fix(browser-test-runner): `NodePolyfillPlugin` aliases

### DIFF
--- a/packages/browser-test-runner/webpack.config.js
+++ b/packages/browser-test-runner/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = function({ entry, libraryName, alias = {} }) {
             },
             plugins: [
                 new NodePolyfillPlugin({
-                    includeAliases: [
+                    additionalAliases: [
                         'constants',
                         'crypto',
                         'path',


### PR DESCRIPTION
Renamed `node-polyfill-webpack-plugin`'s `includeAliases` config option. In v4 the name of that config option is `additionalAliases`.

## Background

The property was renamed in v4.0.0 release of `node-polyfill-webpack-plugin`, see https://github.com/Richienb/node-polyfill-webpack-plugin/releases/tag/v4.0.0. The plugin was updated in https://github.com/streamr-dev/network/pull/2659, but the property name was not updated in that PR.

## Open questions

Do we need these aliases in practice? As the test runs succeeded without this config option, we could maybe just remove the config option? The plugin polyfills most of the listed modules by default: https://github.com/Richienb/node-polyfill-webpack-plugin/blob/08f793b9698e858adc9373facc2b915e18d4a0a9/index.js#L23. It doesn't polyfill the `process` module, but maybe that is not used by any test?