### PR TITLE
test(dht): Fix `getClosestNodes` unit test

### DIFF
--- a/packages/dht/test/unit/getClosestNodes.test.ts
+++ b/packages/dht/test/unit/getClosestNodes.test.ts
@@ -10,7 +10,7 @@ describe('getClosestNodes', () => {
     it('happy path', () => {
         const peerDescriptors = range(10).map(() => createMockPeerDescriptor())
         const referenceId = randomDhtAddress()
-        const excluded = new Set<DhtAddress>(sampleSize(peerDescriptors.map((n) => toNodeId(n), 2)))
+        const excluded = new Set<DhtAddress>(sampleSize(peerDescriptors.map((n) => toNodeId(n)), 2))
 
         const actual = getClosestNodes(
             referenceId,


### PR DESCRIPTION
Fixed the test to use two excluded nodes.

The intention in the test is to exclude two nodes, but in practice it used only one excluded node. The `sampleSize` didn't received any count parameter because the parameter `2` was incorrectly passed to the `map` function instead of the `sampleSize` function. (I.e. it was  uses as the `thisArg` parameter of the `map()` function.)