### PR TITLE
chore(sdk): Use `StreamrClient` cache config in `GapFiller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changes before Tatum release are not documented in this file.
 - **BREAKING CHANGE:** Replace methods `StreamrClient#updateStream()` and `Stream#update()`: (https://github.com/streamr-dev/network/pull/2826, https://github.com/streamr-dev/network/pull/2855, https://github.com/streamr-dev/network/pull/2859, https://github.com/streamr-dev/network/pull/2862)
   - use `StreamrClient#setStreamMetadata()` and `Stream#setMetadata()` instead
   - both methods overwrite metadata instead of merging it
+- Change storage node address caching for gap filling (https://github.com/streamr-dev/network/pull/2877)
 - Upgrade `StreamRegistry` from v4 to v5 (https://github.com/streamr-dev/network/pull/2780)
 - Network-level changes:
   - avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -25,7 +25,7 @@ export interface MessagePipelineOptions {
     signatureValidator: SignatureValidator
     groupKeyManager: GroupKeyManager
     // eslint-disable-next-line max-len
-    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy'>
+    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy' | 'cache'>
     destroySignal: DestroySignal
     loggerFactory: LoggerFactory
 }

--- a/packages/sdk/src/subscribe/ordering/OrderMessages.ts
+++ b/packages/sdk/src/subscribe/ordering/OrderMessages.ts
@@ -33,8 +33,7 @@ const createMessageChain = (
     }
     const chain = new OrderedMessageChain(context, abortSignal)
     chain.on('unfillableGap', (gap: Gap) => onUnfillableGap(gap))
-    // TODO maybe caching should be configurable, i.e. use client's config.cache instead of the constant
-    // - maybe the caching should be done at application level, e.g. with a new CacheStreamStorageRegistry class?
+    // TODO maybe the caching should be done at application level, e.g. with a new CacheStreamStorageRegistry class?
     // - also note that this is a cache which contains just one item (as streamPartId always the same)
     const storageNodeCache = new CachingMap(() => getStorageNodes(StreamPartIDUtils.getStreamID(context.streamPartId)), {
         ...config.cache,

--- a/packages/sdk/test/unit/OrderMessages.test.ts
+++ b/packages/sdk/test/unit/OrderMessages.test.ts
@@ -30,7 +30,11 @@ const CONFIG = {
     gapFillStrategy: 'light',
     maxGapRequests: 5,
     retryResendAfter: 50,
-    gapFillTimeout: 50
+    gapFillTimeout: 50,
+    cache: {
+        maxSize: 999999,
+        maxAge: 999999
+    }
 }
 
 const createOrderMessages = (

--- a/packages/sdk/test/unit/OrderMessages2.test.ts
+++ b/packages/sdk/test/unit/OrderMessages2.test.ts
@@ -158,7 +158,11 @@ describe.skip('OrderMessages2', () => {
                 gapFillStrategy: 'full',
                 gapFillTimeout: PROPAGATION_TIMEOUT,
                 retryResendAfter: RESEND_TIMEOUT,
-                maxGapRequests: MAX_GAP_REQUESTS
+                maxGapRequests: MAX_GAP_REQUESTS,
+                cache: {
+                    maxSize: 999999,
+                    maxAge: 999999
+                }
             }
         )
 

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -115,7 +115,11 @@ describe('resend subscription', () => {
                 gapFill,
                 maxGapRequests: MAX_GAP_REQUESTS,
                 gapFillTimeout: 200,
-                retryResendAfterTimeout: 0
+                retryResendAfterTimeout: 0,
+                cache: {
+                    maxAge: 999999,
+                    maxSize: 999999,
+                }
             } as any,
             eventEmitter,
             mockLoggerFactory()

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -117,8 +117,8 @@ describe('resend subscription', () => {
                 gapFillTimeout: 200,
                 retryResendAfterTimeout: 0,
                 cache: {
-                    maxAge: 999999,
                     maxSize: 999999,
+                    maxAge: 999999
                 }
             } as any,
             eventEmitter,


### PR DESCRIPTION
## Summary

`GapFiller's` storage node cache use `StreamrClient`'s cache config option.

## Background

There is only one cache configuration option in client. Most of the caches should use the `maxSize`/`maxAge` options configured at client level. In some specific cases it could make sense to use hardcoded `maxSize`/`maxAge` values instead. Before this PR storage node cache used 30 min cache, but there was a TODO comment which stated "`TODO maybe caching should be configurable`". 