### PR TITLE
chore: Remove unnecessary `tsconfig.json` references

### DIFF
--- a/packages/autocertifier-client/tsconfig.jest.json
+++ b/packages/autocertifier-client/tsconfig.jest.json
@@ -6,8 +6,6 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
-        { "path": "../proto-rpc/tsconfig.node.json" }
+        { "path": "../utils/tsconfig.node.json" }
     ]
 }

--- a/packages/autocertifier-client/tsconfig.node.json
+++ b/packages/autocertifier-client/tsconfig.node.json
@@ -9,8 +9,6 @@
         "generated/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
-        { "path": "../proto-rpc/tsconfig.node.json" }
+        { "path": "../utils/tsconfig.node.json" }
     ]
 }

--- a/packages/proto-rpc/tsconfig.node.json
+++ b/packages/proto-rpc/tsconfig.node.json
@@ -9,7 +9,6 @@
         "generated/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" }
+        { "path": "../utils/tsconfig.node.json" }
     ]
 }


### PR DESCRIPTION
This is a cherry-pick from @juslesan's https://github.com/streamr-dev/network/pull/2842.

Removed `test-utils` dependency from `autocertifier-client` and `proto-rpc `packages. The dependency is unnecessary as `test-utils` is not used in these packages.

Also removed `proto-rpc `dependency from `autocertifier-client` package for the same reason.