### PR TITLE
fix(test-utils): Update `files` list in `package.json`

### DIFF
--- a/packages/test-utils/.npmignore
+++ b/packages/test-utils/.npmignore
@@ -1,9 +1,0 @@
-.idea
-/src
-/test
-jest.config.js
-tsconfig.json
-tsconfig.*.json
-*.tsbuildinfo
-.eslintignore
-.eslintrc

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,8 +10,10 @@
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [
-    "customMatchers.d.ts",
-    "setupCustomMatchers.js"
+    "dist/",
+    "!dist/tsconfig.node.tsbuildinfo",
+    "setupCustomMatchers.js",
+    "customMatcherTypes.d.ts"
   ],
   "scripts": {
     "build": "tsc --build tsconfig.node.json",


### PR DESCRIPTION
The "files" list didn't include `dist`. Therefore the main JS file and the type definition file weren't included in the published NPM package. Also fixed the name of custom matcher type definition file.