### PR TITLE
ci: use ubuntu-latest as docker host machine in docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,7 +21,7 @@ on:
       host_machine_platform:
         type: string
         required: false
-        default: ubuntu-20.04
+        default: ubuntu-latest
       build_platforms:
         type: string
         required: true


### PR DESCRIPTION
## Summary

Github is moving to deprecated Ubuntu 20 runner in GitHub actions. Update CI script to use `ubuntu-latest`.


> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101
GitHub Actions has encountered an internal error when running your job.

