### PR TITLE
 fix [NET-1407]: add missing .npmignore files so that protobuf files are included in NPM packaging

### DIFF
--- a/packages/autocertifier-client/.npmignore
+++ b/packages/autocertifier-client/.npmignore
@@ -1,0 +1,10 @@
+.idea
+/src
+/test
+/generated
+jest.config.js
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+.eslintignore
+.eslintrc

--- a/packages/dht/.npmignore
+++ b/packages/dht/.npmignore
@@ -1,0 +1,10 @@
+.idea
+/src
+/test
+/generated
+jest.config.js
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+.eslintignore
+.eslintrc

--- a/packages/proto-rpc/.npmignore
+++ b/packages/proto-rpc/.npmignore
@@ -1,0 +1,11 @@
+.idea
+/src
+/test
+/generated
+/examples
+jest.config.js
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+.eslintignore
+.eslintrc

--- a/packages/trackerless-network/.npmignore
+++ b/packages/trackerless-network/.npmignore
@@ -1,0 +1,10 @@
+.idea
+/src
+/test
+/generated
+jest.config.js
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+.eslintignore
+.eslintrc


### PR DESCRIPTION
## Summary

In the absence of the _.npmignore_ file the _.gitignore_ file will be used instead by NPM to exclude files from packaging. This caused an issue for us in some packages as generated protobuf descriptions were not included.

Example error  
```
2025-01-22T14:26:44: Error: Cannot find module '../../generated/packages/dht/protos/DhtRpc'
2025-01-22T14:26:44: Require stack:
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/connection/ConnectionManager.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/dht/DhtNode.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/exports.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/logic/ExternalNetworkRpc.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/NetworkNode.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/exports.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/NetworkNodeFacade.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/publish/Publisher.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/StreamrClient.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/exports.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/exports-commonjs.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/dist/src/broker.js
2025-01-22T14:26:44: - /root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/dist/bin/streamr-node.js
2025-01-22T14:26:44:     at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
2025-01-22T14:26:44:     at Hook._require.Module.require (/root/.nvm/versions/node/v20.15.0/lib/node_modules/pm2/node_modules/require-in-the-middle/index.js:81:25)
2025-01-22T14:26:44:     at require (node:internal/modules/helpers:179:18)
2025-01-22T14:26:44:     at Object.<anonymous> (/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/connection/ConnectionManager.js:42:18)
2025-01-22T14:26:44:     at Module._compile (node:internal/modules/cjs/loader:1358:14)
2025-01-22T14:26:44:     at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
2025-01-22T14:26:44:     at Module.load (node:internal/modules/cjs/loader:1208:32)
2025-01-22T14:26:44:     at Module._load (node:internal/modules/cjs/loader:1024:12)
2025-01-22T14:26:44:     at Module.require (node:internal/modules/cjs/loader:1233:19)
2025-01-22T14:26:44:     at Hook._require.Module.require (/root/.nvm/versions/node/v20.15.0/lib/node_modules/pm2/node_modules/require-in-the-middle/index.js:101:39) {
2025-01-22T14:26:44:   code: 'MODULE_NOT_FOUND',
2025-01-22T14:26:44:   requireStack: [
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/connection/ConnectionManager.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/dht/DhtNode.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/dht/dist/src/exports.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/logic/ExternalNetworkRpc.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/NetworkNode.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/trackerless-network/dist/src/exports.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/NetworkNodeFacade.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/publish/Publisher.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/StreamrClient.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/exports.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/node_modules/@streamr/sdk/src/exports-commonjs.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/dist/src/broker.js',
2025-01-22T14:26:44:     '/root/.nvm/versions/node/v20.15.0/lib/node_modules/@streamr/node/dist/bin/streamr-node.js'
2025-01-22T14:26:44:   ]
2025-01-22T14:26:44: }
```

## Future improvements
- The _.npmignore_ files could be harmonized across sub-packages.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
