### PR TITLE
refactor(network, dht): NET-1392 rename source to remote in appropriate places

### DIFF
--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -11,7 +11,7 @@ import { version as applicationVersion } from '../../package.json'
 const logger = new Logger(module)
 
 interface HandshakerEvents {
-    handshakeRequest: (source: PeerDescriptor, protocolVersion: string, target?: PeerDescriptor) => void
+    handshakeRequest: (remote: PeerDescriptor, protocolVersion: string, target?: PeerDescriptor) => void
     handshakeCompleted: (remote: PeerDescriptor) => void
     handshakeFailed: (error?: HandshakeError) => void
 }

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -168,7 +168,7 @@ export class WebrtcConnector {
             connection.once('localDescription', (description: string) => {
                 remoteConnector.sendRtcAnswer(description, connection.connectionId)
             })
-            handshaker.on('handshakeRequest', (_sourceDescriptor: PeerDescriptor, remoteVersion: string) => {
+            handshaker.on('handshakeRequest', (_remoteDescriptor: PeerDescriptor, remoteVersion: string) => {
                 if (!isMaybeSupportedProtocolVersion(remoteVersion)) {
                     rejectHandshake(pendingConnection!, connection, handshaker, HandshakeError.UNSUPPORTED_PROTOCOL_VERSION)
                 } else {

--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -88,7 +88,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
             rpcCommunicator: this.options.rpcCommunicator,
             markAndCheckDuplicate: (msg: MessageID, prev?: MessageRef) => markAndCheckDuplicate(this.duplicateDetectors, msg, prev),
             broadcast: (message: StreamMessage, previousNode?: DhtAddress) => this.broadcast(message, previousNode),
-            onLeaveNotice: (remoteNodeId: DhtAddress, sourceIsStreamEntryPoint: boolean) => {
+            onLeaveNotice: (remoteNodeId: DhtAddress, remoteIsStreamEntryPoint: boolean) => {
                 if (this.abortController.signal.aborted) {
                     return
                 }
@@ -107,7 +107,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
                     this.options.neighborFinder.start([remoteNodeId])
                     this.options.proxyConnectionRpcLocal?.removeConnection(remoteNodeId)
                 }
-                if (sourceIsStreamEntryPoint) {
+                if (remoteIsStreamEntryPoint) {
                     this.emit('entryPointLeaveDetected')
                 }
             },


### PR DESCRIPTION
## Summary

Renamed references from source to remote in appropriate places. Using the source/target pattern makes sense if there is a need to indicate clearly who is sending and who is receiving. If the sender and receiver is already implicitly known it makes more sense to use remote/local

## Future improvements

- Go over places where the source naming convention is used.
  - For example: In the routing wrappers the source is called sourcePeer. It could make more sense to name it just source. This holds true for any other places where we use ie sourcePeerDescriptor. As the type is known there is no need to include it in the name.
- Rename source to originator? IMO this is not a necessary change since both words have the same meaning in this context
