### PR TITLE
refactor: Fix `@typescript-eslint/await-thenable` warnings

### DIFF
--- a/packages/node/test/integration/broker-subscriptions.test.ts
+++ b/packages/node/test/integration/broker-subscriptions.test.ts
@@ -16,7 +16,7 @@ const createMqttClient = (mqttPort: number) => {
 }
 
 const grantPermissions = async (streams: Stream[], brokerUsers: Wallet[]) => {
-    for await (const s of streams) {
+    for (const s of streams) {
         const assignments = brokerUsers.map((user) => {
             return { permissions: [StreamPermission.SUBSCRIBE], user: user.address }
         })

--- a/packages/sdk/test/unit/Pipeline.test.ts
+++ b/packages/sdk/test/unit/Pipeline.test.ts
@@ -9,7 +9,7 @@ const WAIT = 20
 
 async function* generate(items = expected, waitTime = WAIT) {
     await wait(waitTime * 0.1)
-    for await (const item of items) {
+    for (const item of items) {
         await wait(waitTime * 0.1)
         yield item
         await wait(waitTime * 0.1)

--- a/packages/sdk/test/unit/PushBuffer.test.ts
+++ b/packages/sdk/test/unit/PushBuffer.test.ts
@@ -9,7 +9,7 @@ const WAIT = 20
 
 async function* generate(items = expected, waitTime = WAIT) {
     await wait(waitTime * 0.1)
-    for await (const item of items) {
+    for (const item of items) {
         await wait(waitTime * 0.1)
         yield item
         await wait(waitTime * 0.1)

--- a/packages/sdk/test/unit/iterators.test.ts
+++ b/packages/sdk/test/unit/iterators.test.ts
@@ -8,7 +8,7 @@ const WAIT = 20
 
 async function* generate(items = expected, waitTime = WAIT) {
     await wait(waitTime * 0.1)
-    for await (const item of items) {
+    for (const item of items) {
         await wait(waitTime * 0.1)
         yield item
         await wait(waitTime * 0.1)
@@ -20,7 +20,7 @@ async function* generate(items = expected, waitTime = WAIT) {
 async function* generateThrow(items = expected, { max = MAX_ITEMS, err = new Error('expected') }) {
     let index = 0
     await wait(WAIT * 0.1)
-    for await (const item of items) {
+    for (const item of items) {
         index += 1
         await wait(WAIT * 0.1)
         if (index > max) {
@@ -696,7 +696,7 @@ describe('Iterator Utils', () => {
                 const triggeredForever = jest.fn()
                 const itr = CancelableGenerator((async function* Gen() {
                     let i = 0
-                    for await (const v of expected) {
+                    for (const v of expected) {
                         i += 1
                         await wait((expected.length - i - 1) * 2 * WAIT)
                         yield v

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -76,7 +76,7 @@ describe('resend subscription', () => {
 
     const publish = async (type: string, msgChainId?: string) => {
         const messages = await createMessages(type, msgChainId)
-        for await (const msg of messages) {
+        for (const msg of messages) {
             await sub.push(msg)
         }
         return messages


### PR DESCRIPTION
The `eslint` rule would warn about these when we upgrade to v9.