### PR TITLE
feat(network): new `doNotBufferWhileConnecting` transport flag.

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -309,7 +309,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
 
         if (this.endpoints.get(nodeId)!.connected) {
             (connection as ManagedConnection).send(binary)
-        } else {
+        } else if (!opts.doNotBufferWhileConnecting) {
             return (this.endpoints.get(nodeId)! as ConnectingEndpoint).buffer.push(binary)
         }
     }

--- a/packages/dht/src/rpc-protocol/DhtCallContext.ts
+++ b/packages/dht/src/rpc-protocol/DhtCallContext.ts
@@ -9,6 +9,7 @@ export class DhtCallContext extends ProtoCallContext implements DhtRpcOptions {
     clientId?: number
     connect?: boolean
     sendIfStopped?: boolean
+    doNotBufferWhileConnecting?: boolean
     //used in incoming calls
     incomingSourceDescriptor?: PeerDescriptor
 }

--- a/packages/dht/src/rpc-protocol/DhtRpcOptions.ts
+++ b/packages/dht/src/rpc-protocol/DhtRpcOptions.ts
@@ -7,4 +7,5 @@ export interface DhtRpcOptions extends ProtoRpcOptions {
     clientId?: number
     connect?: boolean
     sendIfStopped?: boolean
+    doNotBufferWhileConnecting?: boolean
 }

--- a/packages/dht/src/transport/ITransport.ts
+++ b/packages/dht/src/transport/ITransport.ts
@@ -9,11 +9,13 @@ export interface TransportEvents {
 export interface SendOptions {
     connect: boolean
     sendIfStopped: boolean
+    doNotBufferWhileConnecting: boolean
 }
 
 export const DEFAULT_SEND_OPTIONS = {
     connect: true,
-    sendIfStopped: false
+    sendIfStopped: false,
+    doNotBufferWhileConnecting: false
 }
 
 export interface ITransport {

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -46,10 +46,12 @@ export class RoutingRpcCommunicator extends RpcCommunicator<DhtCallContext> {
                     // is no point in trying form a new connection
                     connect: false,
                     // TODO maybe this options could be removed?
-                    sendIfStopped: true
+                    sendIfStopped: true,
+                    doNotBufferWhileConnecting: callContext?.doNotBufferWhileConnecting ?? false
                 } : {
                     connect: callContext?.connect ?? DEFAULT_SEND_OPTIONS.connect,
-                    sendIfStopped: callContext?.sendIfStopped ?? DEFAULT_SEND_OPTIONS.sendIfStopped
+                    sendIfStopped: callContext?.sendIfStopped ?? DEFAULT_SEND_OPTIONS.sendIfStopped,
+                    doNotBufferWhileConnecting: callContext?.doNotBufferWhileConnecting ?? false
                 }
             return this.sendFn(message, sendOpts)
         })

--- a/packages/dht/src/transport/RoutingRpcCommunicator.ts
+++ b/packages/dht/src/transport/RoutingRpcCommunicator.ts
@@ -47,11 +47,12 @@ export class RoutingRpcCommunicator extends RpcCommunicator<DhtCallContext> {
                     connect: false,
                     // TODO maybe this options could be removed?
                     sendIfStopped: true,
-                    doNotBufferWhileConnecting: callContext?.doNotBufferWhileConnecting ?? false
+                    // Responses should be buffered if necessary
+                    doNotBufferWhileConnecting: false
                 } : {
                     connect: callContext?.connect ?? DEFAULT_SEND_OPTIONS.connect,
                     sendIfStopped: callContext?.sendIfStopped ?? DEFAULT_SEND_OPTIONS.sendIfStopped,
-                    doNotBufferWhileConnecting: callContext?.doNotBufferWhileConnecting ?? false
+                    doNotBufferWhileConnecting: callContext?.doNotBufferWhileConnecting ?? DEFAULT_SEND_OPTIONS.doNotBufferWhileConnecting
                 }
             return this.sendFn(message, sendOpts)
         })

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -567,9 +567,8 @@ describe('ConnectionManager', () => {
         })            
     
         let receivedMessages = 0
-        connectionManager1.on('message', (msg) => {
+        connectionManager1.on('message', () => {
             receivedMessages++
-            throw 'Invarant violation'
         })
 
         const sendOptions = {

--- a/packages/dht/test/integration/ConnectionManager.test.ts
+++ b/packages/dht/test/integration/ConnectionManager.test.ts
@@ -1,4 +1,4 @@
-import { Logger, MetricsContext, until, waitForEvent3 } from '@streamr/utils'
+import { Logger, MetricsContext, until, wait, waitForEvent3 } from '@streamr/utils'
 import { MarkOptional } from 'ts-essentials'
 import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { DefaultConnectorFacade, DefaultConnectorFacadeOptions } from '../../src/connection/ConnectorFacade'
@@ -523,6 +523,69 @@ describe('ConnectionManager', () => {
         await connectionManager1.stop()
         await connectionManager2.stop()
  
+    })
+
+    it('send doNotBufferWhileConnecting', async () => {
+        const connectionManager1 = createConnectionManager({
+            transport: mockTransport,
+            websocketHost: '127.0.0.1',
+            websocketServerEnableTls: false,
+            websocketPortRange: { min: 10011, max: 10011 }
+        })
+
+        await connectionManager1.start()
+
+        const connectionManager2 = createConnectionManager({
+            transport: mockTransport,
+            websocketHost: '127.0.0.1',
+            websocketServerEnableTls: false,
+            websocketPortRange: { min: 10012, max: 10012 }
+        })
+
+        await connectionManager2.start()
+
+        const msg: Message = {
+            serviceId: SERVICE_ID,
+            messageId: '1',
+            body: {
+                oneofKind: 'rpcMessage',
+                rpcMessage: RpcMessage.create()
+            },
+            targetDescriptor: connectionManager1.getLocalPeerDescriptor()
+        }
+
+        const connectedPromise1 = new Promise<void>((resolve, _reject) => {
+            connectionManager1.on('connected', () => {
+                resolve()
+            })
+        })
+
+        const connectedPromise2 = new Promise<void>((resolve, _reject) => {
+            connectionManager2.on('connected', () => {
+                resolve()
+            })
+        })            
+    
+        let receivedMessages = 0
+        connectionManager1.on('message', (msg) => {
+            receivedMessages++
+            throw 'Invarant violation'
+        })
+
+        const sendOptions = {
+            connect: true,
+            sendIfStopped: false,
+            doNotBufferWhileConnecting: true
+        }
+        await Promise.all([connectedPromise1, connectedPromise2, connectionManager2.send(msg, sendOptions)])
+        await wait(1000)
+        expect(receivedMessages).toEqual(0)
+        expect(connectionManager1.getConnections().length).toEqual(1)
+        expect(connectionManager2.getConnections().length).toEqual(1)
+
+        await connectionManager1.stop()
+        await connectionManager2.stop()
+
     })
 
 })

--- a/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryManager.ts
@@ -67,6 +67,7 @@ export interface ContentDeliveryManagerOptions {
     acceptProxyConnections?: boolean
     rpcRequestTimeout?: number
     neighborUpdateInterval?: number
+    doNotBufferWhileConnecting?: boolean
 }
 
 export const streamPartIdToDataKey = (streamPartId: StreamPartID): DhtAddress => {
@@ -275,7 +276,8 @@ export class ContentDeliveryManager extends EventEmitter<Events> {
             acceptProxyConnections: this.options.acceptProxyConnections,
             rpcRequestTimeout: this.options.rpcRequestTimeout,
             neighborUpdateInterval: this.options.neighborUpdateInterval,
-            isLocalNodeEntryPoint
+            isLocalNodeEntryPoint,
+            doNotBufferWhileConnecting: this.options.doNotBufferWhileConnecting
         })
     }
 

--- a/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
+++ b/packages/trackerless-network/src/logic/ContentDeliveryRpcRemote.ts
@@ -12,9 +12,10 @@ export class ContentDeliveryRpcRemote extends RpcRemote<ContentDeliveryRpcClient
 
     private rtt?: number
 
-    async sendStreamMessage(msg: StreamMessage): Promise<void> {
+    async sendStreamMessage(msg: StreamMessage, doNotBufferWhileConnecting?: boolean): Promise<void> {
         const options = this.formDhtRpcOptions({
-            notification: true
+            notification: true,
+            doNotBufferWhileConnecting
         })
         this.getClient().sendStreamMessage(msg, options).catch(() => {
             logger.trace('Failed to sendStreamMessage')

--- a/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
+++ b/packages/trackerless-network/src/logic/createContentDeliveryLayerNode.ts
@@ -33,6 +33,7 @@ type ContentDeliveryLayerNodeOptions = MarkOptional<StrictContentDeliveryLayerNo
         acceptProxyConnections?: boolean
         neighborUpdateInterval?: number
         maxPropagationBufferSize?: number
+        doNotBufferWhileConnecting?: boolean
     }
 
 const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): StrictContentDeliveryLayerNodeOptions => {
@@ -73,7 +74,7 @@ const createConfigWithDefaults = (options: ContentDeliveryLayerNodeOptions): Str
             const remote = neighbors.get(neighborId) ?? temporaryConnectionRpcLocal.getNodes().get(neighborId)
             const proxyConnection = proxyConnectionRpcLocal?.getConnection(neighborId)
             if (remote) {
-                await remote.sendStreamMessage(msg)
+                await remote.sendStreamMessage(msg, options.doNotBufferWhileConnecting)
             } else if (proxyConnection) {
                 await proxyConnection.remote.sendStreamMessage(msg)
             } else {


### PR DESCRIPTION
## Summary

Added a transport option to avoid buffering while connecting. This is used in the trackerless-network during propagation when only real-time data is wanted.

## Changes

- Added new transport flag `doNotPropagateWhileConnecting`
- Added new configuration option to the trackerless-network to enable the feature.

## Limitations and future improvements

- Might make sense to add a new configuration option ie. `fireAndForgetMode`. This would disable the use of all buffers during propagation if only real-time data is wanted.
- Make such configurations per stream instead of global.

