### PR TITLE
feat(sdk)!: `StreamrClient#updateStream()` return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes before Tatum release are not documented in this file.
 - **BREAKING CHANGE:** Field `StreamMetadata#partitions` is nullable (https://github.com/streamr-dev/network/pull/2825)
 - **BREAKING CHANGE:** Method `Stream#update()` overwrites metadata instead of merging it (https://github.com/streamr-dev/network/pull/2826)
 - **BREAKING CHANGE:** Method `Stream#addToStorageNode()` doesn't wait for acknowledgment by default (https://github.com/streamr-dev/network/pull/2810)
+- **BREAKING CHANGE:** Return type of method `StreamrClient#updateStream()` (https://github.com/streamr-dev/network/pull/2855)
 - Upgrade `StreamRegistry` from v4 to v5 (https://github.com/streamr-dev/network/pull/2780)
 - Network-level changes:
   - avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -399,9 +399,9 @@ export class StreamrClient {
      *
      * @param props - the stream id and the metadata fields to be updated
      */
-    async updateStream(props: Partial<StreamMetadata> & { id: string }): Promise<Stream> {
+    async updateStream(props: Partial<StreamMetadata> & { id: string }): Promise<void> {
         const streamId = await this.streamIdBuilder.toStreamID(props.id)
-        return this.streamRegistry.updateStream(streamId, omit(props, 'id'))
+        await this.streamRegistry.updateStream(streamId, omit(props, 'id'))
     }
 
     /**

--- a/packages/sdk/src/contracts/StreamRegistry.ts
+++ b/packages/sdk/src/contracts/StreamRegistry.ts
@@ -266,7 +266,7 @@ export class StreamRegistry {
 
     // TODO maybe we should require metadata to be StreamMetadata instead of Partial<StreamMetadata>
     // Most likely the contract doesn't make any merging (like we do in Stream#update)?
-    async updateStream(streamId: StreamID, metadata: Partial<StreamMetadata>): Promise<Stream> {
+    async updateStream(streamId: StreamID, metadata: Partial<StreamMetadata>): Promise<void> {
         await this.connectToContract()
         const ethersOverrides = await getEthersOverrides(this.rpcProviderSource, this.config)
         await waitForTx(this.streamRegistryContract!.updateStreamMetadata(
@@ -274,7 +274,6 @@ export class StreamRegistry {
             JSON.stringify(metadata),
             ethersOverrides
         ))
-        return this.streamFactory.createStream(streamId, metadata)
     }
 
     async deleteStream(streamIdOrPath: string): Promise<void> {

--- a/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
@@ -61,14 +61,13 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         }
     }
 
-    async updateStream(streamId: StreamID, metadata: StreamMetadata): Promise<Stream> {
+    async updateStream(streamId: StreamID, metadata: StreamMetadata): Promise<void> {
         const registryItem = this.chain.getStream(streamId)
         if (registryItem === undefined) {
             throw new Error('Stream not found')
         } else {
             registryItem.metadata = metadata
         }
-        return this.streamFactory.createStream(streamId, metadata)
     }
 
     async hasPermission(query: InternalPermissionQuery): Promise<boolean> {


### PR DESCRIPTION
**This is a breaking change as this changes the API**

Changed the return type from `Promise<Stream>` to `Promise<void>`. This unifies the API return types as all other mutators (e.g. `setPermissions()`) already return `Promise<void>`.