### PR TITLE
feat(sdk)!: Export `AbstractSigner` instead of `Signer`

### DIFF
--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -134,4 +134,4 @@ export { _operatorContractUtils }
 export type { SetupOperatorContractOpts, SetupOperatorContractReturnType, DeployOperatorContractOpts, DeploySponsorshipContractOpts }
 
 export type { IceServer, PeerDescriptor, PortRange } from '@streamr/dht'
-export type { Signer, Eip1193Provider, Overrides } from 'ethers'
+export type { AbstractSigner, Eip1193Provider, Overrides } from 'ethers'


### PR DESCRIPTION
Changed SDK to export `ether`'s `AbstractSigner` type instead of `Signer` type. 

## Background

The type is exported because it is part of our public API. It is used in`SignerWithProvider` type (which is used by `StreamrClient#getSigner()`).  In PR https://github.com/streamr-dev/network/pull/2506 we changed `SignerWithProvider`   to use `AbstractSigner` instead of `Signer`. We should have changed the export in that PR.