### PR TITLE
refactor(network): Default configs as constants for layer2

### DIFF
--- a/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryLayerNode.ts
@@ -65,7 +65,9 @@ export interface StrictContentDeliveryLayerNodeOptions {
     rpcRequestTimeout?: number
 }
 
-const RANDOM_NODE_VIEW_SIZE = 20
+export const DEFAULT_NODE_VIEW_SIZE = 20
+export const DEFAULT_NEIGHBOR_TARGET_COUNT = 4
+export const DEFAULT_ACCEPT_PROXY_CONNECTIONS = false
 
 const logger = new Logger(module)
 
@@ -284,7 +286,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(this.options.nodeViewSize)
         this.options.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.options.localPeerDescriptor,
@@ -304,7 +306,7 @@ export class ContentDeliveryLayerNode extends EventEmitter<Events> {
         if (this.isStopped()) {
             return
         }
-        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(RANDOM_NODE_VIEW_SIZE)
+        const randomContacts = this.options.discoveryLayerNode.getRandomContacts(this.options.nodeViewSize)
         this.options.randomNodeView.replaceAll(randomContacts.map((descriptor) =>
             new ContentDeliveryRpcRemote(
                 this.options.localPeerDescriptor,

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -31,6 +31,7 @@ import { createContentDeliveryLayerNode } from './createContentDeliveryLayerNode
 import { ProxyClient } from './proxy/ProxyClient'
 import { ConnectionManager } from '@streamr/dht/src/exports'
 import { StreamPartitionInfo } from '../types'
+import { DEFAULT_MAX_PROPAGATION_BUFFER_SIZE, DEFAULT_MIN_PROPAGATION_TARGETS, DEFAULT_PROPAGATION_BUFFER_TTL } from './propagation/Propagation'
 
 export type StreamPartDelivery = {
     broadcast: (msg: StreamMessage) => void
@@ -325,8 +326,9 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             localPeerDescriptor: this.controlLayerNode!.getLocalPeerDescriptor(),
             streamPartId,
             connectionLocker: this.connectionLocker!,
-            minPropagationTargets: this.options.streamPartitionMinPropagationTargets,
-            maxPropagationBufferSize: this.options.streamPartitionMaxPropagationBufferSize
+            minPropagationTargets: this.options.streamPartitionMinPropagationTargets ?? DEFAULT_MIN_PROPAGATION_TARGETS,
+            maxPropagationBufferSize: this.options.streamPartitionMaxPropagationBufferSize ?? DEFAULT_MAX_PROPAGATION_BUFFER_SIZE,
+            propagationBufferTtl: DEFAULT_PROPAGATION_BUFFER_TTL
         })
     }
 

--- a/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
@@ -1,10 +1,21 @@
 import { DhtAddress, ListeningRpcCommunicator, toNodeId } from '@streamr/dht'
 import { Handshaker } from './neighbor-discovery/Handshaker'
 import { NeighborFinder } from './neighbor-discovery/NeighborFinder'
-import { NeighborUpdateManager } from './neighbor-discovery/NeighborUpdateManager'
-import { StrictContentDeliveryLayerNodeOptions, ContentDeliveryLayerNode } from './ContentDeliveryLayerNode'
+import { DEFAULT_NEIGHBOR_UPDATE_INTERVAL, NeighborUpdateManager } from './neighbor-discovery/NeighborUpdateManager'
+import { 
+    StrictContentDeliveryLayerNodeOptions,
+    ContentDeliveryLayerNode,
+    DEFAULT_NODE_VIEW_SIZE,
+    DEFAULT_ACCEPT_PROXY_CONNECTIONS,
+    DEFAULT_NEIGHBOR_TARGET_COUNT
+} from './ContentDeliveryLayerNode'
 import { NodeList } from './NodeList'
-import { Propagation } from './propagation/Propagation'
+import {
+    DEFAULT_MIN_PROPAGATION_TARGETS,
+    DEFAULT_MAX_PROPAGATION_BUFFER_SIZE,
+    DEFAULT_PROPAGATION_BUFFER_TTL,
+    Propagation
+} from './propagation/Propagation'
 import { StreamMessage } from '../../generated/packages/trackerless-network/protos/NetworkRpc'
 import type { MarkOptional } from 'ts-essentials'
 import { ProxyConnectionRpcLocal } from './proxy/ProxyConnectionRpcLocal'
@@ -30,12 +41,12 @@ const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): Str
         formStreamPartContentDeliveryServiceId(options.streamPartId),
         options.transport
     )
-    const neighborTargetCount = options.neighborTargetCount ?? 4
-    const maxContactCount = options.maxContactCount ?? 20
-    const acceptProxyConnections = options.acceptProxyConnections ?? false
-    const neighborUpdateInterval = options.neighborUpdateInterval ?? 10000
-    const minPropagationTargets = options.minPropagationTargets
-    const maxPropagationBufferSize = options.maxPropagationBufferSize
+    const neighborTargetCount = options.neighborTargetCount ?? DEFAULT_NEIGHBOR_TARGET_COUNT
+    const maxContactCount = options.maxContactCount ?? DEFAULT_NODE_VIEW_SIZE
+    const acceptProxyConnections = options.acceptProxyConnections ?? DEFAULT_ACCEPT_PROXY_CONNECTIONS
+    const neighborUpdateInterval = options.neighborUpdateInterval ?? DEFAULT_NEIGHBOR_UPDATE_INTERVAL
+    const minPropagationTargets = options.minPropagationTargets ?? DEFAULT_MIN_PROPAGATION_TARGETS
+    const maxPropagationBufferSize = options.maxPropagationBufferSize ?? DEFAULT_MAX_PROPAGATION_BUFFER_SIZE
     const neighbors = options.neighbors ?? new NodeList(ownNodeId, maxContactCount)
     const leftNodeView = options.leftNodeView ?? new NodeList(ownNodeId, maxContactCount)
     const rightNodeView = options.rightNodeView ?? new NodeList(ownNodeId, maxContactCount)
@@ -57,6 +68,7 @@ const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): Str
     const propagation = options.propagation ?? new Propagation({
         minPropagationTargets,
         maxMessages: maxPropagationBufferSize,
+        ttl: DEFAULT_PROPAGATION_BUFFER_TTL,
         sendToNeighbor: async (neighborId: DhtAddress, msg: StreamMessage): Promise<void> => {
             const remote = neighbors.get(neighborId) ?? temporaryConnectionRpcLocal.getNodes().get(neighborId)
             const proxyConnection = proxyConnectionRpcLocal?.getConnection(neighborId)

--- a/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
+++ b/packages/trackerless-network/src/logic/neighbor-discovery/NeighborUpdateManager.ts
@@ -21,6 +21,8 @@ interface NeighborUpdateManagerOptions {
 
 const logger = new Logger(module)
 
+export const DEFAULT_NEIGHBOR_UPDATE_INTERVAL = 10 * 1000
+
 export class NeighborUpdateManager {
 
     private readonly abortController: AbortController

--- a/packages/trackerless-network/src/logic/propagation/Propagation.ts
+++ b/packages/trackerless-network/src/logic/propagation/Propagation.ts
@@ -6,14 +6,15 @@ type SendToNeighborFn = (neighborId: DhtAddress, msg: StreamMessage) => Promise<
 
 interface ConstructorOptions {
     sendToNeighbor: SendToNeighborFn
-    minPropagationTargets?: number
-    maxMessages?: number
-    ttl?: number
+    minPropagationTargets: number
+    maxMessages: number
+    ttl: number
 }
 
-const DEFAULT_TTL = 10 * 1000
-const DEFAULT_MIN_PROPAGATION_TARGETS = 2
-const DEFAULT_MAX_MESSAGES = 150
+export const DEFAULT_PROPAGATION_BUFFER_TTL = 10 * 1000
+export const DEFAULT_MIN_PROPAGATION_TARGETS = 2
+export const DEFAULT_MAX_PROPAGATION_BUFFER_SIZE = 150
+
 /**
  * Message propagation logic of a node. Given a message, this class will actively attempt to propagate it to
  * `minPropagationTargets` neighbors until success or TTL expiration.
@@ -29,9 +30,9 @@ export class Propagation {
 
     constructor({
         sendToNeighbor,
-        minPropagationTargets = DEFAULT_MIN_PROPAGATION_TARGETS,
-        maxMessages = DEFAULT_MAX_MESSAGES,
-        ttl = DEFAULT_TTL,
+        minPropagationTargets,
+        maxMessages,
+        ttl
     }: ConstructorOptions) {
         this.sendToNeighbor = sendToNeighbor
         this.minPropagationTargets = minPropagationTargets

--- a/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
+++ b/packages/trackerless-network/src/logic/proxy/ProxyClient.ts
@@ -46,9 +46,9 @@ interface ProxyClientOptions {
     localPeerDescriptor: PeerDescriptor
     streamPartId: StreamPartID
     connectionLocker: ConnectionLocker
-    // TODO could be required options if we apply all defaults somewhere at higher level
-    maxPropagationBufferSize?: number
-    minPropagationTargets?: number
+    maxPropagationBufferSize: number
+    minPropagationTargets: number
+    propagationBufferTtl: number
 }
 
 interface ProxyDefinition {
@@ -107,6 +107,7 @@ export class ProxyClient extends EventEmitter<Events> {
         this.propagation = new Propagation({
             minPropagationTargets: options.minPropagationTargets,
             maxMessages: options.maxPropagationBufferSize,
+            ttl: options.propagationBufferTtl,
             sendToNeighbor: async (neighborId: DhtAddress, msg: StreamMessage): Promise<void> => {
                 const remote = this.neighbors.get(neighborId)
                 if (remote) {


### PR DESCRIPTION
## Summary

Added constants for default configurations for Layer2 classes. 

## Changes

- Random node view count is now configured with the nodeViewSize config option

## Future improvements

- Do the same for the discovery layer #3000 
- Remove remaining magic numbers around ControlLayerNode configuration (Could also clean up on the DHT side).
- Could maybe pass some of the defaults from a higher layer (for example the sdk). This will require some thought as some of the configs could be wanted on a per stream partition basis and others for all streams.
- Rename all fields with `listSize` to ie `listNodeCount `