### PR TITLE
fix(cli-tools): `--env` flag overrides config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,9 @@ Changes before Tatum release are not documented in this file.
 
 #### Changed
 
-- **BREAKING CHANGE:** Replace `--dev` flag with `--env` flag (https://github.com/streamr-dev/network/pull/2817)
+- **BREAKING CHANGE:** Replace `--dev` flag with `--env` flag (https://github.com/streamr-dev/network/pull/2817, https://github.com/streamr-dev/network/pull/2834)
   - the `--env` flag supports multiple environments
+  - it takes precedence over the options defined in a config file
   - use `--env dev2` for the development environment
 
 #### Deprecated

--- a/packages/cli-tools/src/client.ts
+++ b/packages/cli-tools/src/client.ts
@@ -4,12 +4,12 @@ import { Options } from './command'
 import { getConfig } from './config'
 
 export const getClientConfig = (commandOptions: Options, overridenOptions: StreamrClientConfig = {}): StreamrClientConfig => {
-    const environmentOptions = { environment: commandOptions.env }
     const configFileJson = getConfig(commandOptions.config)?.client
+    const environmentOptions = { environment: commandOptions.env }
     const authenticationOptions = (commandOptions.privateKey !== undefined) ? { auth: { privateKey: commandOptions.privateKey } } : undefined
     return merge(
-        environmentOptions,
         configFileJson,
+        environmentOptions,
         authenticationOptions,
         overridenOptions
     )


### PR DESCRIPTION
Now`--env` flag overrides all environment-specific config options which are defined in a config file. This is a good approach as command line arguments should take precedence over the implicit config files (i.e. the `~/streamr/config/default.json`file )

Same logic is applied also when both `--env` and `--config` command line arguments are given.

## Future improvements 

- Add test (maybe easy when we have https://github.com/streamr-dev/network/pull/2835)