### PR TITLE
refactor(sdk): `NetworkNodeFacade#registerOperator()`

### DIFF
--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -1,7 +1,4 @@
 import {
-    OperatorDiscoveryRequest,
-    OperatorDiscoveryResponse,
-    peerDescriptorTranslator,
     ReviewRequestEvent,
     SignerWithProvider,
     StreamrClient
@@ -13,7 +10,7 @@ import {
     Logger,
     scheduleAtInterval,
     setAbortableInterval,
-    StreamPartIDUtils,
+    StreamPartID,
     toEthereumAddress
 } from '@streamr/utils'
 import { Schema } from 'ajv'
@@ -122,15 +119,9 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
         await fleetState.start()
         await maintainTopologyHelper.start()
 
-        const networkNode = streamrClient.getNode()
-
-        const rpcServerFunction = async (request: OperatorDiscoveryRequest) => {
-            const streamPartId = StreamPartIDUtils.parse(request.streamPartId)
-            const operators = streamPartAssignments.getAssignedNodesForStreamPart(streamPartId)
-            return OperatorDiscoveryResponse.create({ operators: operators.map((operator) => peerDescriptorTranslator(operator)) })
-        }
-
-        await networkNode.registerExternalRpcMethod(OperatorDiscoveryRequest, OperatorDiscoveryResponse, 'discoverOperators', rpcServerFunction)
+        await streamrClient.getNode().registerOperator({
+            getAssignedNodesForStreamPart: (streamPartId: StreamPartID) => streamPartAssignments.getAssignedNodesForStreamPart(streamPartId)
+        })
 
         this.abortController.signal.addEventListener('abort', async () => {
             await fleetState.destroy()

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -108,7 +108,7 @@ describe('OperatorPlugin', () => {
         }).rejects.toThrow('Plugin operator doesn\'t support client config value "false" in network.node.acceptProxyConnections')
     })
     
-    it('opeartor discovery', async () => {
+    it('operator discovery', async () => {
         const client = createClient(await fetchPrivateKeyWithGas())
         const stream = await createTestStream(client, module)
 

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -123,16 +123,19 @@ describe('OperatorPlugin', () => {
             privateKey: brokerWallet.privateKey,
             extraPlugins: {
                 operator: {
-                    operatorContractAddress
+                    operatorContractAddress,
+                    heartbeatUpdateIntervalInMs: 100,
+                    fleetState: {
+                        warmupPeriodInMs: 0
+                    }
                 }
             }
         })
         await until(async () => (await broker.getStreamrClient().getSubscriptions(stream.id)).length > 0)
-        // Ensure that heartbeat has been sent (setting heartbeatUpdateIntervalInMs lower did not help)
         await waitForHeartbeatMessage(toEthereumAddress(operatorContractAddress))
         const brokerDescriptor = await broker.getStreamrClient().getPeerDescriptor()
         const operators = await client.getNode().discoverOperators(brokerDescriptor, toStreamPartID(stream.id, DEFAULT_STREAM_PARTITION))
         expect(operators[0].nodeId).toEqual(brokerDescriptor.nodeId)
-    }, 60 * 1000)
+    })
 
 })

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -5,7 +5,7 @@ import {
     _operatorContractUtils
 } from '@streamr/sdk'
 import { fastPrivateKey, fetchPrivateKeyWithGas } from '@streamr/test-utils'
-import { EthereumAddress, StreamPartIDUtils, collect, toEthereumAddress, until } from '@streamr/utils'
+import { EthereumAddress, collect, toEthereumAddress, toStreamPartID, until } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { cloneDeep, set } from 'lodash'
 import { Broker, createBroker } from '../../../../src/broker'
@@ -20,6 +20,8 @@ const {
     sponsor,
     stake
 } = _operatorContractUtils
+
+const DEFAULT_STREAM_PARTITION = 0
 
 describe('OperatorPlugin', () => {
 
@@ -45,7 +47,7 @@ describe('OperatorPlugin', () => {
         const client = createClient(fastPrivateKey())
         const sub = await client.subscribe(formCoordinationStreamId(operatorContractAddress))
         await collect(sub, 1)
-        await client?.destroy()
+        await client.destroy()
     }
 
     it('accepts proxy connections', async () => {
@@ -106,22 +108,22 @@ describe('OperatorPlugin', () => {
         }).rejects.toThrow('Plugin operator doesn\'t support client config value "false" in network.node.acceptProxyConnections')
     })
     
-    it('accepts OperatorDiscoveryRequests', async () => {
+    it('opeartor discovery', async () => {
         const client = createClient(await fetchPrivateKeyWithGas())
         const stream = await createTestStream(client, module)
 
         const sponsorer = await generateWalletWithGasAndTokens()
-        const sponsorship1 = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
-        await sponsor(sponsorer, await sponsorship1.getAddress(), 10000)
+        const sponsorship = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
+        await sponsor(sponsorer, await sponsorship.getAddress(), 10000)
         await delegate(operatorWallet, await operatorContract.getAddress(), 10000)
-        await stake(operatorContract, await sponsorship1.getAddress(), 10000)
+        await stake(operatorContract, await sponsorship.getAddress(), 10000)
 
         const operatorContractAddress = await operatorContract.getAddress()
         broker = await startBroker({
             privateKey: brokerWallet.privateKey,
             extraPlugins: {
                 operator: {
-                    operatorContractAddress,
+                    operatorContractAddress
                 }
             }
         })
@@ -129,7 +131,7 @@ describe('OperatorPlugin', () => {
         // Ensure that heartbeat has been sent (setting heartbeatUpdateIntervalInMs lower did not help)
         await waitForHeartbeatMessage(toEthereumAddress(operatorContractAddress))
         const brokerDescriptor = await broker.getStreamrClient().getPeerDescriptor()
-        const operators = await client.getNode().discoverOperators(brokerDescriptor, StreamPartIDUtils.parse(`${stream.id}#0`))
+        const operators = await client.getNode().discoverOperators(brokerDescriptor, toStreamPartID(stream.id, DEFAULT_STREAM_PARTITION))
         expect(operators[0].nodeId).toEqual(brokerDescriptor.nodeId)
     }, 60 * 1000)
 

--- a/packages/sdk/src/NetworkNodeFacade.ts
+++ b/packages/sdk/src/NetworkNodeFacade.ts
@@ -68,7 +68,7 @@ export interface NetworkNodeStub {
     >(
         request: RequestClass,
         response: ResponseClass,
-        name: string, 
+        name: string,
         fn: (req: RequestType, context: ServerCallContext) => Promise<ResponseType>
     ): void
 
@@ -127,14 +127,14 @@ export class NetworkNodeFacade {
 
     private async getNetworkOptions(): Promise<NetworkOptions> {
         const entryPoints = await this.getEntryPoints()
-        const localPeerDescriptor: PeerDescriptor | undefined = this.config.network.controlLayer.peerDescriptor ? 
+        const localPeerDescriptor: PeerDescriptor | undefined = this.config.network.controlLayer.peerDescriptor ?
             peerDescriptorTranslator(this.config.network.controlLayer.peerDescriptor) : undefined
         return {
             layer0: {
                 ...this.config.network.controlLayer,
                 entryPoints: entryPoints.map(peerDescriptorTranslator),
                 peerDescriptor: localPeerDescriptor,
-                websocketPortRange: (this.config.network.controlLayer.websocketPortRange !== null) 
+                websocketPortRange: (this.config.network.controlLayer.websocketPortRange !== null)
                     ? this.config.network.controlLayer.websocketPortRange
                     : undefined
             },
@@ -234,7 +234,7 @@ export class NetworkNodeFacade {
         const node = await this.getNode()
         node.broadcast(StreamMessageTranslator.toProtobuf(msg))
     }
-    
+
     addMessageListener(listener: (msg: OldStreamMessage) => void): void {
         this.messageListeners.push(listener)
     }
@@ -319,7 +319,7 @@ export class NetworkNodeFacade {
             sourceDescriptor: await this.getPeerDescriptor(),
             targetDescriptor: peerDescriptorTranslator(leader)
         })
-        return response.operators.map((operator) => convertPeerDescriptorToNetworkPeerDescriptor(operator))   
+        return response.operators.map((operator) => convertPeerDescriptorToNetworkPeerDescriptor(operator))
     }
 
     private async createExternalRpcClient<T extends ExternalRpcClient>(clientClass: ExternalRpcClientClass<T> ): Promise<ProtoRpcClient<T>> {
@@ -336,7 +336,7 @@ export class NetworkNodeFacade {
         node.registerExternalNetworkRpcMethod(
             OperatorDiscoveryRequest,
             OperatorDiscoveryResponse,
-            'discoverOperators', 
+            'discoverOperators',
             async (request: OperatorDiscoveryRequest) => {
                 const streamPartId = StreamPartIDUtils.parse(request.streamPartId)
                 const operators = opts.getAssignedNodesForStreamPart(streamPartId)

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -80,8 +80,6 @@ export {
     StreamMessageType
 } from './protocol/StreamMessage'
 
-export { OperatorDiscoveryRequest, OperatorDiscoveryResponse } from './generated/packages/sdk/protos/SdkRpc'
-
 // These are exported for the internal Operator class
 export {
     Operator,


### PR DESCRIPTION
Moved the operator registration functionality from `node` to `sdk`.

## Changes

Added:
- `NetworkNodeFacade#registerOperator()` method

Removed:
- `NetworkNodeFacade#registerExternalRpcMethod()` method
- exports of `OperatorDiscoveryRequest` and `OperatorDiscoveryResponse`

## Other changes

Optimized `OperatorPlugin.test.ts` to use the `warmupPeriodInMs` config option. The `operator discovery` test now takes ~2.5s (i.e. ~80% less time).

## Future improvements

Add unit/integration/end-to-end test to `sdk`? There is currently a test in node (`OperatorPlugin.test.ts`), which covers also `registerOperator()` functionality, but better to have a focused test in `sdk`.