### PR TITLE
test(autocertifier-server): Remove `@streamr/test-utils` dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27000,7 +27000,6 @@
                 "copyARecordsToRoute53": "dist/bin/copyARecordsToRoute53.js"
             },
             "devDependencies": {
-                "@streamr/test-utils": "102.0.0-beta.0",
                 "@types/dns2": "^2.0.9",
                 "@types/express": "^4.17.21",
                 "@types/request": "^2.48.8",

--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -41,7 +41,6 @@
     "uuid": "^11.0.3"
   },
   "devDependencies": {
-    "@streamr/test-utils": "102.0.0-beta.0",
     "@types/dns2": "^2.0.9",
     "@types/express": "^4.17.21",
     "@types/request": "^2.48.8",


### PR DESCRIPTION
Removed the dependency as it was not used by any tests.