### PR TITLE
chore(sdk): Remove references to `vendor` directory

### DIFF
--- a/.github/workflows/reusable/cached-build/action.yml
+++ b/.github/workflows/reusable/cached-build/action.yml
@@ -26,7 +26,6 @@ runs:
         key: cache-build-${{ github.sha }}
         path: |
           packages/*/dist
-          packages/sdk/vendor
           packages/proto-rpc/src/proto
           packages/dht/src/proto
           packages/trackerless-network/src/proto

--- a/packages/sdk/eslint.config.mjs
+++ b/packages/sdk/eslint.config.mjs
@@ -4,7 +4,6 @@ export default [
     {
         ignores: [
             'src/ethereumArtifacts/**',
-            'vendor/**',
             'test/exports/**',
             'test/benchmarks/**',
             'test/memory/*',

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -27,7 +27,7 @@
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
     "check": "tsc -p ./tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist vendor *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "generate-protoc-code": "./proto.sh",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -26,7 +26,6 @@
         "package.json",
         "src/**/*",
         "src/**/*.json",
-        "vendor/**/*",
         "src/config.schema.json"
     ],
     "exclude": ["src/exports-esm.mjs"],

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -13,7 +13,6 @@
         "src/**/*",
         "src/**/*.json",
         "bin/generate-config-validator.js",
-        "vendor/**/*",
         "src/config.schema.json",
         "test/**/*",
         "test/**/*.json"

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -13,7 +13,6 @@
         "package.json",
         "src/**/*",
         "src/**/*.json",
-        "vendor/**/*",
         "src/config.schema.json"
     ],
     "exclude": [

--- a/packages/sdk/webpack.config.js
+++ b/packages/sdk/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env, argv) => {
             ]
         },
         resolve: {
-            modules: ['node_modules', ...require.resolve.paths(''), path.resolve('./vendor')],
+            modules: ['node_modules', ...require.resolve.paths('')],
             extensions: ['.json', '.js', '.ts'],
         },
         plugins: [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.node.json",
     "check": "tsc -p ./tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist vendor *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",
     "test-browser": "karma start karma.config.js"


### PR DESCRIPTION
It was previously used by `quick-lru`. That dependency was replaced in https://github.com/streamr-dev/network/pull/2924 and therefore the directory is no longer used.

## Other changes

Removed reference to the directory in `utils` package's `clean` command. There hasn't been `vendor` directory in that package. 