### PR TITLE
test: Adjust coordinate equality check

### DIFF
--- a/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
@@ -66,7 +66,7 @@ describe('ConnectivityChecking', () => {
         }
         const response = await sendConnectivityRequest(request, server.getLocalPeerDescriptor())
         expect(response.protocolVersion).toEqual(LOCAL_PROTOCOL_VERSION)
-        expect(response.latitude).toEqual(testLatitude)
-        expect(response.longitude).toEqual(testLongitude)
+        expect(response.latitude).toBeCloseTo(testLatitude, 1)
+        expect(response.longitude).toBeCloseTo(testLongitude, 1)
     })
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
@@ -101,7 +101,7 @@ describe('GeoIpLocator', () => {
         expect(location).toBeDefined()
 
         // Helsinki, Finland
-        expect(location!.latitude).toBe(60.1719)
-        expect(location!.longitude).toBe(24.9347)
+        expect(location!.latitude).toBeCloseTo(60.1719, 1)
+        expect(location!.longitude).toBeCloseTo(24.9347, 1)
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
@@ -48,8 +48,8 @@ describe('GeoIpLocatorNoNetworkAtMonthly', () => {
         expect(location).toBeDefined()
 
         // Helsinki, Finland
-        expect(location!.latitude).toBe(60.1719)
-        expect(location!.longitude).toBe(24.9347)
+        expect(location!.latitude).toBeCloseTo(60.1719, 1)
+        expect(location!.longitude).toBeCloseTo(24.9347, 1)
 
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator.test.ts
@@ -39,8 +39,8 @@ describe('GeoIpLocator', () => {
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1719)
-            expect(location!.longitude).toBe(24.9347)
+            expect(location!.latitude).toBeCloseTo(60.1719, 1)
+            expect(location!.longitude).toBeCloseTo(24.9347, 1)
         
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -75,8 +75,8 @@ describe('GeoIpLocator', () => {
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1719)
-            expect(location!.longitude).toBe(24.9347)
+            expect(location!.latitude).toBeCloseTo(60.1719, 1)
+            expect(location!.longitude).toBeCloseTo(24.9347, 1)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -97,8 +97,8 @@ describe('GeoIpLocator', () => {
             expect(location).toBeDefined()
     
             // Helsinki, Finland
-            expect(location!.latitude).toBe(60.1719)
-            expect(location!.longitude).toBe(24.9347)
+            expect(location!.latitude).toBeCloseTo(60.1719, 1)
+            expect(location!.longitude).toBeCloseTo(24.9347, 1)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')


### PR DESCRIPTION
Tolerate 0.05 degree difference, i.e. ~6km distance. 

Should resolves e.g. test failure in PR #3007. There it errors like this:
```
expect(received).toBe(expected) // Object.is equality
Expected: 60.1719
Received: 60.1968
```

## Future improvements

- The same test assertion is in multiple places, maybe there is some test duplication?