### PR TITLE
feat(sdk): Add internal `show-sdk-config` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-show-sdk-config.ts
+++ b/packages/cli-tools/bin/streamr-internal-show-sdk-config.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import '../src/logLevel'
+
+import StreamrClient from '@streamr/sdk'
+import { createClientCommand } from '../src/command'
+
+createClientCommand(async (client: StreamrClient) => {
+    const config = client.getConfig()
+    console.log(JSON.stringify(config, undefined, 4))
+})
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal.ts
+++ b/packages/cli-tools/bin/streamr-internal.ts
@@ -7,4 +7,5 @@ program
     .usage('<command> [<args>]')
     .description('subcommands for internal use, the API of the commands may change')
     .command('visualize-topology', 'visualize network topology')
+    .command('show-sdk-config', 'show config used by internal StreamrClient')
     .parse()


### PR DESCRIPTION
New internal command which prints out the `StreamrClient` config as a JSON.

Maybe useful in the future. We can also use this to implement a test case for https://github.com/streamr-dev/network/pull/2834.