### PR TITLE
refactor(DHT): executeRecursiveOperation helper method in DhtNode

### DIFF
--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -570,7 +570,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
         return this.executeRecursiveOperation(
             async () => {
                 const result = await this.recursiveOperationManager!.execute(key, RecursiveOperation.FETCH_DATA)
-                return result.dataEntries ?? [] 
+                return result.dataEntries ?? [] // TODO is this fallback needed?
             },
             (connectedEntryPoint) => this.fetchDataFromDhtViaPeer(key, connectedEntryPoint)
         )

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -572,7 +572,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 const result = await this.recursiveOperationManager!.execute(key, RecursiveOperation.FETCH_DATA)
                 return result.dataEntries ?? [] 
             },
-            (connectedEntryPoint)  => this.fetchDataFromDhtViaPeer(key, connectedEntryPoint)
+            (connectedEntryPoint) => this.fetchDataFromDhtViaPeer(key, connectedEntryPoint)
         )
     }
 


### PR DESCRIPTION
## Summary

added new executeRecursiveOperation helper method to the network

## Future improvements

- The `deleteDataFromDht` and `findClosestNodesFromDht` should use the function as well.
- Could make the creator parameter in storeDataToDht clearer. There should be no need to provide it for the function. The External API could simply be passed the storeManagers storeData method. Currently it is used in the public API for testing but it should be reserved for internal use only.