### PR TITLE
refactor(network): Default configuration constants for DiscoveryLayerNode

### DIFF
--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -23,7 +23,15 @@ import { sampleSize } from 'lodash'
 import { ProxyDirection, StreamMessage } from '../../generated/packages/trackerless-network/protos/NetworkRpc'
 import { ContentDeliveryLayerNode } from './ContentDeliveryLayerNode'
 import { ControlLayerNode } from './ControlLayerNode'
-import { DiscoveryLayerNode } from './DiscoveryLayerNode'
+import { 
+    formDiscoveryLayerServiceId,
+    DEFAULT_DISCOVERY_LAYER_JOIN_TIMEOUT,
+    DEFAULT_DISCOVERY_LAYER_KBUCKET_SIZE,
+    DEFAULT_DISCOVERY_LAYER_NEIGHBOR_PING_LIMIT,
+    DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_NEIGHBORS,
+    DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_RING_CONTACTS,
+    DiscoveryLayerNode
+} from './DiscoveryLayerNode'
 import { MAX_NODE_COUNT, PeerDescriptorStoreManager } from './PeerDescriptorStoreManager'
 import { MIN_NEIGHBOR_COUNT as NETWORK_SPLIT_AVOIDANCE_MIN_NEIGHBOR_COUNT, StreamPartNetworkSplitAvoidance } from './StreamPartNetworkSplitAvoidance'
 import { StreamPartReconnect } from './StreamPartReconnect'
@@ -245,15 +253,15 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
         return new DhtNode({
             transport: this.controlLayerNode!,
             connectionsView: this.controlLayerNode!.getConnectionsView(),
-            serviceId: 'layer1::' + streamPartId,
+            serviceId: formDiscoveryLayerServiceId(streamPartId),
             peerDescriptor: this.controlLayerNode!.getLocalPeerDescriptor(),
             entryPoints,
-            numberOfNodesPerKBucket: 4,  // TODO use options option or named constant?
+            numberOfNodesPerKBucket: DEFAULT_DISCOVERY_LAYER_KBUCKET_SIZE,
             rpcRequestTimeout: EXISTING_CONNECTION_TIMEOUT,
-            dhtJoinTimeout: 20000,  // TODO use options option or named constant?
-            periodicallyPingNeighbors: true,
-            periodicallyPingRingContacts: true,
-            neighborPingLimit: 16
+            dhtJoinTimeout: DEFAULT_DISCOVERY_LAYER_JOIN_TIMEOUT,
+            periodicallyPingNeighbors: DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_NEIGHBORS,
+            periodicallyPingRingContacts: DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_RING_CONTACTS,
+            neighborPingLimit: DEFAULT_DISCOVERY_LAYER_NEIGHBOR_PING_LIMIT
         })
     }
 

--- a/packages/trackerless-network/src/logic/DiscoveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/DiscoveryLayerNode.ts
@@ -1,4 +1,13 @@
-import { DhtAddress, PeerDescriptor, RingContacts } from '@streamr/dht'
+import { DhtAddress, PeerDescriptor, RingContacts, ServiceID } from '@streamr/dht'
+import { StreamPartID } from '@streamr/utils'
+
+export const DEFAULT_DISCOVERY_LAYER_KBUCKET_SIZE = 4
+export const DEFAULT_DISCOVERY_LAYER_JOIN_TIMEOUT = 20000
+export const DEFAULT_DISCOVERY_LAYER_NEIGHBOR_PING_LIMIT = 16
+export const DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_NEIGHBORS = true
+export const DEFAULT_DISCOVERY_LAYER_PERIODICALLY_PING_RING_CONTACTS = true
+
+export const formDiscoveryLayerServiceId = (streamPartId: StreamPartID): ServiceID => 'layer1::' + streamPartId
 
 export interface DiscoveryLayerNodeEvents {
     manualRejoinRequired: () => void

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -7,14 +7,19 @@ import {
     SimulatorTransport,
     randomDhtAddress,
     getRandomRegion,
-    toDhtAddressRaw
+    toDhtAddressRaw,
+    EXISTING_CONNECTION_TIMEOUT
 } from '@streamr/dht'
 import { RpcCommunicator } from '@streamr/proto-rpc'
 import { StreamPartID, StreamPartIDUtils, UserID, hexToBinary, toUserIdRaw, utf8ToBinary } from '@streamr/utils'
 import { NetworkNode, createNetworkNode } from '../../src/NetworkNode'
 import { ContentDeliveryLayerNode } from '../../src/logic/ContentDeliveryLayerNode'
 import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
-import { DiscoveryLayerNode } from '../../src/logic/DiscoveryLayerNode'
+import { 
+    DEFAULT_DISCOVERY_LAYER_KBUCKET_SIZE,
+    DEFAULT_DISCOVERY_LAYER_NEIGHBOR_PING_LIMIT, 
+    DiscoveryLayerNode
+} from '../../src/logic/DiscoveryLayerNode'
 import { createContentDeliveryLayerNode } from '../../src/logic/createContentDeliveryLayerNode'
 import { HandshakeRpcRemote } from '../../src/logic/neighbor-discovery/HandshakeRpcRemote'
 import {
@@ -48,10 +53,10 @@ export const createMockContentDeliveryLayerNodeAndDhtNode = async (
         transport: mockCm,
         connectionsView: mockCm,
         peerDescriptor: localPeerDescriptor,
-        numberOfNodesPerKBucket: 4,
+        numberOfNodesPerKBucket: DEFAULT_DISCOVERY_LAYER_KBUCKET_SIZE,
         entryPoints: [entryPointDescriptor],
-        rpcRequestTimeout: 5000,
-        neighborPingLimit: 16
+        rpcRequestTimeout: EXISTING_CONNECTION_TIMEOUT,
+        neighborPingLimit: DEFAULT_DISCOVERY_LAYER_NEIGHBOR_PING_LIMIT
     })
     const contentDeliveryLayerNode = createContentDeliveryLayerNode({
         streamPartId,


### PR DESCRIPTION
## Summary

Added constants for default configuration of the DiscoveryLayerNode.

## Future Improvements

Add default configuration configs to the ControlLayerNode and DhtNode
