### PR TITLE
chore: Add `@typescript-eslint/no-confusing-void-expression` rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,9 @@ export default [
                 allowTemplateLiterals: true
             }],
             '@typescript-eslint/default-param-last': 'error',
+            '@typescript-eslint/no-confusing-void-expression': ['error', {
+                ignoreArrowShorthand: true
+            }],
             '@typescript-eslint/no-extraneous-class': 'error',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-invalid-this': 'error',

--- a/packages/autocertifier-server/src/DnsServer.ts
+++ b/packages/autocertifier-server/src/DnsServer.ts
@@ -90,7 +90,8 @@ export class DnsServer {
         if (parts.length < 4 || parts[0] !== '_acme-challenge') {
             // @ts-ignore private field
             response.header.rcode = FORMERR
-            return send(response)
+            send(response)
+            return
         }
 
         const subdomain = parts[1]
@@ -105,7 +106,8 @@ export class DnsServer {
         if (!subdomainRecord) {
             // @ts-ignore private field
             response.header.rcode = NXDOMAIN
-            return send(response)
+            send(response)
+            return
         }
 
         const acmeChallenge = subdomainRecord.acmeChallenge
@@ -162,7 +164,8 @@ export class DnsServer {
         if (parts.length < 3) {
             // @ts-ignore private field
             response.header.rcode = NXDOMAIN
-            return send(response)
+            send(response)
+            return
         }
 
         const subdomain = parts[0]
@@ -182,7 +185,8 @@ export class DnsServer {
                 logger.info('handleAQuery() not found: ' + name)
                 // @ts-ignore private field
                 response.header.rcode = NXDOMAIN
-                return send(response)
+                send(response)
+                return
             }
             retIp = subdomainRecord.ip
         }
@@ -207,7 +211,8 @@ export class DnsServer {
             logger.debug('filtering invalid question')
             // @ts-ignore private field
             response.header.rcode = FORMERR
-            return send(response)
+            send(response)
+            return
         }
         const mixedCaseName = question.name
         const name = mixedCaseName.toLowerCase()
@@ -216,7 +221,8 @@ export class DnsServer {
             logger.debug('invalid domain name in query: ' + name)
             // @ts-ignore private field
             response.header.rcode = NXDOMAIN
-            return send(response)
+            send(response)
+            return
         }
 
         const parts = mixedCaseName.split('.')

--- a/packages/autocertifier-server/src/StreamrChallenger.ts
+++ b/packages/autocertifier-server/src/StreamrChallenger.ts
@@ -53,7 +53,7 @@ export const runStreamrChallenge = (
             const communicator = new RoutingRpcCommunicator(SERVICE_ID,
                 async (msg: Message): Promise<void> => {
                     logger.info('sending message to peer')
-                    return managedConnection.send(Message.toBinary(msg))
+                    managedConnection.send(Message.toBinary(msg))
                 })
             managedConnection.on('managedData', (msg: Uint8Array) => {
                 communicator.handleMessageFromPeer(Message.fromBinary(msg))

--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -308,7 +308,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
         this.metrics.sendMessagesPerSecond.record(1)
 
         if (this.endpoints.get(nodeId)!.connected) {
-            return (connection as ManagedConnection).send(binary)
+            (connection as ManagedConnection).send(binary)
         } else {
             return (this.endpoints.get(nodeId)! as ConnectingEndpoint).buffer.push(binary)
         }

--- a/packages/dht/src/connection/simulator/Simulator.ts
+++ b/packages/dht/src/connection/simulator/Simulator.ts
@@ -191,7 +191,8 @@ export class Simulator {
 
         if (!target) {
             logger.error('Target connector not found when executing connect operation')
-            return operation.association.connectedCallback!('Target connector not found')
+            operation.association.connectedCallback!('Target connector not found')
+            return
         }
 
         target.handleIncomingConnection(operation.sourceConnection)

--- a/packages/dht/test/integration/ConnectionLocking.test.ts
+++ b/packages/dht/test/integration/ConnectionLocking.test.ts
@@ -61,6 +61,7 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)
@@ -73,10 +74,12 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
         ])
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock2')
         ])
         expect(connectionManager1.hasConnection(nodeId2)).toEqual(true)
@@ -89,6 +92,7 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock')
         ])
         expect(connectionManager1.hasConnection(nodeId2))
@@ -106,10 +110,12 @@ describe('Connection Locking', () => {
         const nodeId2 = toNodeId(mockPeerDescriptor2)
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1')
         ])
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock2')
         ])
 
@@ -130,7 +136,9 @@ describe('Connection Locking', () => {
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             until(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1'),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager2.lockConnection(mockPeerDescriptor1, 'testLock1')
         ])
 
@@ -155,7 +163,9 @@ describe('Connection Locking', () => {
         await Promise.all([
             until(() => connectionManager2.hasRemoteLockedConnection(nodeId1)),
             until(() => connectionManager1.hasRemoteLockedConnection(nodeId2)),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager1.lockConnection(mockPeerDescriptor2, 'testLock1'),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             connectionManager2.lockConnection(mockPeerDescriptor1, 'testLock1')
         ])
         expect(connectionManager1.hasConnection(nodeId2))

--- a/packages/node/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/node/test/integration/multiple-publisher-plugins.test.ts
@@ -14,8 +14,8 @@ const mqttPort = 13611
 const wsPort = 13612
 const httpPort = 13613
 
-const sendPostRequest = (url: string, content: object): Promise<unknown> => {
-    return fetch(url, {
+const sendPostRequest = async (url: string, content: object): Promise<void> => {
+    await fetch(url, {
         method: 'POST',
         body: JSON.stringify(content),
         headers: { 'Content-Type': 'application/json' }
@@ -24,7 +24,7 @@ const sendPostRequest = (url: string, content: object): Promise<unknown> => {
 
 interface PluginPublisher {
     connect: (streamId: string) => Promise<void>
-    publish: (msg: object, streamId: string) => Promise<unknown>
+    publish: (msg: object, streamId: string) => Promise<void>
     close: () => Promise<void>
 }
 
@@ -33,7 +33,7 @@ class MqttPluginPublisher implements PluginPublisher {
     async connect(): Promise<void> {
         this.client = await mqtt.connectAsync(`mqtt://127.0.0.1:${mqttPort}`)
     }
-    publish(msg: object, streamId: string): Promise<unknown> {
+    publish(msg: object, streamId: string): Promise<void> {
         return this.client!.publish(streamId, JSON.stringify(msg))
     }
     close(): Promise<void> {
@@ -47,9 +47,8 @@ class WebsocketPluginPublisher implements PluginPublisher {
         this.client = new WebSocket(`ws://127.0.0.1:${wsPort}/streams/${encodeURIComponent(streamId)}/publish`)
         await waitForEvent(this.client, 'open')
     }
-    async publish(msg: object): Promise<unknown> {
+    async publish(msg: object): Promise<void> {
         this.client!.send(JSON.stringify(msg))
-        return
     }
     async close(): Promise<void> {
         this.client!.close()
@@ -60,7 +59,7 @@ class WebsocketPluginPublisher implements PluginPublisher {
 class HttpPluginPublisher implements PluginPublisher {
     async connect(): Promise<void> {
     }
-    async publish(msg: object, streamId: string): Promise<unknown> {
+    async publish(msg: object, streamId: string): Promise<void> {
         return sendPostRequest(`http://127.0.0.1:${httpPort}/streams/${encodeURIComponent(streamId)}`, msg)
     }
     async close(): Promise<void> {

--- a/packages/node/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/node/test/integration/multiple-publisher-plugins.test.ts
@@ -48,10 +48,11 @@ class WebsocketPluginPublisher implements PluginPublisher {
         await waitForEvent(this.client, 'open')
     }
     async publish(msg: object): Promise<unknown> {
-        return this.client!.send(JSON.stringify(msg))
+        this.client!.send(JSON.stringify(msg))
+        return
     }
     async close(): Promise<void> {
-        return this.client!.close()
+        this.client!.close()
     }
 }
 

--- a/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -52,7 +52,7 @@ class ProxyClient {
         if (this.hasError(query)) {
             resultCallback!(ProxyClient.ERROR, undefined)
         } else {
-            return this.realClient.eachRow(query, params, options, rowCallback, resultCallback)
+            this.realClient.eachRow(query, params, options, rowCallback, resultCallback)
         }
     }
 

--- a/packages/node/test/unit/ConfigWizard.test.ts
+++ b/packages/node/test/unit/ConfigWizard.test.ts
@@ -1482,7 +1482,8 @@ function act(
                 }
 
                 if (action === 'enter') {
-                    return void events.keypress('enter')
+                    events.keypress('enter')
+                    return
                 }
 
                 if ('find' in action) {
@@ -1506,7 +1507,8 @@ function act(
                 }
 
                 if ('type' in action) {
-                    return void events.type(action.type)
+                    events.type(action.type)
+                    return
                 }
 
                 events.keypress(action.keypress)
@@ -1643,7 +1645,7 @@ async function scenario(mocks: AnswerMock[]): Promise<Scenario> {
         jest.spyOn(process.stdout, 'clearLine').mockImplementation(() => true)
     }
 
-    void [checkbox, confirm, input, password, select].forEach((prompt) => {
+    [checkbox, confirm, input, password, select].forEach((prompt) => {
         prompt.mockImplementation(async (config: any) => {
             const inq = mocksCopy.find(
                 (inq) =>

--- a/packages/node/test/unit/helpers/weightedSample.test.ts
+++ b/packages/node/test/unit/helpers/weightedSample.test.ts
@@ -3,8 +3,7 @@ import { range, repeat, sum } from 'lodash'
 
 describe(weightedSample, () => {
     it('returns undefined on empty array', () => {
-        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-        const result = weightedSample([], () => 1)
+        const result = weightedSample<number>([], () => 1)
         expect(result).toBeUndefined()
     })
 

--- a/packages/node/test/unit/helpers/weightedSample.test.ts
+++ b/packages/node/test/unit/helpers/weightedSample.test.ts
@@ -3,6 +3,7 @@ import { range, repeat, sum } from 'lodash'
 
 describe(weightedSample, () => {
     it('returns undefined on empty array', () => {
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
         const result = weightedSample([], () => 1)
         expect(result).toBeUndefined()
     })

--- a/packages/sdk/src/MetricsPublisher.ts
+++ b/packages/sdk/src/MetricsPublisher.ts
@@ -71,7 +71,7 @@ export class MetricsPublisher {
             const metricsContext = await this.node.getMetricsContext()
             const nodeId = await this.node.getNodeId()
             this.config.periods.forEach((config) => {
-                return metricsContext.createReportProducer(async (report: MetricsReport) => {
+                metricsContext.createReportProducer(async (report: MetricsReport) => {
                     await this.publish(report, config.streamId, nodeId)
                 }, config.duration, this.destroySignal.abortSignal)
             })

--- a/packages/sdk/src/utils/PushPipeline.ts
+++ b/packages/sdk/src/utils/PushPipeline.ts
@@ -45,11 +45,11 @@ export class PushPipeline<InType, OutType = InType> extends Pipeline<InType, Out
     }
 
     end(err?: Error): void {
-        return this.source.end(err)
+        this.source.end(err)
     }
 
     endWrite(err?: Error): void {
-        return this.source.endWrite(err)
+        this.source.endWrite(err)
     }
 
     isDone(): boolean {
@@ -61,6 +61,6 @@ export class PushPipeline<InType, OutType = InType> extends Pipeline<InType, Out
     }
 
     clear(): void {
-        return this.source.clear()
+        this.source.clear()
     }
 }

--- a/packages/sdk/src/utils/Scaffold.ts
+++ b/packages/sdk/src/utils/Scaffold.ts
@@ -117,7 +117,8 @@ export function Scaffold(
                     collectErrors(err)
                 }
                 onDownSteps.push(onDownStep ?? (() => {}))
-                return await nextScaffoldStep() // return await gives us a better stack trace
+                await nextScaffoldStep() // return await gives us a better stack trace
+                return
             }
         } else if (onDownSteps.length) {
             isDone = false
@@ -129,7 +130,8 @@ export function Scaffold(
                 collectErrors(err)
             }
             nextSteps.push(prevSteps.pop()!)
-            return await nextScaffoldStep() // return await gives us a better stack trace
+            await nextScaffoldStep() // return await gives us a better stack trace
+            return
         } else if (error) {
             const err = error
             error = undefined

--- a/packages/sdk/src/utils/Signal.ts
+++ b/packages/sdk/src/utils/Signal.ts
@@ -239,7 +239,7 @@ export class Signal<ArgsType extends any[] = []> {
         const task = this.execTrigger(...args)
         this.currentTask = task
         try {
-            return await this.currentTask
+            await this.currentTask
         } finally {
             if (this.currentTask === task) {
                 this.currentTask = undefined

--- a/packages/sdk/test/end-to-end/Permissions.test.ts
+++ b/packages/sdk/test/end-to-end/Permissions.test.ts
@@ -114,7 +114,7 @@ describe('Stream permissions', () => {
         await stream.grantPermissions({ public: true, permissions: [StreamPermission.PUBLISH] })
         const permissions = await stream.getPermissions()
         const owner = await client.getUserId()
-        return expect(permissions).toIncludeSameMembers([{
+        expect(permissions).toIncludeSameMembers([{
             userId: owner,
             permissions: [
                 StreamPermission.EDIT,

--- a/packages/sdk/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/sdk/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -55,7 +55,7 @@ describe('StorageNodeRegistry2', () => {
 
         it('all', async () => {
             const storageNodeUrls = await client.getStorageNodes()
-            return expect(storageNodeUrls).toContain(storageNodeAddress)
+            expect(storageNodeUrls).toContain(storageNodeAddress)
         }, TIMEOUT)
     })
 

--- a/packages/sdk/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StreamRegistry.test.ts
@@ -208,11 +208,11 @@ describe('StreamRegistry', () => {
         it('returns true for valid publishers', async () => {
             const userId = await client.getUserId()
             const valid = await client.isStreamPublisher(createdStream.id, userId)
-            return expect(valid).toBe(true)
+            expect(valid).toBe(true)
         }, TIMEOUT)
         it('returns false for invalid publishers', async () => {
             const valid = await client.isStreamPublisher(createdStream.id, randomUserId())
-            return expect(valid).toBe(false)
+            expect(valid).toBe(false)
         }, TIMEOUT)
     })
 
@@ -227,11 +227,11 @@ describe('StreamRegistry', () => {
         it('returns true for valid subscribers', async () => {
             const userId = await client.getUserId()
             const valid = await client.isStreamSubscriber(createdStream.id, userId)
-            return expect(valid).toBe(true)
+            expect(valid).toBe(true)
         }, TIMEOUT)
         it('returns false for invalid subscribers', async () => {
             const valid = await client.isStreamSubscriber(createdStream.id, randomUserId())
-            return expect(valid).toBe(false)
+            expect(valid).toBe(false)
         }, TIMEOUT)
     })
 

--- a/packages/sdk/test/integration/basics.test.ts
+++ b/packages/sdk/test/integration/basics.test.ts
@@ -76,7 +76,7 @@ describe('Basics', () => {
                     }
                 }
                 expect(received.map((s) => s.content)).toEqual(published.map((s) => s.content))
-                return expect(received.map((streamMessage) => streamMessage.timestamp)).toEqual(published.map(() => 1111111))
+                expect(received.map((streamMessage) => streamMessage.timestamp)).toEqual(published.map(() => 1111111))
             }
             const stream2 = await createTestStream(client, module)
             await stream2.grantPermissions({ permissions: [StreamPermission.SUBSCRIBE], public: true })

--- a/packages/sdk/test/unit/iterators.test.ts
+++ b/packages/sdk/test/unit/iterators.test.ts
@@ -388,6 +388,7 @@ describe('nextValue', () => {
 
     it('empty', async () => {
         const generator = async function* () {}()
+        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
         expect(await nextValue(generator)).toBe(undefined)
     })
 })

--- a/packages/sdk/test/unit/iterators.test.ts
+++ b/packages/sdk/test/unit/iterators.test.ts
@@ -387,8 +387,7 @@ describe('nextValue', () => {
     })
 
     it('empty', async () => {
-        const generator = async function* () {}()
-        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+        const generator: AsyncGenerator<number, any, any> = async function* () {}()
         expect(await nextValue(generator)).toBe(undefined)
     })
 })

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -167,11 +167,19 @@ export function isRunningInElectron(): boolean {
 }
 
 export function testOnlyInNodeJs(...args: Parameters<typeof it>): void {
-    return isRunningInElectron() ? it.skip(...args) : it(...args)
+    if (isRunningInElectron()) {
+        it.skip(...args)
+    } else {
+        it(...args)
+    }
 }
 
 export function describeOnlyInNodeJs(...args: Parameters<typeof describe>): void {
-    return isRunningInElectron() ? describe.skip(...args) : describe(...args)
+    if (isRunningInElectron()) {
+        describe.skip(...args)
+    } else {
+        describe(...args)
+    }
 }
 
 /**

--- a/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
+++ b/packages/trackerless-network/test/end-to-end/content-delivery-layer-node-with-real-connections.test.ts
@@ -106,10 +106,15 @@ describe('content delivery layer node with real connections', () => {
             dhtNode2.stop(),
             dhtNode3.stop(),
             dhtNode4.stop(),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             contentDeliveryLayerNode1.stop(),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             contentDeliveryLayerNode2.stop(),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             contentDeliveryLayerNode3.stop(),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             contentDeliveryLayerNode4.stop(),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             contentDeliveryLayerNode5.stop(),
             (epDhtNode.getTransport() as ConnectionManager).stop(),
             (dhtNode1.getTransport() as ConnectionManager).stop(),

--- a/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryManager.test.ts
@@ -97,6 +97,7 @@ describe('ContentDeliveryManager', () => {
         await until(() => manager2.getNeighbors(STREAM_PART_ID).length === 1)
         await Promise.all([
             waitForEvent3<Events>(manager1, 'newMessage'),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             manager2.broadcast(msg)
         ])
     })
@@ -123,7 +124,9 @@ describe('ContentDeliveryManager', () => {
         await Promise.all([
             waitForEvent3<Events>(manager1, 'newMessage'),
             waitForEvent3<Events>(manager2, 'newMessage'),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             manager1.broadcast(msg2),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             manager2.broadcast(msg)
         ])
     })

--- a/packages/trackerless-network/test/unit/InspectSession.test.ts
+++ b/packages/trackerless-network/test/unit/InspectSession.test.ts
@@ -52,6 +52,7 @@ describe('InspectSession', () => {
         inspectSession.markMessage(anotherNode, messageId1)
         await Promise.all([
             waitForEvent3<Events>(inspectSession, 'done', 100),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             inspectSession.markMessage(inspectedNode, messageId1)
         ])
         expect(inspectSession.getInspectedMessageCount()).toBe(1)
@@ -61,6 +62,7 @@ describe('InspectSession', () => {
         inspectSession.markMessage(inspectedNode, messageId1)
         await Promise.all([
             waitForEvent3<Events>(inspectSession, 'done', 100),
+            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
             inspectSession.markMessage(anotherNode, messageId1)
         ])
         expect(inspectSession.getInspectedMessageCount()).toBe(1)
@@ -71,6 +73,7 @@ describe('InspectSession', () => {
         await expect(async () => {
             await Promise.all([
                 waitForEvent3<Events>(inspectSession, 'done', 100),
+                // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
                 inspectSession.markMessage(anotherNode, messageId2)
             ])
         }).rejects.toThrow('waitForEvent3')

--- a/packages/utils/src/Metric.ts
+++ b/packages/utils/src/Metric.ts
@@ -213,7 +213,7 @@ export class MetricsContext {
         formatNumber?: (value: number) => string,
     ): void {
         const ongoingSamples: Map<string, Sampler> = new Map()
-        return scheduleAtFixedRate(async (now: number) => {
+        scheduleAtFixedRate(async (now: number) => {
             if (ongoingSamples.size > 0) {
                 const report = {
                     period: {

--- a/packages/utils/test/StreamID.test.ts
+++ b/packages/utils/test/StreamID.test.ts
@@ -12,7 +12,7 @@ describe('toStreamID', () => {
 
     it('path-only format with no domain', () => {
         const path = '/foo/BAR'
-        return expect(() => {
+        expect(() => {
             toStreamID(path)
         }).toThrowError('path-only format "/foo/BAR" provided without domain')
     })
@@ -38,7 +38,7 @@ describe('toStreamID', () => {
     })
 
     it('empty string throws error', () => {
-        return expect(() => {
+        expect(() => {
             toStreamID('')
         }).toThrowError('stream id may not be empty')
     })

--- a/packages/utils/test/randomString.test.ts
+++ b/packages/utils/test/randomString.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CHARSET, randomString } from '../src/randomString'
 
 function assertStringConsistsOfCharset(actual: string, expectedCharset: string): void {
-    return actual.split('').forEach((char) => {
+    actual.split('').forEach((char) => {
         expect(char).toBeOneOf(expectedCharset.split(''))
     })
 }


### PR DESCRIPTION
Added new `eslint` rule: https://typescript-eslint.io/rules/no-confusing-void-expression/

This rule disallows e.g. using `return foobar()` when `foobar()` method returns `void`. It is better to just call the method and do explicit return separately, if needed. (Quite typically the `return` is not needed at all as the line is the last line of the method.)

Simplified `multiple-publisher-plugins.test.ts` so that it uses `Promise<void>` instead of `Promise<unknown>` and therefore doesn't need any special handling related to this rule.