### PR TITLE
test: [NET-1420] Use `createTestWallet()` instead of `fastWallet()`

### DIFF
--- a/packages/node/test/integration/broker-subscriptions.test.ts
+++ b/packages/node/test/integration/broker-subscriptions.test.ts
@@ -1,5 +1,5 @@
 import { Stream, StreamPartID, StreamPermission, StreamrClient } from '@streamr/sdk'
-import { createTestPrivateKey, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { until, wait } from '@streamr/utils'
 import mqtt, { AsyncMqttClient } from 'async-mqtt'
 import { Wallet } from 'ethers'
@@ -41,8 +41,8 @@ describe('broker subscriptions', () => {
     let mqttClient2: AsyncMqttClient
 
     beforeEach(async () => {
-        const broker1User = fastWallet()
-        const broker2User = fastWallet()
+        const broker1User = await createTestWallet()
+        const broker2User = await createTestWallet()
         broker1 = await startBroker({
             privateKey: broker1User.privateKey,
             extraPlugins: {

--- a/packages/node/test/integration/multiple-publisher-plugins.test.ts
+++ b/packages/node/test/integration/multiple-publisher-plugins.test.ts
@@ -1,5 +1,5 @@
 import { StreamPermission } from '@streamr/sdk'
-import { createTestPrivateKey, fastPrivateKey, Queue } from '@streamr/test-utils'
+import { createTestPrivateKey, Queue } from '@streamr/test-utils'
 import { until, wait, waitForEvent } from '@streamr/utils'
 import mqtt, { AsyncMqttClient } from 'async-mqtt'
 import range from 'lodash/range'
@@ -135,7 +135,7 @@ describe('multiple publisher plugins', () => {
     it('subscribe by StreamrClient', async () => {
 
         const receivedMessages: Queue<unknown> = new Queue()
-        const subscriber = createClient(fastPrivateKey())
+        const subscriber = createClient()
         await subscriber.subscribe(streamId, (message: unknown) => {
             receivedMessages.push(message)
         })

--- a/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
+++ b/packages/node/test/integration/plugins/operator/MaintainTopologyService.test.ts
@@ -1,7 +1,7 @@
 import {
     Stream, StreamrClient, _operatorContractUtils
 } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { StreamPartID, toEthereumAddress, until } from '@streamr/utils'
 import { parseEther } from 'ethers'
 import { MaintainTopologyHelper } from '../../../../src/plugins/operator/MaintainTopologyHelper'
@@ -56,7 +56,7 @@ describe('MaintainTopologyService', () => {
     let operatorFleetState: OperatorFleetState
 
     beforeEach(() => {
-        client = createClient(fastPrivateKey())
+        client = createClient()
     })
 
     afterEach(async () => {

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -5,7 +5,7 @@ import {
     StreamPermission,
     _operatorContractUtils
 } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { EthereumAddress, collect, toEthereumAddress, toStreamPartID, until } from '@streamr/utils'
 import { Wallet, parseEther } from 'ethers'
 import { cloneDeep, set } from 'lodash'
@@ -45,7 +45,7 @@ describe('OperatorPlugin', () => {
     })
 
     async function waitForHeartbeatMessage(operatorContractAddress: EthereumAddress): Promise<void> {
-        const client = createClient(fastPrivateKey())
+        const client = createClient()
         const sub = await client.subscribe(formCoordinationStreamId(operatorContractAddress))
         await collect(sub, 1)
         await client.destroy()
@@ -61,7 +61,7 @@ describe('OperatorPlugin', () => {
         await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('10000'))
         await stake(operatorContract, await sponsorship1.getAddress(), parseEther('10000'))
 
-        const publisher = createClient(fastPrivateKey())
+        const publisher = createClient()
         await stream.grantPermissions({
             permissions: [StreamPermission.PUBLISH],
             userId: await publisher.getUserId()

--- a/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
+++ b/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
@@ -1,5 +1,5 @@
 import { _operatorContractUtils } from '@streamr/sdk'
-import { fastPrivateKey, createTestWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { collect, toEthereumAddress } from '@streamr/utils'
 import { version as applicationVersion } from '../../../../package.json'
 import { announceNodeToStream } from '../../../../src/plugins/operator/announceNodeToStream'
@@ -19,7 +19,7 @@ describe('announceNodeToStream', () => {
         const nodeWallet = nodeWallets[0]
         const client = createClient(nodeWallet.privateKey)
         const streamId = formCoordinationStreamId(operatorContractAddress)
-        const anonymousClient = createClient(fastPrivateKey())
+        const anonymousClient = createClient()
         const subscription = await anonymousClient.subscribe(streamId)
 
         await announceNodeToStream(operatorContractAddress, client)

--- a/packages/node/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
+++ b/packages/node/test/integration/plugins/subscriber/SubscriberPlugin.test.ts
@@ -1,18 +1,10 @@
 import { createClient } from '../../../utils'
 import { SubscriberPlugin } from '../../../../src/plugins/subscriber/SubscriberPlugin'
 import { StreamrClient } from '@streamr/sdk'
-import { fastWallet } from '@streamr/test-utils'
 import { until } from '@streamr/utils'
-
-const wallet = fastWallet()
 
 const createMockPlugin = async () => {
     const brokerConfig: any = {
-        client: {
-            auth: {
-                privateKey: wallet.privateKey
-            }
-        },
         plugins: {
             subscriber: {
                 streams: [
@@ -40,7 +32,7 @@ describe('Subscriber Plugin', () => {
     let plugin: any
 
     beforeAll(async () => {
-        client = createClient(wallet.privateKey)
+        client = createClient()
         plugin = await createMockPlugin()
         await plugin.start(client)
     })

--- a/packages/node/test/utils.ts
+++ b/packages/node/test/utils.ts
@@ -75,15 +75,13 @@ export const createEthereumAddress = (id: number): EthereumAddress => {
 }
 
 export const createClient = (
-    privateKey: string,
+    privateKey?: string,
     clientOptions?: StreamrClientConfig
 ): StreamrClient => {
     const opts = merge<StreamrClientConfig>(
         {
             environment: 'dev2',
-            auth: {
-                privateKey
-            }
+            auth: (privateKey !== undefined) ? { privateKey } : undefined
         },
         clientOptions
     )

--- a/packages/sdk/test/benchmarks/signingUtils.test.ts
+++ b/packages/sdk/test/benchmarks/signingUtils.test.ts
@@ -1,7 +1,6 @@
+import { createTestWallet } from '@streamr/test-utils'
+import { areEqualBinaries, binaryToHex, createSignature, hexToBinary, randomString, toEthereumAddress, verifySignature } from '@streamr/utils'
 import { verifyMessage, Wallet } from 'ethers'
-import { randomString, toEthereumAddress, hexToBinary, areEqualBinaries, binaryToHex } from '@streamr/utils'
-import { fastWallet } from '@streamr/test-utils'
-import { createSignature, verifySignature } from '@streamr/utils'
 
 /*
  * Benchmarking signingUtils against ether.js implementation. This test is skipped
@@ -33,7 +32,7 @@ describe('SigningUtil', () => {
         let payload: Uint8Array
 
         beforeEach(async () => {
-            wallet = fastWallet()
+            wallet = await createTestWallet()
             payload = Buffer.from(randomString(payloadSize))
             hexSignature = await wallet.signMessage(payload)
             binarySignature = hexToBinary(hexSignature)  

--- a/packages/sdk/test/end-to-end/Permissions.test.ts
+++ b/packages/sdk/test/end-to-end/Permissions.test.ts
@@ -1,4 +1,4 @@
-import { createTestWallet, fastWallet, randomUserId } from '@streamr/test-utils'
+import { createTestWallet, randomUserId } from '@streamr/test-utils'
 import { toUserId } from '@streamr/utils'
 import { randomBytes } from 'crypto'
 import { Wallet } from 'ethers'
@@ -17,7 +17,7 @@ describe('Stream permissions', () => {
 
     beforeAll(async () => {
         const wallet = await createTestWallet({ gas: true })
-        otherUser = fastWallet()
+        otherUser = await createTestWallet()
         client = new StreamrClient({
             environment: 'dev2',
             auth: {

--- a/packages/sdk/test/end-to-end/StreamrClient.test.ts
+++ b/packages/sdk/test/end-to-end/StreamrClient.test.ts
@@ -1,4 +1,4 @@
-import { fastPrivateKey, isRunningInElectron } from '@streamr/test-utils'
+import { isRunningInElectron } from '@streamr/test-utils'
 import { StreamrClient } from '../../src'
 
 describe('StreamrClient', () => {
@@ -6,10 +6,7 @@ describe('StreamrClient', () => {
 
     beforeEach(async () => {
         client = new StreamrClient({
-            environment: 'dev2',
-            auth: {
-                privateKey: fastPrivateKey(),
-            }
+            environment: 'dev2'
         })
     }, 30 * 1000)
 

--- a/packages/sdk/test/end-to-end/binary-publish.test.ts
+++ b/packages/sdk/test/end-to-end/binary-publish.test.ts
@@ -1,4 +1,4 @@
-import { createTestPrivateKey, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { areEqualBinaries, until } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { StreamPermission } from '../../src/permission'
@@ -20,7 +20,7 @@ describe('binary publish', () => {
     const TIMEOUT = 15 * 1000
 
     beforeAll(async () => {
-        subscriberWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
         publisherPk = await createTestPrivateKey({ gas: true })
     }, 30 * 1000)
 

--- a/packages/sdk/test/end-to-end/contract-call-error.test.ts
+++ b/packages/sdk/test/end-to-end/contract-call-error.test.ts
@@ -1,4 +1,4 @@
-import { createTestPrivateKey, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import { StreamrClient } from '../../src/StreamrClient'
 
 describe('contract call error', () => {
@@ -6,10 +6,7 @@ describe('contract call error', () => {
     // TODO: see NET-1007, could improve error messages in fast-chain
     it('insufficient funds', async () => {
         const client = new StreamrClient({
-            environment: 'dev2',
-            auth: {
-                privateKey: fastWallet().privateKey
-            }
+            environment: 'dev2'
         })
         await expect(() => client.createStream('/path')).rejects.toThrow(
             'Error while executing contract call "streamRegistry.createStream", code=UNKNOWN_ERROR'

--- a/packages/sdk/test/end-to-end/erc1271-publish-subscribe.test.ts
+++ b/packages/sdk/test/end-to-end/erc1271-publish-subscribe.test.ts
@@ -1,4 +1,4 @@
-import { createTestPrivateKey, createTestWallet, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { EthereumAddress, StreamID, areEqualBinaries, toEthereumAddress, until } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { MessageMetadata } from '../../src'
@@ -16,7 +16,7 @@ describe('ERC-1271: publish', () => {
     let erc1271ContractAddress: EthereumAddress
 
     beforeAll(async () => {
-        subscriberWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
         publisherWallet = await createTestWallet({ gas: true })
         erc1271ContractAddress = await deployTestERC1271Contract([toEthereumAddress(publisherWallet.address)])
     }, TIMEOUT)
@@ -82,7 +82,7 @@ describe('ERC-1271: subscribe', () => {
     let erc1271ContractAddress: EthereumAddress
 
     beforeAll(async () => {
-        subscriberWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
         publisherWallet = await createTestWallet({ gas: true })
         erc1271ContractAddress = await deployTestERC1271Contract([toEthereumAddress(subscriberWallet.address)])
     }, TIMEOUT)
@@ -143,7 +143,7 @@ describe('ERC-1271: publish and subscribe', () => {
     let erc1271PublisherContractAddress: EthereumAddress
 
     beforeAll(async () => {
-        subscriberWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
         publisherWallet = await createTestWallet({ gas: true })
         erc1271SubscriberContractAddress = await deployTestERC1271Contract([toEthereumAddress(subscriberWallet.address)])
         erc1271PublisherContractAddress = await deployTestERC1271Contract([toEthereumAddress(publisherWallet.address)])

--- a/packages/sdk/test/end-to-end/publish-subscribe-via-proxy.test.ts
+++ b/packages/sdk/test/end-to-end/publish-subscribe-via-proxy.test.ts
@@ -1,4 +1,4 @@
-import { createTestPrivateKey, describeOnlyInNodeJs, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, describeOnlyInNodeJs } from '@streamr/test-utils'
 import { ProxyDirection } from '@streamr/trackerless-network'
 import { collect, wait, withTimeout } from '@streamr/utils'
 import { Wallet } from 'ethers'
@@ -15,12 +15,12 @@ describeOnlyInNodeJs('publish/subscribe via proxy', () => { // Cannot run proxy 
 
     let stream: Stream
     let client: StreamrClient
-    let proxyUser: Wallet = fastWallet()
+    let proxyUser: Wallet
 
     beforeEach(async () => {
         client = createTestClient(await createTestPrivateKey({ gas: true }))
         stream = await createTestStream(client, module)
-        proxyUser = fastWallet()
+        proxyUser = await createTestWallet()
         await stream.grantPermissions({
             permissions: [StreamPermission.PUBLISH, StreamPermission.SUBSCRIBE],
             userId: proxyUser.address

--- a/packages/sdk/test/end-to-end/publish-subscribe.test.ts
+++ b/packages/sdk/test/end-to-end/publish-subscribe.test.ts
@@ -1,6 +1,6 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { DhtAddress, NodeType, toDhtAddressRaw } from '@streamr/dht'
-import { createTestPrivateKey, fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { createNetworkNode } from '@streamr/trackerless-network'
 import { StreamID, toStreamPartID, until } from '@streamr/utils'
 import { Wallet } from 'ethers'
@@ -65,7 +65,7 @@ describe('publish-subscribe', () => {
     let subscriberClient: StreamrClient
 
     beforeAll(async () => {
-        subscriberWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
         publisherPk = await createTestPrivateKey({ gas: true })
     })
 

--- a/packages/sdk/test/end-to-end/resend.test.ts
+++ b/packages/sdk/test/end-to-end/resend.test.ts
@@ -1,4 +1,4 @@
-import { createTestPrivateKey, fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import { until, wait } from '@streamr/utils'
 import { randomBytes } from 'crypto'
 import random from 'lodash/random'
@@ -21,7 +21,7 @@ describe('resend', () => {
 
     beforeEach(async () => {
         publisherClient = createTestClient(await createTestPrivateKey({ gas: true }), 43232)
-        resendClient = createTestClient(fastPrivateKey(), 43233)
+        resendClient = createTestClient(undefined, 43233)
         const binaryPayloads = range(NUM_OF_MESSAGES / 2).map(() => randomBytes(random(0, 256)))
         const jsonPayloads = range(NUM_OF_MESSAGES / 2).map((idx) => ({ idx }))
         payloads = shuffle([...binaryPayloads, ...jsonPayloads])

--- a/packages/sdk/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/sdk/test/integration/GroupKeyPersistence.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import { collect, toStreamPartID, until } from '@streamr/utils'
 import { Message } from '../../src/Message'
 import { Stream } from '../../src/Stream'
@@ -50,8 +50,8 @@ describe('Group Key Persistence', () => {
             return client
         }
         beforeEach(async () => {
-            publisherPrivateKey = fastPrivateKey()
-            subscriberPrivateKey = fastPrivateKey()
+            publisherPrivateKey = await createTestPrivateKey()
+            subscriberPrivateKey = await createTestPrivateKey()
 
             publisher = await setupPublisher({
                 id: 'publisher',

--- a/packages/sdk/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/sdk/test/integration/NetworkNodeFacade.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey } from '@streamr/test-utils'
 import { NetworkNodeStub } from '../../src/NetworkNodeFacade'
 import { StreamrClient } from '../../src/StreamrClient'
 import { peerDescriptorTranslator } from '../../src/utils/utils'
@@ -28,11 +27,7 @@ describe('NetworkNodeFacade', () => {
         }
 
         beforeEach(async () => {
-            client = environment.createClient({
-                auth: {
-                    privateKey: fastPrivateKey()
-                }
-            })
+            client = environment.createClient()
         })
 
         it('caches node', async () => {

--- a/packages/sdk/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/sdk/test/integration/PublisherKeyExchange.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import { EthereumAddress, StreamPartID, StreamPartIDUtils, toUserId, UserID } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -64,8 +64,8 @@ describe('PublisherKeyExchange', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = fastWallet()
-        subscriberWallet = fastWallet()
+        publisherWallet = await createTestWallet()
+        subscriberWallet = await createTestWallet()
         environment = new FakeEnvironment()
         publisherClient = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/Resends.test.ts
+++ b/packages/sdk/test/integration/Resends.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { mock } from 'jest-mock-extended'
 import { createPrivateKeyAuthentication } from '../../src/Authentication'
@@ -22,7 +22,7 @@ describe('Resends', () => {
     let environment: FakeEnvironment
 
     beforeEach(async () => {
-        const publisherPrivateKey = fastWallet().privateKey
+        const publisherPrivateKey = await createTestPrivateKey()
         environment = new FakeEnvironment()
         const publisher = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/Resends2.test.ts
+++ b/packages/sdk/test/integration/Resends2.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { StreamID, collect, toStreamPartID, until } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { Message, MessageMetadata } from '../../src/Message'
@@ -29,9 +29,9 @@ describe('Resends2', () => {
         return task(count)
     }
 
-    beforeAll(() => {
+    beforeAll(async () => {
         environment = new FakeEnvironment()
-        publisherWallet = fastWallet()
+        publisherWallet = await createTestWallet()
         publisher = environment.createClient({
             auth: {
                 privateKey: publisherWallet.privateKey

--- a/packages/sdk/test/integration/StreamrClient.test.ts
+++ b/packages/sdk/test/integration/StreamrClient.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey, createTestWallet } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { Defer, StreamPartID, StreamPartIDUtils, collect, wait } from '@streamr/utils'
 import { MessageMetadata } from '../../src/Message'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -27,7 +27,7 @@ describe('StreamrClient', () => {
     let environment: FakeEnvironment
 
     beforeEach(async () => {
-        privateKey = fastPrivateKey()
+        privateKey = await createTestPrivateKey()
         environment = new FakeEnvironment()
         client = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/StreamrClient.test.ts
+++ b/packages/sdk/test/integration/StreamrClient.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey, fastWallet } from '@streamr/test-utils'
+import { fastPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { Defer, StreamPartID, StreamPartIDUtils, collect, wait } from '@streamr/utils'
 import { MessageMetadata } from '../../src/Message'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -36,7 +36,7 @@ describe('StreamrClient', () => {
         })
         const stream = await createTestStream(client, module)
         streamDefinition = (await stream.getStreamParts())[0]
-        const publisherWallet = fastWallet()
+        const publisherWallet = await createTestWallet()
         await stream.grantPermissions({
             userId: publisherWallet.address,
             permissions: [StreamPermission.PUBLISH]

--- a/packages/sdk/test/integration/Subscriber.test.ts
+++ b/packages/sdk/test/integration/Subscriber.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -21,8 +21,8 @@ describe('Subscriber', () => {
     let environment: FakeEnvironment
 
     beforeEach(async () => {
-        subscriberWallet = fastWallet()
-        publisherWallet = fastWallet()
+        subscriberWallet = await createTestWallet()
+        publisherWallet = await createTestWallet()
         environment = new FakeEnvironment()
         subscriber = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/Subscriber2.test.ts
+++ b/packages/sdk/test/integration/Subscriber2.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
-import { Defer, StreamID, collect, utf8ToBinary, until, toUserId } from '@streamr/utils'
+import { createTestWallet } from '@streamr/test-utils'
+import { Defer, StreamID, collect, toUserId, until, utf8ToBinary } from '@streamr/utils'
 import sample from 'lodash/sample'
 import shuffle from 'lodash/shuffle'
 import { createPrivateKeyAuthentication } from '../../src/Authentication'
@@ -63,7 +63,7 @@ describe('Subscriber', () => {
 
     beforeAll(async () => {
         environment = new FakeEnvironment()
-        const publisherWallet = fastWallet()
+        const publisherWallet = await createTestWallet()
         publisher = environment.createClient({
             auth: {
                 privateKey: publisherWallet.privateKey

--- a/packages/sdk/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/sdk/test/integration/SubscriberKeyExchange.test.ts
@@ -1,14 +1,14 @@
 import 'reflect-metadata'
 
-import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import {
     StreamID,
     StreamPartID,
     StreamPartIDUtils,
     toStreamPartID,
     toUserId,
-    UserID,
-    until
+    until,
+    UserID
 } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { StreamrClient } from '../../src/StreamrClient'
@@ -80,8 +80,8 @@ describe('SubscriberKeyExchange', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = fastWallet()
-        subscriberWallet = fastWallet()
+        publisherWallet = await createTestWallet()
+        subscriberWallet = await createTestWallet()
         environment = new FakeEnvironment()
         subscriber = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/gap-fill.test.ts
+++ b/packages/sdk/test/integration/gap-fill.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet, testOnlyInNodeJs } from '@streamr/test-utils'
+import { createTestWallet, testOnlyInNodeJs } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { mock } from 'jest-mock-extended'
@@ -31,7 +31,7 @@ describe('gap fill', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = fastWallet()
+        publisherWallet = await createTestWallet()
         environment = new FakeEnvironment()
         const publisher = environment.createClient({
             auth: {

--- a/packages/sdk/test/integration/invalid-messages.test.ts
+++ b/packages/sdk/test/integration/invalid-messages.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { StreamID, toStreamPartID, wait } from '@streamr/utils'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'
@@ -48,7 +48,7 @@ describe('client behaviour on invalid message', () => {
         await subscriberClient.subscribe(streamId, () => {
             throw new Error('should not get here')
         })
-        const publisherWallet = fastWallet()
+        const publisherWallet = await createTestWallet()
         const msg = await createMockMessage({
             streamPartId: toStreamPartID(streamId, 0),
             publisher: publisherWallet

--- a/packages/sdk/test/integration/parallel-publish.test.ts
+++ b/packages/sdk/test/integration/parallel-publish.test.ts
@@ -3,7 +3,6 @@ import 'reflect-metadata'
 import { wait } from '@streamr/utils'
 import random from 'lodash/random'
 import uniq from 'lodash/uniq'
-import { fastWallet } from '@streamr/test-utils'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from './../test-utils/fake/FakeEnvironment'
@@ -15,18 +14,13 @@ const MESSAGE_COUNT = 100
  */
 describe('parallel publish', () => {
 
-    const publisherWallet = fastWallet()
     let publisher: StreamrClient
     let stream: Stream
     let environment: FakeEnvironment
 
     beforeAll(async () => {
         environment = new FakeEnvironment()
-        publisher = environment.createClient({
-            auth: {
-                privateKey: publisherWallet.privateKey
-            }
-        })
+        publisher = environment.createClient()
         stream = await publisher.createStream('/path')
     })
 

--- a/packages/sdk/test/integration/publisher-key-reuse.test.ts
+++ b/packages/sdk/test/integration/publisher-key-reuse.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
@@ -26,7 +26,7 @@ describe('publisher key reuse', () => {
     }
 
     beforeEach(async () => {
-        publisherWallet = fastWallet()
+        publisherWallet = await createTestWallet()
         environment = new FakeEnvironment()
         publisher = createPublisherClient()
         subscriber = environment.createClient()
@@ -57,7 +57,7 @@ describe('publisher key reuse', () => {
     })
 
     it('happy path: different publisher address', async () => {
-        const otherWallet = fastWallet()
+        const otherWallet = await createTestWallet()
         await stream.grantPermissions({
             permissions: [StreamPermission.PUBLISH],
             userId: otherWallet.address

--- a/packages/sdk/test/integration/resend-and-subscribe.test.ts
+++ b/packages/sdk/test/integration/resend-and-subscribe.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
+import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -18,8 +19,8 @@ import { nextValue } from './../../src/utils/iterators'
  */
 describe('resend and subscribe', () => {
 
-    const subscriberWallet = fastWallet()
-    const publisherWallet = fastWallet()
+    let subscriberWallet: Wallet
+    let publisherWallet: Wallet
     let subscriber: StreamrClient
     let stream: Stream
     let storageNode: FakeStorageNode
@@ -27,6 +28,8 @@ describe('resend and subscribe', () => {
 
     beforeAll(async () => {
         environment = new FakeEnvironment()
+        subscriberWallet = await createTestWallet()
+        publisherWallet = await createTestWallet()
         subscriber = environment.createClient({
             auth: {
                 privateKey: subscriberWallet.privateKey

--- a/packages/sdk/test/integration/resend-with-existing-key.test.ts
+++ b/packages/sdk/test/integration/resend-with-existing-key.test.ts
@@ -1,7 +1,8 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { collect, toEthereumAddress, toStreamID, toUserId } from '@streamr/utils'
+import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { GroupKey } from '../../src/encryption/GroupKey'
@@ -17,8 +18,8 @@ import { createMockMessage, createRelativeTestStreamId, getLocalGroupKeyStore } 
  */
 describe('resend with existing key', () => {
 
-    const subscriberWallet = fastWallet()
-    const publisherWallet = fastWallet()
+    let subscriberWallet: Wallet
+    let publisherWallet: Wallet
     let subscriber: StreamrClient
     let stream: Stream
     let initialKey: GroupKey
@@ -71,6 +72,11 @@ describe('resend with existing key', () => {
             code: 'DECRYPT_ERROR'
         })
     }
+
+    beforeAll(async () => {
+        subscriberWallet = await createTestWallet()
+        publisherWallet = await createTestWallet()
+    })
 
     beforeEach(async () => {
         const streamId = toStreamID(createRelativeTestStreamId(module), toEthereumAddress(publisherWallet.address))

--- a/packages/sdk/test/integration/revoke-permissions.test.ts
+++ b/packages/sdk/test/integration/revoke-permissions.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import { Defer, merge } from '@streamr/utils'
 import { Message } from '../../src/Message'
 import { StreamPermission } from '../../src/permission'
@@ -59,8 +59,8 @@ describe('revoke permissions', () => {
         if (subscriber) {
             await subscriber.destroy()
         }
-        publisherPrivateKey = fastPrivateKey()
-        subscriberPrivateKey = fastPrivateKey()
+        publisherPrivateKey = await createTestPrivateKey()
+        subscriberPrivateKey = await createTestPrivateKey()
         // eslint-disable-next-line require-atomic-updates
         publisher = environment.createClient(
             merge(

--- a/packages/sdk/test/integration/unsubscribe.test.ts
+++ b/packages/sdk/test/integration/unsubscribe.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import range from 'lodash/range'
@@ -21,7 +21,7 @@ describe('unsubscribe', () => {
 
     beforeEach(async () => {
         environment = new FakeEnvironment()
-        wallet = fastWallet()
+        wallet = await createTestWallet()
         client = environment.createClient({
             auth: {
                 privateKey: wallet.privateKey

--- a/packages/sdk/test/integration/waitForStorage.test.ts
+++ b/packages/sdk/test/integration/waitForStorage.test.ts
@@ -24,7 +24,7 @@ describe('waitForStorage', () => {
     let environment: FakeEnvironment
 
     beforeEach(async () => {
-        messageSigner = new MessageSigner(createRandomAuthentication())
+        messageSigner = new MessageSigner(await createRandomAuthentication())
         environment = new FakeEnvironment()
         client = environment.createClient()
         stream = await client.createStream({

--- a/packages/sdk/test/test-utils/fake/FakeEnvironment.ts
+++ b/packages/sdk/test/test-utils/fake/FakeEnvironment.ts
@@ -1,4 +1,3 @@
-import { fastPrivateKey } from '@streamr/test-utils'
 import merge from 'lodash/merge'
 import { DependencyContainer, container } from 'tsyringe'
 import { StreamrClientConfig } from '../../../src/Config'
@@ -57,15 +56,7 @@ export class FakeEnvironment {
     }
 
     createClient(opts?: StreamrClientConfig): StreamrClient {
-        let authOpts
-        if (opts?.auth === undefined) {
-            authOpts = {
-                auth: {
-                    privateKey: fastPrivateKey()
-                }
-            }
-        }
-        const configWithDefaults = merge({}, DEFAULT_CLIENT_OPTIONS, authOpts, opts)
+        const configWithDefaults = merge({}, DEFAULT_CLIENT_OPTIONS, opts)
         const client = new StreamrClient(configWithDefaults, this.dependencyContainer)
         this.destroySignal.onDestroy.listen(async () => {
             await client.destroy()

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -178,7 +178,7 @@ export const startPublisherKeyExchangeSubscription = async (
 }
 
 export const createRandomAuthentication = (): Authentication => {
-    return createPrivateKeyAuthentication(`0x${fastPrivateKey()}`)
+    return createPrivateKeyAuthentication(fastPrivateKey())
 }
 
 export const createStreamRegistry = (opts?: {

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -248,12 +248,10 @@ export const waitForCalls = async (mockFunction: jest.Mock<any>, n: number): Pro
     })
 }
 
-export const createTestClient = (privateKey: string, wsPort?: number, acceptProxyConnections = false): StreamrClient => {
+export const createTestClient = (privateKey?: string, wsPort?: number, acceptProxyConnections = false): StreamrClient => {
     return new StreamrClient({
         environment: 'dev2',
-        auth: {
-            privateKey
-        },
+        auth: (privateKey !== undefined) ? { privateKey } : undefined,
         network: {
             controlLayer: {
                 websocketPortRange: wsPort !== undefined ? { min: wsPort, max: wsPort } : undefined

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { createTestPrivateKey, fastPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey } from '@streamr/test-utils'
 import {
     DEFAULT_PARTITION_COUNT,
     Logger,
@@ -177,8 +177,8 @@ export const startPublisherKeyExchangeSubscription = async (
     await node.join(streamPartId)
 }
 
-export const createRandomAuthentication = (): Authentication => {
-    return createPrivateKeyAuthentication(fastPrivateKey())
+export const createRandomAuthentication = async (): Promise<Authentication> => {
+    return createPrivateKeyAuthentication(await createTestPrivateKey())
 }
 
 export const createStreamRegistry = (opts?: {
@@ -204,10 +204,10 @@ export const createStreamRegistry = (opts?: {
     } as any
 }
 
-export const createGroupKeyManager = (
+export const createGroupKeyManager = async (
     groupKeyStore: LocalGroupKeyStore = mock<LocalGroupKeyStore>(),
-    authentication = createRandomAuthentication()
-): GroupKeyManager => {
+    authentication?: Authentication 
+): Promise<GroupKeyManager> => {
     return new GroupKeyManager(
         mock<SubscriberKeyExchange>(),
         mock<LitProtocolFacade>(),
@@ -221,7 +221,7 @@ export const createGroupKeyManager = (
                 rsaKeyLength: CONFIG_TEST.encryption!.rsaKeyLength!
             }
         },
-        authentication,
+        authentication ?? await createRandomAuthentication(),
         new StreamrClientEventEmitter(),
         new DestroySignal()
     )
@@ -231,7 +231,7 @@ export const createGroupKeyQueue = async (authentication: Authentication, curren
     const queue = await GroupKeyQueue.createInstance(
         undefined as any,
         authentication,
-        createGroupKeyManager(undefined, authentication)
+        await createGroupKeyManager(undefined, authentication)
     )
     if (current !== undefined) {
         await queue.rekey(current)

--- a/packages/sdk/test/unit/Decrypt.test.ts
+++ b/packages/sdk/test/unit/Decrypt.test.ts
@@ -42,7 +42,7 @@ describe('Decrypt', () => {
 
     it('group key not available: timeout while waiting', async () => {
         const wallet = await createTestWallet()
-        const groupKeyManager = createGroupKeyManager(undefined, createPrivateKeyAuthentication(wallet.privateKey))
+        const groupKeyManager = await createGroupKeyManager(undefined, createPrivateKeyAuthentication(wallet.privateKey))
         const destroySignal = new DestroySignal()
         const groupKey = GroupKey.generate()
         const msg = await createMockMessage({

--- a/packages/sdk/test/unit/Decrypt.test.ts
+++ b/packages/sdk/test/unit/Decrypt.test.ts
@@ -1,16 +1,16 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { StreamPartIDUtils, utf8ToBinary } from '@streamr/utils'
 import { mock } from 'jest-mock-extended'
 import { createPrivateKeyAuthentication } from '../../src/Authentication'
 import { DestroySignal } from '../../src/DestroySignal'
+import { StreamrClientError } from '../../src/StreamrClientError'
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { GroupKeyManager } from '../../src/encryption/GroupKeyManager'
 import { decrypt } from '../../src/encryption/decrypt'
 import { createGroupKeyManager, createMockMessage } from '../test-utils/utils'
 import { EncryptionType, StreamMessage, StreamMessageAESEncrypted } from './../../src/protocol/StreamMessage'
-import { StreamrClientError } from '../../src/StreamrClientError'
 
 describe('Decrypt', () => {
 
@@ -23,7 +23,7 @@ describe('Decrypt', () => {
         const unencryptedContent = Buffer.from(utf8ToBinary(JSON.stringify({ hello: 'world' })))
         const encryptedMessage = await createMockMessage({
             streamPartId: StreamPartIDUtils.parse('stream#0'),
-            publisher: fastWallet(),
+            publisher: await createTestWallet(),
             encryptionKey: groupKey,
             content: unencryptedContent
         }) as StreamMessageAESEncrypted
@@ -41,7 +41,7 @@ describe('Decrypt', () => {
     })
 
     it('group key not available: timeout while waiting', async () => {
-        const wallet = fastWallet()
+        const wallet = await createTestWallet()
         const groupKeyManager = createGroupKeyManager(undefined, createPrivateKeyAuthentication(wallet.privateKey))
         const destroySignal = new DestroySignal()
         const groupKey = GroupKey.generate()

--- a/packages/sdk/test/unit/ERC1271ContractFacade.test.ts
+++ b/packages/sdk/test/unit/ERC1271ContractFacade.test.ts
@@ -1,24 +1,29 @@
 import 'reflect-metadata'
-import { ERC1271ContractFacade, SUCCESS_MAGIC_VALUE } from '../../src/contracts/ERC1271ContractFacade'
+
+import { createTestPrivateKey, randomEthereumAddress } from '@streamr/test-utils'
+import { createSignature, hash, hexToBinary } from '@streamr/utils'
+import { Provider } from 'ethers'
 import { mock, MockProxy } from 'jest-mock-extended'
-import type { IERC1271 as ERC1271Contract } from '../../src/ethereumArtifacts/IERC1271'
-import { fastPrivateKey, randomEthereumAddress } from '@streamr/test-utils'
-import { createSignature, hexToBinary, hash } from '@streamr/utils'
 import { RpcProviderSource } from '../../src/RpcProviderSource'
 import { ContractFactory } from '../../src/contracts/ContractFactory'
-import { Provider } from 'ethers'
+import { ERC1271ContractFacade, SUCCESS_MAGIC_VALUE } from '../../src/contracts/ERC1271ContractFacade'
 import { ObservableContract } from '../../src/contracts/contract'
+import type { IERC1271 as ERC1271Contract } from '../../src/ethereumArtifacts/IERC1271'
 
-const PRIVATE_KEY = fastPrivateKey()
 const PAYLOAD = new Uint8Array([1, 2, 3])
-const SIGNATURE = createSignature(PAYLOAD, hexToBinary(PRIVATE_KEY))
 const CONTRACT_ADDRESS_ONE = randomEthereumAddress()
 const CONTRACT_ADDRESS_TWO = randomEthereumAddress()
 
 describe('ERC1271ContractFacade', () => {
+
     let contractOne: MockProxy<ERC1271Contract>
     let contractTwo: MockProxy<ERC1271Contract>
     let contractFacade: ERC1271ContractFacade
+    let signature: Uint8Array
+
+    beforeAll(async () => {
+        signature = createSignature(PAYLOAD, hexToBinary(await createTestPrivateKey()))
+    })
 
     beforeEach(() => {
         contractOne = mock<ERC1271Contract>()
@@ -40,41 +45,41 @@ describe('ERC1271ContractFacade', () => {
     })
 
     it('isValidSignature delegates to isValidSignature', async () => {
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
-        expect(contractOne.isValidSignature).toHaveBeenCalledWith(hash(PAYLOAD), SIGNATURE)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
+        expect(contractOne.isValidSignature).toHaveBeenCalledWith(hash(PAYLOAD), signature)
     })
 
     it('isValidSignature: valid case', async () => {
         contractOne.isValidSignature.mockResolvedValue(SUCCESS_MAGIC_VALUE)
-        const result = await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
+        const result = await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
         expect(result).toEqual(true)
     })
 
     it('isValidSignature: invalid case', async () => {
         contractOne.isValidSignature.mockResolvedValue('0xaaaaaaaa')
-        const result = await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
+        const result = await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
         expect(result).toEqual(false)
     })
 
     it('isValidSignature: caches the valid result', async () => {
         contractOne.isValidSignature.mockResolvedValue(SUCCESS_MAGIC_VALUE)
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
         expect(contractOne.isValidSignature).toHaveBeenCalledTimes(1)
     })
 
     it('isValidSignature: caches the invalid result', async () => {
         contractOne.isValidSignature.mockResolvedValue('0xaaaaaaaa')
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
         expect(contractOne.isValidSignature).toHaveBeenCalledTimes(1)
     })
 
     it('differentiates between different contracts based on contract address', async () => {
         contractOne.isValidSignature.mockResolvedValue(SUCCESS_MAGIC_VALUE)
         contractTwo.isValidSignature.mockResolvedValue('0xaaaaaaaa')
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, SIGNATURE)
-        await contractFacade.isValidSignature(CONTRACT_ADDRESS_TWO, PAYLOAD, SIGNATURE)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_ONE, PAYLOAD, signature)
+        await contractFacade.isValidSignature(CONTRACT_ADDRESS_TWO, PAYLOAD, signature)
         expect(contractOne.isValidSignature).toHaveBeenCalledTimes(1)
         expect(contractTwo.isValidSignature).toHaveBeenCalledTimes(1)
     })

--- a/packages/sdk/test/unit/EncryptionUtil.test.ts
+++ b/packages/sdk/test/unit/EncryptionUtil.test.ts
@@ -1,11 +1,11 @@
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet } from '@streamr/test-utils'
 import { StreamPartIDUtils, hexToBinary, toStreamID, toStreamPartID, utf8ToBinary } from '@streamr/utils'
 import { EncryptionUtil, INITIALIZATION_VECTOR_LENGTH } from '../../src/encryption/EncryptionUtil'
 import { GroupKey } from '../../src/encryption/GroupKey'
+import { StreamrClientError } from '../../src/StreamrClientError'
 import { createMockMessage } from '../test-utils/utils'
 import { EncryptedGroupKey } from './../../src/protocol/EncryptedGroupKey'
 import { StreamMessage, StreamMessageAESEncrypted } from './../../src/protocol/StreamMessage'
-import { StreamrClientError } from '../../src/StreamrClientError'
 
 const STREAM_ID = toStreamID('streamId')
 
@@ -39,7 +39,7 @@ describe('EncryptionUtil', () => {
         const nextKey = GroupKey.generate()
         const streamMessage = await createMockMessage({
             streamPartId: StreamPartIDUtils.parse('stream#0'),
-            publisher: fastWallet(),
+            publisher: await createTestWallet(),
             content: {
                 foo: 'bar'
             },
@@ -54,7 +54,7 @@ describe('EncryptionUtil', () => {
     it('StreamMessage decryption throws if newGroupKey invalid', async () => {
         const key = GroupKey.generate()
         const msg = await createMockMessage({
-            publisher: fastWallet(),
+            publisher: await createTestWallet(),
             streamPartId: toStreamPartID(STREAM_ID, 0),
             encryptionKey: key
         })

--- a/packages/sdk/test/unit/GroupKeyQueue.test.ts
+++ b/packages/sdk/test/unit/GroupKeyQueue.test.ts
@@ -20,8 +20,8 @@ describe('GroupKeyQueue', () => {
 
     beforeEach(async () => {
         groupKeyStore = mock<LocalGroupKeyStore>()
-        authentication = createRandomAuthentication()
-        groupKeyManager = createGroupKeyManager(groupKeyStore, authentication)
+        authentication = await createRandomAuthentication()
+        groupKeyManager = await createGroupKeyManager(groupKeyStore, authentication)
         queue = await GroupKeyQueue.createInstance(streamId, authentication, groupKeyManager)
     })
 

--- a/packages/sdk/test/unit/MessageStream.test.ts
+++ b/packages/sdk/test/unit/MessageStream.test.ts
@@ -29,7 +29,7 @@ describe('MessageStream', () => {
     }
 
     beforeEach(async () => {
-        messageSigner = new MessageSigner(createRandomAuthentication())
+        messageSigner = new MessageSigner(await createRandomAuthentication())
     })
 
     it('onMessage', async () => {

--- a/packages/sdk/test/unit/Publisher.test.ts
+++ b/packages/sdk/test/unit/Publisher.test.ts
@@ -9,7 +9,7 @@ import { createGroupKeyManager, createRandomAuthentication } from '../test-utils
 
 describe('Publisher', () => {
     it('error message', async () => {
-        const authentication = createRandomAuthentication()
+        const authentication = await createRandomAuthentication()
         const streamIdBuilder = new StreamIDBuilder(authentication)
         const streamRegistry = {
             isStreamPublisher: async () => false,
@@ -18,7 +18,7 @@ describe('Publisher', () => {
         const publisher = new Publisher(
             undefined as any,
             streamRegistry as any,
-            createGroupKeyManager(undefined, authentication),
+            await createGroupKeyManager(undefined, authentication),
             streamIdBuilder,
             authentication,
             mock<SignatureValidator>(),

--- a/packages/sdk/test/unit/PushPipeline.test.ts
+++ b/packages/sdk/test/unit/PushPipeline.test.ts
@@ -32,7 +32,7 @@ describe('PushPipeline', () => {
 
     beforeEach(async () => {
         leaksDetector = new LeaksDetector()
-        messageSigner = new MessageSigner(createRandomAuthentication())
+        messageSigner = new MessageSigner(await createRandomAuthentication())
     })
 
     afterEach(async () => {

--- a/packages/sdk/test/unit/messagePipeline.test.ts
+++ b/packages/sdk/test/unit/messagePipeline.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet, randomEthereumAddress } from '@streamr/test-utils'
+import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import { StreamPartID, StreamPartIDUtils, collect, hexToBinary, toUserId, utf8ToBinary } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { mock } from 'jest-mock-extended'
@@ -61,7 +61,7 @@ describe('messagePipeline', () => {
 
     beforeEach(async () => {
         streamPartId = StreamPartIDUtils.parse(`${randomEthereumAddress()}/path#0`)
-        publisher = fastWallet()
+        publisher = await createTestWallet()
         const groupKeyStore = {
             get: async () => undefined
         } as any

--- a/packages/sdk/test/unit/resendSubscription.test.ts
+++ b/packages/sdk/test/unit/resendSubscription.test.ts
@@ -51,7 +51,7 @@ describe('resend subscription', () => {
 
     beforeEach(async () => {
         outputMessages = new Queue<Message>
-        const authentication = createRandomAuthentication()
+        const authentication = await createRandomAuthentication()
         messageFactory = new MessageFactory({
             authentication,
             streamId: StreamPartIDUtils.getStreamID(STREAM_PART_ID),

--- a/packages/sdk/test/unit/validateStreamMessage.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { fastWallet } from '@streamr/test-utils'
+import { createTestWallet, fastWallet } from '@streamr/test-utils'
 import { hexToBinary, toStreamID, toStreamPartID, UserID } from '@streamr/utils'
 import { Wallet } from 'ethers'
 import { mock } from 'jest-mock-extended'
@@ -64,7 +64,7 @@ describe('Validator', () => {
         })
 
         it('invalid publisher', async () => {
-            const otherWallet = fastWallet()
+            const otherWallet = await createTestWallet()
             await expect(() => validate({
                 publisher: otherWallet
             })).rejects.toThrow('is not a publisher on stream streamId')

--- a/packages/sdk/test/unit/validateStreamMessage2.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage2.test.ts
@@ -41,13 +41,13 @@ const groupKeyMessageToStreamMessage = async (
     }, SignatureType.SECP256K1)
 }
 
-const publisherAuthentication = createRandomAuthentication()
-const subscriberAuthentication = createRandomAuthentication()
-
 describe('Validator2', () => {
+
     let getStreamMetadata: (streamId: string) => Promise<StreamMetadata>
     let isPublisher: (userId: UserID, streamId: string) => Promise<boolean>
     let isSubscriber: (userId: UserID, streamId: string) => Promise<boolean>
+    let publisherAuthentication: Authentication
+    let subscriberAuthentication: Authentication
     let msg: StreamMessage
     let msgWithNewGroupKey: StreamMessage
     let msgWithPrevMsgRef: StreamMessage
@@ -63,6 +63,11 @@ describe('Validator2', () => {
             } as any, new SignatureValidator(mock<ERC1271ContractFacade>()))
         }
     }
+
+    beforeAll(async () => {
+        publisherAuthentication = await createRandomAuthentication()
+        subscriberAuthentication = await createRandomAuthentication()
+    })
 
     beforeEach(async () => {
         const publisher = await publisherAuthentication.getUserId()

--- a/packages/sdk/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/sdk/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -9,30 +9,7 @@ import { waitForAssignmentsToPropagate } from '../../src/utils/waitForAssignment
 import { createRandomAuthentication, mockLoggerFactory } from '../test-utils/utils'
 import { MessageID } from './../../src/protocol/MessageID'
 import { ContentType, EncryptionType, SignatureType, StreamMessage, StreamMessageType } from './../../src/protocol/StreamMessage'
-
-const authentication = createRandomAuthentication()
-const messageSigner = new MessageSigner(authentication)
-
-async function makeMsg(ts: number, content: unknown): Promise<StreamMessage> {
-    return messageSigner.createSignedMessage({
-        messageId: new MessageID(toStreamID('assignmentStreamId'), 0, ts, 0, await authentication.getUserId(), 'msgChain'),
-        messageType: StreamMessageType.MESSAGE,
-        content: utf8ToBinary(JSON.stringify(content)),
-        contentType: ContentType.JSON,
-        encryptionType: EncryptionType.NONE,
-    }, SignatureType.SECP256K1)
-}
-
-async function createAssignmentMessagesFor(stream: {
-    id: StreamID
-    partitions: number
-}): Promise<StreamMessage[]> {
-    return Promise.all(range(0, stream.partitions).map((partition) => (
-        makeMsg(partition * 1000, {
-            streamPart: toStreamPartID(stream.id, partition)
-        })
-    )))
-}
+import { Authentication } from '../../src/Authentication'
 
 const RACE_TIMEOUT_IN_MS = 20
 
@@ -42,9 +19,36 @@ const TARGET_STREAM = Object.freeze({
 })
 
 describe(waitForAssignmentsToPropagate, () => {
+
     let messageStream: MessageStream
     let propagatePromiseState: 'rejected' | 'resolved' | 'pending'
     let propagatePromise: Promise<any>
+    let authentication: Authentication
+
+    async function makeMsg(ts: number, content: unknown): Promise<StreamMessage> {
+        return new MessageSigner(authentication).createSignedMessage({
+            messageId: new MessageID(toStreamID('assignmentStreamId'), 0, ts, 0, await authentication.getUserId(), 'msgChain'),
+            messageType: StreamMessageType.MESSAGE,
+            content: utf8ToBinary(JSON.stringify(content)),
+            contentType: ContentType.JSON,
+            encryptionType: EncryptionType.NONE,
+        }, SignatureType.SECP256K1)
+    }
+
+    async function createAssignmentMessagesFor(stream: {
+        id: StreamID
+        partitions: number
+    }): Promise<StreamMessage[]> {
+        return Promise.all(range(0, stream.partitions).map((partition) => (
+            makeMsg(partition * 1000, {
+                streamPart: toStreamPartID(stream.id, partition)
+            })
+        )))
+    }
+
+    beforeAll(async () => {
+        authentication = await createRandomAuthentication()
+    })
 
     beforeEach(() => {
         messageStream = new MessageStream()

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -280,27 +280,29 @@ const getTestAdminWallet = (provider: Provider): Wallet => {
 export const createTestWallet = async (opts?: { gas?: boolean, tokens?: boolean }): Promise<Wallet & AbstractSigner<Provider>> => {
     const provider = getTestProvider()
     const newWallet = fastWallet()
-    const adminWallet = getTestAdminWallet(provider)
-    const token = getTestTokenContract(adminWallet)
-    await retry(
-        async () => {
-            if (opts?.gas) {
-                await (await adminWallet.sendTransaction({
-                    to: newWallet.address,
-                    value: parseEther('1')
-                })).wait()
-            }
-            if (opts?.tokens) {
-                await (await token.mint(newWallet.address, parseEther('1000000'))).wait()
-            }
-        },
-        (message: string, err: any) => {
-            logger.debug(message, { err })
-        },
-        'Token minting',
-        10,
-        100
-    )
+    if (opts?.gas || opts?.tokens) {
+        const adminWallet = getTestAdminWallet(provider)
+        const token = getTestTokenContract(adminWallet)
+        await retry(
+            async () => {
+                if (opts?.gas) {
+                    await (await adminWallet.sendTransaction({
+                        to: newWallet.address,
+                        value: parseEther('1')
+                    })).wait()
+                }
+                if (opts?.tokens) {
+                    await (await token.mint(newWallet.address, parseEther('1000000'))).wait()
+                }
+            },
+            (message: string, err: any) => {
+                logger.debug(message, { err })
+            },
+            'Token minting',
+            10,
+            100
+        )
+    }
     return newWallet.connect(provider) as (Wallet & AbstractSigner<Provider>)
 }
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -148,10 +148,6 @@ export function fastPrivateKey(): string {
     return binaryToHex(crypto.randomBytes(32), true)
 }
 
-export function fastWallet(): Wallet {
-    return new Wallet(fastPrivateKey())
-}
-
 export function randomEthereumAddress(): EthereumAddress {
     return toEthereumAddress('0x' + crypto.randomBytes(20).toString('hex'))
 }
@@ -279,7 +275,7 @@ const getTestAdminWallet = (provider: Provider): Wallet => {
 
 export const createTestWallet = async (opts?: { gas?: boolean, tokens?: boolean }): Promise<Wallet & AbstractSigner<Provider>> => {
     const provider = getTestProvider()
-    const newWallet = fastWallet()
+    const newWallet = new Wallet(fastPrivateKey())
     if (opts?.gas || opts?.tokens) {
         const adminWallet = getTestAdminWallet(provider)
         const token = getTestTokenContract(adminWallet)

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -307,6 +307,10 @@ export const createTestWallet = async (opts?: { gas?: boolean, tokens?: boolean 
 }
 
 export const createTestPrivateKey = async (opts?: { gas?: boolean, tokens?: boolean }): Promise<string> => {
-    const wallet = await createTestWallet(opts)
-    return wallet.privateKey
+    if (opts?.gas || opts?.tokens) {
+        const wallet = await createTestWallet(opts)
+        return wallet.privateKey
+    } else {
+        return fastPrivateKey()
+    }
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -144,10 +144,6 @@ export const toReadableStream = (...args: unknown[]): Readable => {
     return rs
 }
 
-export function fastPrivateKey(): string {
-    return binaryToHex(crypto.randomBytes(32), true)
-}
-
 export function randomEthereumAddress(): EthereumAddress {
     return toEthereumAddress('0x' + crypto.randomBytes(20).toString('hex'))
 }
@@ -271,6 +267,10 @@ const getTestTokenContract = (adminWallet: Wallet): { mint: (targetAddress: stri
 
 const getTestAdminWallet = (provider: Provider): Wallet => {
     return new Wallet(TEST_CHAIN_CONFIG.adminPrivateKey).connect(provider)
+}
+
+const fastPrivateKey = (): string => {
+    return binaryToHex(crypto.randomBytes(32), true)
 }
 
 export const createTestWallet = async (opts?: { gas?: boolean, tokens?: boolean }): Promise<Wallet & AbstractSigner<Provider>> => {

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,4 +1,4 @@
-import { EthereumAddress, toEthereumAddress, toUserId, UserID, until, waitForEvent, Logger, retry } from '@streamr/utils'
+import { EthereumAddress, toEthereumAddress, toUserId, UserID, until, waitForEvent, Logger, retry, binaryToHex } from '@streamr/utils'
 import crypto, { randomBytes } from 'crypto'
 import { AbstractSigner, Contract, JsonRpcProvider, parseEther, Provider, TransactionResponse, Wallet } from 'ethers'
 import { EventEmitter, once } from 'events'
@@ -145,7 +145,7 @@ export const toReadableStream = (...args: unknown[]): Readable => {
 }
 
 export function fastPrivateKey(): string {
-    return crypto.randomBytes(32).toString('hex')
+    return binaryToHex(crypto.randomBytes(32), true)
 }
 
 export function fastWallet(): Wallet {


### PR DESCRIPTION
Also use `createTestPrivateKey()` instead of `fastPrivateKey()`. This way we have cleaner test API.

## Refactoring

As the new methods are async, it is no longer possible to create test wallets / private keys outside of the `describe` blocks. Therefore some wallet / private key setups were moved e.g. to `beforeAll()`.

The `createClient()` and `createTestClient()` utils were simplified: the `privateKey` parameter is now optional. Also we can omit the `auth` section from the client options if just a random private key is needed (the client will autogenerate it in that case).