### PR TITLE
refactor(browser-test-runner): Remove redundant `NodePolyfillPlugin` options

### DIFF
--- a/packages/browser-test-runner/src/createWebpackConfig.ts
+++ b/packages/browser-test-runner/src/createWebpackConfig.ts
@@ -26,15 +26,7 @@ export const createWebpackConfig = (
                 ],
             },
             plugins: [
-                new NodePolyfillPlugin({
-                    additionalAliases: [
-                        'constants',
-                        'crypto',
-                        'path',
-                        'process',
-                        'stream'
-                    ]
-                }),
+                new NodePolyfillPlugin(),
                 new webpack.ProvidePlugin({
                     process: 'process/browser'
                 }),


### PR DESCRIPTION
The options are not needed, because most of the modules are already included by default: https://github.com/Richienb/node-polyfill-webpack-plugin/blob/08f793b9698e858adc9373facc2b915e18d4a0a9/index.js#L23

The only exception is the `process` module. It is not included by default, but we use a separate plugin for it:
```ts
new webpack.ProvidePlugin({
    process: 'process/browser'
})
```