### PR TITLE
refactor(sdk)!: Rename storage node event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Changes before Tatum release are not documented in this file.
   - use `StreamrClient#setStreamMetadata()` and `Stream#setMetadata()` instead
   - both methods overwrite metadata instead of merging it
 - **BREAKING CHANGE:** Methods `Stream#getMetadata()` and `Stream#getStreamParts()` are async (https://github.com/streamr-dev/network/pull/2883)
+- **BREAKING CHANGE:** Rename event `streamRemovedFromFromStorageNode` to `streamRemovedFromStorageNode` (https://github.com/streamr-dev/network/pull/2930)
 - Caching changes:
   - storage node addresses (https://github.com/streamr-dev/network/pull/2877, https://github.com/streamr-dev/network/pull/2878)
   - stream metadata and permissions (https://github.com/streamr-dev/network/pull/2889)

--- a/packages/node/src/plugins/storage/StorageEventListener.ts
+++ b/packages/node/src/plugins/storage/StorageEventListener.ts
@@ -41,11 +41,11 @@ export class StorageEventListener {
 
     start(): void {
         this.streamrClient.on('streamAddedToStorageNode', this.onAddToStorageNode)
-        this.streamrClient.on('streamRemovedFromFromStorageNode', this.onRemoveFromStorageNode)
+        this.streamrClient.on('streamRemovedFromStorageNode', this.onRemoveFromStorageNode)
     }
 
     destroy(): void {
         this.streamrClient.off('streamAddedToStorageNode', this.onAddToStorageNode)
-        this.streamrClient.off('streamRemovedFromFromStorageNode', this.onRemoveFromStorageNode)
+        this.streamrClient.off('streamRemovedFromStorageNode', this.onRemoveFromStorageNode)
     }
 }

--- a/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
@@ -101,7 +101,7 @@ describe(StorageConfig, () => {
         beforeEach(async () => {
             await storageConfig.start()
             const addToStorageNodeListener = storageEventListeners.get('streamAddedToStorageNode')!
-            const removeFromStorageNodeListener = storageEventListeners.get('streamRemovedFromFromStorageNode')!
+            const removeFromStorageNodeListener = storageEventListeners.get('streamRemovedFromStorageNode')!
             addToStorageNodeListener({
                 streamId: toStreamID('stream-1'),
                 nodeAddress: CLUSTER_ID,

--- a/packages/sdk/src/contracts/StreamStorageRegistry.ts
+++ b/packages/sdk/src/contracts/StreamStorageRegistry.ts
@@ -108,7 +108,7 @@ export class StreamStorageRegistry {
         initContractEventGateway({
             sourceName: 'Removed', 
             sourceEmitter: chainEventPoller,
-            targetName: 'streamRemovedFromFromStorageNode',
+            targetName: 'streamRemovedFromStorageNode',
             targetEmitter: eventEmitter,
             transformation,
             loggerFactory

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -8,7 +8,7 @@ import { StreamMessage } from './protocol/StreamMessage'
 export interface StreamrClientEvents {
     streamCreated: (payload: StreamCreationEvent) => void
     streamAddedToStorageNode: (payload: StorageNodeAssignmentEvent) => void
-    streamRemovedFromFromStorageNode: (payload: StorageNodeAssignmentEvent) => void
+    streamRemovedFromStorageNode: (payload: StorageNodeAssignmentEvent) => void
     /** @internal */
     encryptionKeyStoredToLocalStore: (keyId: string) => void
     /** @internal */

--- a/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
@@ -81,7 +81,7 @@ describe('StorageNodeRegistry', () => {
         listenerClient.on('streamAddedToStorageNode', (payload: any) => {
             onAddPayloads.push(payload)
         })
-        listenerClient.on('streamRemovedFromFromStorageNode', (payload: any) => {
+        listenerClient.on('streamRemovedFromStorageNode', (payload: any) => {
             onRemovePayloads.push(payload)
         })
 


### PR DESCRIPTION
**This is a breaking change.**

Fixed typo in event name by renaming `streamRemovedFromFromStorageNode` -> `streamRemovedFromStorageNode`.