### PR TITLE
refactor(sdk): Move storage node caching to `StreamStorageRegistry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Changes before Tatum release are not documented in this file.
 - **BREAKING CHANGE:** Replace methods `StreamrClient#updateStream()` and `Stream#update()`: (https://github.com/streamr-dev/network/pull/2826, https://github.com/streamr-dev/network/pull/2855, https://github.com/streamr-dev/network/pull/2859, https://github.com/streamr-dev/network/pull/2862)
   - use `StreamrClient#setStreamMetadata()` and `Stream#setMetadata()` instead
   - both methods overwrite metadata instead of merging it
-- Change storage node address caching for gap filling (https://github.com/streamr-dev/network/pull/2877)
+- Change storage node address caching (https://github.com/streamr-dev/network/pull/2877, https://github.com/streamr-dev/network/pull/2878)
 - Upgrade `StreamRegistry` from v4 to v5 (https://github.com/streamr-dev/network/pull/2780)
 - Network-level changes:
   - avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 

--- a/packages/sdk/src/contracts/StreamStorageRegistry.ts
+++ b/packages/sdk/src/contracts/StreamStorageRegistry.ts
@@ -135,6 +135,7 @@ export class StreamStorageRegistry {
         await this.connectToContract()
         const ethersOverrides = await getEthersOverrides(this.rpcProviderSource, this.config)
         await waitForTx(this.streamStorageRegistryContract!.addStorageNode(streamId, nodeAddress, ethersOverrides))
+        this.getStorageNodes_cached.invalidate((key) => key === streamId)
     }
 
     async removeStreamFromStorageNode(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<void> {
@@ -143,6 +144,7 @@ export class StreamStorageRegistry {
         await this.connectToContract()
         const ethersOverrides = await getEthersOverrides(this.rpcProviderSource, this.config)
         await waitForTx(this.streamStorageRegistryContract!.removeStorageNode(streamId, nodeAddress, ethersOverrides))
+        this.getStorageNodes_cached.invalidate((key) => key === streamId)
     }
 
     async isStoredStream(streamIdOrPath: string, nodeAddress: EthereumAddress): Promise<boolean> {

--- a/packages/sdk/src/contracts/StreamStorageRegistry.ts
+++ b/packages/sdk/src/contracts/StreamStorageRegistry.ts
@@ -14,6 +14,7 @@ import { LoggerFactory } from '../utils/LoggerFactory'
 import { ChainEventPoller } from './ChainEventPoller'
 import { ContractFactory } from './ContractFactory'
 import { initContractEventGateway, waitForTx } from './contract'
+import { CachingMap } from '../utils/CachingMap'
 
 export interface StorageNodeAssignmentEvent {
     readonly streamId: StreamID
@@ -26,6 +27,8 @@ interface NodeQueryResult {
     metadata: string
     lastseen: string
 }
+
+const GET_ALL_STORAGE_NODES = Symbol('GET_ALL_STORAGE_NODES')
 
 /**
  * Stores storage node assignments (mapping of streamIds <-> storage nodes addresses)
@@ -42,13 +45,14 @@ export class StreamStorageRegistry {
     private readonly config: Pick<StrictStreamrClientConfig, 'contracts' | '_timeouts'>
     private readonly authentication: Authentication
     private readonly logger: Logger
+    private readonly getStorageNodes_cached: CachingMap<string | typeof GET_ALL_STORAGE_NODES, EthereumAddress[], [string | undefined]>
 
     constructor(
         streamIdBuilder: StreamIDBuilder,
         contractFactory: ContractFactory,
         rpcProviderSource: RpcProviderSource,
         theGraphClient: TheGraphClient,
-        @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'contracts' | '_timeouts'>,
+        @inject(ConfigInjectionToken) config: Pick<StrictStreamrClientConfig, 'contracts' | 'cache' | '_timeouts'>,
         @inject(AuthenticationInjectionToken) authentication: Authentication,
         eventEmitter: StreamrClientEventEmitter,
         loggerFactory: LoggerFactory
@@ -74,6 +78,14 @@ export class StreamStorageRegistry {
             )
         }), config.contracts.pollInterval)
         this.initStreamAssignmentEventListeners(eventEmitter, chainEventPoller, loggerFactory)
+        this.getStorageNodes_cached = new CachingMap((streamIdOrPath?: string) => {
+            return this.getStorageNodes_nonCached(streamIdOrPath)
+        }, {
+            ...config.cache,
+            cacheKey: ([streamIdOrPath]): string | typeof GET_ALL_STORAGE_NODES => {
+                return streamIdOrPath ?? GET_ALL_STORAGE_NODES
+            }
+        })
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -178,6 +190,10 @@ export class StreamStorageRegistry {
     }
 
     async getStorageNodes(streamIdOrPath?: string): Promise<EthereumAddress[]> {
+        return this.getStorageNodes_cached.get(streamIdOrPath)
+    }
+
+    private async getStorageNodes_nonCached(streamIdOrPath?: string): Promise<EthereumAddress[]> {
         let queryResults: NodeQueryResult[]
         if (streamIdOrPath !== undefined) {
             const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -25,7 +25,7 @@ export interface MessagePipelineOptions {
     signatureValidator: SignatureValidator
     groupKeyManager: GroupKeyManager
     // eslint-disable-next-line max-len
-    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy'>
+    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy' | 'cache'>
     destroySignal: DestroySignal
     loggerFactory: LoggerFactory
 }

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -25,7 +25,7 @@ export interface MessagePipelineOptions {
     signatureValidator: SignatureValidator
     groupKeyManager: GroupKeyManager
     // eslint-disable-next-line max-len
-    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy' | 'cache'>
+    config: Pick<StrictStreamrClientConfig, 'orderMessages' | 'gapFillTimeout' | 'retryResendAfter' | 'maxGapRequests' | 'gapFill' | 'gapFillStrategy'>
     destroySignal: DestroySignal
     loggerFactory: LoggerFactory
 }

--- a/packages/sdk/src/subscribe/ordering/OrderMessages.ts
+++ b/packages/sdk/src/subscribe/ordering/OrderMessages.ts
@@ -33,8 +33,7 @@ const createMessageChain = (
     }
     const chain = new OrderedMessageChain(context, abortSignal)
     chain.on('unfillableGap', (gap: Gap) => onUnfillableGap(gap))
-    // TODO maybe caching should be configurable, i.e. use client's config.cache instead of the constant
-    // - maybe the caching should be done at application level, e.g. with a new CacheStreamStorageRegistry class?
+    // TODO maybe the caching should be done at application level, e.g. with a new CacheStreamStorageRegistry class?
     // - also note that this is a cache which contains just one item (as streamPartId always the same)
     const storageNodeCache = new CachingMap(() => getStorageNodes(StreamPartIDUtils.getStreamID(context.streamPartId)), {
         ...config.cache,

--- a/packages/sdk/test/unit/OrderMessages.test.ts
+++ b/packages/sdk/test/unit/OrderMessages.test.ts
@@ -30,7 +30,11 @@ const CONFIG = {
     gapFillStrategy: 'light',
     maxGapRequests: 5,
     retryResendAfter: 50,
-    gapFillTimeout: 50
+    gapFillTimeout: 50,
+    cache: {
+        maxSize: 999999,
+        maxAge: 999999
+    }
 }
 
 const createOrderMessages = (

--- a/packages/sdk/test/unit/OrderMessages.test.ts
+++ b/packages/sdk/test/unit/OrderMessages.test.ts
@@ -30,11 +30,7 @@ const CONFIG = {
     gapFillStrategy: 'light',
     maxGapRequests: 5,
     retryResendAfter: 50,
-    gapFillTimeout: 50,
-    cache: {
-        maxSize: 999999,
-        maxAge: 999999
-    }
+    gapFillTimeout: 50
 }
 
 const createOrderMessages = (

--- a/packages/sdk/test/unit/OrderMessages2.test.ts
+++ b/packages/sdk/test/unit/OrderMessages2.test.ts
@@ -158,7 +158,11 @@ describe.skip('OrderMessages2', () => {
                 gapFillStrategy: 'full',
                 gapFillTimeout: PROPAGATION_TIMEOUT,
                 retryResendAfter: RESEND_TIMEOUT,
-                maxGapRequests: MAX_GAP_REQUESTS
+                maxGapRequests: MAX_GAP_REQUESTS,
+                cache: {
+                    maxSize: 999999,
+                    maxAge: 999999
+                }
             }
         )
 

--- a/packages/sdk/test/unit/OrderMessages2.test.ts
+++ b/packages/sdk/test/unit/OrderMessages2.test.ts
@@ -158,11 +158,7 @@ describe.skip('OrderMessages2', () => {
                 gapFillStrategy: 'full',
                 gapFillTimeout: PROPAGATION_TIMEOUT,
                 retryResendAfter: RESEND_TIMEOUT,
-                maxGapRequests: MAX_GAP_REQUESTS,
-                cache: {
-                    maxSize: 999999,
-                    maxAge: 999999
-                }
+                maxGapRequests: MAX_GAP_REQUESTS
             }
         )
 

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -115,11 +115,7 @@ describe('resend subscription', () => {
                 gapFill,
                 maxGapRequests: MAX_GAP_REQUESTS,
                 gapFillTimeout: 200,
-                retryResendAfterTimeout: 0,
-                cache: {
-                    maxSize: 999999,
-                    maxAge: 999999
-                }
+                retryResendAfterTimeout: 0
             } as any,
             eventEmitter,
             mockLoggerFactory()

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -115,7 +115,11 @@ describe('resend subscription', () => {
                 gapFill,
                 maxGapRequests: MAX_GAP_REQUESTS,
                 gapFillTimeout: 200,
-                retryResendAfterTimeout: 0
+                retryResendAfterTimeout: 0,
+                cache: {
+                    maxAge: 999999,
+                    maxSize: 999999,
+                }
             } as any,
             eventEmitter,
             mockLoggerFactory()

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -117,8 +117,8 @@ describe('resend subscription', () => {
                 gapFillTimeout: 200,
                 retryResendAfterTimeout: 0,
                 cache: {
-                    maxAge: 999999,
                     maxSize: 999999,
+                    maxAge: 999999
                 }
             } as any,
             eventEmitter,


### PR DESCRIPTION
Moved the caching of storage nodes from `OrderMessages` to `StremStorageRegistry`. This way the implementation is unified with StreamRegistry (which caches permissions and metadata information).

## Functionality changes

As `StremStorageRegistry#getStorageNodes()` is now cached, all callers of that method receive cached data:
- `StreamrClient#getStorageNodes()`
- `Stream#getStorageNodes()`
- `MessagePipelineFactory`
- `Resends`