### PR TITLE
feat(sdk): Unify `addStreamToStorageNode` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes before Tatum release are not documented in this file.
   - `Stream#getDescription()` and `Stream#setDescription()`
   - `Stream#getStorageDayCount()` and `Stream#setStorageDayCount()`
 - Add validation for public permissions (https://github.com/streamr-dev/network/pull/2819)
+- Add `opts` parameter to `StreamrClient#addStreamToStorageNode` (https://github.com/streamr-dev/network/pull/2858)
+  - controls how long to wait for storage node to pick up on assignment
 
 #### Changed
 

--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -230,14 +230,9 @@ export class Stream {
     }
 
     /**
-     * Assigns the stream to a storage node.
-     *
+     * See {@link StreamrClient.addStreamToStorageNode | StreamrClient.addStreamToStorageNode}.
+     * 
      * @category Important
-     *
-     * @param opts - control how long to wait for storage node to pick up on assignment
-     * @returns If opts.wait=true, the promise resolves when the storage node acknowledges the assignment and
-     * is therefore ready to store published messages. If we don't receive the acknowledgment within the `timeout`,
-     * the promise rejects, but the assignment may still succeed later.
      */
     async addToStorageNode(storageNodeAddress: HexString, opts: { wait: boolean, timeout?: number } = { wait: false }): Promise<void> {
         await addStreamToStorageNode(

--- a/packages/sdk/src/utils/addStreamToStorageNode.ts
+++ b/packages/sdk/src/utils/addStreamToStorageNode.ts
@@ -1,0 +1,61 @@
+import { EthereumAddress, StreamID, toStreamPartID, withTimeout } from '@streamr/utils'
+import EventEmitter from 'eventemitter3'
+import { StrictStreamrClientConfig } from '../Config'
+import { StreamRegistry } from '../contracts/StreamRegistry'
+import { StreamStorageRegistry } from '../contracts/StreamStorageRegistry'
+import { DEFAULT_PARTITION } from '../StreamIDBuilder'
+import { Subscriber } from '../subscribe/Subscriber'
+import { Subscription, SubscriptionEvents } from '../subscribe/Subscription'
+import { formStorageNodeAssignmentStreamId } from '../utils/utils'
+import { waitForAssignmentsToPropagate } from '../utils/waitForAssignmentsToPropagate'
+import { LoggerFactory } from './LoggerFactory'
+
+export const addStreamToStorageNode = async (
+    streamId: StreamID,
+    storageNodeAddress: EthereumAddress,
+    opts: { wait: boolean, timeout?: number },
+    partitionCount: number,
+    subscriber: Subscriber,
+    streamRegistry: StreamRegistry,
+    streamStorageRegistry: StreamStorageRegistry,
+    loggerFactory: LoggerFactory,
+    config: Pick<StrictStreamrClientConfig, '_timeouts'>
+): Promise<void> => {
+    if (opts.wait) {
+        // check whether the stream is already stored: the assignment event listener logic requires that
+        // there must not be an existing assignment (it timeouts if there is an existing assignment as the
+        // storage node doesn't send an assignment event in that case)
+        const isAlreadyStored = await streamStorageRegistry.isStoredStream(streamId, storageNodeAddress)
+        if (isAlreadyStored) {
+            return
+        }
+        let assignmentSubscription
+        try {
+            const streamPartId = toStreamPartID(formStorageNodeAssignmentStreamId(storageNodeAddress), DEFAULT_PARTITION)
+            assignmentSubscription = new Subscription(
+                streamPartId,
+                false,
+                undefined,
+                new EventEmitter<SubscriptionEvents>(),
+                loggerFactory
+            )
+            await subscriber.add(assignmentSubscription)
+            const propagationPromise = waitForAssignmentsToPropagate(assignmentSubscription, {
+                id: streamId,
+                partitions: partitionCount
+            }, loggerFactory)
+            await streamStorageRegistry.addStreamToStorageNode(streamId, storageNodeAddress)
+            await withTimeout(
+                propagationPromise,
+                // eslint-disable-next-line no-underscore-dangle
+                opts.timeout ?? config._timeouts.storageNode.timeout,
+                'storage node did not respond'
+            )
+        } finally {
+            streamRegistry.clearStreamCache(streamId)
+            await assignmentSubscription?.unsubscribe() // should never reject...
+        }
+    } else {
+        await streamStorageRegistry.addStreamToStorageNode(streamId, storageNodeAddress)
+    }
+}


### PR DESCRIPTION
Add opts parameter to `StreamrClient#addStreamToStorageNode`. That parameter was already in `Stream#addToStorageNode` method. After this change both methods have unified API.

## Other changes

Extracted the implementation to a separate file so that it can be called from both classes.