### PR TITLE
NET-1383: Reduce the size of the routing tables to 5 for performance

### DIFF
--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -16,7 +16,7 @@ import { RoutingTable, RoutingTablesCache } from './RoutingTablesCache'
 const logger = new Logger(module)
 
 const MAX_FAILED_HOPS = 2
-const ROUTING_TABLE_MAX_SIZE = 8
+const ROUTING_TABLE_MAX_SIZE = 5
 
 export class RoutingRemoteContact extends Contact {
 
@@ -163,7 +163,7 @@ export class RoutingSession extends EventEmitter<RoutingSessionEvents> {
         const previousId = previousPeer ? toNodeId(previousPeer) : undefined
         const targetId = toDhtAddress(this.options.routedMessage.target)
         let routingTable: RoutingTable
-        if (this.options.routingTablesCache.has(targetId, previousId)) {
+        if (this.options.routingTablesCache.has(targetId, previousId) && this.options.routingTablesCache.get(targetId, previousId)!.getSize() > 0) {
             routingTable = this.options.routingTablesCache.get(targetId, previousId)!
         } else {
             routingTable = new SortedContactList<RoutingRemoteContact>({

--- a/packages/dht/src/dht/routing/RoutingSession.ts
+++ b/packages/dht/src/dht/routing/RoutingSession.ts
@@ -16,7 +16,7 @@ import { RoutingTable, RoutingTablesCache } from './RoutingTablesCache'
 const logger = new Logger(module)
 
 const MAX_FAILED_HOPS = 2
-const ROUTING_TABLE_MAX_SIZE = 20
+const ROUTING_TABLE_MAX_SIZE = 8
 
 export class RoutingRemoteContact extends Contact {
 

--- a/packages/dht/src/dht/routing/RoutingTablesCache.ts
+++ b/packages/dht/src/dht/routing/RoutingTablesCache.ts
@@ -6,7 +6,7 @@ import { LRUCache } from 'lru-cache'
 type RoutingTableID = string
 export type RoutingTable = Pick<
     SortedContactList<RoutingRemoteContact>,
-    'getClosestContacts' | 'addContacts' | 'addContact' | 'removeContact' | 'stop'>
+    'getClosestContacts' | 'addContacts' | 'addContact' | 'removeContact' | 'stop' | 'getSize'>
 
 const createRoutingTableId = (targetId: DhtAddress, previousId?: DhtAddress): RoutingTableID => {
     return targetId + (previousId ? previousId : '')

--- a/packages/dht/test/unit/RoutingSession.test.ts
+++ b/packages/dht/test/unit/RoutingSession.test.ts
@@ -76,4 +76,11 @@ describe('RoutingSession', () => {
         expect(session.updateAndGetRoutablePeers().length).toBe(0)
     })
 
+    it('recalculates Routing Table if it is empty', () => {
+        connections.set(toNodeId(mockPeerDescriptor2), createMockDhtNodeRpcRemote(mockPeerDescriptor2))
+        expect(session.updateAndGetRoutablePeers().length).toBe(1)
+        routingTablesCache.onNodeDisconnected(toNodeId(mockPeerDescriptor2))
+        expect(session.updateAndGetRoutablePeers().length).toBe(1)
+    })
+
 })


### PR DESCRIPTION
## Summary

Reduce the size of the routing tables for performance. This reduces used memory in the cache and CPU when constructing the routing tables.
