### PR TITLE
test(sdk): Optimize gap fill test case

### DIFF
--- a/packages/sdk/test/integration/gap-fill.test.ts
+++ b/packages/sdk/test/integration/gap-fill.test.ts
@@ -73,7 +73,8 @@ describe('gap fill', () => {
         const storageNode = await startFailingStorageNode(new Error('expected'), environment)
         await stream.addToStorageNode(storageNode.getAddress())
         const subscriber = environment.createClient({
-            gapFillTimeout: 50
+            gapFillTimeout: 50,
+            retryResendAfter: 50
         })
         subscriber.addEncryptionKey(GROUP_KEY, publisherWallet.address)
         const sub = await subscriber.subscribe(stream.id)


### PR DESCRIPTION
Added `retryResendAfter` client config option for the "failing storage node" test case. This speeds up the test runs significantly. 

## Benchmark

- before: 20115 ms
- after: 315 ms