### PR TITLE
test(cli-tools): `--env` flag precedence test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Changes before Tatum release are not documented in this file.
 
 - **BREAKING CHANGE:** Replace `--dev` flag with `--env` flag (https://github.com/streamr-dev/network/pull/2817, https://github.com/streamr-dev/network/pull/2834)
   - the `--env` flag supports multiple environments
-  - it takes precedence over the options defined in a config file
+  - if there is a value for `environment` in a config file, this overrides it
   - use `--env dev2` for the development environment
 
 #### Deprecated

--- a/packages/cli-tools/test/environment.test.ts
+++ b/packages/cli-tools/test/environment.test.ts
@@ -1,6 +1,26 @@
+import { randomString } from '@streamr/utils'
+import fs from 'fs/promises'
 import { runCommand } from './utils'
+import { StreamrClientConfig } from '@streamr/sdk'
+
+const POLYGON_AMOY_CHAIN_ID = 80002
 
 describe('env command line option', () => {
+
+    it('takes precedence over client.environment config', async () => {
+        const configFileName = `test-${randomString(10)}.json`
+        await fs.writeFile(configFileName, JSON.stringify({
+            client: {
+                environment: 'dev2'
+            }
+        }))
+        const outputLines = await runCommand(`internal show-sdk-config --env polygonAmoy --config ${configFileName}`, {
+            devEnvironment: false
+        })
+        const outputJson: StreamrClientConfig = JSON.parse(outputLines.join(''))
+        await fs.unlink(configFileName)
+        expect(outputJson.contracts!.ethereumNetwork!.chainId).toBe(POLYGON_AMOY_CHAIN_ID)
+    })
 
     it('invalid value', async () => {
         const outputLines = await runCommand('stream show foobar --env invalid-environment', {


### PR DESCRIPTION
Added test case to ensure that `--env` flag overrides a config file environment definition.

Also reworded a changelog item.