### PR TITLE
chore(dht): Use `URLSearchParams` to parse search params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23446,16 +23446,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/querystring": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-            "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.x"
-            }
-        },
         "node_modules/querystring-es3": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
@@ -28875,7 +28865,6 @@
                 "lodash": "^4.17.21",
                 "lru-cache": "^11.0.2",
                 "node-datachannel": "^0.10.1",
-                "querystring": "0.2.1",
                 "uuid": "^11.0.5",
                 "websocket": "^1.0.34",
                 "ws": "^8.18.0"

--- a/packages/browser-test-runner/src/createWebpackConfig.ts
+++ b/packages/browser-test-runner/src/createWebpackConfig.ts
@@ -46,7 +46,6 @@ export const createWebpackConfig = (
                     'net': false,
                     'timers': require.resolve('timers-browserify'),
                     'os': false,
-                    'querystring': false,
                     'zlib': require.resolve('browserify-zlib'),
                     'tls': false
                 }
@@ -68,7 +67,6 @@ export const createWebpackConfig = (
                 'express': 'Express',
                 'process': 'process',
                 'ws': 'WebSocket',
-                'querystring': 'QueryString',
             }
         }
     }

--- a/packages/browser-test-runner/src/preload.js
+++ b/packages/browser-test-runner/src/preload.js
@@ -8,7 +8,6 @@ process.once('loaded', () => {
     window.HTTP = require('http')
     window.HTTPS = require('https')
     window.Buffer = require('buffer/').Buffer
-    window.QueryString = require('querystring')
     // maybe we can set this karma-setup
     // eslint-disable-next-line no-underscore-dangle
     window._streamr_electron_test = true

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -41,7 +41,6 @@
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.2",
     "node-datachannel": "^0.10.1",
-    "querystring": "0.2.1",
     "uuid": "^11.0.5",
     "websocket": "^1.0.34",
     "ws": "^8.18.0"

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -11,7 +11,6 @@ import { ipv4ToNumber, Logger, wait } from '@streamr/utils'
 import { attachConnectivityRequestHandler, DISABLE_CONNECTIVITY_PROBE } from '../connectivityRequestHandler'
 import { WebsocketServerConnection } from './WebsocketServerConnection'
 import { ConnectionType, IConnection } from '../IConnection'
-import queryString from 'querystring'
 import { isMaybeSupportedProtocolVersion, LOCAL_PROTOCOL_VERSION } from '../../helpers/version'
 import { shuffle } from 'lodash'
 import { sendConnectivityRequest } from '../connectivityChecker'
@@ -75,7 +74,8 @@ export class WebsocketServerConnector {
         if (!this.abortController.signal.aborted && this.websocketServer) {
             this.websocketServer.on('connected', (connection: IConnection) => {
                 const serverSocket = connection as unknown as WebsocketServerConnection
-                const query = queryString.parse(serverSocket.resourceURL.query as string ?? '')
+                const urlParams = new URLSearchParams(serverSocket.resourceURL.query as string ?? '')
+                const query = Object.fromEntries(urlParams.entries())
                 const action = query.action as (Action | undefined)
                 logger.trace('WebSocket client connected', { action, remoteAddress: serverSocket.getRemoteIpAddress() })
                 if (action === 'connectivityRequest') {

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -75,8 +75,7 @@ export class WebsocketServerConnector {
             this.websocketServer.on('connected', (connection: IConnection) => {
                 const serverSocket = connection as unknown as WebsocketServerConnection
                 const urlParams = new URLSearchParams(serverSocket.resourceURL.query as string ?? '')
-                const query = Object.fromEntries(urlParams.entries())
-                const action = query.action as (Action | undefined)
+                const action = urlParams.get('action') as (Action | undefined)
                 logger.trace('WebSocket client connected', { action, remoteAddress: serverSocket.getRemoteIpAddress() })
                 if (action === 'connectivityRequest') {
                     attachConnectivityRequestHandler(serverSocket, this.geoIpLocator)


### PR DESCRIPTION
## Summary

I switch to `URLSearchParams` for query param parsing and kill a dependency (`querystring`).

`URLSearchParams` is
- Widely supported by browsers (97%+).
- Available in node (global scope) since v15, stable since v10.

`querystring` is
- Deprecated.
- Doesn't seem to work well in browsers (breaks browser tests if not treated properly).

## Changes

- Ditch `querystring`
- Use `URLSearchParams` instead

## Limitations and future improvements

- n/a

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
