### PR TITLE
chore: Update `tsconfig` includes

### DIFF
--- a/packages/autocertifier-server/tsconfig.jest.json
+++ b/packages/autocertifier-server/tsconfig.jest.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.jest.json",
     "include": [
         "src/**/*",
+        "bin/**/*",
         "test/**/*"
     ],
     "references": [

--- a/packages/cdn-location/tsconfig.jest.json
+++ b/packages/cdn-location/tsconfig.jest.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.jest.json",
     "include": [
         "src/**/*",
+        "data-generation/**/*",
         "test/**/*"
     ],
     "references": [

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -11,7 +11,7 @@
     "streamr": "dist/bin/streamr.js"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.json",
+    "build": "tsc -b tsconfig.node.json",
     "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.jest.json",
   "include": [
     "src/**/*",
+    "bin/**/*",
     "test/**/*"
   ]
 }

--- a/packages/cli-tools/tsconfig.json
+++ b/packages/cli-tools/tsconfig.json
@@ -1,16 +1,3 @@
 {
-    "extends": "../../tsconfig.node.json",
-    "compilerOptions": {
-        "composite": true,
-        "outDir": "dist"
-    },
-    "include": [
-        "package.json",
-        "src/**/*",
-        "bin/**/*"
-    ],
-    "references": [
-        { "path": "../utils/tsconfig.node.json" },
-        { "path": "../sdk/tsconfig.node.json" }
-    ]
+    "extends": "./tsconfig.jest.json"
 }

--- a/packages/cli-tools/tsconfig.node.json
+++ b/packages/cli-tools/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../../tsconfig.node.json",
+    "compilerOptions": {
+        "composite": true,
+        "outDir": "dist"
+    },
+    "include": [
+        "package.json",
+        "src/**/*",
+        "bin/**/*"
+    ],
+    "references": [
+        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../sdk/tsconfig.node.json" }
+    ]
+}

--- a/packages/node/tsconfig.jest.json
+++ b/packages/node/tsconfig.jest.json
@@ -3,6 +3,7 @@
     "include": [
         "src/**/*",
         "src/**/*.json",
+        "bin/*.ts",
         "package.json",
         "test/**/*"
     ],

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -12,6 +12,7 @@
         "package.json",
         "src/**/*",
         "src/**/*.json",
+        "bin/generate-config-validator.js",
         "vendor/**/*",
         "src/config.schema.json",
         "test/**/*",


### PR DESCRIPTION
Update `tsconfig.jest.json` files to include `bin` directories and other source file directories (e.g. the `data-generation` directory in `cdn-location` package). This way these directories are processed by the `eslint` and `check` tasks.

## Other changes

Unified `tsconfig` files for `cli-tools`. Now it uses the same structure as other packages:
- `tsconfig.node.json` for building
- `tsconfig.json` refers to `tsconfig.jest.json`