### PR TITLE
chore: Bump `typescript` v5.8

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -22,9 +22,9 @@
         "@docusaurus/types": "3.7.0",
         "docusaurus-plugin-typedoc": "^1.1.1",
         "rimraf": "^6.0.1",
-        "typedoc": "^0.27.3",
+        "typedoc": "^0.27.9",
         "typedoc-plugin-markdown": "^4.3.1",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -17200,9 +17200,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
+      "version": "0.27.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.9.tgz",
+      "integrity": "sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17219,7 +17219,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
@@ -17262,9 +17262,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,9 +23,9 @@
     "@docusaurus/types": "3.7.0",
     "docusaurus-plugin-typedoc": "^1.1.1",
     "rimraf": "^6.0.1",
-    "typedoc": "^0.27.3",
+    "typedoc": "^0.27.9",
     "typedoc-plugin-markdown": "^4.3.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   },
   "browserslist": {
     "production": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "lerna": "^8.2.0",
                 "semver": "^7.7.1",
                 "ts-jest": "^29.2.6",
-                "typescript": "^5.7.2",
+                "typescript": "^5.8.2",
                 "typescript-eslint": "^8.25.0",
                 "yarn": "^1.22.22",
                 "zx": "^8.3.2"
@@ -27117,9 +27117,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "lerna": "^8.2.0",
         "semver": "^7.7.1",
         "ts-jest": "^29.2.6",
-        "typescript": "^5.7.2",
+        "typescript": "^5.8.2",
         "typescript-eslint": "^8.25.0",
         "yarn": "^1.22.22",
         "zx": "^8.3.2"


### PR DESCRIPTION
Upgraded to TypeScript v5.8.

Also upgraded `typedoc` dependency as the earlier version didn't support TypeScript v5.8.