### PR TITLE
feat(sdk)!: Method parameters of `StreamrClient#updateStream` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Changes before Tatum release are not documented in this file.
   - no default values are injected (https://github.com/streamr-dev/network/pull/2851)
 - **BREAKING CHANGE:** Method `Stream#update()` overwrites metadata instead of merging it (https://github.com/streamr-dev/network/pull/2826)
 - **BREAKING CHANGE:** Method `Stream#addToStorageNode()` doesn't wait for acknowledgment by default (https://github.com/streamr-dev/network/pull/2810)
-- **BREAKING CHANGE:** Return type of method `StreamrClient#updateStream()` (https://github.com/streamr-dev/network/pull/2855)
+- **BREAKING CHANGE:** Parameters and return type of method `StreamrClient#updateStream()` (https://github.com/streamr-dev/network/pull/2859, https://github.com/streamr-dev/network/pull/2855)
 - Upgrade `StreamRegistry` from v4 to v5 (https://github.com/streamr-dev/network/pull/2780)
 - Network-level changes:
   - avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -403,12 +403,10 @@ export class StreamrClient {
 
     /**
      * Updates the metadata of a stream.
-     *
-     * @param props - the stream id and the metadata fields to be updated
      */
-    async updateStream(props: StreamMetadata & { id: string }): Promise<void> {
-        const streamId = await this.streamIdBuilder.toStreamID(props.id)
-        await this.streamRegistry.updateStreamMetadata(streamId, omit(props, 'id'))
+    async updateStream(streamIdOrPath: string, metadata: StreamMetadata): Promise<void> {
+        const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
+        await this.streamRegistry.updateStreamMetadata(streamId, metadata)
     }
 
     /**


### PR DESCRIPTION
**This is a breaking change as this changes the API**

Changed the method to have two parameters instead of one: this way the `id` field of metadata is not an exception, and it is possible to set values for that field.

This is needed in a follow-up PR where `Stream` class will be refactored to call `StreamrClient` methods.