### PR TITLE
test(network): fix test flakyness `end-to-end/websocket-full-node-network.test.ts` 

### DIFF
--- a/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
+++ b/packages/trackerless-network/test/end-to-end/websocket-full-node-network.test.ts
@@ -7,7 +7,7 @@ import { randomUserId } from '@streamr/test-utils'
 
 describe('Full node network with WebSocket connections only', () => {
 
-    const NUM_OF_NODES = 20
+    const NUM_OF_NODES = 12
     const epPeerDescriptor = createMockPeerDescriptor({
         websocket: { host: '127.0.0.1', port: 15555, tls: false }
     })


### PR DESCRIPTION
## Summary

After #2827 the increased cpu load is causing problems in the websocket test. This seems to be caused by a known issue with local connections with the `ws` library especially since it does not really appear in the browser. This issue should not exist in production but it probably would make sense to investigate it. (Possibly related to NET-1349)