### PR TITLE
refactor(sdk): Remove obsolete `onError` index parameter

### DIFF
--- a/packages/sdk/src/subscribe/MessageStream.ts
+++ b/packages/sdk/src/subscribe/MessageStream.ts
@@ -24,7 +24,7 @@ export class MessageStream implements AsyncIterable<Message> {
     /** @internal */
     onBeforeFinally: Signal<[]>
     /** @internal */
-    onError: Signal<[Error, (StreamMessage | undefined)?, (number | undefined)?]>
+    onError: Signal<[Error, (StreamMessage | undefined)?]>
 
     /** @internal */
     constructor(pipeline?: PushPipeline<StreamMessage, StreamMessage>) {

--- a/packages/sdk/src/subscribe/MsgChainUtil.ts
+++ b/packages/sdk/src/subscribe/MsgChainUtil.ts
@@ -5,7 +5,7 @@ import { Signal } from './../utils/Signal'
 
 type ProcessMessageFn = (streamMessage: StreamMessage) => Promise<StreamMessage>
 
-type OnError = Signal<[Error, StreamMessage?, number?]>
+type OnError = Signal<[Error, StreamMessage?]>  // TODO could remove the StreamMessage parameter or use it?
 
 class MsgChainProcessor {
 

--- a/packages/sdk/src/utils/GeneratorUtils.ts
+++ b/packages/sdk/src/utils/GeneratorUtils.ts
@@ -4,7 +4,7 @@ export type GeneratorForEach<InType> = MaybeAsync<(value: InType, index: number,
 export type GeneratorFilter<InType> = MaybeAsync<(value: InType, index: number, src: AsyncGenerator<InType>) => any>
 export type GeneratorMap<InType, OutType> = (value: InType, index: number, src: AsyncGenerator<InType>) => OutType | Promise<OutType>
 
-type OnError<ValueType> = (err: Error, value: ValueType, index: number) => Promise<any> | any
+type OnError<ValueType> = (err: Error, value: ValueType) => Promise<any> | any
 
 const noopConsume = async (src: AsyncGenerator) => {
     // eslint-disable-next-line no-underscore-dangle
@@ -29,7 +29,7 @@ export async function* forEach<InType>(
             await fn(v, index, src)
         } catch (err) {
             if (onError) {
-                await onError(err, v, index)
+                await onError(err, v)
                 continue
             } else {
                 throw err
@@ -55,7 +55,7 @@ export async function* map<InType, OutType>(
             yield await fn(v, index, src)
         } catch (err) {
             if (onError) {
-                await onError(err, v, index)
+                await onError(err, v)
                 continue
             } else {
                 throw err
@@ -81,7 +81,7 @@ export async function* filter<InType>(
             ok = await fn(v, index, src)
         } catch (err) {
             if (onError) {
-                await onError(err, v, index)
+                await onError(err, v)
                 continue
             } else {
                 throw err

--- a/packages/sdk/src/utils/Pipeline.ts
+++ b/packages/sdk/src/utils/Pipeline.ts
@@ -103,7 +103,7 @@ export class Pipeline<InType, OutType = InType> implements IPipeline<InType, Out
 
     onMessage = Signal.create<[OutType]>()
 
-    onError = ErrorSignal.create<[Error, (InType | OutType)?, number?]>()
+    onError = ErrorSignal.create<[Error, (InType | OutType)?]>()
 
     filter(fn: G.GeneratorFilter<OutType>): Pipeline<InType, OutType> {
         return this.pipe((src) => G.filter(src, fn, this.onError.trigger))


### PR DESCRIPTION
Removed the `index` parameter from `onError` signal. It was not used by any component.

## Future improvements

- `MsgChainUtils#onError` has a `StreamMessage` parameter, which is not used. We should remove the parameter or start to use it. (I.e. investigate if we should remove the whole `onError` listener in `createMessagePipeline()` if the `ignoreMessages` handling is no longer needed.)