### PR TITLE
feat(DHT): NET-1436: Cut off connections to all application versions before v102.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27359,6 +27359,7 @@
                 "lodash": "^4.17.21",
                 "lru-cache": "^11.0.2",
                 "node-datachannel": "^0.26.0",
+                "semver": "7.7.1",
                 "uuid": "^11.1.0",
                 "websocket": "^1.0.34",
                 "ws": "^8.18.1"
@@ -27369,6 +27370,7 @@
                 "@types/heap": "^0.2.34",
                 "@types/k-bucket": "^5.0.1",
                 "@types/lodash": "^4.17.16",
+                "@types/semver": "^7.5.8",
                 "@types/websocket": "^1.0.10",
                 "@types/ws": "^8.18.0",
                 "jest-leak-detector": "^27.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27359,7 +27359,7 @@
                 "lodash": "^4.17.21",
                 "lru-cache": "^11.0.2",
                 "node-datachannel": "^0.26.0",
-                "semver": "7.7.1",
+                "semver": "^7.7.1",
                 "uuid": "^11.1.0",
                 "websocket": "^1.0.34",
                 "ws": "^8.18.1"

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -52,7 +52,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.2",
     "node-datachannel": "^0.26.0",
-    "semver": "7.7.1",
+    "semver": "^7.7.1",
     "uuid": "^11.1.0",
     "websocket": "^1.0.34",
     "ws": "^8.18.1"

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -52,6 +52,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.2",
     "node-datachannel": "^0.26.0",
+    "semver": "7.7.1",
     "uuid": "^11.1.0",
     "websocket": "^1.0.34",
     "ws": "^8.18.1"
@@ -62,6 +63,7 @@
     "@types/heap": "^0.2.34",
     "@types/k-bucket": "^5.0.1",
     "@types/lodash": "^4.17.16",
+    "@types/semver": "^7.5.8",
     "@types/websocket": "^1.0.10",
     "@types/ws": "^8.18.0",
     "jest-leak-detector": "^27.3.1",

--- a/packages/dht/protos/DhtRpc.proto
+++ b/packages/dht/protos/DhtRpc.proto
@@ -237,7 +237,7 @@ message HandshakeResponse {
 enum HandshakeError {
   DUPLICATE_CONNECTION = 0;
   INVALID_TARGET_PEER_DESCRIPTOR = 1;
-  UNSUPPORTED_PROTOCOL_VERSION = 2;
+  UNSUPPORTED_VERSION = 2;
 }
 
 // Wraps all messages

--- a/packages/dht/src/connection/Handshaker.ts
+++ b/packages/dht/src/connection/Handshaker.ts
@@ -180,7 +180,7 @@ export class Handshaker extends EventEmitter<HandshakerEvents> {
                 const error = !isMaybeSupportedProtocolVersion(handshake.protocolVersion) 
                         // All versions before 102.0.0 are not supported
                         || semver.satisfies(semver.coerce(handshake.applicationVersion)!, '< 102.0.0')
-                        ? HandshakeError.UNSUPPORTED_VERSION : handshake.error
+                    ? HandshakeError.UNSUPPORTED_VERSION : handshake.error
                 if (error !== undefined) {
                     this.emit('handshakeFailed', error)
                 } else {

--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -170,7 +170,7 @@ export class WebrtcConnector {
             })
             handshaker.on('handshakeRequest', (_sourceDescriptor: PeerDescriptor, remoteVersion: string) => {
                 if (!isMaybeSupportedProtocolVersion(remoteVersion)) {
-                    rejectHandshake(pendingConnection!, connection, handshaker, HandshakeError.UNSUPPORTED_PROTOCOL_VERSION)
+                    rejectHandshake(pendingConnection!, connection, handshaker, HandshakeError.UNSUPPORTED_VERSION)
                 } else {
                     acceptHandshake(handshaker, pendingConnection, connection)
                 }

--- a/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServerConnector.ts
@@ -133,7 +133,7 @@ export class WebsocketServerConnector {
         if (this.ongoingConnectRequests.has(nodeId)) {
             const { pendingConnection, delFunc } = this.ongoingConnectRequests.get(nodeId)!
             if (!isMaybeSupportedProtocolVersion(remoteProtocolVersion)) {
-                rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.UNSUPPORTED_PROTOCOL_VERSION)
+                rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.UNSUPPORTED_VERSION)
                 delFunc()
             } else if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {
                 rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.INVALID_TARGET_PEER_DESCRIPTOR)
@@ -145,7 +145,7 @@ export class WebsocketServerConnector {
             const pendingConnection = new PendingConnection(remotePeerDescriptor)
             
             if (!isMaybeSupportedProtocolVersion(remoteProtocolVersion)) {
-                rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.UNSUPPORTED_PROTOCOL_VERSION)  
+                rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.UNSUPPORTED_VERSION)  
             } else if (targetPeerDescriptor && !areEqualPeerDescriptors(this.localPeerDescriptor!, targetPeerDescriptor)) {
                 rejectHandshake(pendingConnection, websocketServerConnection, handshaker, HandshakeError.INVALID_TARGET_PEER_DESCRIPTOR)  
             } else if (this.options.onNewConnection(pendingConnection)) {

--- a/packages/dht/src/helpers/version.ts
+++ b/packages/dht/src/helpers/version.ts
@@ -6,7 +6,7 @@ export const LOCAL_PROTOCOL_VERSION = '1.1'
  * 
  * The older version assumes optimistically that it may be supported by the newer
  * version. It can't know for sure, but the other node will tell if it is not
- * supported (e.g. rejecting the handshake with UNSUPPORTED_PROTOCOL_VERSION error).
+ * supported (e.g. rejecting the handshake with UNSUPPORTED_VERSION error).
  */
 export const isMaybeSupportedProtocolVersion = (remoteVersion: string): boolean => {
     const localMajor = parseVersion(LOCAL_PROTOCOL_VERSION)!.major

--- a/packages/dht/test/unit/Handshaker.test.ts
+++ b/packages/dht/test/unit/Handshaker.test.ts
@@ -104,7 +104,7 @@ describe('Handshaker', () => {
         })
 
         it('onHandshakeFailed unsupported version', () => {
-            handshaker.emit('handshakeFailed', HandshakeError.UNSUPPORTED_PROTOCOL_VERSION)
+            handshaker.emit('handshakeFailed', HandshakeError.UNSUPPORTED_VERSION)
             expect(mockOnHandshakeCompleted).not.toHaveBeenCalled()
             expect(mockPendingConnectionClose).toHaveBeenCalledTimes(1)
         })


### PR DESCRIPTION
## Summary

Cut off connections to all application versions before v102.0.0

## Changes

- Renamed handshake error `UNSUPPORTED_PROTOCOL_VERSION` -> `UNSUPPORTED_VERSION`. Version incompatibilities are handled similarly between protocol and application versions.
