### PR TITLE
fix(dht): [NET-1448] Memory leak in `DhtNode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Fix memory leak in `DhtNode` (https://github.com/streamr-dev/network/pull/3065)
+
 #### Security
 
 ### @streamr/node

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -263,7 +263,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             { rpcRequestTimeout: this.options.rpcRequestTimeout }
         )
 
-        addManagedEventListener<'message', (message: Message) => void>(  // TODO refactor ITransport so that explicit generic type is not needed
+        /* eslint-disable indent */
+        addManagedEventListener<'message', (message: Message) => void>(  // TODO remove explicit type in NET-1449
             this.transport,
             'message',
             (message: Message) => this.handleMessageFromTransport(message),
@@ -387,7 +388,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
                 }
             }
         })
-        addManagedEventListener<'connected', (eerDescriptor: PeerDescriptor) => void>(  // TODO refactor ITransport so that explicit generic type is not needed
+        /* eslint-disable indent */
+        addManagedEventListener<'connected', (peerDescriptor: PeerDescriptor) => void>(  // TODO remove explicit type in NET-1449
             this.transport!,
             'connected',
             (peerDescriptor: PeerDescriptor) => {
@@ -396,7 +398,8 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             },
             this.abortController.signal
         )
-        addManagedEventListener<'disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => void>(  // TODO refactor ITransport so that explicit generic type is not needed
+        /* eslint-disable indent, max-len */
+        addManagedEventListener<'disconnected', (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => void>(  // TODO remove explicit type in NET-1449
             this.transport!,
             'disconnected',
             (peerDescriptor: PeerDescriptor, gracefulLeave: boolean) => {


### PR DESCRIPTION
## Bug

When a node leaves from a stream part the layer1 `DhtNode` instance is not garbage collected.

## Fix

Use `addManagedEventListener` for transport events. This way the listeners are correctly cleaned up when a layer1 `DhtNode` stops.

## Benchmark

Running two iterations of [metrics-indexer Crawler](https://github.com/streamr-dev/stream-metrics-index), i.e. do joins and leaves for about 500 stream parts:

Before:
![before](https://github.com/user-attachments/assets/893b1153-b4e7-49cb-a202-76bd53bb74ad)
After:
![after](https://github.com/user-attachments/assets/d6b19873-dc1a-43a8-be67-8b125f796bf5)
