### PR TITLE
feat(sdk): `Mapping` concurrency

### DIFF
--- a/packages/sdk/src/utils/Mapping.ts
+++ b/packages/sdk/src/utils/Mapping.ts
@@ -23,9 +23,9 @@ export class Mapping<K extends (string | number)[], V> {
 
     async get(...args: K): Promise<V> {
         const key = formLookupKey(...args)
-        const pendingPromises = this.pendingPromises.get(key)
-        if (pendingPromises !== undefined) {
-            return await pendingPromises
+        const pendingPromise = this.pendingPromises.get(key)
+        if (pendingPromise !== undefined) {
+            return await pendingPromise
         } else {
             let valueWrapper = this.delegate.get(key)
             if (valueWrapper === undefined) {

--- a/packages/sdk/src/utils/Mapping.ts
+++ b/packages/sdk/src/utils/Mapping.ts
@@ -13,8 +13,8 @@ interface ValueWrapper<V> {
  */
 export class Mapping<K extends (string | number)[], V> {
 
-    private delegate: Map<string, ValueWrapper<V>> = new Map()
-    private valueFactory: (...args: K) => Promise<V>
+    private readonly delegate: Map<string, ValueWrapper<V>> = new Map()
+    private readonly valueFactory: (...args: K) => Promise<V>
 
     constructor(valueFactory: (...args: K) => Promise<V>) {
         this.valueFactory = valueFactory

--- a/packages/sdk/test/unit/Mapping.test.ts
+++ b/packages/sdk/test/unit/Mapping.test.ts
@@ -1,3 +1,4 @@
+import { wait } from '@streamr/utils'
 import { Mapping } from '../../src/utils/Mapping'
 
 describe('Mapping', () => {
@@ -27,7 +28,49 @@ describe('Mapping', () => {
         const mapping = new Mapping(valueFactory)
         expect(await mapping.get('foo')).toBe(undefined)
         expect(await mapping.get('foo')).toBe(undefined)
-        expect(valueFactory).toBeCalledTimes(1)
+        expect(valueFactory).toHaveBeenCalledTimes(1)
     })
 
+    it('rejections are not cached', async () => {
+        const valueFactory = jest.fn().mockImplementation(async (p1: string, p2: number) => {
+            throw new Error(`error ${p1}-${p2}`)
+        })
+        const mapping = new Mapping(valueFactory)
+        await expect(mapping.get('foo', 1)).rejects.toEqual(new Error('error foo-1'))
+        await expect(mapping.get('foo', 1)).rejects.toEqual(new Error('error foo-1'))
+        expect(valueFactory).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws are not cached', async () => {
+        const valueFactory = jest.fn().mockImplementation((p1: string, p2: number) => {
+            throw new Error(`error ${p1}-${p2}`)
+        })
+        const mapping = new Mapping(valueFactory)
+        await expect(mapping.get('foo', 1)).rejects.toEqual(new Error('error foo-1'))
+        await expect(mapping.get('foo', 1)).rejects.toEqual(new Error('error foo-1'))
+        expect(valueFactory).toHaveBeenCalledTimes(2)
+    })
+
+    it('concurrency', async () => {
+        const valueFactory = jest.fn().mockImplementation(async (p1: string, p2: number) => {
+            await wait(50)
+            return `${p1}${p2}`
+        })
+        const mapping = new Mapping(valueFactory)
+        const results = await Promise.all([
+            mapping.get('foo', 1),
+            mapping.get('foo', 2),
+            mapping.get('foo', 2),
+            mapping.get('foo', 1),
+            mapping.get('foo', 1)
+        ])
+        expect(valueFactory).toHaveBeenCalledTimes(2)
+        expect(results).toEqual([
+            'foo1',
+            'foo2',
+            'foo2',
+            'foo1',
+            'foo1'
+        ])
+    })
 })


### PR DESCRIPTION
Improved concurrency for `Mapping` class. Now concurrent equal `get()` calls share the same promise, i.e. they evaluate the `valueFactory` only once.

## Example

```ts
const valueFactory = async () => ...
const mapping = new Mapping(valueFactory)
await Promise.all([
    mapping.get('foo'),
    mapping.get('bar'),
    mapping.get('bar'),
    mapping.get('foo'),
    mapping.get('foo')
])
```

Triggers two calls to `valueFactory` (one for `foo` and another for `bar`). Before this PR it triggered 5 calls.

## Small refactoring

- Added `readonly` field annotations
- Updated deprecated `jest` method call