### PR TITLE
test(sdk): Add `toEqualStreamrClientError()` custom matcher

### DIFF
--- a/packages/sdk/test/unit/customMatchers.test.ts
+++ b/packages/sdk/test/unit/customMatchers.test.ts
@@ -56,4 +56,25 @@ describe('custom matchers', () => {
             })
         })
     })
+
+    describe('toEqualStreamrClientError', () => {
+
+        it('happy path', () => {
+            const error = new StreamrClientError('Foobar', 'UNKNOWN_ERROR')
+            expect(error).toEqualStreamrClientError({
+                code: error.code,
+                message: error.message
+            })
+        })
+
+        describe('error message', () => {
+
+            it('inverse', () => {
+                const actual = new StreamrClientError('Foobar', 'UNKNOWN_ERROR')
+                expect(() => {
+                    expect(actual).not.toEqualStreamrClientError(actual)
+                }).toThrow('treamrClientErrors are equal')
+            })
+        })
+    })
 })


### PR DESCRIPTION
Based on https://github.com/streamr-dev/network/pull/2896, merge that first.

Added new custom matcher. Will be used e.g. in https://github.com/streamr-dev/network/pull/2895.