### PR TITLE
chore(DHT): update node-datachannel to 0.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21142,39 +21142,6 @@
                 "semver": "^7.3.5"
             }
         },
-        "node_modules/node-datachannel": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.10.1.tgz",
-            "integrity": "sha512-rhxb1iQgbFLY6HMt3W6Xcs8Q1k4jIMgI7KduXcYvIn2UMKYK6e/eegya2caF/+XYAqTeo1743gOr11CXvJ/DJA==",
-            "hasInstallScript": true,
-            "license": "MPL 2.0",
-            "dependencies": {
-                "node-domexception": "^2.0.1",
-                "prebuild-install": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/node-domexception": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-2.0.1.tgz",
-            "integrity": "sha512-M85rnSC7WQ7wnfQTARPT4LrK7nwCHLdDFOCcItZMhTQjyCebJH8GciKqYJNgaOFZs9nFmTmd/VMyi3OW5jA47w==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -28751,7 +28718,7 @@
                 "k-bucket": "^5.1.0",
                 "lodash": "^4.17.21",
                 "lru-cache": "^11.0.2",
-                "node-datachannel": "^0.10.1",
+                "node-datachannel": "^0.26.0",
                 "uuid": "^11.1.0",
                 "websocket": "^1.0.34",
                 "ws": "^8.18.1"
@@ -28781,6 +28748,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "packages/dht/node_modules/node-datachannel": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.26.0.tgz",
+            "integrity": "sha512-i9ZcFNszK1HeV6Ym2AoQokmRHE5jk0L5023CdRLzbQl8rqyjJkOGecMxEjo1WSjNHDvRO3I3ay9waclBdD3jRQ==",
+            "hasInstallScript": true,
+            "license": "MPL 2.0",
+            "dependencies": {
+                "prebuild-install": "^7.1.3"
+            },
+            "engines": {
+                "node": ">=18.20.0"
             }
         },
         "packages/geoip-location": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
         "typescript-eslint": "^8.25.0",
         "yarn": "^1.22.22",
         "zx": "^8.3.2"
-    },
-    "overrides": {
-        "prebuild-install": "7.1.3"
     }
 }

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -51,7 +51,7 @@
     "k-bucket": "^5.1.0",
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.2",
-    "node-datachannel": "^0.10.1",
+    "node-datachannel": "^0.26.0",
     "uuid": "^11.1.0",
     "websocket": "^1.0.34",
     "ws": "^8.18.1"


### PR DESCRIPTION
## Summary

Update node-data channel to the latest version.

## Changes

- Removed hack from monorepo package.json 
