### PR TITLE
Switch to using helsinki.fi instead of suomi.fi in GeoIpLocation tests

### DIFF
--- a/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
@@ -8,12 +8,12 @@ import { LOCAL_PROTOCOL_VERSION } from '../../src/helpers/version'
 import { WebsocketServerConnection } from '../../src/connection/websocket/WebsocketServerConnection'
 import fs from 'fs'
 
-// www.gov.za
-const testIp = '164.151.129.20'
+// helsinki.fi
+const testIp = '128.214.222.50'
 
-// Pretoria, South Africa
-const testLatitude = -25.7599
-const testLongitude = 28.2604
+// Helsinki, Finland
+const testLatitude = 60.1719
+const testLongitude = 24.9347
 
 const dbPath = '/tmp/geoipdatabasesintegration'
 

--- a/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
@@ -96,12 +96,12 @@ describe('GeoIpLocator', () => {
         // expect the db to be there
         await until(() => fs.existsSync(dbDir + '/' + DB_FILENAME), 10000)
 
-        // suomi.fi
-        const location = locator.lookup('62.241.198.245')
+        // helsinki.fi
+        const location = locator.lookup('128.214.222.50')
         expect(location).toBeDefined()
 
         // Helsinki, Finland
-        expect(location!.latitude).toBe(60.1797)
-        expect(location!.longitude).toBe(24.9344)
+        expect(location!.latitude).toBe(60.1719)
+        expect(location!.longitude).toBe(24.9347)
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
@@ -43,13 +43,13 @@ describe('GeoIpLocatorNoNetworkAtMonthly', () => {
 
         fetchMock.mockRestore()
 
-        // suomi.fi
-        const location = locator!.lookup('62.241.198.245')
+        // helsinki.fi
+        const location = locator!.lookup('128.214.222.50')
         expect(location).toBeDefined()
 
         // Helsinki, Finland
-        expect(location!.latitude).toBe(60.1797)
-        expect(location!.longitude).toBe(24.9344)
+        expect(location!.latitude).toBe(60.1719)
+        expect(location!.longitude).toBe(24.9347)
 
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator.test.ts
@@ -33,14 +33,14 @@ describe('GeoIpLocator', () => {
             locator = new GeoIpLocator(dbDir, 5000, 5000, serverUrl)
             await locator.start()
 
-            // suomi.fi
-            const location = locator.lookup('62.241.198.245')
+            // helsinki.fi
+            const location = locator.lookup('128.214.222.50')
     
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1797)
-            expect(location!.longitude).toBe(24.9344)
+            expect(location!.latitude).toBe(60.1719)
+            expect(location!.longitude).toBe(24.9347)
         
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -70,13 +70,13 @@ describe('GeoIpLocator', () => {
 
             await wait(7000)
     
-            // suomi.fi
-            const location = locator.lookup('62.241.198.245')
+            // helsinki.fi
+            const location = locator.lookup('128.214.222.50')
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1797)
-            expect(location!.longitude).toBe(24.9344)
+            expect(location!.latitude).toBe(60.1719)
+            expect(location!.longitude).toBe(24.9347)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -92,13 +92,13 @@ describe('GeoIpLocator', () => {
     
             await wait(10000)
     
-            // suomi.fi
-            const location = locator.lookup('62.241.198.245')
+            // helsinki.fi
+            const location = locator.lookup('128.214.222.50')
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1797)
-            expect(location!.longitude).toBe(24.9344)
+            expect(location!.latitude).toBe(60.1719)
+            expect(location!.longitude).toBe(24.9347)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -110,7 +110,7 @@ describe('GeoIpLocator', () => {
         it('returns undefined if not started', async () => {
             const dbDir = getDbDir()
             const locator = new GeoIpLocator(dbDir)
-            const location = locator.lookup('62.241.198.245')
+            const location = locator.lookup('128.214.222.50')
             expect(location).toBeUndefined()
         })
 


### PR DESCRIPTION
* The coodrinates of suomi.fi had apparently changed in the geoip databases, which caused the GeoIpLocation tests to fail
* This pull request fixes the problem by using helsinki.fi as the address whose location is checked in the tests instead. Helsinki.fi is the domain of the university of Helsinki, and its coordinates are unlikely to change in the near future as the university has its own IT department and the domain is not hosted at third-party cloud providers.
