### PR TITLE
refactor(sdk): Improve `InternalPermissionQuery` type safety

### DIFF
--- a/packages/sdk/src/Stream.ts
+++ b/packages/sdk/src/Stream.ts
@@ -15,8 +15,7 @@ import {
     PermissionAssignment,
     PublicPermissionQuery,
     UserPermissionQuery,
-    toInternalPermissionAssignment,
-    toInternalPermissionQuery
+    toInternalPermissionAssignment
 } from './permission'
 
 /**
@@ -52,10 +51,10 @@ export class Stream {
      * @category Important
      */
     async hasPermission(query: Omit<UserPermissionQuery, 'streamId'> | Omit<PublicPermissionQuery, 'streamId'>): Promise<boolean> {
-        return this.client.hasPermission(toInternalPermissionQuery({
+        return this.client.hasPermission({
             streamId: this.id,
             ...query
-        }))
+        })
     }
 
     /**

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -473,8 +473,8 @@ export class StreamrClient {
     /**
      * Checks whether the given permission is in effect.
      */
-    hasPermission(query: PermissionQuery): Promise<boolean> {
-        return this.streamRegistry.hasPermission(toInternalPermissionQuery(query))
+    async hasPermission(query: PermissionQuery): Promise<boolean> {
+        return this.streamRegistry.hasPermission(await toInternalPermissionQuery(query, this.streamIdBuilder))
     }
 
     /**

--- a/packages/sdk/src/contracts/StreamRegistry.ts
+++ b/packages/sdk/src/contracts/StreamRegistry.ts
@@ -369,14 +369,13 @@ export class StreamRegistry {
     // --------------------------------------------------------------------------------------------
 
     async hasPermission(query: InternalPermissionQuery): Promise<boolean> {
-        const streamId = await this.streamIdBuilder.toStreamID(query.streamId)
         if (isPublicPermissionQuery(query)) {
             const permissionType = streamPermissionToSolidityType(query.permission)
-            return this.streamRegistryContractReadonly.hasPublicPermission(streamId, permissionType)
+            return this.streamRegistryContractReadonly.hasPublicPermission(query.streamId, permissionType)
         } else {
             const chainPermissions = query.allowPublic
-                ? await this.streamRegistryContractReadonly.getPermissionsForUserId(streamId, query.userId)
-                : await this.streamRegistryContractReadonly.getDirectPermissionsForUserId(streamId, query.userId)
+                ? await this.streamRegistryContractReadonly.getPermissionsForUserId(query.streamId, query.userId)
+                : await this.streamRegistryContractReadonly.getDirectPermissionsForUserId(query.streamId, query.userId)
             const permissions = convertChainPermissionsToStreamPermissions(chainPermissions)
             return permissions.includes(query.permission)
         }

--- a/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
+++ b/packages/sdk/test/test-utils/fake/FakeStreamRegistry.ts
@@ -177,12 +177,12 @@ export class FakeStreamRegistry implements Methods<StreamRegistry> {
         // no-op
     }
 
-    async isStreamPublisher(streamIdOrPath: string, userId: UserID): Promise<boolean> {
-        return this.hasPermission({ streamId: streamIdOrPath, userId, permission: StreamPermission.PUBLISH, allowPublic: true })
+    async isStreamPublisher(streamId: StreamID, userId: UserID): Promise<boolean> {
+        return this.hasPermission({ streamId, userId, permission: StreamPermission.PUBLISH, allowPublic: true })
     }
 
-    async isStreamSubscriber(streamIdOrPath: string, userId: UserID): Promise<boolean> {
-        return this.hasPermission({ streamId: streamIdOrPath, userId, permission: StreamPermission.SUBSCRIBE, allowPublic: true })
+    async isStreamSubscriber(streamId: StreamID, userId: UserID): Promise<boolean> {
+        return this.hasPermission({ streamId, userId, permission: StreamPermission.SUBSCRIBE, allowPublic: true })
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
The type of `streamId` field is now `StreamID` instead of `string`.

Also remove obsolete `toInternalPermissionQuery()` call in `Stream#hasPermissions()`. There is no need to convert the query as the we call the client method which does the same conversion.

Also fixed method signatures in `FakeStreamRegistry` so that they matched `StreamRegistry` methods.
