### PR TITLE
test(sdk): Custom matchers accept message substrings

### DIFF
--- a/packages/sdk/test/integration/resend-with-existing-key.test.ts
+++ b/packages/sdk/test/integration/resend-with-existing-key.test.ts
@@ -9,7 +9,6 @@ import { StreamPermission } from '../../src/permission'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'
 import { createMockMessage, createRelativeTestStreamId, getLocalGroupKeyStore } from '../test-utils/utils'
-import { StreamrClientError } from '../../src/StreamrClientError'
 
 /*
  * A subscriber has some GroupKeys in the local store and reads historical data
@@ -68,8 +67,9 @@ describe('resend with existing key', () => {
         await collect(messageStream)
         expect(onError).toHaveBeenCalled()
         const error = onError.mock.calls[0][0]
-        expect(error).toBeInstanceOf(StreamrClientError)
-        expect(error.code).toBe('DECRYPT_ERROR')
+        expect(error).toEqualStreamrClientError({
+            code: 'DECRYPT_ERROR'
+        })
     }
 
     beforeEach(async () => {

--- a/packages/sdk/test/integration/update-encryption-key.test.ts
+++ b/packages/sdk/test/integration/update-encryption-key.test.ts
@@ -161,8 +161,9 @@ describe('update encryption key', () => {
                 mockId: 2
             })
             await until(() => onError.mock.calls.length > 0, 10 * 1000)
-            expect(onError.mock.calls[0][0]).toBeInstanceOf(StreamrClientError)
-            expect(onError.mock.calls[0][0].code).toBe('DECRYPT_ERROR')
+            expect(onError.mock.calls[0][0]).toEqualStreamrClientError({
+                code: 'DECRYPT_ERROR'
+            })
         }, 10 * 1000)
     })
 })

--- a/packages/sdk/test/integration/update-encryption-key.test.ts
+++ b/packages/sdk/test/integration/update-encryption-key.test.ts
@@ -7,7 +7,6 @@ import { StreamPermission } from '../../src/permission'
 import { nextValue } from '../../src/utils/iterators'
 import { StreamrClient } from './../../src/StreamrClient'
 import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
-import { StreamrClientError } from '../../src/StreamrClientError'
 
 /*
  * Subscriber has subscribed to a stream, and the publisher updates the encryption key for that stream.

--- a/packages/sdk/test/test-utils/customMatchers.ts
+++ b/packages/sdk/test/test-utils/customMatchers.ts
@@ -66,6 +66,7 @@ const createAssertionErrors = (
             assertionErrors.push(formErrorMessage('code', expectedError.code, actualError.code))
         }
         if (expectedError.message !== undefined) {
+            // similar matching logic as in https://jestjs.io/docs/expect#tothrowerror
             const isMatch = (expectedError instanceof Error)
                 ? (actualError.message === expectedError.message)
                 : actualError.message.includes(expectedError.message)

--- a/packages/sdk/test/test-utils/customMatchers.ts
+++ b/packages/sdk/test/test-utils/customMatchers.ts
@@ -65,8 +65,13 @@ const createAssertionErrors = (
         if (actualError.code !== expectedError.code) {
             assertionErrors.push(formErrorMessage('code', expectedError.code, actualError.code))
         }
-        if ((expectedError.message !== undefined) && (actualError.message !== expectedError.message)) {
-            assertionErrors.push(formErrorMessage('message', expectedError.message, actualError.message))
+        if (expectedError.message !== undefined) {
+            const isMatch = (expectedError instanceof Error)
+                ? (actualError.message === expectedError.message)
+                : actualError.message.includes(expectedError.message)
+            if (!isMatch) {
+                assertionErrors.push(formErrorMessage('message', expectedError.message, actualError.message))
+            }
         }
     }
     return assertionErrors

--- a/packages/sdk/test/unit/customMatchers.test.ts
+++ b/packages/sdk/test/unit/customMatchers.test.ts
@@ -73,7 +73,7 @@ describe('custom matchers', () => {
                 const actual = new StreamrClientError('Foobar', 'UNKNOWN_ERROR')
                 expect(() => {
                     expect(actual).not.toEqualStreamrClientError(actual)
-                }).toThrow('treamrClientErrors are equal')
+                }).toThrow('StreamrClientErrors are equal')
             })
         })
     })

--- a/packages/sdk/test/unit/customMatchers.test.ts
+++ b/packages/sdk/test/unit/customMatchers.test.ts
@@ -8,9 +8,20 @@ describe('custom matchers', () => {
             const error = new StreamrClientError('Foobar', 'UNKNOWN_ERROR')
             expect(() => {
                 throw error
+            }).toThrowStreamrClientError(error)
+            expect(() => {
+                throw error
+            }).not.toThrowStreamrClientError(new StreamrClientError('bar', 'UNKNOWN_ERROR'))
+            expect(() => {
+                throw error
             }).toThrowStreamrClientError({
-                code: error.code,
-                message: error.message
+                code: 'UNKNOWN_ERROR',
+                message: 'bar'
+            })
+            expect(() => {
+                throw error
+            }).toThrowStreamrClientError({
+                code: 'UNKNOWN_ERROR'
             })
         })
 
@@ -61,9 +72,14 @@ describe('custom matchers', () => {
 
         it('happy path', () => {
             const error = new StreamrClientError('Foobar', 'UNKNOWN_ERROR')
+            expect(error).toEqualStreamrClientError(error)
+            expect(error).not.toEqualStreamrClientError(new StreamrClientError('bar', 'UNKNOWN_ERROR'))
             expect(error).toEqualStreamrClientError({
-                code: error.code,
-                message: error.message
+                code: 'UNKNOWN_ERROR',
+                message: 'bar'
+            })
+            expect(error).toEqualStreamrClientError({
+                code: 'UNKNOWN_ERROR'
             })
         })
 

--- a/packages/sdk/test/unit/messagePipeline.test.ts
+++ b/packages/sdk/test/unit/messagePipeline.test.ts
@@ -169,9 +169,10 @@ describe('messagePipeline', () => {
         const output = await collect(pipeline)
         expect(onError).toHaveBeenCalledTimes(1)
         const error = onError.mock.calls[0][0]
-        expect(error).toBeInstanceOf(StreamrClientError)
-        expect(error.code).toBe('DECRYPT_ERROR')
-        expect(error.message).toMatch(/Could not get encryption key/)
+        expect(error).toEqualStreamrClientError({
+            code: 'DECRYPT_ERROR',
+            message: 'Could not get encryption key'
+        })
         expect(output).toEqual([])
         expect(streamRegistry.invalidatePermissionCaches).toHaveBeenCalledTimes(1)
         expect(streamRegistry.invalidatePermissionCaches).toHaveBeenCalledWith(StreamPartIDUtils.getStreamID(streamPartId))

--- a/packages/sdk/test/unit/messagePipeline.test.ts
+++ b/packages/sdk/test/unit/messagePipeline.test.ts
@@ -22,7 +22,6 @@ import { PushPipeline } from '../../src/utils/PushPipeline'
 import { mockLoggerFactory } from '../test-utils/utils'
 import { MessageID } from './../../src/protocol/MessageID'
 import { ContentType, EncryptionType, SignatureType, StreamMessage, StreamMessageType } from './../../src/protocol/StreamMessage'
-import { StreamrClientError } from '../../src/StreamrClientError'
 
 const CONTENT = {
     foo: 'bar'


### PR DESCRIPTION
Modified the functionality of `toThrowStreamrClientError()` and `toEqualStreamrClientError()` so that the functions handle error messages similarly to Jest's `toThrow()` function. In Jest the the error message must match exactly if the provider argument is an `Error` object, but a substring match is accepted if the provider argument is a `string`. See https://jestjs.io/docs/expect#tothrowerror.

Before this PR the custom matchers required an exact match in both cases.

Also modified some tests the `toEqualStreamrClientError()` function and improved test coverage in `customMatchers.test.ts`.