### PR TITLE
docs(sdk): Fix `@remarks` tag

### DIFF
--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -719,7 +719,7 @@ export class StreamrClient {
     /**
      * Get diagnostic info about the underlying network. Useful for debugging issues.
      *
-     * @remark returned object's structure can change without semver considerations
+     * @remarks returned object's structure can change without semver considerations
      */
     async getDiagnosticInfo(): Promise<Record<string, unknown>> {
         return this.node.getDiagnosticInfo()


### PR DESCRIPTION
Using `@remarks` tag instead of `@remark`. Was most likely a typo. TypeDoc supports only the tag as plural (https://typedoc.org/tags/remarks/).

The unknown tag would trigger a warning when we update to latest TypeDoc (https://github.com/streamr-dev/network/pull/2552). 