### PR TITLE
test: use Jest instead of NodeJS assertions

### DIFF
--- a/packages/sdk/test/unit/MessageRef.test.ts
+++ b/packages/sdk/test/unit/MessageRef.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { MessageRef } from '../../src/protocol/MessageRef'
 
 describe('MessageRef', () => {
@@ -6,27 +5,27 @@ describe('MessageRef', () => {
         it('should be equal', () => {
             const mr1 = new MessageRef(2018043150, 3)
             const mr2 = new MessageRef(2018043150, 3)
-            assert.equal(mr1.compareTo(mr2), 0)
+            expect(mr1.compareTo(mr2)).toBe(0)
         })
         it('should be less than', () => {
             const mr1 = new MessageRef(2018043150, 7)
             const mr2 = new MessageRef(9998043150, 3)
-            assert.equal(mr1.compareTo(mr2), -1)
+            expect(mr1.compareTo(mr2)).toBe(-1)
         })
         it('should be greater than', () => {
             const mr1 = new MessageRef(9998043150, 3)
             const mr2 = new MessageRef(2018043150, 6)
-            assert.equal(mr1.compareTo(mr2), 1)
+            expect(mr1.compareTo(mr2)).toBe(1)
         })
         it('should be less than', () => {
             const mr1 = new MessageRef(2018043150, 4)
             const mr2 = new MessageRef(2018043150, 8)
-            assert.equal(mr1.compareTo(mr2), -1)
+            expect(mr1.compareTo(mr2)).toBe(-1)
         })
         it('should be greater than', () => {
             const mr1 = new MessageRef(2018043150, 5)
             const mr2 = new MessageRef(2018043150, 2)
-            assert.equal(mr1.compareTo(mr2), 1)
+            expect(mr1.compareTo(mr2)).toBe(1)
         })
     })
 })

--- a/packages/sdk/test/unit/StreamMessage.test.ts
+++ b/packages/sdk/test/unit/StreamMessage.test.ts
@@ -1,6 +1,5 @@
 import { randomUserId } from '@streamr/test-utils'
 import { StreamPartIDUtils, hexToBinary, toStreamID, utf8ToBinary } from '@streamr/utils'
-import assert from 'assert'
 import { EncryptedGroupKey } from '../../src/protocol/EncryptedGroupKey'
 import { MessageID } from '../../src/protocol/MessageID'
 import { MessageRef } from '../../src/protocol/MessageRef'
@@ -41,21 +40,21 @@ describe('StreamMessage', () => {
     describe('constructor', () => {
         it('create a StreamMessage with all fields defined', () => {
             const streamMessage = msg()
-            assert.strictEqual(streamMessage.getStreamId(), 'streamId')
-            assert.strictEqual(streamMessage.getStreamPartition(), 0)
-            assert.strictEqual(streamMessage.getTimestamp(), 1564046332168)
-            assert.strictEqual(streamMessage.getSequenceNumber(), 10)
-            assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
-            assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, new MessageRef(1564046332168, 5))
-            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, ContentType.JSON)
-            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, undefined)
-            assert.deepStrictEqual(streamMessage.getParsedContent(), content)
+            expect(streamMessage.getStreamId()).toEqual('streamId')
+            expect(streamMessage.getStreamPartition()).toEqual(0)
+            expect(streamMessage.getTimestamp()).toEqual(1564046332168)
+            expect(streamMessage.getSequenceNumber()).toEqual(10)
+            expect(streamMessage.getPublisherId()).toEqual(PUBLISHER_ID)
+            expect(streamMessage.getMsgChainId()).toEqual('msgChainId')
+            expect(streamMessage.prevMsgRef).toEqual(new MessageRef(1564046332168, 5))
+            expect(streamMessage.messageType).toEqual(StreamMessageType.MESSAGE)
+            expect(streamMessage.contentType).toEqual(ContentType.JSON)
+            expect(streamMessage.encryptionType).toEqual(EncryptionType.NONE)
+            expect(streamMessage.groupKeyId).toBeUndefined()
+            expect(streamMessage.getParsedContent()).toEqual(content)
             expect(streamMessage.content).toEqualBinary(utf8ToBinary(JSON.stringify(content)))
-            assert.strictEqual(streamMessage.signature, signature)
-            assert.strictEqual(streamMessage.getStreamPartID(), StreamPartIDUtils.parse('streamId#0'))
+            expect(streamMessage.signature).toEqualBinary(signature)
+            expect(streamMessage.getStreamPartID()).toEqual(StreamPartIDUtils.parse('streamId#0'))
         })
 
         it('create StreamMessage with minimum fields defined', () => {
@@ -67,20 +66,20 @@ describe('StreamMessage', () => {
                 signatureType: SignatureType.SECP256K1,
                 signature
             })
-            assert.strictEqual(streamMessage.getStreamId(), 'streamId')
-            assert.strictEqual(streamMessage.getStreamPartition(), 0)
-            assert.strictEqual(streamMessage.getTimestamp(), 1564046332168)
-            assert.strictEqual(streamMessage.getSequenceNumber(), 10)
-            assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
-            assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
-            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, ContentType.JSON)
-            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, undefined)
-            assert.deepStrictEqual(streamMessage.getParsedContent(), content)
+            expect(streamMessage.getStreamId()).toEqual('streamId')
+            expect(streamMessage.getStreamPartition()).toEqual(0)
+            expect(streamMessage.getTimestamp()).toEqual(1564046332168)
+            expect(streamMessage.getSequenceNumber()).toEqual(10)
+            expect(streamMessage.getPublisherId()).toEqual(PUBLISHER_ID)
+            expect(streamMessage.getMsgChainId()).toEqual('msgChainId')
+            expect(streamMessage.prevMsgRef).toBeUndefined()
+            expect(streamMessage.messageType).toEqual(StreamMessageType.MESSAGE)
+            expect(streamMessage.contentType).toEqual(ContentType.JSON)
+            expect(streamMessage.encryptionType).toEqual(EncryptionType.NONE)
+            expect(streamMessage.groupKeyId).toBeUndefined()
+            expect(streamMessage.getParsedContent()).toEqual(content)
             expect(streamMessage.content).toEqualBinary(utf8ToBinary(JSON.stringify(content)))
-            assert.strictEqual(streamMessage.signature, signature)
+            expect(streamMessage.signature).toEqualBinary(signature)
         })
 
         it('create StreamMessage binary content', () => {
@@ -92,20 +91,20 @@ describe('StreamMessage', () => {
                 signatureType: SignatureType.SECP256K1,
                 signature
             })
-            assert.strictEqual(streamMessage.getStreamId(), 'streamId')
-            assert.strictEqual(streamMessage.getStreamPartition(), 0)
-            assert.strictEqual(streamMessage.getTimestamp(), 1564046332168)
-            assert.strictEqual(streamMessage.getSequenceNumber(), 10)
-            assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
-            assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
-            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, ContentType.BINARY)
-            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, undefined)
-            assert.deepStrictEqual(streamMessage.content, new Uint8Array([1, 2, 3]))
-            expect(streamMessage.content).toEqual(new Uint8Array([1, 2, 3]))
-            assert.strictEqual(streamMessage.signature, signature)
+            expect(streamMessage.getStreamId()).toEqual('streamId')
+            expect(streamMessage.getStreamPartition()).toEqual(0)
+            expect(streamMessage.getTimestamp()).toEqual(1564046332168)
+            expect(streamMessage.getSequenceNumber()).toEqual(10)
+            expect(streamMessage.getPublisherId()).toEqual(PUBLISHER_ID)
+            expect(streamMessage.getMsgChainId()).toEqual('msgChainId')
+            expect(streamMessage.prevMsgRef).toBeUndefined()
+            expect(streamMessage.messageType).toEqual(StreamMessageType.MESSAGE)
+            expect(streamMessage.contentType).toEqual(ContentType.BINARY)
+            expect(streamMessage.encryptionType).toEqual(EncryptionType.NONE)
+            expect(streamMessage.groupKeyId).toBeUndefined()
+            expect(streamMessage.content).toEqualBinary(new Uint8Array([1, 2, 3]))
+            expect(streamMessage.content).toEqualBinary(new Uint8Array([1, 2, 3]))
+            expect(streamMessage.signature).toEqualBinary(signature)
         })
 
         it('create StreamMessage binary content', () => {
@@ -117,20 +116,20 @@ describe('StreamMessage', () => {
                 encryptionType: EncryptionType.NONE,
                 signature
             })
-            assert.strictEqual(streamMessage.getStreamId(), 'streamId')
-            assert.strictEqual(streamMessage.getStreamPartition(), 0)
-            assert.strictEqual(streamMessage.getTimestamp(), 1564046332168)
-            assert.strictEqual(streamMessage.getSequenceNumber(), 10)
-            assert.strictEqual(streamMessage.getPublisherId(), PUBLISHER_ID)
-            assert.strictEqual(streamMessage.getMsgChainId(), 'msgChainId')
-            assert.deepStrictEqual(streamMessage.prevMsgRef, undefined)
-            assert.strictEqual(streamMessage.messageType, StreamMessageType.MESSAGE)
-            assert.strictEqual(streamMessage.contentType, ContentType.BINARY)
-            assert.strictEqual(streamMessage.encryptionType, EncryptionType.NONE)
-            assert.strictEqual(streamMessage.groupKeyId, undefined)
-            assert.deepStrictEqual(streamMessage.content, new Uint8Array([1, 2, 3]))
-            assert.strictEqual(streamMessage.newGroupKey, undefined)
-            assert.strictEqual(streamMessage.signature, signature)
+            expect(streamMessage.getStreamId()).toEqual('streamId')
+            expect(streamMessage.getStreamPartition()).toEqual(0)
+            expect(streamMessage.getTimestamp()).toEqual(1564046332168)
+            expect(streamMessage.getSequenceNumber()).toEqual(10)
+            expect(streamMessage.getPublisherId()).toEqual(PUBLISHER_ID)
+            expect(streamMessage.getMsgChainId()).toEqual('msgChainId')
+            expect(streamMessage.prevMsgRef).toBeUndefined()
+            expect(streamMessage.messageType).toEqual(StreamMessageType.MESSAGE)
+            expect(streamMessage.contentType).toEqual(ContentType.BINARY)
+            expect(streamMessage.encryptionType).toEqual(EncryptionType.NONE)
+            expect(streamMessage.groupKeyId).toBeUndefined()
+            expect(streamMessage.content).toEqualBinary(new Uint8Array([1, 2, 3]))
+            expect(streamMessage.newGroupKey).toBeUndefined()
+            expect(streamMessage.signature).toEqualBinary(signature)
         })
 
         it('can detect encrypted', () => {
@@ -157,58 +156,58 @@ describe('StreamMessage', () => {
         })
 
         it('should not throw when encrypted content', () => {
-            assert.doesNotThrow(() => msg({
+            expect(() => msg({
                 // @ts-expect-error TODO
                 content: utf8ToBinary('encrypted content'),
                 encryptionType: EncryptionType.AES,
                 groupKeyId: 'mock-id'
-            }))
+            })).not.toThrow()
         })
 
         it('Throws with an no group key for AES encrypted message', () => {
-            assert.throws(() => msg({
+            expect(() => msg({
                 encryptionType: EncryptionType.AES
-            } as any), ValidationError)
+            } as any)).toThrow(ValidationError)
         })
 
         describe('prevMsgRef validation', () => {
             it('Throws with identical id + prevMsgRef', () => {
                 const ts = Date.now()
-                assert.throws(() => msg({
+                expect(() => msg({
                     timestamp: ts,
                     sequenceNumber: 0,
                     // @ts-expect-error TODO
                     prevMsgRef: new MessageRef(ts, 0)
-                }), 'must come before current')
+                })).toThrow()
             })
             it('Throws with an invalid ts', () => {
                 const ts = Date.now()
-                assert.throws(() => msg({
+                expect(() => msg({
                     timestamp: ts,
                     sequenceNumber: 0,
                     // @ts-expect-error TODO
                     prevMsgRef: new MessageRef(ts + 1, 0)
-                }), 'must come before current')
+                })).toThrow()
             })
 
             it('Throws with an invalid sequence', () => {
                 const ts = Date.now()
-                assert.throws(() => msg({
+                expect(() => msg({
                     timestamp: ts,
                     sequenceNumber: 0,
                     // @ts-expect-error TODO
                     prevMsgRef: new MessageRef(ts, 1)
-                }), 'must come before current')
+                })).toThrow()
             })
 
             it('Throws with an invalid ts + seq', () => {
                 const ts = Date.now()
-                assert.throws(() => msg({
+                expect(() => msg({
                     timestamp: ts,
                     sequenceNumber: 0,
                     // @ts-expect-error TODO
                     prevMsgRef: new MessageRef(ts + 1, 1)
-                }), 'must come before current')
+                })).toThrow()
             })
 
             it('works with valid seq', () => {

--- a/packages/sdk/test/unit/validateStreamMessage2.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage2.test.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata'
 
 import { UserID, hexToBinary, toStreamID, utf8ToBinary } from '@streamr/utils'
-import assert from 'assert'
 import { mock } from 'jest-mock-extended'
 import { Authentication } from '../../src/Authentication'
 import { StreamMetadata } from '../../src/StreamMetadata'
@@ -98,7 +97,7 @@ describe('Validator2', () => {
             contentType: ContentType.JSON,
             encryptionType: EncryptionType.NONE,
         }, SignatureType.SECP256K1)
-        assert.notStrictEqual(msg.signature, msgWithNewGroupKey.signature)
+        expect(msg.signature).not.toEqualBinary(msgWithNewGroupKey.signature)
 
         msgWithPrevMsgRef = await publisherSigner.createSignedMessage({
             messageId: new MessageID(toStreamID('streamId'), 0, 2000, 0, publisher, 'msgChainId'),
@@ -108,7 +107,7 @@ describe('Validator2', () => {
             contentType: ContentType.JSON,
             encryptionType: EncryptionType.NONE
         }, SignatureType.SECP256K1)
-        assert.notStrictEqual(msg.signature, msgWithPrevMsgRef.signature)
+        expect(msg.signature).not.toEqualBinary(msgWithPrevMsgRef.signature)
 
         groupKeyRequest = await groupKeyMessageToStreamMessage(new GroupKeyRequest({
             requestId: 'requestId',
@@ -130,10 +129,7 @@ describe('Validator2', () => {
     describe('validate(unknown message type)', () => {
         it('throws on unknown message type', async () => {
             (msg as any).messageType = 666
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
-                assert(err instanceof Error, err.message)
-                return true
-            })
+            await expect(getValidator().validate(msg)).rejects.toThrow(Error)
         })
     })
 
@@ -156,10 +152,7 @@ describe('Validator2', () => {
                 signature: Buffer.from(msg.signature).reverse()
             })
 
-            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(invalidMsg)).rejects.toThrow(ValidationError)
         })
 
         it('rejects tampered content', async () => {
@@ -168,10 +161,7 @@ describe('Validator2', () => {
                 content: utf8ToBinary('{"attack":true}')
             })
 
-            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(invalidMsg)).rejects.toThrow(ValidationError)
         })
 
         it('rejects tampered newGroupKey', async () => {
@@ -180,39 +170,27 @@ describe('Validator2', () => {
                 newGroupKey: new EncryptedGroupKey('foo', msgWithNewGroupKey.newGroupKey!.data)
             })
 
-            await assert.rejects(getValidator().validate(invalidMsg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(invalidMsg)).rejects.toThrow(ValidationError)
         })
 
         it('rejects messages from unpermitted publishers', async () => {
             isPublisher = jest.fn().mockResolvedValue(false)
 
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                expect(isPublisher).toHaveBeenCalledWith(msg.getPublisherId(), msg.getStreamId())
-                return true
-            })
+            await expect(getValidator().validate(msg)).rejects.toThrow(ValidationError)
+            expect(isPublisher).toHaveBeenCalledWith(msg.getPublisherId(), msg.getStreamId())
         })
 
         it('rejects if getStreamMetadata rejects', async () => {
             const testError = new Error('test error')
             getStreamMetadata = jest.fn().mockRejectedValue(testError)
 
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(msg)).rejects.toThrow(testError)
         })
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = jest.fn().mockRejectedValue(testError)
-            await assert.rejects(getValidator().validate(msg), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(msg)).rejects.toThrow(testError)
         })
     })
 
@@ -224,10 +202,7 @@ describe('Validator2', () => {
         it('rejects group key requests on unexpected streams', async () => {
             groupKeyRequest.getStreamId = jest.fn().mockReturnValue('foo')
 
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyRequest)).rejects.toThrow(ValidationError)
         })
 
         it('rejects invalid signatures', async () => {
@@ -236,50 +211,35 @@ describe('Validator2', () => {
                 signature: Buffer.from(groupKeyRequest.signature).reverse()
             })
 
-            await assert.rejects(getValidator().validate(invalidGroupKeyRequest), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(invalidGroupKeyRequest)).rejects.toThrow(ValidationError)
         })
 
         it('rejects messages to invalid publishers', async () => {
             isPublisher = jest.fn().mockResolvedValue(false)
             const publisher = await publisherAuthentication.getUserId()
 
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                expect(isPublisher).toHaveBeenCalledWith(publisher, 'streamId')
-                return true
-            })
+            await expect(getValidator().validate(groupKeyRequest)).rejects.toThrow(ValidationError)
+            expect(isPublisher).toHaveBeenCalledWith(publisher, 'streamId')
         })
 
         it('rejects messages from unpermitted subscribers', async () => {
             isSubscriber = jest.fn().mockResolvedValue(false)
             const subscriber = await subscriberAuthentication.getUserId()
 
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                expect(isSubscriber).toHaveBeenCalledWith(subscriber, 'streamId')
-                return true
-            })
+            await expect(getValidator().validate(groupKeyRequest)).rejects.toThrow(ValidationError)
+            expect(isSubscriber).toHaveBeenCalledWith(subscriber, 'streamId')
         })
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = jest.fn().mockRejectedValue(testError)
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyRequest)).rejects.toThrow(testError)
         })
 
         it('rejects if isSubscriber rejects', async () => {
             const testError = new Error('test error')
             isSubscriber = jest.fn().mockRejectedValue(testError)
-            await assert.rejects(getValidator().validate(groupKeyRequest), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyRequest)).rejects.toThrow(testError)
         })
     })
 
@@ -294,59 +254,41 @@ describe('Validator2', () => {
                 signature: Buffer.from(groupKeyResponse.signature).reverse()
             })
 
-            await assert.rejects(getValidator().validate(invalidGroupKeyResponse), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(invalidGroupKeyResponse)).rejects.toThrow(ValidationError)
         })
 
         it('rejects group key responses on unexpected streams', async () => {
             groupKeyResponse.getStreamId = jest.fn().mockReturnValue('foo')
 
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyResponse)).rejects.toThrow(ValidationError)
         })
 
         it('rejects messages from invalid publishers', async () => {
             isPublisher = jest.fn().mockResolvedValue(false)
             const publisher = await publisherAuthentication.getUserId()
 
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                expect(isPublisher).toHaveBeenCalledWith(publisher, 'streamId')
-                return true
-            })
+            await expect(getValidator().validate(groupKeyResponse)).rejects.toThrow(ValidationError)
+            expect(isPublisher).toHaveBeenCalledWith(publisher, 'streamId')
         })
 
         it('rejects messages to unpermitted subscribers', async () => {
             isSubscriber = jest.fn().mockResolvedValue(false)
             const subscriber = await subscriberAuthentication.getUserId()
 
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
-                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
-                expect(isSubscriber).toHaveBeenCalledWith(subscriber, 'streamId')
-                return true
-            })
+            await expect(getValidator().validate(groupKeyResponse)).rejects.toThrow(ValidationError)
+            expect(isSubscriber).toHaveBeenCalledWith(subscriber, 'streamId')
         })
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = jest.fn().mockRejectedValue(testError)
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyResponse)).rejects.toThrow(testError)
         })
 
         it('rejects if isSubscriber rejects', async () => {
             const testError = new Error('test error')
             isSubscriber = jest.fn().mockRejectedValue(testError)
-            await assert.rejects(getValidator().validate(groupKeyResponse), (err: Error) => {
-                assert(err === testError)
-                return true
-            })
+            await expect(getValidator().validate(groupKeyResponse)).rejects.toThrow(testError)
         })
     })
 })

--- a/packages/utils/test/signingUtils.test.ts
+++ b/packages/utils/test/signingUtils.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-len */
-import assert from 'assert'
 import { hexToBinary } from '../src/binaryUtils'
 import { createSignature, recoverSignerUserId, verifySignature } from '../src/signingUtils'
 import { toUserId, toUserIdRaw } from '../src/UserID'
@@ -20,7 +19,7 @@ describe('recoverAddress', () => {
         const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const recoveredUserId = recoverSignerUserId(signature, payload)
-        assert.strictEqual(toUserId(recoveredUserId), userId)
+        expect(toUserId(recoveredUserId)).toEqual(userId)
     })
 
     it('can handle missing 0x in signature', async () => {
@@ -28,7 +27,7 @@ describe('recoverAddress', () => {
         const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('c97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const recoveredUserId = recoverSignerUserId(signature, payload)
-        assert.strictEqual(toUserId(recoveredUserId), userId)
+        expect(toUserId(recoveredUserId)).toEqual(userId)
     })
 
     it('throws if the address can not be recovered (invalid signature)', async () => {
@@ -42,7 +41,7 @@ describe('recoverAddress', () => {
         const payload = Buffer.from('foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const recoveredUserId = recoverSignerUserId(signature, payload)
-        assert.notStrictEqual(toUserId(recoveredUserId), userId)
+        expect(toUserId(recoveredUserId)).not.toEqual(userId)
     })
 })
 
@@ -52,7 +51,7 @@ describe('verifySignature', () => {
         const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const isValid = verifySignature(toUserIdRaw(userId), payload, signature)
-        assert(isValid)
+        expect(isValid).toBe(true)
     })
 
     it('returns false on invalid signature', async () => {
@@ -60,7 +59,7 @@ describe('verifySignature', () => {
         const payload = Buffer.from('ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xf00f00bb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const isValid = verifySignature(toUserIdRaw(userId), payload, signature)
-        assert(!isValid)
+        expect(isValid).toBe(false)
     })
 
     it('returns false if the message is tampered', async () => {
@@ -68,6 +67,6 @@ describe('verifySignature', () => {
         const payload = Buffer.from('foo_ogzCJrTdQGuKQO7nkLd3Rw0156700333876720x752c8dcac0788759acb1b4bb7a9103596bee3e6ckxYyLiSUQO0SRvMx6gA115670033387671{"numero":86}')
         const signature = hexToBinary('0xc97f1fbb4f506a53ecb838db59017f687892494a9073315f8a187846865bf8325333315b116f1142921a97e49e3881eced2b176c69f9d60666b98b7641ad11e01b')
         const isValid = verifySignature(toUserIdRaw(userId), payload, signature)
-        assert(!isValid)
+        expect(isValid).toBe(false)
     })
 })


### PR DESCRIPTION
Replaced usages of `assert` NodeJS calls with equivalent Jest calls. There is no need to use two separate test utilities in our code base.