### PR TITLE
chore: Bump `eslint-config-streamr-ts`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "@types/node": "^20.14.8",
                 "cli-table": "^0.3.6",
                 "eslint": "^9.14.0",
-                "eslint-config-streamr-ts": "^6.1.0",
+                "eslint-config-streamr-ts": "^7.0.0",
                 "eslint-import-resolver-typescript": "^3.8.3",
                 "eslint-plugin-import": "^2.31.0",
                 "eslint-plugin-jest": "^28.11.0",
@@ -14079,18 +14079,17 @@
             }
         },
         "node_modules/eslint-config-streamr-ts": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-streamr-ts/-/eslint-config-streamr-ts-6.1.0.tgz",
-            "integrity": "sha512-13RgQvMXF+x3QlnZZtHe5JEB1BSUHrdxNXX2XXfGtE0gf6+OPkV9VvlCCnOPoGf2qn2Ry0NgTsjCqsHZ0o520g==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-streamr-ts/-/eslint-config-streamr-ts-7.0.0.tgz",
+            "integrity": "sha512-LZ7y86e+NHj45DpTIKGTZDCR/+SjKkiW7waQsWBvV5yAf/G2o0ybO2wdRbxDlRyg26HUncZhAkw2+YSpkISkQA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "^9.18.0",
-                "@stylistic/eslint-plugin": "^2.9.0",
-                "eslint": "^9.18.0",
-                "eslint-plugin-promise": "^7.1.0",
-                "typescript-eslint": "^8.21.0"
+                "@eslint/js": "^9.21.0",
+                "@stylistic/eslint-plugin": "^4.2.0",
+                "eslint": "^9.21.0",
+                "eslint-plugin-promise": "^7.2.1",
+                "typescript-eslint": "^8.26.0"
             }
         },
         "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@types/node": "^20.14.8",
         "cli-table": "^0.3.6",
         "eslint": "^9.14.0",
-        "eslint-config-streamr-ts": "^6.1.0",
+        "eslint-config-streamr-ts": "^7.0.0",
         "eslint-import-resolver-typescript": "^3.8.3",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.11.0",


### PR DESCRIPTION
Upgrade to v7, which supports ESM. See https://github.com/streamr-dev/eslint-config-streamr/pull/268.