### PR TITLE
feat(docs): Hide internal methods from API docs

### DIFF
--- a/packages/sdk/src/NetworkNodeFacade.ts
+++ b/packages/sdk/src/NetworkNodeFacade.ts
@@ -204,7 +204,7 @@ export class NetworkNodeFacade {
 
     startNode: () => Promise<unknown> = this.startNodeTask
 
-    getNode(): Promise<NetworkNodeStub> {
+    getNode(): Promise<Omit<NetworkNodeStub, 'start' | 'stop'>> {
         this.destroySignal.assertNotDestroyed()
         return this.startNodeTask()
     }

--- a/packages/sdk/src/NetworkNodeFacade.ts
+++ b/packages/sdk/src/NetworkNodeFacade.ts
@@ -28,8 +28,6 @@ import { StreamMessageTranslator } from './protocol/StreamMessageTranslator'
 import { pOnce } from './utils/promises'
 import { convertPeerDescriptorToNetworkPeerDescriptor, peerDescriptorTranslator } from './utils/utils'
 
-// TODO should we make getNode() an internal method, and provide these all these services as client methods?
-/** @deprecated This in an internal interface */
 export interface NetworkNodeStub {
     getNodeId: () => DhtAddress
     addMessageListener: (listener: (msg: NewStreamMessage) => void) => void
@@ -45,11 +43,8 @@ export interface NetworkNodeStub {
     getDiagnosticInfo: () => Record<string, unknown>
     hasStreamPart: (streamPartId: StreamPartID) => boolean
     inspect(node: PeerDescriptor, streamPartId: StreamPartID): Promise<boolean>
-    /** @internal */
     start: (doJoin?: boolean) => Promise<void>
-    /** @internal */
     stop: () => Promise<void>
-    /** @internal */
     setProxies: (
         streamPartId: StreamPartID,
         nodes: PeerDescriptor[],
@@ -71,7 +66,6 @@ export interface NetworkNodeStub {
         name: string,
         fn: (req: RequestType, context: ServerCallContext) => Promise<ResponseType>
     ): void
-
 }
 
 export interface Events {

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -652,6 +652,7 @@ export class StreamrClient {
 
     /**
      * @deprecated This in an internal method
+     * @hidden
      */
     getNode(): NetworkNodeFacade {
         return this.node
@@ -748,6 +749,7 @@ export class StreamrClient {
 
     /**
      * @deprecated This in an internal method
+     * @hidden
      */
     getConfig(): StrictStreamrClientConfig {
         return this.config

--- a/packages/sdk/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/sdk/test/integration/NetworkNodeFacade.test.ts
@@ -23,7 +23,7 @@ describe('NetworkNodeFacade', () => {
 
         let client: StreamrClient
 
-        const getNode = (): Promise<NetworkNodeStub> => {
+        const getNode = (): Promise<Omit<NetworkNodeStub, 'start' | 'stop'>> => {
             return client.getNode().getNode()
         }
 


### PR DESCRIPTION
Added `@hidden` TypeDoc annotation for internal methods:
- `getNode()`
- `getConfig()`

This way these methods are not included in the API docs. The internal `StreamrClient#getOperator()` was already annotated like this.

Removed redundant `@internal` annotations from the `NetworkNodeStub` as it is not used by any publicly available method anymore:
- also modified `NetworkNodeFacade#getNode()` to return `Promise<Omit<NetworkNodeStub, 'start' | 'stop'>>` as a consequence of removing the `@internal` annotations
- also removed unnecessary `@internal` annotation from `NetworkNodeFacade#setProxies()`

## Note

It would be possible annotate those method with `@internal`. But then the methods wouldn't be included to the  generated `.d.ts` files (as we use `"stripInternal": true` in `tsconfig.node.json`). The type definitions are needed by `node` and `cli-tools` packages which use these internal methods.