### PR TITLE
test(sdk): Fix ANSI color handling in `customMatchers` test

### DIFF
--- a/packages/sdk/test/unit/customMatchers.test.ts
+++ b/packages/sdk/test/unit/customMatchers.test.ts
@@ -45,7 +45,7 @@ describe('custom matchers', () => {
                         message: 'Foobar',
                         code: 'UNSUPPORTED_OPERATION'
                     })
-                }).toThrow('Not an instance of StreamrClientError:\nReceived: "mock-error')
+                }).toThrow('Not an instance of StreamrClientError:\nReceived: "mock-error"')
             })
 
             it('inverse', () => {

--- a/packages/sdk/test/unit/customMatchers.test.ts
+++ b/packages/sdk/test/unit/customMatchers.test.ts
@@ -1,5 +1,7 @@
 import { StreamrClientError } from '../../src/StreamrClientError'
 
+const ESCAPED_ANSI_COLOR_REGEXP = '(\\x1B\\[\\d+m)?'
+
 describe('custom matchers', () => {
 
     describe('toThrowStreamrClientError', () => {
@@ -35,7 +37,8 @@ describe('custom matchers', () => {
                         message: 'Foobar',
                         code: 'UNSUPPORTED_OPERATION'
                     })
-                }).toThrow('Not an instance of StreamrClientError:\nReceived: "TestClass"')
+                // eslint-disable-next-line max-len
+                }).toThrow(new RegExp(`Not an instance of StreamrClientError:\nReceived: ${ESCAPED_ANSI_COLOR_REGEXP}"TestClass"${ESCAPED_ANSI_COLOR_REGEXP}`))
             })
 
             it('unexpected primitive', () => {
@@ -45,7 +48,8 @@ describe('custom matchers', () => {
                         message: 'Foobar',
                         code: 'UNSUPPORTED_OPERATION'
                     })
-                }).toThrow('Not an instance of StreamrClientError:\nReceived: "mock-error"')
+                // eslint-disable-next-line max-len
+                }).toThrow(new RegExp(`Not an instance of StreamrClientError:\nReceived: ${ESCAPED_ANSI_COLOR_REGEXP}"mock-error"${ESCAPED_ANSI_COLOR_REGEXP}`))
             })
 
             it('inverse', () => {


### PR DESCRIPTION
## Background

Jest error messages typically contain ANSI color codes. In `customMatchers.test.ts`, we asserted these messages without accounting for the color codes, which caused test failures. However, the tests passed in environments where colors were disabled (e.g., CI).

These test cases were added in https://github.com/streamr-dev/network/pull/2894.

## Changes

Modified the assertions to allow color codes.