### PR TITLE
fix(sdk): [NET-1387] Character encoding error in minified browser bundle

### DIFF
--- a/packages/sdk/webpack.config.js
+++ b/packages/sdk/webpack.config.js
@@ -174,14 +174,15 @@ module.exports = (env, argv) => {
                             ecma: 2018,
                             output: {
                                 comments: false,
-                            },
-                        },
-                    }),
-                ],
+                                ascii_only: true
+                            }
+                        }
+                    })
+                ]
             },
             output: {
                 filename: '[name].web.min.js',
-            },
+            }
         })
     }
 }


### PR DESCRIPTION
## Changes

Added `ascii_only: true` option to `TerserPlugin`.

## Bug

There was a character encoding problem in minified browser bundle. The browser was unable to load the client when the client was loaded from local http server.

On Firefox it showed this error:
```
Uncaught SyntaxError: illegal character U+20AC [streamr-sdk-9143d44d2.web.min.js:2:2896284](http://localhost:8080/streamr-sdk-9143d44d2.web.min.js?cachemiss=1898789)
```

Similar error was shown in Chrome and Safari on Mac. Other operating systems were not tested.

That location contains an implementation which does some kind of translation for special characters. The characters were stored as plain Unicode characters. After the change the characters are escaped like this:
```
var or=Zt({\u00c0:"A",\u00c1:"A",\u00c2:"A",\u00c3:"A" ...
```

The bug occurred only if there was no character encoding information available for the JavaScript file. I.e. the information was not in the  `ContentType` HTTP header, nor there was e.g. `<meta charset="UTF-8">` in the `<head>` section.

## Production usage

There was no problem in the production as it specified the character encoding in the header:
```
curl -I -L https://unpkg.com/@streamr/sdk/streamr-sdk.web.js
...
content-type: application/javascript; charset=utf-8
```

i.e. this works ok:

```html
<!DOCTYPE html>
<html>
<body>
    <script src="https://unpkg.com/@streamr/sdk/streamr-sdk.web.js"></script>
    <script>
        const client = new StreamrClient()
        client.getAddress().then(console.log)
    </script>
</body>
</html>
```

## Other setups which work

1) Charset in html:

```html
<!DOCTYPE html>
<html>
<head>
    <meta charset="UTF-8">
</head>
<body>
    <script src="streamr-sdk-9143d44d2.web.min.js"></script>
    <script>
        const client = new StreamrClient()
        client.getUserId().then(console.log)
    </script>
</body>
</html>
```

2) Local web server provides character encoding info:

```python
#!/usr/bin/python3
import http.server
import socketserver

class NoCacheHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
    def end_headers(self):
        self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate')
        self.send_header('Pragma', 'no-cache')
        self.send_header('Expires', '0')
        super().end_headers()
    def guess_type(self, path):
        mime_type = super().guess_type(path)
        if path.endswith('.js'):
            return 'application/javascript; charset=utf-8'  # by default would use text/javascript and no explicit character encoding
        return mime_type

PORT = 8080

with socketserver.TCPServer(("", PORT), NoCacheHTTPRequestHandler) as httpd:
    print("Serving at port", PORT)
    httpd.serve_forever()
```
    
```html
<!DOCTYPE html>
<html>
<body>
    <script src="streamr-sdk-9143d44d2.web.min.js"></script>
    <script>
        const client = new StreamrClient()
        client.getUserId().then(console.log)
    </script>
</body>
</html>
```