### PR TITLE
refactor: Fix `@typescript-eslint/array-type` warnings

### DIFF
--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -46,8 +46,8 @@ export class Database {
         return ret
     }
 
-    public async getAllSubdomains(): Promise<Array<Subdomain> | undefined> {
-        let ret: Array<Subdomain> | undefined
+    public async getAllSubdomains(): Promise<Subdomain[] | undefined> {
+        let ret: Subdomain[] | undefined
         try {
             ret = await this.getAllSubdomainsStatement!.all()
         } catch (e) {

--- a/packages/cdn-location/src/getLocalRegion.ts
+++ b/packages/cdn-location/src/getLocalRegion.ts
@@ -21,7 +21,7 @@ export const getLocalAirportCode: () => Promise<string | undefined> = async () =
 }
 
 export const getLocalAirportCodeByCoordinates: (latitude: number, longitude: number) => string = (latitude, longitude) => {
-    const distances: Array<[airportCode: string, distance: number]> = []
+    const distances: [airportCode: string, distance: number][] = []
 
     Object.keys(airportCodeToRegion).forEach((key) => {
         const airport = airportCodeToRegion[key]
@@ -78,7 +78,7 @@ export const getLocalRegion: () => Promise<number> = async () => {
 }
 
 export const getLocalRegionByCoordinates: (latitude: number, longitude: number) => number = (latitude, longitude) => {
-    const distances: Array<[regionNumber: number, distance: number]> = []
+    const distances: [regionNumber: number, distance: number][] = []
 
     Object.keys(airportCodeToRegion).forEach((key) => {
         const airport = airportCodeToRegion[key]

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -90,7 +90,7 @@ class CloseOperation extends SimulatorOperation {
 export class Simulator {
     private stopped = false
     private connectors: Map<DhtAddress, SimulatorConnector> = new Map()
-    private latencyTable?: Array<Array<number>>
+    private latencyTable?: number[][]
     private associations: Map<ConnectionID, Association> = new Map()
 
     private latencyType: LatencyType

--- a/packages/dht/src/connection/simulator/pings.ts
+++ b/packages/dht/src/connection/simulator/pings.ts
@@ -25,7 +25,7 @@ export const regionPingMatrix = [
     [205.555, 178.082, 186.533, 195.774, 216.701, 117.089, 128.001, 175.761, 176.018, 125.551, 303.904, 285.782, 323.15, 309.618, 255.904, 0.262]
 ]
 
-export function getRegionDelayMatrix(): Array<Array<number>> {
+export function getRegionDelayMatrix(): number[][] {
     const ret = []
     for (let i = 0; i < regionPingMatrix.length; i++) {
         const row = []

--- a/packages/dht/src/dht/DhtNodeRpcLocal.ts
+++ b/packages/dht/src/dht/DhtNodeRpcLocal.ts
@@ -19,7 +19,7 @@ import { RingIdRaw } from './contact/ringIdentifiers'
 
 interface DhtNodeRpcLocalOptions {
     peerDiscoveryQueryBatchSize: number
-    getNeighbors: () => ReadonlyArray<PeerDescriptor>
+    getNeighbors: () => readonly PeerDescriptor[]
     getClosestRingContactsTo: (id: RingIdRaw, limit: number) => RingContacts
     addContact: (contact: PeerDescriptor) => void
     removeContact: (nodeId: DhtAddress) => void

--- a/packages/dht/src/dht/PeerManager.ts
+++ b/packages/dht/src/dht/PeerManager.ts
@@ -266,7 +266,7 @@ export class PeerManager extends EventEmitter<PeerManagerEvents> {
         return this.neighbors.count()
     }
 
-    getNeighbors(): ReadonlyArray<DhtNodeRpcRemote> {
+    getNeighbors(): readonly DhtNodeRpcRemote[] {
         return this.neighbors.toArray()
     }
 

--- a/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
+++ b/packages/dht/src/dht/recursive-operation/RecursiveOperationManager.ts
@@ -39,7 +39,7 @@ interface RecursiveOperationManagerOptions {
     createDhtNodeRpcRemote: (peerDescriptor: PeerDescriptor) => DhtNodeRpcRemote
 }
 
-export interface RecursiveOperationResult { closestNodes: Array<PeerDescriptor>, dataEntries?: Array<DataEntry> }
+export interface RecursiveOperationResult { closestNodes: PeerDescriptor[], dataEntries?: DataEntry[] }
 
 const logger = new Logger(module)
 

--- a/packages/dht/src/dht/routing/DuplicateDetector.ts
+++ b/packages/dht/src/dht/routing/DuplicateDetector.ts
@@ -1,7 +1,7 @@
 export class DuplicateDetector {
 
     private values: Set<string> = new Set()
-    private queue: Array<string> = []
+    private queue: string[] = []
     private maxItemCount: number
 
     constructor(

--- a/packages/dht/src/dht/store/StoreManager.ts
+++ b/packages/dht/src/dht/store/StoreManager.ts
@@ -32,7 +32,7 @@ interface StoreManagerOptions {
     serviceId: ServiceID
     highestTtl: number
     redundancyFactor: number
-    getNeighbors: () => ReadonlyArray<PeerDescriptor>
+    getNeighbors: () => readonly PeerDescriptor[]
     createRpcRemote: (contact: PeerDescriptor) => StoreRpcRemote
 }
 

--- a/packages/dht/src/dht/store/StoreRpcLocal.ts
+++ b/packages/dht/src/dht/store/StoreRpcLocal.ts
@@ -17,7 +17,7 @@ interface StoreRpcLocalOptions {
     localDataStore: LocalDataStore
     localPeerDescriptor: PeerDescriptor
     replicateDataToContact: (dataEntry: DataEntry, contact: PeerDescriptor) => Promise<void>
-    getStorers: (key: DhtAddress) => ReadonlyArray<PeerDescriptor>
+    getStorers: (key: DhtAddress) => readonly PeerDescriptor[]
 }
 
 const logger = new Logger(module)

--- a/packages/dht/src/helpers/protoClasses.ts
+++ b/packages/dht/src/helpers/protoClasses.ts
@@ -28,7 +28,7 @@ import {
 
 } from '../../generated/packages/dht/protos/DhtRpc'
 
-export const protoClasses: Array<IMessageType<any>> = [
+export const protoClasses: IMessageType<any>[] = [
     ClosestPeersRequest,
     ClosestPeersResponse,
     RecursiveOperationRequest,

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -21,7 +21,7 @@ describe('Find correctness', () => {
         execSync('npm run prepare-kademlia-simulation')
     }
 
-    const dhtIds: Array<{ type: string, data: Array<number> }> = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
+    const dhtIds: { type: string, data: number[] }[] = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
 
     beforeEach(async () => {
 

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -22,8 +22,8 @@ describe('Kademlia correctness', () => {
         execSync('npm run prepare-kademlia-simulation')
     }
 
-    const dhtIds: Array<{ type: string, data: Array<number> }> = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
-    const groundTruth: Record<string, Array<{ name: string, distance: number, id: { type: string, data: Array<number> } }>>
+    const dhtIds: { type: string, data: number[] }[] = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
+    const groundTruth: Record<string, { name: string, distance: number, id: { type: string, data: number[] } }[]>
         = JSON.parse(fs.readFileSync('test/data/orderedneighbors.json').toString())
 
     beforeEach(async () => {

--- a/packages/dht/test/benchmark/RingCorrectness.test.ts
+++ b/packages/dht/test/benchmark/RingCorrectness.test.ts
@@ -18,7 +18,7 @@ describe('Ring correctness', () => {
     const NUM_NODES = 900
     const nodeIndicesById: Record<DhtAddress, number> = {}
 
-    const regions: Array<number> = []
+    const regions: number[] = []
     for (let i = 0; i < (NUM_NODES + 1); i++) {
         regions.push(i)
     }
@@ -36,8 +36,8 @@ describe('Ring correctness', () => {
         execSync('npm run prepare-kademlia-simulation')
     }
 
-    const dhtIds: Array<{ type: string, data: Array<number> }> = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
-    const groundTruth: Record<string, Array<{ name: string, distance: number, id: { type: string, data: Array<number> } }>>
+    const dhtIds: { type: string, data: number[] }[] = JSON.parse(fs.readFileSync('test/data/nodeids.json').toString())
+    const groundTruth: Record<string, { name: string, distance: number, id: { type: string, data: number[] } }[]>
         = JSON.parse(fs.readFileSync('test/data/orderedneighbors.json').toString())
 
     beforeEach(async () => {

--- a/packages/dht/test/benchmark/hybrid-network-simulation/RingContactList.test.ts
+++ b/packages/dht/test/benchmark/hybrid-network-simulation/RingContactList.test.ts
@@ -39,7 +39,7 @@ class MockNode {
 }
 
 // populate with mock ip addresses
-const mockData: Array< [number, string] > = [
+const mockData: [number, string][] = [
     [0, '5.2.4.2'],
     [0, '6.23.2.4'],
     [0, '7.2.4.2'],

--- a/packages/node/test/unit/plugins/operator/inspectionUtils.test.ts
+++ b/packages/node/test/unit/plugins/operator/inspectionUtils.test.ts
@@ -26,7 +26,7 @@ describe(findTarget, () => {
     let operator: MockProxy<Operator>
     let assignments: MockProxy<StreamPartAssignments>
 
-    function setupEnv(sponsorships: Array<{ address: EthereumAddress, operators: EthereumAddress[], streamId: StreamID }>) {
+    function setupEnv(sponsorships: { address: EthereumAddress, operators: EthereumAddress[], streamId: StreamID }[]) {
         operator.getSponsorships.mockImplementation(async () => {
             return sponsorships
                 .filter(({ operators }) => operators.includes(MY_OPERATOR_ADDRESS))

--- a/packages/proto-rpc/src/protoClasses.ts
+++ b/packages/proto-rpc/src/protoClasses.ts
@@ -1,4 +1,4 @@
 import { IMessageType } from '@protobuf-ts/runtime'
 import { RpcMessage } from '../generated/ProtoRpc'
 
-export const protoClasses: Array<IMessageType<any>> = [ RpcMessage ]
+export const protoClasses: IMessageType<any>[] = [ RpcMessage ]

--- a/packages/sdk/src/NetworkNodeFacade.ts
+++ b/packages/sdk/src/NetworkNodeFacade.ts
@@ -38,7 +38,7 @@ export interface NetworkNodeStub {
     leave: (streamPartId: StreamPartID) => Promise<void>
     broadcast: (streamMessage: NewStreamMessage) => Promise<void>
     getStreamParts: () => StreamPartID[]
-    getNeighbors: (streamPartId: StreamPartID) => ReadonlyArray<DhtAddress>
+    getNeighbors: (streamPartId: StreamPartID) => readonly DhtAddress[]
     getPeerDescriptor: () => PeerDescriptor
     getOptions: () => NetworkOptions
     getMetricsContext: () => MetricsContext
@@ -263,12 +263,12 @@ export class NetworkNodeFacade {
         return node.getDiagnosticInfo()
     }
 
-    async getStreamParts(): Promise<ReadonlyArray<StreamPartID>> {
+    async getStreamParts(): Promise<readonly StreamPartID[]> {
         const node = await this.getNode()
         return node.getStreamParts()
     }
 
-    async getNeighbors(streamPartId: StreamPartID): Promise<ReadonlyArray<DhtAddress>> {
+    async getNeighbors(streamPartId: StreamPartID): Promise<readonly DhtAddress[]> {
         const node = await this.getNode()
         return node.getNeighbors(streamPartId)
     }

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -73,7 +73,7 @@ function getFieldType(value: any): (Field['type'] | undefined) {
         case type === 'object': {
             return 'map'
         }
-        case (VALID_FIELD_TYPES as ReadonlyArray<string>).includes(type): {
+        case (VALID_FIELD_TYPES as readonly string[]).includes(type): {
             // see https://github.com/microsoft/TypeScript/issues/36275
             return type as Field['type']
         }

--- a/packages/sdk/src/protocol/GroupKeyRequest.ts
+++ b/packages/sdk/src/protocol/GroupKeyRequest.ts
@@ -12,7 +12,7 @@ export class GroupKeyRequest {
     readonly requestId: string
     readonly recipient: UserID
     readonly rsaPublicKey: string
-    readonly groupKeyIds: ReadonlyArray<string>
+    readonly groupKeyIds: readonly string[]
 
     constructor({ requestId, recipient, rsaPublicKey, groupKeyIds }: Options) {
         this.requestId = requestId

--- a/packages/sdk/src/protocol/GroupKeyResponse.ts
+++ b/packages/sdk/src/protocol/GroupKeyResponse.ts
@@ -12,7 +12,7 @@ interface Options {
 export class GroupKeyResponse {
     readonly requestId: string
     readonly recipient: UserID
-    readonly encryptedGroupKeys: ReadonlyArray<EncryptedGroupKey>
+    readonly encryptedGroupKeys: readonly EncryptedGroupKey[]
 
     constructor({ requestId, recipient, encryptedGroupKeys }: Options) {
         this.requestId = requestId

--- a/packages/sdk/src/protocol/StreamMessage.ts
+++ b/packages/sdk/src/protocol/StreamMessage.ts
@@ -147,7 +147,7 @@ export class StreamMessage implements StreamMessageOptions {
     }
 
     // TODO: consider replacing later half of type with a "JSON type" from a ts-toolbelt or type-fest or ts-essentials
-    getParsedContent(): Uint8Array | Record<string, unknown> | Array<unknown> {
+    getParsedContent(): Uint8Array | Record<string, unknown> | unknown[] {
         if (this.encryptionType !== EncryptionType.NONE || this.contentType === ContentType.BINARY) {
             return this.content
         } else if (this.contentType === ContentType.JSON) {

--- a/packages/sdk/test/end-to-end/resend.test.ts
+++ b/packages/sdk/test/end-to-end/resend.test.ts
@@ -17,7 +17,7 @@ const TIMEOUT = 60 * 1000
 describe('resend', () => {
     let publisherClient: StreamrClient
     let resendClient: StreamrClient
-    let payloads: Array<Uint8Array | { idx: number }>
+    let payloads: (Uint8Array | { idx: number })[]
 
     beforeEach(async () => {
         publisherClient = createTestClient(await fetchPrivateKeyWithGas(), 43232)

--- a/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
+++ b/packages/sdk/test/test-utils/fake/FakeNetworkNode.ts
@@ -66,7 +66,7 @@ export class FakeNetworkNode implements NetworkNodeStub {
         return [...this.subscriptions]
     }
 
-    getNeighbors(streamPartId: StreamPartID): ReadonlyArray<DhtAddress> {
+    getNeighbors(streamPartId: StreamPartID): readonly DhtAddress[] {
         const allNodes = this.network.getNodes()
         return allNodes
             .filter((node) => (node.id !== this.id))

--- a/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
@@ -76,7 +76,7 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         if (registryItem === undefined) {
             return false
         }
-        const targets: Array<UserID | PublicPermissionTarget> = []
+        const targets: (UserID | PublicPermissionTarget)[] = []
         if (isPublicPermissionQuery(query) || query.allowPublic) {
             targets.push(PUBLIC_PERMISSION_TARGET)
         }

--- a/packages/sdk/test/unit/OrderMessages2.test.ts
+++ b/packages/sdk/test/unit/OrderMessages2.test.ts
@@ -49,7 +49,7 @@ function intoChunks<T>(arr: readonly T[], chunkSize: number): T[][] {
     return chunks
 }
 
-function formChainOfMessages(publisherId: UserID): Array<MessageInfo> {
+function formChainOfMessages(publisherId: UserID): MessageInfo[] {
     const chainOfMessages: MessageInfo[] = [{
         publisherId,
         timestamp: 1,

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -33,15 +33,15 @@ export const waitForStreamToEnd = (stream: Readable): Promise<unknown[]> => {
 // internal
 const runAndWait = async (
     operations: (() => void) | ((() => void)[]),
-    waitedEvents: [emitter: EventEmitter, event: Event] | Array<[emitter: EventEmitter, event: Event]>,
+    waitedEvents: [emitter: EventEmitter, event: Event] | [emitter: EventEmitter, event: Event][],
     timeout: number,
-    promiseFn: (args: Array<Promise<unknown>>) => Promise<unknown[]>
+    promiseFn: (args: Promise<unknown>[]) => Promise<unknown[]>
 ): Promise<unknown[]> => {
     const ops = Array.isArray(operations) ? operations : [operations]
 
-    let evs: Array<[emitter: EventEmitter, event: Event]>
+    let evs: [emitter: EventEmitter, event: Event][]
     if (Array.isArray(waitedEvents) && Array.isArray(waitedEvents[0])) {
-        evs = waitedEvents as Array<[emitter: EventEmitter, event: Event]>
+        evs = waitedEvents as [emitter: EventEmitter, event: Event][]
     } else {
         evs = [waitedEvents as [emitter: EventEmitter, event: Event]]
     }
@@ -63,7 +63,7 @@ const runAndWait = async (
  */
 export const runAndWaitForEvents = async (
     operations: (() => void) | ((() => void)[]), 
-    waitedEvents: [emitter: EventEmitter, event: Event] | Array<[emitter: EventEmitter, event: Event]>,
+    waitedEvents: [emitter: EventEmitter, event: Event] | [emitter: EventEmitter, event: Event][],
     timeout = 5000
 ): Promise<unknown[]> => {
     return runAndWait(operations, waitedEvents, timeout, Promise.all.bind(Promise))
@@ -81,7 +81,7 @@ export const runAndWaitForEvents = async (
  */
 export const runAndRaceEvents = async (
     operations: (() => void) | ((() => void)[]), 
-    waitedEvents: [emitter: EventEmitter, event: Event] | Array<[emitter: EventEmitter, event: Event]>, 
+    waitedEvents: [emitter: EventEmitter, event: Event] | [emitter: EventEmitter, event: Event][], 
     timeout = 5000
 ): Promise<unknown[]> => {
     return runAndWait(operations, waitedEvents, timeout, Promise.race.bind(Promise))
@@ -129,8 +129,8 @@ export const runAndWaitForConditions = async (
  * @returns {Array<Event>} array that is pushed to every time emitter emits an event that
  * is defined in `events`
  */
-export const eventsToArray = (emitter: EventEmitter, events: ReadonlyArray<Event>): Event[] => {
-    const array: Array<Event> = []
+export const eventsToArray = (emitter: EventEmitter, events: readonly Event[]): Event[] => {
+    const array: Event[] = []
     events.forEach((e) => {
         emitter.on(e, () => array.push(e))
     })
@@ -145,8 +145,8 @@ export const eventsToArray = (emitter: EventEmitter, events: ReadonlyArray<Event
  * @returns {Array<[Event, ...any]>} array that is pushed to every time emitter emits an event that
  * is defined in `events`, includes event arguments
  */
-export const eventsWithArgsToArray = (emitter: EventEmitter, events: ReadonlyArray<Event>): Array<[Event, ...any]> => {
-    const array: Array<[Event, ...any]> = []
+export const eventsWithArgsToArray = (emitter: EventEmitter, events: readonly Event[]): [Event, ...any][] => {
+    const array: [Event, ...any][] = []
     events.forEach((e) => {
         emitter.on(e, (...args) => array.push([e, ...args]))
     })

--- a/packages/trackerless-network/src/NetworkNode.ts
+++ b/packages/trackerless-network/src/NetworkNode.ts
@@ -75,7 +75,7 @@ export class NetworkNode {
         await this.stack.getContentDeliveryManager().leaveStreamPart(streamPartId)
     }
 
-    getNeighbors(streamPartId: StreamPartID): ReadonlyArray<DhtAddress> {
+    getNeighbors(streamPartId: StreamPartID): readonly DhtAddress[] {
         return this.stack.getContentDeliveryManager().getNeighbors(streamPartId)
     }
 

--- a/packages/trackerless-network/src/logic/DuplicateMessageDetector.ts
+++ b/packages/trackerless-network/src/logic/DuplicateMessageDetector.ts
@@ -83,7 +83,7 @@ export class GapMisMatchError extends Error {
  */
 export class DuplicateMessageDetector {
     private readonly maxGapCount: number
-    private readonly gaps: Array<[NumberPair, NumberPair]>
+    private readonly gaps: [NumberPair, NumberPair][]
 
     constructor(maxGapCount = 10000) {
         this.maxGapCount = maxGapCount

--- a/packages/trackerless-network/test/unit/Propagation.test.ts
+++ b/packages/trackerless-network/test/unit/Propagation.test.ts
@@ -45,7 +45,7 @@ const N4 = 'n4' as DhtAddress
 const N5 = 'n5' as DhtAddress
 
 describe(Propagation, () => {
-    let getNeighbors: jest.Mock<ReadonlyArray<DhtAddress>, [string]>
+    let getNeighbors: jest.Mock<readonly DhtAddress[], [string]>
     let sendToNeighbor: jest.Mock<Promise<void>, [DhtAddress, StreamMessage]>
     let propagation: Propagation
 

--- a/packages/utils/src/waitForEvent3.ts
+++ b/packages/utils/src/waitForEvent3.ts
@@ -66,10 +66,10 @@ export type RunAndRaceEventsReturnType<T extends EventEmitter.ValidEventTypes> =
 
 export function raceEvents3<T extends EventEmitter.ValidEventTypes>(
     emitter: EventEmitter<T>,
-    eventNames: Array<keyof T>,
+    eventNames: (keyof T)[],
     timeout: number | null = 5000
 ): Promise<RunAndRaceEventsReturnType<T>> {
-    const promises: Array<{ task: Promise<RunAndRaceEventsReturnType<T>>, cancel: () => void }> = []
+    const promises: { task: Promise<RunAndRaceEventsReturnType<T>>, cancel: () => void }[] = []
     eventNames.forEach((eventName) => {
         const item = once(emitter, eventName)
         const wrappedTask = item.task.then((value: any[]) => {
@@ -102,9 +102,9 @@ export function raceEvents3<T extends EventEmitter.ValidEventTypes>(
 }
 
 export function runAndRaceEvents3<T extends EventEmitter.ValidEventTypes>(
-    operations: Array<(() => void)>,
+    operations: (() => void)[],
     emitter: EventEmitter<T>,
-    eventNames: Array<keyof T>,
+    eventNames: (keyof T)[],
     timeout: number
 ): Promise<RunAndRaceEventsReturnType<T>> {
     const promise = raceEvents3(emitter, eventNames, timeout)
@@ -123,7 +123,7 @@ const runAndWait = async <T extends EventEmitter.ValidEventTypes>(
     operations: (() => void)[],
     waitedEvents: [emitter: EventEmitter<T>, event: keyof T][],
     timeout: number,
-    promiseFn: (args: Array<Promise<unknown>>) => Promise<unknown[]>
+    promiseFn: (args: Promise<unknown>[]) => Promise<unknown[]>
 ): Promise<unknown[]> => {
     const promise = promiseFn(waitedEvents.map(([emitter, event]) => waitForEvent3(emitter, event, timeout)))
     operations.forEach((op) => { op() })

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -8,7 +8,7 @@ declare let _streamr_electron_test: any
 
 describe('Logger', () => {
     let logger: Logger
-    let logs: Array<{ level: unknown, msg: unknown }>
+    let logs: { level: unknown, msg: unknown }[]
 
     beforeEach(() => {
         logs = []

--- a/packages/utils/test/pTransaction.test.ts
+++ b/packages/utils/test/pTransaction.test.ts
@@ -1,6 +1,6 @@
 import { pTransaction } from '../src/pTransaction'
 
-function promisify(...sequence: Array<string | Error>): Array<Promise<string>> {
+function promisify(...sequence: (string | Error)[]): Promise<string>[] {
     return sequence.map((v) => {
         if (typeof v === 'string') {
             return Promise.resolve(v)


### PR DESCRIPTION
The `eslint` rule would warn about these when we upgrade to v9.

Applied the code changes using `eslint`'s autofix feature.