### PR TITLE
test(node): Fix config wizard storage path tests

### DIFF
--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -80,11 +80,7 @@ const OPERATOR_ADDRESS = '0x54d68882d5329397928787ec496da3ba8e45c48c'
 
 const parseStoragePath = (summary: string): string | undefined => {
     const match = summary.match(/streamr-node ([^\s]w+)/)
-    if (match !== null) {
-        return match[1]
-    } else {
-        return undefined
-    }
+    return (match !== null) ? match[1] : undefined
 }
 
 const expectPathsEqual = (actual: string | undefined, expected: string): void => {

--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -78,7 +78,7 @@ const IMPORTED_PRIVATE_KEY =
 
 const OPERATOR_ADDRESS = '0x54d68882d5329397928787ec496da3ba8e45c48c'
 
-const parseStoragePath = (summary: string): string | undefined => {
+const extractStoragePath = (summary: string): string | undefined => {
     const match = summary.match(/streamr-node ([^\s]w+)/)
     return (match !== null) ? match[1] : undefined
 }
@@ -172,7 +172,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('prints out the generated private key onto the screen if told to', async () => {
@@ -235,7 +235,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Flee Kit Stomach\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('validates given private key', async () => {
@@ -314,7 +314,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('validates the operator address', async () => {
@@ -402,7 +402,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables websocket plugin on a custom port', async () => {
@@ -460,7 +460,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables mqtt plugin on the default port', async () => {
@@ -522,7 +522,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables mqtt plugin on a custom port', async () => {
@@ -584,7 +584,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables http plugin on the default port', async () => {
@@ -647,7 +647,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables http plugin on a custom port', async () => {
@@ -708,7 +708,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables all pubsub plugins on default ports', async () => {
@@ -781,7 +781,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('enables all pubsub plugins on custom ports', async () => {
@@ -852,7 +852,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('validates port number values', async () => {
@@ -962,7 +962,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('disallows taking default ports if they are inexplicitly used', async () => {
@@ -1039,7 +1039,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('allows to uses a custom file path for the config file', async () => {
@@ -1249,7 +1249,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expectPathsEqual(parseStoragePath(summary), storagePath)
+        expectPathsEqual(extractStoragePath(summary), storagePath)
     })
 
     it('tells the user to fund their node address if the balance is too low', async () => {

--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import { getNodeMnemonic, start } from '../../src/config/ConfigWizard'
@@ -77,6 +77,25 @@ const IMPORTED_PRIVATE_KEY =
     '0xb269c55ff525eac7633e80c01732d499015d5c22ce952e68272023c1d6c7f92f'
 
 const OPERATOR_ADDRESS = '0x54d68882d5329397928787ec496da3ba8e45c48c'
+
+const parseStoragePath = (summary: string): string | undefined => {
+    const match = summary.match(/streamr-node ([^\s]w+)/)
+    if (match !== null) {
+        return match[1]
+    } else {
+        return undefined
+    }
+}
+
+const expectPathsEqual = (actual: string | undefined, expected: string): void => {
+    if (actual !== undefined) {
+        const normalizedActual = path.normalize(realpathSync(actual))
+        const normaliszedExpected = path.normalize(realpathSync(expected))
+        expect(normalizedActual).toEqual(normaliszedExpected)
+    } else {
+        expect.fail('Path is undefined')
+    }
+}
 
 describe('Config wizard', () => {
     let tempDir: string
@@ -157,7 +176,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('prints out the generated private key onto the screen if told to', async () => {
@@ -220,7 +239,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Flee Kit Stomach\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('validates given private key', async () => {
@@ -299,7 +318,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('validates the operator address', async () => {
@@ -387,7 +406,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables websocket plugin on a custom port', async () => {
@@ -445,7 +464,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables mqtt plugin on the default port', async () => {
@@ -507,7 +526,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables mqtt plugin on a custom port', async () => {
@@ -569,7 +588,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables http plugin on the default port', async () => {
@@ -632,7 +651,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables http plugin on a custom port', async () => {
@@ -693,7 +712,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables all pubsub plugins on default ports', async () => {
@@ -766,7 +785,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('enables all pubsub plugins on custom ports', async () => {
@@ -837,7 +856,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('validates port number values', async () => {
@@ -947,7 +966,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('disallows taking default ports if they are inexplicitly used', async () => {
@@ -1024,7 +1043,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('allows to uses a custom file path for the config file', async () => {
@@ -1234,7 +1253,7 @@ describe('Config wizard', () => {
 
         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
 
-        expect(summary).toInclude(`streamr-node ${storagePath}\n`)
+        expectPathsEqual(parseStoragePath(summary), storagePath)
     })
 
     it('tells the user to fund their node address if the balance is too low', async () => {

--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -79,9 +79,9 @@ const IMPORTED_PRIVATE_KEY =
 const OPERATOR_ADDRESS = '0x54d68882d5329397928787ec496da3ba8e45c48c'
 
 describe('Config wizard', () => {
-    let tempDir = mkdtempSync(path.join(os.tmpdir(), 'test-config-wizard'))
+    let tempDir: string
 
-    let storagePath = path.join(tempDir, 'config.json')
+    let storagePath: string
 
     const fakeBalance = jest.fn(() => '0.0')
 


### PR DESCRIPTION
Fixed config wizard storage path assertions to be compatible with Mac OS. In the assertion we compare the real path to a symbolic link in Mac OS and thererore the test fails.

## Change

Now compares normalized paths, i.e. uses `realpathSync` which resolves symbolic links.

## Error

```
    expect(received).toInclude(expected)

    Expected string to include:
      "streamr-node /var/folders/_1/sztmfs_j15zg4t29k2nql0040000gn/T/test-config-wizardhSM4Wz/config.json
    "
    Received:
      "Welcome to the Streamr Network!
        This Config Wizard will help you setup your node.·····
        The steps are documented here:
        https://docs.streamr.network/guides/how-to-run-streamr-node#config-wizard
    ✓ Congratulations, you've setup your Streamr node!
        Your node address is 0x909DC59FF7A3b23126bc6F86ad44dD808fd424Dc
        Your node's generated name is Mountain Until Gun
    You can start your Streamr node now with
        streamr-node /var/folders/1/sztmfsj15zg4t29k2nql0040000gn/T/test-config-wizardhSM4Wz/config.json·····
        For environment specific run instructions, see
        https://docs.streamr.network/guides/how-to-run-streamr-node"

      158 |         expect(summary).toInclude(`generated name is Mountain Until Gun\n`)
      159 |
    > 160 |         expect(summary).toInclude(`streamr-node ${storagePath}\n`)
          |                         ^
      161 |     })
      162 |
      163 |     it('prints out the generated private key onto the screen if told to', async () => {

      at Object.<anonymous> (test/unit/ConfigWizard.test.ts:160:25)
```      