### PR TITLE
chore(sdk) [NET-1394]: add new storage node cluster address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
+- Add new storage node cluster address `STREAMR_STORAGE_DEFAULT` (https://github.com/streamr-dev/network/pull/3020)
+
 #### Changed
 
 #### Deprecated
+
+- Deprecate storage node cluster address `STREAMR_STORAGE_NODE_GERMANY` (https://github.com/streamr-dev/network/pull/3020)
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
-- Add new storage node cluster address `STREAMR_STORAGE_DEFAULT` (https://github.com/streamr-dev/network/pull/3020)
+- Add new storage node cluster address `STREAMR_STORAGE_NODE_ADDRESS` (https://github.com/streamr-dev/network/pull/3020)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
-- Add new storage node cluster address `STREAMR_STORAGE_NODE_ADDRESS` (https://github.com/streamr-dev/network/pull/3020)
+- Add new storage node address `STREAMR_STORAGE_NODE_ADDRESS` (https://github.com/streamr-dev/network/pull/3020)
 
 #### Changed
 
 #### Deprecated
 
-- Deprecate storage node cluster address `STREAMR_STORAGE_NODE_GERMANY` (https://github.com/streamr-dev/network/pull/3020)
+- Deprecate storage node address `STREAMR_STORAGE_NODE_GERMANY` (https://github.com/streamr-dev/network/pull/3020)
 
 #### Removed
 

--- a/docs/docs/usage/streams/store-and-retrieve.md
+++ b/docs/docs/usage/streams/store-and-retrieve.md
@@ -15,18 +15,18 @@ To retrieve data from storage, a key exchange between the publisher and subscrib
 ```ts
 const {
   StreamrClient,
-  STREAMR_STORAGE_DEFAULT,
+    STREAMR_STORAGE_NODE_ADDRESS,
 } = require('@streamr/sdk');
 
 // assign a stream to a storage node
-await stream.addToStorageNode(STREAMR_STORAGE_DEFAULT);
+await stream.addToStorageNode(STREAMR_STORAGE_NODE_ADDRESS);
 ```
 
 Other operations with storage:
 
 ```ts
 // remove the stream from a storage node
-await stream.removeFromStorageNode(STREAMR_STORAGE_DEFAULT);
+await stream.removeFromStorageNode(STREAMR_STORAGE_NODE_ADDRESS);
 
 // fetch the storage nodes for a stream
 const storageNodes = stream.getStorageNodes();

--- a/docs/docs/usage/streams/store-and-retrieve.md
+++ b/docs/docs/usage/streams/store-and-retrieve.md
@@ -15,18 +15,18 @@ To retrieve data from storage, a key exchange between the publisher and subscrib
 ```ts
 const {
   StreamrClient,
-  STREAMR_STORAGE_NODE_GERMANY,
+  STREAMR_STORAGE_DEFAULT,
 } = require('@streamr/sdk');
 
 // assign a stream to a storage node
-await stream.addToStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+await stream.addToStorageNode(STREAMR_STORAGE_DEFAULT);
 ```
 
 Other operations with storage:
 
 ```ts
 // remove the stream from a storage node
-await stream.removeFromStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+await stream.removeFromStorageNode(STREAMR_STORAGE_DEFAULT);
 
 // fetch the storage nodes for a stream
 const storageNodes = stream.getStorageNodes();

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -442,7 +442,7 @@ export type StrictStreamrClientConfig = MarkOptional<Required<StreamrClientConfi
  */
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
-export const STREAMR_STORAGE_DEFAULT = '0x9dc08ff97f5c156181ec6a0b13fc3946454e529a'
+export const STREAMR_STORAGE_DEFAULT = '0x9dc08ff97f5c156181ec6a0b13fc3946454e529a' as HexString
 
 export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStreamrClientConfig => {
     // TODO is it good to cloneDeep the input object as it may have object references (e.g. auth.ethereum)?

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -442,6 +442,8 @@ export type StrictStreamrClientConfig = MarkOptional<Required<StreamrClientConfi
  */
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
+export const STREAMR_STORAGE_DEFAULT = '0x9dc08ff97f5c156181ec6a0b13fc3946454e529a'
+
 export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStreamrClientConfig => {
     // TODO is it good to cloneDeep the input object as it may have object references (e.g. auth.ethereum)?
     let config = cloneDeep(input)

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -438,11 +438,11 @@ export type StrictStreamrClientConfig = MarkOptional<Required<StreamrClientConfi
 }
 
 /**
- * @deprecated use {@link STREAMR_STORAGE_DEFAULT} instead
+ * @deprecated use {@link STREAMR_STORAGE_NODE_ADDRESS} instead
  */
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
-export const STREAMR_STORAGE_DEFAULT = '0x9dc08ff97f5c156181ec6a0b13fc3946454e529a' as HexString
+export const STREAMR_STORAGE_NODE_ADDRESS = '0x9dc08ff97f5c156181ec6a0b13fc3946454e529a' as HexString
 
 export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStreamrClientConfig => {
     // TODO is it good to cloneDeep the input object as it may have object references (e.g. auth.ethereum)?

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -437,6 +437,9 @@ export type StrictStreamrClientConfig = MarkOptional<Required<StreamrClientConfi
     _timeouts: Exclude<DeepRequired<StreamrClientConfig['_timeouts']>, undefined>
 }
 
+/**
+ * @deprecated use {@link STREAMR_STORAGE_DEFAULT} instead
+ */
 export const STREAMR_STORAGE_NODE_GERMANY = '0x31546eEA76F2B2b3C5cC06B1c93601dc35c9D916'
 
 export const createStrictConfig = (input: StreamrClientConfig = {}): StrictStreamrClientConfig => {

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -31,7 +31,7 @@ export {
     ProviderAuthConfig,
     PrivateKeyAuthConfig,
     STREAMR_STORAGE_NODE_GERMANY,
-    STREAMR_STORAGE_DEFAULT,
+    STREAMR_STORAGE_NODE_ADDRESS,
     NetworkConfig,
     ControlLayerConfig,
     NetworkNodeConfig,

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -31,6 +31,7 @@ export {
     ProviderAuthConfig,
     PrivateKeyAuthConfig,
     STREAMR_STORAGE_NODE_GERMANY,
+    STREAMR_STORAGE_DEFAULT,
     NetworkConfig,
     ControlLayerConfig,
     NetworkNodeConfig,


### PR DESCRIPTION
## Summary

- Add new storage node cluster address constant `STREAMR_STORAGE_NODE_ADDRESS`
- Deprecate existing constant `STREAMR_STORAGE_NODE_GERMANY` 
- Adjust docs to reflect this change

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
