### PR TITLE
feat(sdk): Consistent state for metadata and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ Changes before Tatum release are not documented in this file.
 - **BREAKING CHANGE:** Replace methods `StreamrClient#updateStream()` and `Stream#update()`: (https://github.com/streamr-dev/network/pull/2826, https://github.com/streamr-dev/network/pull/2855, https://github.com/streamr-dev/network/pull/2859, https://github.com/streamr-dev/network/pull/2862)
   - use `StreamrClient#setStreamMetadata()` and `Stream#setMetadata()` instead
   - both methods overwrite metadata instead of merging it
-- Change storage node address caching (https://github.com/streamr-dev/network/pull/2877, https://github.com/streamr-dev/network/pull/2878)
+- Caching changes:
+  - storage node addresses (https://github.com/streamr-dev/network/pull/2877, https://github.com/streamr-dev/network/pull/2878)
+  - stream metadata and permissions (https://github.com/streamr-dev/network/pull/2889)
 - Upgrade `StreamRegistry` from v4 to v5 (https://github.com/streamr-dev/network/pull/2780)
 - Network-level changes:
   - avoid routing through proxy connections (https://github.com/streamr-dev/network/pull/2801) 

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -357,7 +357,7 @@ export class StreamrClient {
      */
     async getStream(streamIdOrPath: string): Promise<Stream> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        const metadata = await this.streamRegistry.getStreamMetadata(streamId, false)
+        const metadata = await this.streamRegistry.getStreamMetadata(streamId)
         return new Stream(streamId, metadata, this)
     }
 
@@ -501,7 +501,7 @@ export class StreamrClient {
      */
     async isStreamPublisher(streamIdOrPath: string, userId: HexString): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        return this.streamRegistry.isStreamPublisher(streamId, toUserId(userId), false)
+        return this.streamRegistry.isStreamPublisher(streamId, toUserId(userId))
     }
 
     /**
@@ -509,7 +509,7 @@ export class StreamrClient {
      */
     async isStreamSubscriber(streamIdOrPath: string, userId: HexString): Promise<boolean> {
         const streamId = await this.streamIdBuilder.toStreamID(streamIdOrPath)
-        return this.streamRegistry.isStreamSubscriber(streamId, toUserId(userId), false)
+        return this.streamRegistry.isStreamSubscriber(streamId, toUserId(userId))
     }
 
     // --------------------------------------------------------------------------------------------

--- a/packages/sdk/src/contracts/StreamRegistry.ts
+++ b/packages/sdk/src/contracts/StreamRegistry.ts
@@ -172,13 +172,13 @@ export class StreamRegistry {
             cacheKey: ([streamId]) => formCacheKeyPrefix(streamId)
         })
         this.isStreamPublisher_cached = new CachingMap((streamId: StreamID, userId: UserID) => {
-            return this.isStreamPublisher(streamId, userId, false)
+            return this.isStreamPublisherOrSubscriber_nonCached(streamId, userId, StreamPermission.PUBLISH)
         }, {
             ...config.cache,
             cacheKey: ([streamId, userId]) =>`${formCacheKeyPrefix(streamId)}${userId}`
         })
         this.isStreamSubscriber_cached = new CachingMap((streamId: StreamID, userId: UserID) => {
-            return this.isStreamSubscriber(streamId, userId, false)
+            return this.isStreamPublisherOrSubscriber_nonCached(streamId, userId, StreamPermission.SUBSCRIBE)
         }, {
             ...config.cache,
             cacheKey: ([streamId, userId]) =>`${formCacheKeyPrefix(streamId)}${userId}`
@@ -511,28 +511,16 @@ export class StreamRegistry {
     // Caching
     // --------------------------------------------------------------------------------------------
 
-    getStreamMetadata(streamId: StreamID, useCache = true): Promise<StreamMetadata> {
-        if (useCache) {
-            return this.getStreamMetadata_cached.get(streamId)
-        } else {
-            return this.getStreamMetadata_nonCached(streamId)
-        }
+    getStreamMetadata(streamId: StreamID): Promise<StreamMetadata> {
+        return this.getStreamMetadata_cached.get(streamId)
     }
 
-    isStreamPublisher(streamId: StreamID, userId: UserID, useCache = true): Promise<boolean> {
-        if (useCache) {
-            return this.isStreamPublisher_cached.get(streamId, userId)
-        } else {
-            return this.isStreamPublisherOrSubscriber_nonCached(streamId, userId, StreamPermission.PUBLISH)
-        }
+    isStreamPublisher(streamId: StreamID, userId: UserID): Promise<boolean> {
+        return this.isStreamPublisher_cached.get(streamId, userId)
     }
 
-    isStreamSubscriber(streamId: StreamID, userId: UserID, useCache = true): Promise<boolean> {
-        if (useCache) {
-            return this.isStreamSubscriber_cached.get(streamId, userId)
-        } else {
-            return this.isStreamPublisherOrSubscriber_nonCached(streamId, userId, StreamPermission.SUBSCRIBE)
-        }
+    isStreamSubscriber(streamId: StreamID, userId: UserID): Promise<boolean> {
+        return this.isStreamSubscriber_cached.get(streamId, userId)
     }
 
     hasPublicSubscribePermission(streamId: StreamID): Promise<boolean> {


### PR DESCRIPTION
Changed these `StreamrClient` methods to use cached `StreamRegistry` data:
- `getStream()`
- `isStreamPublisher()`
- `isStreamSubscriber()`

Before these PRs explicitly bypassed the cache. Therefore it was possible that these methods saw different state for metadata and permissions than other components of the SDK.

It is better that the whole SDK uses consistent state. Now that is achieved by using cached `StreamRegistry` data by all components.

## Future improvements

- Maybe we could add a public API method for invalidating the caches?