### PR TITLE
test: Replace deprecated `toThrowError()` calls

### DIFF
--- a/packages/dht/test/integration/StoreRpcRemote.test.ts
+++ b/packages/dht/test/integration/StoreRpcRemote.test.ts
@@ -45,7 +45,7 @@ describe('StoreRpcRemote', () => {
 
     it('storeData rejects', async () => {
         serverRpcCommunicator.registerRpcMethod(StoreDataRequest, StoreDataResponse, 'storeData', mockStoreRpc.throwStoreDataError)
-        await expect(rpcRemote.storeData(request)).rejects.toThrowError(
+        await expect(rpcRemote.storeData(request)).rejects.toThrow(
             'Could not store data to'
             + ` ${toNodeId(serverPeerDescriptor)} from ${toNodeId(clientPeerDescriptor)}`
             + ' Error: Mock'

--- a/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
+++ b/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
@@ -11,13 +11,13 @@ describe('heartbeatUtils', () => {
                 tls: false
             }
         })
-        expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrowError()
+        expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrow()
     })
 
     it('invalid message does not pass validation', () => {
         const msg = createHeartbeatMessage({
             foo: 'bar'
         } as any)
-        expect(() => HeartbeatMessageSchema.parse(msg)).toThrowError(ZodError)
+        expect(() => HeartbeatMessageSchema.parse(msg)).toThrow(ZodError)
     })
 })

--- a/packages/sdk/test/unit/Operator.test.ts
+++ b/packages/sdk/test/unit/Operator.test.ts
@@ -14,23 +14,23 @@ import { mockLoggerFactory } from '../test-utils/utils'
 
 describe(parsePartitionFromReviewRequestMetadata, () => {
     it('throws given undefined', () => {
-        expect(() => parsePartitionFromReviewRequestMetadata(undefined)).toThrowError(ParseError)
+        expect(() => parsePartitionFromReviewRequestMetadata(undefined)).toThrow(ParseError)
     })
 
     it('throws given invalid json', () => {
-        expect(() => parsePartitionFromReviewRequestMetadata('invalidjson')).toThrowError(ParseError)
+        expect(() => parsePartitionFromReviewRequestMetadata('invalidjson')).toThrow(ParseError)
     })
 
     it('throws given valid json without field "partition"', () => {
-        expect(() => parsePartitionFromReviewRequestMetadata('{}')).toThrowError(ParseError)
+        expect(() => parsePartitionFromReviewRequestMetadata('{}')).toThrow(ParseError)
     })
 
     it('throws given valid json with field "partition" but not as a number', () => {
-        expect(() => parsePartitionFromReviewRequestMetadata('{ "partition": "foo" }')).toThrowError(ParseError)
+        expect(() => parsePartitionFromReviewRequestMetadata('{ "partition": "foo" }')).toThrow(ParseError)
     })
 
     it('throws given valid json with field "partition" but outside integer range', () => {
-        expect(() => parsePartitionFromReviewRequestMetadata('{ "partition": -50 }')).toThrowError(ParseError)
+        expect(() => parsePartitionFromReviewRequestMetadata('{ "partition": -50 }')).toThrow(ParseError)
     })
 
     it('returns partition given valid json with field "partition" within integer range', () => {

--- a/packages/trackerless-network/test/unit/DuplicateMessageDetector.test.ts
+++ b/packages/trackerless-network/test/unit/DuplicateMessageDetector.test.ts
@@ -153,28 +153,28 @@ describe('erroneous messages that overlap gaps', () => {
     })
 
     it('completely around gap', () => {
-        expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(30, 0))).toThrowError(GapMisMatchError)
+        expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(30, 0))).toThrow(GapMisMatchError)
     })
 
     it('previousNumber below gap while number in gap', () => {
-        expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(15, 0))).toThrowError(GapMisMatchError)
+        expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(15, 0))).toThrow(GapMisMatchError)
     })
 
     it('previousNumber in gap while number over gap', () => {
-        expect(() => detector.markAndCheck(new NumberPair(15, 0), new NumberPair(20, 5))).toThrowError(GapMisMatchError)
+        expect(() => detector.markAndCheck(new NumberPair(15, 0), new NumberPair(20, 5))).toThrow(GapMisMatchError)
     })
 
     it('completely around multiple gaps', () => {
-        expect(() => detector.markAndCheck(new NumberPair(10, 0), new NumberPair(200, 0))).toThrowError(GapMisMatchError)
+        expect(() => detector.markAndCheck(new NumberPair(10, 0), new NumberPair(200, 0))).toThrow(GapMisMatchError)
     })
 })
 
 test('checks that number > previousNumber', () => {
     const detector = new DuplicateMessageDetector()
     expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(1, 0)))
-        .toThrowError(InvalidNumberingError)
+        .toThrow(InvalidNumberingError)
     expect(() => detector.markAndCheck(new NumberPair(5, 5), new NumberPair(5, 5)))
-        .toThrowError(InvalidNumberingError)
+        .toThrow(InvalidNumberingError)
 })
 
 test('lowest gaps get dropped when reaching maximum number of gaps', () => {

--- a/packages/utils/test/ENSName.test.ts
+++ b/packages/utils/test/ENSName.test.ts
@@ -2,11 +2,11 @@ import { toENSName } from '../src/ENSName'
 
 describe('toENSName', () => {
     it.each(['noperiod', '.domain'])('throws on invalid ENS name "%s"', (str) => {
-        expect(() => toENSName(str)).toThrowError()
+        expect(() => toENSName(str)).toThrow()
     })
 
     it('does not throw on valid ENS name', () => {
-        expect(() => toENSName('valid.eth')).not.toThrowError()
+        expect(() => toENSName('valid.eth')).not.toThrow()
     })
 
     it('returned ENS name is in lowercase', () => {

--- a/packages/utils/test/EthereumAddress.test.ts
+++ b/packages/utils/test/EthereumAddress.test.ts
@@ -2,13 +2,13 @@ import { toEthereumAddress } from '../src/EthereumAddress'
 
 describe('toEthereumAddress', () => {
     it('invalid addresses', () => {
-        expect(() => toEthereumAddress('')).toThrowError()
-        expect(() => toEthereumAddress('0x')).toThrowError()
-        expect(() => toEthereumAddress('0xabcabc')).toThrowError()
-        expect(() => toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toThrowError() // missing 1 char
-        expect(() => toEthereumAddress('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toThrowError()
-        expect(() => toEthereumAddress('0xhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh')).toThrowError()
-        expect(() => toEthereumAddress('hello.eth')).toThrowError()
+        expect(() => toEthereumAddress('')).toThrow()
+        expect(() => toEthereumAddress('0x')).toThrow()
+        expect(() => toEthereumAddress('0xabcabc')).toThrow()
+        expect(() => toEthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toThrow() // missing 1 char
+        expect(() => toEthereumAddress('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toThrow()
+        expect(() => toEthereumAddress('0xhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh')).toThrow()
+        expect(() => toEthereumAddress('hello.eth')).toThrow()
     })
 
     it('valid addresses are lowercased', () => {

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -211,6 +211,6 @@ describe('metrics', () => {
         context.addMetrics('mockNamespace', metric)
         expect(() => {
             context.addMetrics('mockNamespace', metric)
-        }).toThrowError('Metrics "mockNamespace.foo" already created')
+        }).toThrow('Metrics "mockNamespace.foo" already created')
     })
 })

--- a/packages/utils/test/StreamID.test.ts
+++ b/packages/utils/test/StreamID.test.ts
@@ -14,7 +14,7 @@ describe('toStreamID', () => {
         const path = '/foo/BAR'
         return expect(() => {
             toStreamID(path)
-        }).toThrowError('path-only format "/foo/BAR" provided without domain')
+        }).toThrow('path-only format "/foo/BAR" provided without domain')
     })
 
     it('full stream id format', () => {
@@ -40,7 +40,7 @@ describe('toStreamID', () => {
     it('empty string throws error', () => {
         return expect(() => {
             toStreamID('')
-        }).toThrowError('stream id may not be empty')
+        }).toThrow('stream id may not be empty')
     })
 })
 

--- a/packages/utils/test/collect.test.ts
+++ b/packages/utils/test/collect.test.ts
@@ -42,6 +42,6 @@ describe('collect', () => {
             yield 1
             throw new Error('mock-error')
         }()
-        await expect(() => collect(source)).rejects.toThrowError('mock-error')
+        await expect(() => collect(source)).rejects.toThrow('mock-error')
     })
 })

--- a/packages/utils/test/pTransaction.test.ts
+++ b/packages/utils/test/pTransaction.test.ts
@@ -37,7 +37,7 @@ describe('pTransaction', () => {
 
     it('rejects given an array containing a rejection', async () => {
         const promises = promisify('a', 'b', new Error('something bad'), 'c')
-        await expect(pTransaction(promises, () => {})).rejects.toThrowError('something bad')
+        await expect(pTransaction(promises, () => {})).rejects.toThrow('something bad')
     })
 
     it('invokes rollback given an array containing a rejection', async () => {

--- a/packages/utils/test/signingUtils.test.ts
+++ b/packages/utils/test/signingUtils.test.ts
@@ -34,7 +34,7 @@ describe('recoverAddress', () => {
     it('throws if the address can not be recovered (invalid signature)', async () => {
         const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
-        expect(() => recoverSignerUserId(signature, payload)).toThrowError()
+        expect(() => recoverSignerUserId(signature, payload)).toThrow()
     })
 
     it('returns a different address if the content is tampered', async () => {

--- a/packages/utils/test/toEthereumAddressOrENSName.test.ts
+++ b/packages/utils/test/toEthereumAddressOrENSName.test.ts
@@ -11,6 +11,6 @@ describe('toEthereumAddressOrENSName', () => {
     })
 
     it('throws given invalid value', () => {
-        expect(() => toEthereumAddressOrENSName('invalid')).toThrowError()
+        expect(() => toEthereumAddressOrENSName('invalid')).toThrow()
     })
 })


### PR DESCRIPTION
Use `toThrow()` instead of deprecated `toThrowError()` method. Just a simple search-and-replace.