### PR TITLE
build(deps): Bump `uuid` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28702,7 +28702,7 @@
                 "lodash": "^4.17.21",
                 "sqlite": "^5.1.1",
                 "sqlite3": "^5.1.7",
-                "uuid": "^10.0.0"
+                "uuid": "^11.0.2"
             },
             "bin": {
                 "autocertifier": "dist/bin/run.js",
@@ -28713,7 +28713,6 @@
                 "@types/dns2": "^2.0.9",
                 "@types/express": "^4.17.21",
                 "@types/request": "^2.48.8",
-                "@types/uuid": "^10.0.0",
                 "request": "^2.88.2"
             }
         },
@@ -28726,6 +28725,18 @@
             },
             "funding": {
                 "url": "https://dotenvx.com"
+            }
+        },
+        "packages/autocertifier-server/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "packages/broker": {
@@ -29041,7 +29052,7 @@
                 "lru-cache": "11.0.1",
                 "node-datachannel": "^0.10.1",
                 "querystring": "0.2.1",
-                "uuid": "^10.0.0",
+                "uuid": "^11.0.2",
                 "websocket": "^1.0.34",
                 "ws": "^8.18.0"
             },
@@ -29051,7 +29062,6 @@
                 "@types/heap": "^0.2.34",
                 "@types/k-bucket": "^5.0.1",
                 "@types/lodash": "^4.17.12",
-                "@types/uuid": "^10.0.0",
                 "@types/websocket": "^1.0.10",
                 "@types/ws": "^8.5.12",
                 "jest-leak-detector": "^27.3.1",
@@ -29061,6 +29071,18 @@
             "optionalDependencies": {
                 "bufferutil": "^4.0.8",
                 "utf-8-validate": "^6.0.3"
+            }
+        },
+        "packages/dht/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "packages/geoip-location": {
@@ -29073,12 +29095,24 @@
                 "long-timeout": "^0.1.1",
                 "mmdb-lib": "^2.1.1",
                 "tar": "^7.4.3",
-                "uuid": "^10.0.0"
+                "uuid": "^11.0.2"
             },
             "devDependencies": {
                 "@types/long-timeout": "^0.1.2",
                 "@types/tar": "^6.1.11",
                 "express": "^4.21.1"
+            }
+        },
+        "packages/geoip-location/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "packages/node": {
@@ -29108,7 +29142,7 @@
                 "node-fetch": "^2.7.0",
                 "p-limit": "^3.1.0",
                 "qs": "^6.13.0",
-                "uuid": "^10.0.0",
+                "uuid": "^11.0.2",
                 "ws": "^8.18.0",
                 "zod": "^3.22.4"
             },
@@ -29132,7 +29166,6 @@
                 "@types/qs": "^6.9.16",
                 "@types/stream-to-array": "^2.3.3",
                 "@types/supertest": "^6.0.2",
-                "@types/uuid": "^10.0.0",
                 "@types/ws": "^8.5.12",
                 "async-mqtt": "^2.6.1",
                 "stream-to-array": "^2.3.0",
@@ -29217,6 +29250,18 @@
                 "node": ">=8"
             }
         },
+        "packages/node/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
         "packages/proto-rpc": {
             "name": "@streamr/proto-rpc",
             "version": "102.0.0-beta.0",
@@ -29227,17 +29272,28 @@
                 "@streamr/utils": "102.0.0-beta.0",
                 "eventemitter3": "^5.0.0",
                 "lodash": "^4.17.21",
-                "uuid": "^10.0.0"
+                "uuid": "^11.0.2"
             },
             "devDependencies": {
                 "@streamr/browser-test-runner": "^0.0.1",
                 "@streamr/test-utils": "102.0.0-beta.0",
-                "@types/lodash": "^4.17.12",
-                "@types/uuid": "^10.0.0"
+                "@types/lodash": "^4.17.12"
             },
             "optionalDependencies": {
                 "bufferutil": "^4.0.8",
                 "utf-8-validate": "^6.0.3"
+            }
+        },
+        "packages/proto-rpc/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "packages/protocol": {
@@ -29287,7 +29343,7 @@
                 "ts-essentials": "^10.0.2",
                 "ts-toolbelt": "^9.6.0",
                 "tsyringe": "^4.8.0",
-                "uuid": "^10.0.0",
+                "uuid": "^11.0.2",
                 "zod": "^3.22.4"
             },
             "devDependencies": {
@@ -29348,6 +29404,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "packages/sdk/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
         "packages/test-utils": {
             "name": "@streamr/test-utils",
             "version": "102.0.0-beta.0",
@@ -29382,16 +29450,27 @@
                 "eventemitter3": "^5.0.0",
                 "lodash": "^4.17.21",
                 "ts-essentials": "^10.0.2",
-                "uuid": "^10.0.0",
+                "uuid": "^11.0.2",
                 "yallist": "^5.0.0"
             },
             "devDependencies": {
                 "@streamr/browser-test-runner": "^0.0.1",
                 "@types/lodash": "^4.17.12",
-                "@types/uuid": "^10.0.0",
                 "@types/yallist": "^4.0.1",
                 "expect": "^29.6.2",
                 "ts-node": "^10.9.2"
+            }
+        },
+        "packages/trackerless-network/node_modules/uuid": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+            "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "packages/utils": {

--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -38,14 +38,13 @@
     "lodash": "^4.17.21",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.2"
   },
   "devDependencies": {
     "@streamr/test-utils": "102.0.0-beta.0",
     "@types/dns2": "^2.0.9",
     "@types/express": "^4.17.21",
     "@types/request": "^2.48.8",
-    "@types/uuid": "^10.0.0",
     "request": "^2.88.2"
   }
 }

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -42,7 +42,7 @@
     "lru-cache": "11.0.1",
     "node-datachannel": "^0.10.1",
     "querystring": "0.2.1",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.2",
     "websocket": "^1.0.34",
     "ws": "^8.18.0"
   },
@@ -52,7 +52,6 @@
     "@types/heap": "^0.2.34",
     "@types/k-bucket": "^5.0.1",
     "@types/lodash": "^4.17.12",
-    "@types/uuid": "^10.0.0",
     "@types/websocket": "^1.0.10",
     "@types/ws": "^8.5.12",
     "jest-leak-detector": "^27.3.1",

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -30,7 +30,7 @@
     "long-timeout": "^0.1.1",
     "mmdb-lib": "^2.1.1",
     "tar": "^7.4.3",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.2"
   },
   "devDependencies": {
     "@types/long-timeout": "^0.1.2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "^2.7.0",
     "p-limit": "^3.1.0",
     "qs": "^6.13.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.2",
     "ws": "^8.18.0",
     "zod": "^3.22.4"
   },
@@ -68,7 +68,6 @@
     "@types/qs": "^6.9.16",
     "@types/stream-to-array": "^2.3.3",
     "@types/supertest": "^6.0.2",
-    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.12",
     "async-mqtt": "^2.6.1",
     "stream-to-array": "^2.3.0",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -29,13 +29,12 @@
     "@streamr/utils": "102.0.0-beta.0",
     "eventemitter3": "^5.0.0",
     "lodash": "^4.17.21",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.2"
   },
   "devDependencies": {
     "@streamr/browser-test-runner": "^0.0.1",
     "@streamr/test-utils": "102.0.0-beta.0",
-    "@types/lodash": "^4.17.12",
-    "@types/uuid": "^10.0.0"
+    "@types/lodash": "^4.17.12"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,7 +54,6 @@
     "@types/heap": "^0.2.34",
     "@types/lodash": "^4.17.12",
     "@types/node-fetch": "^2.6.4",
-    "@types/uuid": "^10.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "babel-loader": "^9.2.1",
@@ -113,7 +112,7 @@
     "ts-essentials": "^10.0.2",
     "ts-toolbelt": "^9.6.0",
     "tsyringe": "^4.8.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.2",
     "zod": "^3.22.4"
   },
   "optionalDependencies": {

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -37,13 +37,12 @@
     "eventemitter3": "^5.0.0",
     "lodash": "^4.17.21",
     "ts-essentials": "^10.0.2",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.2",
     "yallist": "^5.0.0"
   },
   "devDependencies": {
     "@streamr/browser-test-runner": "^0.0.1",
     "@types/lodash": "^4.17.12",
-    "@types/uuid": "^10.0.0",
     "@types/yallist": "^4.0.1",
     "expect": "^29.6.2",
     "ts-node": "^10.9.2"


### PR DESCRIPTION
Updated to v11. The `@types/uuid` dependency is no longer needed as the new version supports TypeScripts natively.