### PR TITLE
test(sdk): Simplify `karma-setup.js`

### DIFF
--- a/packages/sdk/karma-setup.js
+++ b/packages/sdk/karma-setup.js
@@ -4,15 +4,7 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { toThrowStreamrError } = require('./test/test-utils/customMatchers')
-
-// Karma runner ends up reporting an error if we don't have this check here. TODO: investigate why this is
-if (toThrowStreamrError !== undefined) {
-    // eslint-disable-next-line no-undef
-    expect.extend({
-        toThrowStreamrError
-    })
-}
+require('./test/test-utils/customMatchers')
 
 const { customMatchers } = require('@streamr/test-utils')
 expect.extend(customMatchers)


### PR DESCRIPTION
There is no need to call `expect.extend()` as we already call that in the imported `./test/test-utils/customMatchers.ts`.