### PR TITLE
test(dht): Fix `toEqualPeerDescriptor` inverse custom matcher

### DIFF
--- a/packages/dht/test/unit/customMatchers.test.ts
+++ b/packages/dht/test/unit/customMatchers.test.ts
@@ -13,4 +13,22 @@ describe('custom matchers', () => {
     it('no match', () => {
         expect(createMockPeerDescriptor()).not.toEqualPeerDescriptor(createMockPeerDescriptor())
     })
+
+    describe('error message', () => {
+
+        it('normal', () => {
+            const actual = createMockPeerDescriptor()
+            const expected = createMockPeerDescriptor()
+            expect(() => {
+                expect(actual).toEqualPeerDescriptor(expected)
+            }).toThrow('PeerDescriptor nodeId values don\'t match')
+        })
+
+        it('inverse', () => {
+            const peerDescriptor = createMockPeerDescriptor()
+            expect(() => {
+                expect(peerDescriptor).not.toEqualPeerDescriptor(peerDescriptor)
+            }).toThrow('PeerDescriptors are equal')
+        })
+    })
 })

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -15,8 +15,8 @@ declare global {
     }
 }
 
-const formErrorMessage = (description: string, expected: string | number | undefined, actual: string | number | undefined): string => {
-    return `PeerDescriptor ${description} values don't match:\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
+const formErrorMessage = (field: keyof PeerDescriptor, expected: string | number | undefined, actual: string | number | undefined): string => {
+    return `PeerDescriptor ${field} values don't match:\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
 }
 
 const toEqualPeerDescriptor = (
@@ -51,7 +51,7 @@ const toEqualPeerDescriptor = (
 }
 
 const expectEqualConnectivityMethod = (
-    description: string,
+    field: keyof PeerDescriptor,
     method1: ConnectivityMethod | undefined,
     method2: ConnectivityMethod | undefined,
     messages: string[]
@@ -62,7 +62,7 @@ const expectEqualConnectivityMethod = (
             : undefined
     }
     if (!isEqual(method1, method2)) {
-        messages.push(formErrorMessage(description, toOutput(method1), toOutput(method2)))
+        messages.push(formErrorMessage(field, toOutput(method1), toOutput(method2)))
     }
 }
 

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -45,7 +45,7 @@ const toEqualPeerDescriptor = (
     } else {
         return {
             pass: true,
-            message: () => `Expected not to throw ${printReceived('StreamrClientError')}`
+            message: () => 'PeerDescriptors are equal'
         }
     }
 }

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -16,7 +16,7 @@ declare global {
 }
 
 const formErrorMessage = (description: string, expected: string | number | undefined, actual: string | number | undefined): string => {
-    return `${description}\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
+    return `PeerDescriptor ${description} values don't match:\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)}`
 }
 
 const toEqualPeerDescriptor = (

--- a/packages/dht/test/utils/customMatchers.ts
+++ b/packages/dht/test/utils/customMatchers.ts
@@ -32,7 +32,7 @@ const toEqualPeerDescriptor = (
         messages.push(formErrorMessage('type', typeNames[expected.type], typeNames[actual.type]))
     }
     expectEqualConnectivityMethod('udp', expected.udp, actual.udp, messages)
-    expectEqualConnectivityMethod('tpc', expected.tcp, actual.tcp, messages)
+    expectEqualConnectivityMethod('tcp', expected.tcp, actual.tcp, messages)
     expectEqualConnectivityMethod('websocket', expected.websocket, actual.websocket, messages)
     if (expected.region !== actual.region) {
         messages.push(formErrorMessage('region', expected?.region, actual?.region))


### PR DESCRIPTION
Fixed error message for `toBeEqualPeerDescriptor` for a use case where it is used like this:
```ts
expect(foo).not.toEqualPeerDescriptor(foo)
```

## Other changes

Also fixed `tcp` field name in error messages. The custom matcher implementation now uses stricter types.

Also improved error message for normal use case. Now the error message mentions that we are comparing `PeerDescriptor` instances. Typical error message is like this:
```
PeerDescriptor nodeId values don't match:
Expected: "5d7e7be5ba676dda8a390d557e345c85e19458b4"
Received: "61c7c821496d1d151ea1932655c40140f6cd44d2"
```
