### PR TITLE
feat(sdk)!: Remove `StreamrClient#findOperators()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Changes before Tatum release are not documented in this file.
 - **BREAKING CHANGE:** Remove `Stream#detectFields()` method (https://github.com/streamr-dev/network/pull/2864)
 - **BREAKING CHANGE:** Remove `Stream#delete()` method (https://github.com/streamr-dev/network/pull/2863)
   - use `StreamrClient#deleteStream()` instead
+- **BREAKING CHANGE:** Remove `StreamrClient#findOperators()` method (https://github.com/streamr-dev/network/pull/2876)
 - Remove support for legacy encryption keys (https://github.com/streamr-dev/network/pull/2757)
 - Remove obsolete config options:
   - `network.node.id` (https://github.com/streamr-dev/network/pull/2777)

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -758,8 +758,12 @@ export class StreamrClient {
         )
     }
 
-    /* 
-     * Discover operators that have been recently online on a given stream
+    /** 
+     * Discover operators that have been recently online on a given stream.
+     *
+     * The API may change soon (NET-1374).
+     * 
+     * @internal
      */
     findOperators(streamId: StreamID): Promise<NetworkPeerDescriptor[]> {
         return this.operatorRegistry.findOperatorsOnStream(streamId, 10, 1)


### PR DESCRIPTION
**This is a breaking change as this changes the API**

Removed the method from public API by annotating it as `@internal`. 

The API of this method and some other related methods may change soon (NET-1374).

## Background

The method signature use internal `StreamID` type. If we re-include the method to public API that parameter type should be changed to `streamIdOrPath: string`.

Also the magic numbers (`maxQueryResults`, `maxHeartbeatAgeHours`) should be configurable, or the method name should reflect the fact that it finds only a subset of operators? Note also that query currently excludes non-TLS operator nodes. We could either add a configuration option to handle that exclusion or rename the method (e.g. `findConnectableOperators()`).