### PR TITLE
feat(sdk): Export stream metadata utils

### DIFF
--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -3,7 +3,7 @@
  */
 export { StreamrClient, SubscribeOptions, ExtraSubscribeOptions } from './StreamrClient'
 export { Stream } from './Stream'
-export { StreamMetadata } from './StreamMetadata'
+export { StreamMetadata, parseMetadata as parseStreamMetadata, getPartitionCount as getStreamPartitionCount } from './StreamMetadata'
 export { Message, MessageMetadata } from './Message'
 export { StreamrClientEvents } from './events'
 export { PublishMetadata } from './publish/Publisher'


### PR DESCRIPTION
Export `parseStreamMetadata()` and `getStreamPartitionCount()` utility functions. Note that we've added word _stream_ to make it more explicit which kind of metadata these process.

The `getStreamPartitionCount()` is needed e.g. when parsing `StreamMetadata` which has been emitted from `streamCreated` event. For other usages `parseStreamMetadata()` is maybe useful.