### PR TITLE
refactor: Simplify partition handling

### DIFF
--- a/docs/docs/usage/streams/partitioning.md
+++ b/docs/docs/usage/streams/partitioning.md
@@ -38,7 +38,7 @@ const stream = await streamr.createStream({
 });
 console.log(
   `Stream created: ${stream.id}. It has ${
-    stream.getMetadata().partitions
+    stream.getPartitionCount()
   } partitions.`
 );
 ```

--- a/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
+++ b/packages/cli-tools/bin/streamr-storage-node-list-streams.ts
@@ -11,7 +11,7 @@ createClientCommand((async (client: StreamrClient, storageNodeAddress: string) =
         console.info(EasyTable.print(streams.map((stream) => {
             return {
                 id: stream.id,
-                partitions: stream.getMetadata().partitions
+                partitions: stream.getPartitionCount()
             }
         })))
     }

--- a/packages/cli-tools/test/stream-create.test.ts
+++ b/packages/cli-tools/test/stream-create.test.ts
@@ -19,7 +19,7 @@ describe('create stream', () => {
         })
         const client = createTestClient()
         const stream = await client.getStream(streamId)
-        expect(stream.getMetadata().partitions).toBe(1)
+        expect(stream.getPartitionCount()).toBe(1)
         await client.destroy()
     }, 20 * 1000)
 

--- a/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
@@ -17,15 +17,13 @@ const PARTITION_COUNT_LOOKUP: Record<string, number> = Object.freeze({
 
 function makeStubStream(streamId: string): Stream {
     const partitions = PARTITION_COUNT_LOOKUP[streamId]
-    return {
+    const stub: Partial<Stream> = {
         id: toStreamID(streamId),
-        getMetadata: () => ({
-            partitions
-        }),
         getStreamParts(): StreamPartID[] { // TODO: duplicated code from client
-            return range(0, partitions).map((p) => toStreamPartID(this.id, p))
+            return range(0, partitions).map((p) => toStreamPartID(toStreamID(streamId), p))
         }
-    } as Stream
+    }
+    return stub as Stream
 }
 
 describe(StorageConfig, () => {

--- a/packages/node/test/unit/plugins/storage/StorageEventListener.test.ts
+++ b/packages/node/test/unit/plugins/storage/StorageEventListener.test.ts
@@ -3,10 +3,7 @@ import { EthereumAddress, toEthereumAddress, toStreamID, wait } from '@streamr/u
 import { StorageEventListener } from '../../../../src/plugins/storage/StorageEventListener'
 
 const MOCK_STREAM = {
-    id: 'streamId',
-    getMetadata: () => ({
-        partitions: 3
-    })
+    id: 'streamId'
 } as Stream
 const clusterId = toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
 const otherClusterId = toEthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')

--- a/packages/node/test/unit/plugins/storage/StoragePoller.test.ts
+++ b/packages/node/test/unit/plugins/storage/StoragePoller.test.ts
@@ -6,8 +6,8 @@ const POLL_TIME = 5
 
 const POLL_RESULT = Object.freeze({
     streams: [
-        { id: 'stream-1', getMetadata: () => ({ partitions: 1 }) },
-        { id: 'stream-2', getMetadata: () => ({ partitions: 5 }) },
+        { id: 'stream-1' },
+        { id: 'stream-2' },
     ] as Stream[],
     blockNumber: 13
 })

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -270,7 +270,7 @@ export class Stream {
             await this._subscriber.add(assignmentSubscription)
             const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
                 id: this.id,
-                partitions: this.getMetadata().partitions ?? DEFAULT_PARTITION_COUNT
+                partitions: this.getPartitionCount() ?? DEFAULT_PARTITION_COUNT
             }, this._loggerFactory)
             await this._streamStorageRegistry.addStreamToStorageNode(this.id, normalizedNodeAddress)
             await withTimeout(

--- a/packages/sdk/test/unit/searchStreams.test.ts
+++ b/packages/sdk/test/unit/searchStreams.test.ts
@@ -87,8 +87,8 @@ describe('searchStreams', () => {
 
         expect(streams).toHaveLength(2)
         expect(streams[0].id).toBe(stream1)
-        expect(streams[0].getMetadata().partitions).toBe(11)
+        expect(streams[0].getPartitionCount()).toBe(11)
         expect(streams[1].id).toBe(stream4)
-        expect(streams[1].getMetadata().partitions).toBe(44)
+        expect(streams[1].getPartitionCount()).toBe(44)
     })
 })

--- a/packages/sdk/test/unit/searchStreams.test.ts
+++ b/packages/sdk/test/unit/searchStreams.test.ts
@@ -70,9 +70,7 @@ describe('searchStreams', () => {
             const props = Stream.parseMetadata(metadata)
             return {
                 id,
-                getMetadata: () => ({
-                    partitions: props.partitions
-                })
+                getPartitionCount: () => props.partitions
             } as any
         }
 


### PR DESCRIPTION
Use `Stream#getPartitionCount()` instead of `getMetadata().partitions`. 
- both of these return same value in practice as we initialize partitions field with the default value in `Stream` constructor

Also simplified some tests which don't actually need the metadata.