### PR TITLE
feat(docs): [DREL-252] External classes as link in API docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -44,6 +44,7 @@ const config: Config = {
         excludePrivate: true,
         excludeProtected: true,
         excludeInternal: true,
+        excludeExternals: true,
         includeVersion: true,
         categorizeByGroup: true,
         treatWarningsAsErrors: true,

--- a/packages/sdk/src/Authentication.ts
+++ b/packages/sdk/src/Authentication.ts
@@ -7,6 +7,9 @@ import { pLimitFn } from './utils/promises'
 
 export const AuthenticationInjectionToken = Symbol('Authentication')
 
+/**
+ * The {@link https://docs.ethers.org/v6/api/providers/abstract-signer/#AbstractSigner AbstractSigner} type is from the `ethers` library.
+ */
 export type SignerWithProvider = AbstractSigner<Provider>
 
 export interface Authentication {

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -11,6 +11,9 @@ import { config as CHAIN_CONFIG } from '@streamr/config'
 import { CONFIG_TEST } from './ConfigTest'
 
 export interface ProviderAuthConfig {
+    /**
+     * The {@link https://docs.ethers.org/v6/api/providers/#Eip1193Provider Eip1193Provider} type is from the `ethers` library.
+     */
     ethereum: Eip1193Provider
 }
 

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -756,6 +756,8 @@ export class StreamrClient {
     /**
      * Get overrides for transaction options. Use as a parameter when submitting
      * transactions via ethers library.
+     *
+     * The {@link https://docs.ethers.org/v6/api/contract/#Overrides Overrides} type is from the `ethers` library.
      */
     getEthersOverrides(): Promise<Overrides> {
         return _getEthersOverrides(this.rpcProviderSource, this.config)

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -134,4 +134,4 @@ export { _operatorContractUtils }
 export type { SetupOperatorContractOpts, SetupOperatorContractReturnType, DeployOperatorContractOpts, DeploySponsorshipContractOpts }
 
 export type { IceServer, PeerDescriptor, PortRange } from '@streamr/dht'
-export type { Signer, Eip1193Provider, Overrides } from 'ethers'
+export type { AbstractSigner, Eip1193Provider, Overrides } from 'ethers'


### PR DESCRIPTION
Added `excludeExternals: true` TypeDoc config option. That excludes external classes/interface/enums from the API docs. It is better to link to the external API documentations instead of inlining the docs into our API docs.

There are three external interfaces and no external classes/enums. All are from the `ethers` package:
- `AbstractSigner`
- `Eip1193Provider`
- `Overrides`
