### PR TITLE
test(DHT): NET-1380: removed test case `Disconnects webrtcconnection while being connected`

### DIFF
--- a/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
+++ b/packages/dht/test/integration/WebrtcConnectionManagement.test.ts
@@ -163,34 +163,6 @@ describe('WebRTC Connection Management', () => {
 
     }, 20000)
 
-    it('Disconnects webrtcconnection while being connected', async () => {
-        const msg: Message = {
-            serviceId,
-            messageId: '1',
-            body: {
-                oneofKind: 'rpcMessage',
-                rpcMessage: RpcMessage.create()
-            },
-        }
-
-        const disconnectedPromise1 = new Promise<void>((resolve, _reject) => {
-            manager1.on('disconnected', () => {
-                resolve()
-            })
-        })
-
-        msg.targetDescriptor = peerDescriptor2
-        manager1.send(msg).catch((e) => {
-            expect(e.code).toEqual('SEND_FAILED')
-        })
-
-        // @ts-expect-error private field
-        manager1.closeConnection(peerDescriptor2)
-
-        await disconnectedPromise1
-
-    }, 20000)
-
     it('failed connections are cleaned up', async () => {
         const msg: Message = {
             serviceId,


### PR DESCRIPTION
## Summary

Remove test case that is using too much internals. Removing more tests from the test file in the future with replacements in the ConnetionManager test files
