### PR TITLE
fix(trackerless-network): `@streamr/test-utils` as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27587,7 +27587,6 @@
                 "@protobuf-ts/runtime-rpc": "^2.8.2",
                 "@streamr/dht": "102.0.0-beta.0",
                 "@streamr/proto-rpc": "102.0.0-beta.0",
-                "@streamr/test-utils": "102.0.0-beta.0",
                 "@streamr/utils": "102.0.0-beta.0",
                 "eventemitter3": "^5.0.0",
                 "lodash": "^4.17.21",
@@ -27597,6 +27596,7 @@
             },
             "devDependencies": {
                 "@streamr/browser-test-runner": "^0.0.1",
+                "@streamr/test-utils": "102.0.0-beta.0",
                 "@types/lodash": "^4.17.13",
                 "@types/yallist": "^4.0.1",
                 "expect": "^29.6.2",

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -32,7 +32,6 @@
     "@protobuf-ts/runtime-rpc": "^2.8.2",
     "@streamr/dht": "102.0.0-beta.0",
     "@streamr/proto-rpc": "102.0.0-beta.0",
-    "@streamr/test-utils": "102.0.0-beta.0",
     "@streamr/utils": "102.0.0-beta.0",
     "eventemitter3": "^5.0.0",
     "lodash": "^4.17.21",
@@ -42,6 +41,7 @@
   },
   "devDependencies": {
     "@streamr/browser-test-runner": "^0.0.1",
+    "@streamr/test-utils": "102.0.0-beta.0",
     "@types/lodash": "^4.17.13",
     "@types/yallist": "^4.0.1",
     "expect": "^29.6.2",


### PR DESCRIPTION
This is a cherry-pick from @juslesan's https://github.com/streamr-dev/network/pull/2842.

Moved `@streamr/test-utils` from `dependencies` to `devDependencies`. The package is used only in tests.