### PR TITLE
chore(docs): [DREL-250] Smoke test for API docs

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -22,3 +22,6 @@ jobs:
       - name: Build documentation
         working-directory: ./docs
         run: npm ci && npm run build
+      - name: API docs smoke test
+        working-directory: ./docs
+        run: ./api-docs-smoke-test.sh

--- a/docs/api-docs-smoke-test.sh
+++ b/docs/api-docs-smoke-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# If TypeDoc succeeds, it creates the directory with markdown files that Docusaurus uses to generate the API docs.
+# If TypeDoc fails, Docusaurus ignores the error, builds the site without API docs, and the "npm run build"
+# script still returns 0. This is why this separate smoke test is needed.
+
+if [ ! -d "docs/usage/sdk/api" ]; then
+    echo 'No files in "docs/usage/sdk/api" directory. Maybe TypeDoc failed?'
+    exit 1
+fi


### PR DESCRIPTION
Added additional check for `test-docs` CI job. It checks whether the `docs/usage/sdk/api` directory exists. It it doesn't, TypeDoc most likely failed and the whole API docs section is missing.

## Example

CI output when [test fails](https://github.com/streamr-dev/network/actions/runs/12236169946/job/34129034071?pr=2929):
```
Run ./api-docs-smoke-test.sh
No files in "docs/usage/sdk/api" directory. Maybe TypeDoc failed?
Error: Process completed with exit code 1.
```