### PR TITLE
refactor(network): always use createMockDescriptor in trackerless-network tests

### DIFF
--- a/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
@@ -13,7 +13,7 @@ import {
     StreamMessage
 } from '../../generated/packages/trackerless-network/protos/NetworkRpc'
 import { ContentDeliveryRpcClient } from '../../generated/packages/trackerless-network/protos/NetworkRpc.client'
-import { createStreamMessage } from '../utils/utils'
+import { createMockPeerDescriptor, createStreamMessage } from '../utils/utils'
 import { randomUserId } from '@streamr/test-utils'
 
 describe('ContentDeliveryRpcRemote', () => {
@@ -21,14 +21,8 @@ describe('ContentDeliveryRpcRemote', () => {
     let clientRpc: ListeningRpcCommunicator
     let rpcRemote: ContentDeliveryRpcRemote
 
-    const clientNode: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
-    const serverNode: PeerDescriptor = {
-        nodeId: new Uint8Array([2, 2, 2]),
-        type: NodeType.NODEJS
-    }
+    const clientNode = createMockPeerDescriptor()
+    const serverNode = createMockPeerDescriptor()
 
     let recvCounter: number
 

--- a/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/ContentDeliveryRpcRemote.test.ts
@@ -1,10 +1,4 @@
-import {
-    ListeningRpcCommunicator,
-    NodeType,
-    PeerDescriptor,
-    Simulator,
-    SimulatorTransport
-} from '@streamr/dht'
+import { ListeningRpcCommunicator, Simulator, SimulatorTransport } from '@streamr/dht'
 import { StreamPartIDUtils, until } from '@streamr/utils'
 import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
 import { Empty } from '../../generated/google/protobuf/empty'

--- a/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
@@ -14,20 +14,15 @@ import {
 import {
     HandshakeRpcClient,
 } from '../../generated/packages/trackerless-network/protos/NetworkRpc.client'
+import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('HandshakeRpcRemote', () => {
     let mockServerRpc: ListeningRpcCommunicator
     let clientRpc: ListeningRpcCommunicator
     let rpcRemote: HandshakeRpcRemote
 
-    const clientNode: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
-    const serverNode: PeerDescriptor = {
-        nodeId: new Uint8Array([2, 2, 2]),
-        type: NodeType.NODEJS
-    }
+    const clientNode = createMockPeerDescriptor()
+    const serverNode = createMockPeerDescriptor()
 
     let simulator: Simulator
     let mockConnectionManager1: SimulatorTransport

--- a/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/HandshakeRpcRemote.test.ts
@@ -1,10 +1,4 @@
-import {
-    ListeningRpcCommunicator,
-    NodeType,
-    PeerDescriptor,
-    Simulator,
-    SimulatorTransport
-} from '@streamr/dht'
+import { ListeningRpcCommunicator, Simulator, SimulatorTransport } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { HandshakeRpcRemote } from '../../src/logic/neighbor-discovery/HandshakeRpcRemote'
 import {

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -1,7 +1,5 @@
 import {
     ListeningRpcCommunicator,
-    NodeType,
-    PeerDescriptor,
     Simulator,
     SimulatorTransport,
     toNodeId

--- a/packages/trackerless-network/test/integration/Handshakes.test.ts
+++ b/packages/trackerless-network/test/integration/Handshakes.test.ts
@@ -12,21 +12,14 @@ import { Handshaker } from '../../src/logic/neighbor-discovery/Handshaker'
 import { StreamPartHandshakeRequest, StreamPartHandshakeResponse } from '../../generated/packages/trackerless-network/protos/NetworkRpc'
 import { ContentDeliveryRpcClient } from '../../generated/packages/trackerless-network/protos/NetworkRpc.client'
 import { ContentDeliveryRpcRemote } from '../../src/logic/ContentDeliveryRpcRemote'
+import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('Handshakes', () => {
 
-    const peerDescriptor1: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
-    const peerDescriptor2: PeerDescriptor = {
-        nodeId: new Uint8Array([2, 1, 1]),
-        type: NodeType.NODEJS
-    }
-    const peerDescriptor3: PeerDescriptor = {
-        nodeId: new Uint8Array([3, 1, 1]),
-        type: NodeType.NODEJS
-    }
+    const peerDescriptor1 = createMockPeerDescriptor()
+    const peerDescriptor2 = createMockPeerDescriptor()
+    const peerDescriptor3 = createMockPeerDescriptor()
+
     let rpcCommunicator1: ListeningRpcCommunicator
     let rpcCommunicator2: ListeningRpcCommunicator
     let rpcCommunicator3: ListeningRpcCommunicator

--- a/packages/trackerless-network/test/integration/NeighborUpdateRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/NeighborUpdateRpcRemote.test.ts
@@ -1,10 +1,4 @@
-import {
-    ListeningRpcCommunicator,
-    NodeType,
-    PeerDescriptor,
-    Simulator,
-    SimulatorTransport
-} from '@streamr/dht'
+import { ListeningRpcCommunicator, Simulator, SimulatorTransport } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { NeighborUpdateRpcRemote } from '../../src/logic/neighbor-discovery/NeighborUpdateRpcRemote'
 import { NeighborUpdate } from '../../generated/packages/trackerless-network/protos/NetworkRpc'

--- a/packages/trackerless-network/test/integration/NeighborUpdateRpcRemote.test.ts
+++ b/packages/trackerless-network/test/integration/NeighborUpdateRpcRemote.test.ts
@@ -11,20 +11,15 @@ import { NeighborUpdate } from '../../generated/packages/trackerless-network/pro
 import {
     NeighborUpdateRpcClient,
 } from '../../generated/packages/trackerless-network/protos/NetworkRpc.client'
+import { createMockPeerDescriptor } from '../utils/utils'
 
 describe('NeighborUpdateRpcRemote', () => {
     let mockServerRpc: ListeningRpcCommunicator
     let clientRpc: ListeningRpcCommunicator
     let rpcRemote: NeighborUpdateRpcRemote
 
-    const clientNode: PeerDescriptor = {
-        nodeId: new Uint8Array([1, 1, 1]),
-        type: NodeType.NODEJS
-    }
-    const serverNode: PeerDescriptor = {
-        nodeId: new Uint8Array([2, 2, 2]),
-        type: NodeType.NODEJS
-    }
+    const clientNode = createMockPeerDescriptor()
+    const serverNode = createMockPeerDescriptor()
 
     let simulator: Simulator
     let mockConnectionManager1: SimulatorTransport
@@ -45,10 +40,7 @@ describe('NeighborUpdateRpcRemote', () => {
             NeighborUpdate,
             'neighborUpdate',
             async (): Promise<NeighborUpdate> => {
-                const node: PeerDescriptor = {
-                    nodeId: new Uint8Array([4, 2, 4]),
-                    type: NodeType.NODEJS
-                }
+                const node = createMockPeerDescriptor()
                 const update: NeighborUpdate = {
                     streamPartId: StreamPartIDUtils.parse('stream#0'),
                     neighborDescriptors: [

--- a/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
@@ -1,4 +1,4 @@
-import { DhtAddress, NodeType, toNodeId, toDhtAddressRaw } from '@streamr/dht'
+import { DhtAddress, toNodeId } from '@streamr/dht'
 import { StreamPartIDUtils } from '@streamr/utils'
 import { NodeList } from '../../src/logic/NodeList'
 import { HandshakeRpcLocal } from '../../src/logic/neighbor-discovery/HandshakeRpcLocal'

--- a/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
+++ b/packages/trackerless-network/test/unit/HandshakeRpcLocal.test.ts
@@ -85,10 +85,7 @@ describe('HandshakeRpcLocal', () => {
 
     it('handshakeWithInterleaving success', async () => {
         const req: InterleaveRequest = {
-            interleaveTargetDescriptor: {
-                nodeId: toDhtAddressRaw('0x2222' as DhtAddress),
-                type: NodeType.NODEJS
-            }
+            interleaveTargetDescriptor: createMockPeerDescriptor()
         }
         await rpcLocal.interleaveRequest(req, {
             incomingSourceDescriptor: createMockPeerDescriptor()

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -42,10 +42,9 @@ describe('NodeList', () => {
     beforeEach(() => {
         nodeList = new NodeList(ownId, 6)
         for (const id of ids) {
-            const peerDescriptor: PeerDescriptor = {
-                nodeId: id,
-                type: NodeType.NODEJS
-            }
+            const peerDescriptor = createMockPeerDescriptor({
+                nodeId: id
+            })
             nodeList.add(createRemoteGraphNode(peerDescriptor))
         }
     })

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -51,18 +51,12 @@ describe('NodeList', () => {
     })
 
     it('add', () => {
-        const newDescriptor = {
-            nodeId: new Uint8Array([1, 2, 3]),
-            type: NodeType.NODEJS
-        }
+        const newDescriptor = createMockPeerDescriptor()
         const newNode = createRemoteGraphNode(newDescriptor)
         nodeList.add(newNode)
         expect(nodeList.has(toNodeId(newDescriptor))).toEqual(true)
 
-        const newDescriptor2 = {
-            nodeId: new Uint8Array([1, 2, 4]),
-            type: NodeType.NODEJS
-        }
+        const newDescriptor2 = createMockPeerDescriptor()
         const newNode2 = createRemoteGraphNode(newDescriptor2)
         nodeList.add(newNode2)
         expect(nodeList.has(toNodeId(newDescriptor2))).toEqual(false)

--- a/packages/trackerless-network/test/unit/NodeList.test.ts
+++ b/packages/trackerless-network/test/unit/NodeList.test.ts
@@ -1,6 +1,5 @@
 import {
     ListeningRpcCommunicator,
-    NodeType,
     PeerDescriptor,
     randomDhtAddress,
     toDhtAddress,

--- a/packages/trackerless-network/test/utils/utils.ts
+++ b/packages/trackerless-network/test/utils/utils.ts
@@ -96,12 +96,12 @@ export const createStreamMessage = (
     return msg
 }
 
-export const createMockPeerDescriptor = (opts?: Omit<Partial<PeerDescriptor>, 'nodeId' | 'type'>): PeerDescriptor => {
+export const createMockPeerDescriptor = (opts?: Partial<PeerDescriptor>): PeerDescriptor => {
     return {
-        ...opts,
         nodeId: toDhtAddressRaw(randomDhtAddress()),
         type: NodeType.NODEJS,
-        region: getRandomRegion()
+        region: getRandomRegion(),
+        ...opts
     }
 }
 


### PR DESCRIPTION
## Summary

Use `createMockPeerDescriptor` in trackerless-network's tests whereever easily applicable.

## Future improvements 

- createMockPeerDescriptor is in multiple packages in test utils. This duplicate code should be fixed
