### PR TITLE
ci: Default value for `tag` in NPM publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: latest
         options:
+          - <SELECT>
           - latest
           - beta
           - alpha

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,7 @@ on:
       tag:
         type: choice
         required: true
-        default: latest
+        default: <SELECT>
         options:
           - <SELECT>
           - latest

--- a/release.sh
+++ b/release.sh
@@ -7,6 +7,12 @@ if [[ "$1" == "" ]]; then
     exit 1
 fi
 
+# check that there was some tag value selected in the manual workflow UI (see publish-npm.yml)
+if [[ "$1" == "<SELECT>" ]]; then
+    echo 'invalid value for "tag"'
+    exit 1
+fi
+
 npm run build
 
 # Build sdk webpack bundle


### PR DESCRIPTION
Require that we select tag explicitly.