### PR TITLE
refactor: Fix `@typescript-eslint/dot-notation` warnings

### DIFF
--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -293,7 +293,7 @@ export class Simulator {
             logger.error('connect() called on a stopped simulator ' + (new Error().stack))
             return
         }
-        debugVars['simulatorHeapSize'] = this.operationQueue.size()
+        debugVars.simulatorHeapSize = this.operationQueue.size()
 
         const association = new Association(sourceConnection, undefined, connectedCallback)
         this.associations.set(sourceConnection.connectionId, association)

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -49,10 +49,10 @@ describe('Find correctness', () => {
         )
 
         logger.info('waiting 120s')
-        debugVars['waiting'] = true
+        debugVars.waiting = true
 
         await wait(120000)
-        debugVars['waiting'] = false
+        debugVars.waiting = false
         logger.info('waiting over')
 
         nodes.forEach((node) => logger.info(toNodeId(node.getLocalPeerDescriptor()) + ': connections:' +

--- a/packages/node/src/helpers/partitions.ts
+++ b/packages/node/src/helpers/partitions.ts
@@ -9,8 +9,8 @@ export class PublishPartitionDefinition {
 
 export const parsePublishPartitionDefinition = (queryParams: ParsedQs): PublishPartitionDefinition => {
     const partition = parseQueryParameter<number>('partition', queryParams, parsePositiveInteger)
-    const partitionKey = queryParams['partitionKey'] as string | undefined
-    const partitionKeyField = queryParams['partitionKeyField'] as string | undefined
+    const partitionKey = queryParams.partitionKey as string | undefined
+    const partitionKeyField = queryParams.partitionKeyField as string | undefined
     const partitionDefinitions = [partition, partitionKey, partitionKeyField].filter((d) => d !== undefined)
     if (partitionDefinitions.length > 1) {
         throw new Error('Invalid combination of "partition", "partitionKey" and "partitionKeyField"')

--- a/packages/node/src/plugins/http/publishEndpoint.ts
+++ b/packages/node/src/plugins/http/publishEndpoint.ts
@@ -19,7 +19,7 @@ const createHandler = (msgChainId: string, streamrClient: StreamrClient): Reques
             content = PAYLOAD_FORMAT.createMessage(req.body.toString()).content
             timestamp = parseQueryParameter<number>('timestamp', req.query, parseTimestamp)
             partition = parseQueryParameter<number>('partition', req.query, parsePositiveInteger)
-            partitionKey = req.query['partitionKey'] as string
+            partitionKey = req.query.partitionKey as string
         } catch (e) {
             res.status(400).send({
                 error: e.message

--- a/packages/node/test/unit/helpers/parser.test.ts
+++ b/packages/node/test/unit/helpers/parser.test.ts
@@ -24,7 +24,7 @@ describe('parse', () => {
         it('with parameters', () => {
             const { base, query } = parseQueryAndBase('foobar?lorem=ipsum')
             expect(base).toBe('foobar')
-            expect(query['lorem']).toBe('ipsum')
+            expect(query.lorem).toBe('ipsum')
         })
         it('without parameters', () => {
             const { base, query } = parseQueryAndBase('foobar')

--- a/packages/node/test/unit/helpers/weightedSample.test.ts
+++ b/packages/node/test/unit/helpers/weightedSample.test.ts
@@ -36,10 +36,10 @@ describe(weightedSample, () => {
             return weightedSample(['a', 'b', 'c', 'd'], (item) => weights[item], () => counter++)
         })
         expect(results).toEqual([
-            ...repeat('a', weights['a']),
-            ...repeat('b', weights['b']),
-            ...repeat('c', weights['c']),
-            ...repeat('d', weights['d'])
+            ...repeat('a', weights.a),
+            ...repeat('b', weights.b),
+            ...repeat('c', weights.c),
+            ...repeat('d', weights.d)
         ])
     })
 

--- a/packages/node/test/utils.ts
+++ b/packages/node/test/utils.ts
@@ -34,7 +34,7 @@ export const formConfig = ({
     const plugins: Record<string, any> = { ...extraPlugins }
     if (httpPort) {
         if (enableCassandra) {
-            plugins['storage'] = {
+            plugins.storage = {
                 cassandra: {
                     hosts: [STREAMR_DOCKER_DEV_HOST],
                     datacenter: 'datacenter1',

--- a/packages/sdk/bin/generate-config-validator.js
+++ b/packages/sdk/bin/generate-config-validator.js
@@ -21,9 +21,9 @@ const ajv = new Ajv({
 })
 // addFormats(ajv) does not work properly when generating stand-alone code
 // (https://github.com/ajv-validator/ajv-formats/issues/68) so adding formats one-by-one
-ajv.addFormat('uri', fastFormats['uri'])
-ajv.addFormat('ipv4', fullFormats['ipv4'])
-ajv.addFormat('hostname', fullFormats['hostname'])
+ajv.addFormat('uri', fastFormats.uri)
+ajv.addFormat('ipv4', fullFormats.ipv4)
+ajv.addFormat('hostname', fullFormats.hostname)
 ajv.addFormat('ethereum-address', /^0x[a-zA-Z0-9]{40}$/)
 ajv.addFormat('ethereum-private-key', /^(0x)?[a-zA-Z0-9]{64}$/)
 

--- a/packages/sdk/src/contracts/contract.ts
+++ b/packages/sdk/src/contracts/contract.ts
@@ -148,7 +148,7 @@ export const createDecoratedContract = <T extends BaseContract>(
      * single-value results: the return type of contract.functions[methodName] is always
      * Promise<Result> (see https://docs.ethers.org/v6/api/contract/#BaseContract)
      */
-    const methodNames = contract['interface'].fragments.filter((f) => FunctionFragment.isFunction(f)).map((f) => (f as FunctionFragment).name)
+    const methodNames = contract.interface.fragments.filter((f) => FunctionFragment.isFunction(f)).map((f) => (f as FunctionFragment).name)
     methodNames.forEach((methodName) => {
         decoratedContract[methodName] = createWrappedContractMethod(
             contract,

--- a/packages/sdk/src/utils/persistence/ServerPersistence.ts
+++ b/packages/sdk/src/utils/persistence/ServerPersistence.ts
@@ -142,6 +142,7 @@ export default class ServerPersistence implements PersistenceContext {
             `SELECT value_ FROM ${namespace} WHERE key_ = ?`,
             key
         )
+        // eslint-disable-next-line no-underscore-dangle
         return row?.value_
     }
 

--- a/packages/sdk/src/utils/persistence/ServerPersistence.ts
+++ b/packages/sdk/src/utils/persistence/ServerPersistence.ts
@@ -142,7 +142,7 @@ export default class ServerPersistence implements PersistenceContext {
             `SELECT value_ FROM ${namespace} WHERE key_ = ?`,
             key
         )
-        return row?.['value_']
+        return row?.value_
     }
 
     async set(key: string, value: string, namespace: string): Promise<void> {


### PR DESCRIPTION
The `eslint` rule would warn about these when we upgrade to v9.

Applied the code changes using `eslint`'s autofix feature.