### PR TITLE
test(node): Fix `MaintainTopologyService` test variable shadowning

### DIFF
--- a/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
@@ -60,8 +60,8 @@ describe('MaintainTopologyService', () => {
     })
 
     afterEach(async () => {
-        await client?.destroy()
-        await operatorFleetState?.destroy()
+        await client.destroy()
+        await operatorFleetState.destroy()
     })
 
     it('happy path', async () => {

--- a/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
@@ -82,7 +82,7 @@ describe('MaintainTopologyService', () => {
             0
         )
         const operatorContractAddress = toEthereumAddress(await operatorContract.getAddress())
-        const operatorFleetState = createOperatorFleetState(formCoordinationStreamId(operatorContractAddress))
+        operatorFleetState = createOperatorFleetState(formCoordinationStreamId(operatorContractAddress))
         const maintainTopologyHelper = new MaintainTopologyHelper(
             createClient(operatorWallet.privateKey).getOperator(toEthereumAddress(operatorContractAddress))
         )


### PR DESCRIPTION
Fixed a variable shadowing issues in `MaintainTopologyService.test.ts`. The test state variable `operatorFleetState ` wasn't used because it was shadowed by a local variable. 

Also removed optional chaining. The optional chaining hide this shadowing issue, i.e. better to not to use optional chaining so that test would fail without the fix.

This is a blocker to https://github.com/streamr-dev/network/pull/2936. In TypeScript v5.7 the `npm run check` errors like:
```
Error: test/integration/plugins/operator/MaintainTopologyService.test.ts(64,15): error TS2454: Variable 'operatorFleetState' is used before being assigned.
```