### PR TITLE
test: Remove optional chaining in test setups

### DIFF
--- a/packages/dht/test/integration/StoreOnDhtWithThreeNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithThreeNodes.test.ts
@@ -34,7 +34,7 @@ describe('Storing data in DHT with two peers', () => {
         await entryPoint.stop()
         await node1.stop()
         await node2.stop()
-        simulator?.stop()
+        simulator!.stop()
     })
 
     it('Node can store on three peer DHT', async () => {

--- a/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
+++ b/packages/dht/test/integration/StoreOnDhtWithTwoNodes.test.ts
@@ -26,7 +26,7 @@ describe('Storing data in DHT with two peers', () => {
     afterEach(async () => {
         await entryPoint.stop()
         await otherNode.stop()
-        simulator?.stop()
+        simulator!.stop()
     })
 
     it('Node can store on two peer DHT', async () => {

--- a/packages/node/test/integration/broker-subscriptions.test.ts
+++ b/packages/node/test/integration/broker-subscriptions.test.ts
@@ -74,12 +74,12 @@ describe('broker subscriptions', () => {
 
     afterEach(async () => {
         await Promise.allSettled([
-            mqttClient1?.end(true),
-            mqttClient2?.end(true),
-            client1?.destroy(),
-            client2?.destroy(),
-            broker1?.stop(),
-            broker2?.stop(),
+            mqttClient1.end(true),
+            mqttClient2.end(true),
+            client1.destroy(),
+            client2.destroy(),
+            broker1.stop(),
+            broker2.stop(),
         ])
 
     })

--- a/packages/node/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/node/test/integration/multiple-publisher-plugins.test.ts
@@ -130,7 +130,7 @@ describe('multiple publisher plugins', () => {
     })
 
     afterEach(async () => {
-        await broker?.stop()
+        await broker.stop()
     })
 
     it('subscribe by StreamrClient', async () => {

--- a/packages/node/test/integration/plugins/mqtt/Bridge.test.ts
+++ b/packages/node/test/integration/plugins/mqtt/Bridge.test.ts
@@ -51,7 +51,7 @@ describe('MQTT Bridge', () => {
     })
 
     afterEach(async () => {
-        await streamrClient?.destroy()
+        await streamrClient.destroy()
     })
 
     test('message published by a MQTT client is delivered only once', async () => {

--- a/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
@@ -60,8 +60,8 @@ describe('MaintainTopologyService', () => {
     })
 
     afterEach(async () => {
-        await client?.destroy()
-        await operatorFleetState?.destroy()
+        await client.destroy()
+        await operatorFleetState.destroy()
     })
 
     it('happy path', async () => {

--- a/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
@@ -82,7 +82,7 @@ describe('MaintainTopologyService', () => {
             0
         )
         const operatorContractAddress = toEthereumAddress(await operatorContract.getAddress())
-        const operatorFleetState = createOperatorFleetState(formCoordinationStreamId(operatorContractAddress))
+        operatorFleetState = createOperatorFleetState(formCoordinationStreamId(operatorContractAddress))
         const maintainTopologyHelper = new MaintainTopologyHelper(
             createClient(operatorWallet.privateKey).getOperator(toEthereumAddress(operatorContractAddress))
         )

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -38,14 +38,14 @@ describe('OperatorPlugin', () => {
     }, 30 * 1000)
 
     afterEach(async () => {
-        await broker?.stop()
+        await broker.stop()
     })
 
     async function waitForHeartbeatMessage(operatorContractAddress: EthereumAddress): Promise<void> {
         const client = createClient(fastPrivateKey())
         const sub = await client.subscribe(formCoordinationStreamId(operatorContractAddress))
         await collect(sub, 1)
-        await client?.destroy()
+        await client.destroy()
     }
 
     it('accepts proxy connections', async () => {

--- a/packages/node/test/integration/plugins/storage/Storage.test.ts
+++ b/packages/node/test/integration/plugins/storage/Storage.test.ts
@@ -136,8 +136,8 @@ describe('Storage', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            storage?.close(),
-            cassandraClient?.shutdown()
+            storage.close(),
+            cassandraClient.shutdown()
         ])
     })
 

--- a/packages/node/test/integration/plugins/storage/StorageConfig.test.ts
+++ b/packages/node/test/integration/plugins/storage/StorageConfig.test.ts
@@ -38,7 +38,7 @@ describe('StorageConfig', () => {
     })
 
     afterAll(async () => {
-        await cassandraClient?.shutdown()
+        await cassandraClient.shutdown()
     })
 
     beforeEach(async () => {
@@ -50,7 +50,7 @@ describe('StorageConfig', () => {
     afterEach(async () => {
         await client.destroy()
         await Promise.allSettled([
-            storageNode?.stop(),
+            storageNode.stop(),
         ])
     })
 

--- a/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
+++ b/packages/node/test/integration/plugins/storage/cassanda-queries.test.ts
@@ -121,7 +121,7 @@ describe('cassanda-queries', () => {
     })
 
     afterAll(async () => {
-        await storage?.close() // also cleans up realClient
+        await storage.close() // also cleans up realClient
     })
 
     beforeEach(async () => {

--- a/packages/node/test/integration/plugins/storage/dataMetadataEndpoint.test.ts
+++ b/packages/node/test/integration/plugins/storage/dataMetadataEndpoint.test.ts
@@ -40,8 +40,8 @@ describe('dataMetadataEndpoints', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            client1?.destroy(),
-            storageNode?.stop()
+            client1.destroy(),
+            storageNode.stop()
         ])
     }, TIMEOUT)
 

--- a/packages/node/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/node/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -47,8 +47,8 @@ describe('Subscriber Plugin', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            client?.destroy(),
-            plugin?.stop()
+            client.destroy(),
+            plugin.stop()
         ])
     })
 

--- a/packages/node/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/node/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -51,7 +51,7 @@ describe(OperatorFleetState, () => {
     })
 
     afterEach(() => {
-        state?.destroy()
+        state.destroy()
     })
 
     it('cannot double start', async () => {

--- a/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
+++ b/packages/node/test/unit/plugins/storage/StorageConfig.test.ts
@@ -59,7 +59,7 @@ describe(StorageConfig, () => {
     })
 
     afterEach(() => {
-        storageConfig?.destroy()
+        storageConfig.destroy()
     })
 
     it('state starts empty', () => {

--- a/packages/node/test/unit/plugins/storage/StorageEventListener.test.ts
+++ b/packages/node/test/unit/plugins/storage/StorageEventListener.test.ts
@@ -29,7 +29,7 @@ describe(StorageEventListener, () => {
     })
 
     afterEach(() => {
-        listener?.destroy()
+        listener.destroy()
     })
 
     it('start() registers storage event listener on client', async () => {

--- a/packages/node/test/unit/plugins/websocket/WebsocketServer.test.ts
+++ b/packages/node/test/unit/plugins/websocket/WebsocketServer.test.ts
@@ -48,8 +48,8 @@ describe('WebsocketServer', () => {
     })
 
     afterEach(async () => {
-        wsClient?.close()
-        await wsServer?.stop()
+        wsClient.close()
+        await wsServer.stop()
     })
 
     describe.each([

--- a/packages/sdk/test/end-to-end/Metrics.test.ts
+++ b/packages/sdk/test/end-to-end/Metrics.test.ts
@@ -40,8 +40,8 @@ describe('NodeMetrics', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            generatorClient?.destroy(),
-            subscriberClient?.destroy()
+            generatorClient.destroy(),
+            subscriberClient.destroy()
         ])
     })
 

--- a/packages/sdk/test/end-to-end/Permissions.test.ts
+++ b/packages/sdk/test/end-to-end/Permissions.test.ts
@@ -27,7 +27,7 @@ describe('Stream permissions', () => {
     }, TIMEOUT)
 
     afterAll(async () => {
-        await client?.destroy()
+        await client.destroy()
     })
 
     beforeEach(async () => {

--- a/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
@@ -26,8 +26,8 @@ describe('StorageNodeRegistry', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            creatorClient?.destroy(),
-            listenerClient?.destroy()
+            creatorClient.destroy(),
+            listenerClient.destroy()
         ])
     })
 

--- a/packages/sdk/test/end-to-end/StorageNodeRegistry2.test.ts
+++ b/packages/sdk/test/end-to-end/StorageNodeRegistry2.test.ts
@@ -28,8 +28,8 @@ describe('StorageNodeRegistry2', () => {
 
     afterAll(async () => {
         await Promise.allSettled([
-            client?.destroy(),
-            storageNodeClient?.destroy()
+            client.destroy(),
+            storageNodeClient.destroy()
         ])
     })
 

--- a/packages/sdk/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/sdk/test/end-to-end/publish-subscribe.test.ts
@@ -76,8 +76,8 @@ describe('publish-subscribe', () => {
 
     afterEach(async () => {
         await Promise.allSettled([
-            publisherClient?.destroy(),
-            subscriberClient?.destroy(),
+            publisherClient.destroy(),
+            subscriberClient.destroy(),
         ])
     }, TIMEOUT)
 

--- a/packages/sdk/test/end-to-end/resend.test.ts
+++ b/packages/sdk/test/end-to-end/resend.test.ts
@@ -29,8 +29,8 @@ describe('resend', () => {
 
     afterEach(async () => {
         await Promise.allSettled([
-            publisherClient?.destroy(),
-            resendClient?.destroy(),
+            publisherClient.destroy(),
+            resendClient.destroy(),
         ])
     }, TIMEOUT)
 

--- a/packages/sdk/test/end-to-end/searchStreams.test.ts
+++ b/packages/sdk/test/end-to-end/searchStreams.test.ts
@@ -75,7 +75,7 @@ describe('searchStreams', () => {
     }, TIMEOUT)
 
     afterAll(async () => {
-        await client?.destroy()
+        await client.destroy()
     })
 
     it('search term matches', async () => {

--- a/packages/sdk/test/integration/Resends2.test.ts
+++ b/packages/sdk/test/integration/Resends2.test.ts
@@ -55,11 +55,11 @@ describe('Resends2', () => {
     })
 
     afterEach(async () => {
-        await client?.destroy()
+        await client.destroy()
     })
 
     afterAll(async () => {
-        await publisher?.destroy()
+        await publisher.destroy()
     })
 
     it('throws if no storage assigned', async () => {

--- a/packages/sdk/test/integration/unsubscribe.test.ts
+++ b/packages/sdk/test/integration/unsubscribe.test.ts
@@ -35,7 +35,7 @@ describe('unsubscribe', () => {
     })
 
     afterEach(async () => {
-        await client?.destroy()
+        await client.destroy()
     })
 
     it('Subscription#unsubscribe', async () => {

--- a/packages/sdk/test/unit/MetricsPublisher.test.ts
+++ b/packages/sdk/test/unit/MetricsPublisher.test.ts
@@ -70,7 +70,7 @@ describe('MetricsPublisher', () => {
     })
 
     afterEach(() => {
-        destroySignal?.destroy()
+        destroySignal.destroy()
     })
 
     it('happy path', async () => {

--- a/packages/utils/test/Metric.test.ts
+++ b/packages/utils/test/Metric.test.ts
@@ -30,7 +30,7 @@ describe('metrics', () => {
         })
     
         afterEach(() => {
-            abortController?.abort()
+            abortController.abort()
         })
     
         it('happy path', async () => {

--- a/packages/utils/test/scheduleAtFixedRate.test.ts
+++ b/packages/utils/test/scheduleAtFixedRate.test.ts
@@ -14,7 +14,7 @@ describe('scheduleAtFixedRate', () => {
     })
 
     afterEach(() => {
-        abortController?.abort()
+        abortController.abort()
     })
 
     it('repeats task every `interval`', async () => {

--- a/packages/utils/test/scheduleAtInterval.test.ts
+++ b/packages/utils/test/scheduleAtInterval.test.ts
@@ -15,7 +15,7 @@ describe('scheduleAtInterval', () => {
     })
 
     afterEach(() => {
-        abortController?.abort()
+        abortController.abort()
     })
 
     it('execute at start enabled', async () => {


### PR DESCRIPTION
Removed optional chaining in test setups. I.e. calls like `client?.destroy()` don't use the `?` operator anymore. In https://github.com/streamr-dev/network/pull/2936 this kind of issue hide a variable shadowing problem. Removed the optional chaining so that tests would fail if test state variables aren't initialized correctly.