### PR TITLE
fix(node): Use `StreamrClient#getConfig()` to check WebRTC private address config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ Changes before Tatum release are not documented in this file.
 
 - Fix operator flag voting behavior when using custom gas estimation (https://github.com/streamr-dev/network/pull/2784)
 - Fix a bug causing the inspection process to freeze (https://github.com/streamr-dev/network/pull/2893)
+- Fix analysis of WebRTC private address probing warning (https://github.com/streamr-dev/network/pull/3070)
 
 ### @streamr/cli-tools
 

--- a/packages/node/src/broker.ts
+++ b/packages/node/src/broker.ts
@@ -63,7 +63,7 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
 
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
 
-            if (!streamrClient.getConfig().network?.controlLayer?.webrtcAllowPrivateAddresses) {
+            if (!streamrClient.getConfig().network.controlLayer.webrtcAllowPrivateAddresses) {
                 logger.warn('WebRTC private address probing is disabled. ' +
                     'This makes it impossible to create network layer connections directly via local routers ' +
                     'More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')

--- a/packages/node/src/broker.ts
+++ b/packages/node/src/broker.ts
@@ -63,7 +63,7 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
 
             logger.info(`Plugins: ${JSON.stringify(plugins.map((p) => p.name))}`)
 
-            if (!config.client.network?.controlLayer?.webrtcAllowPrivateAddresses) {
+            if (!streamrClient.getConfig().network?.controlLayer?.webrtcAllowPrivateAddresses) {
                 logger.warn('WebRTC private address probing is disabled. ' +
                     'This makes it impossible to create network layer connections directly via local routers ' +
                     'More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')


### PR DESCRIPTION
## Background

The node checks a config value and prints "WebRTC private address probing is disabled" if `webrtcAllowPrivateAddresses` is not true.

## Changes

Previously the client config was read directly from the config JSON. In that approach the client defaults were not applied. 
E.g. when using `"environment": "dev2"` node config option, it incorrectly printed the warning (as `webrtcAllowPrivateAddresses` has a default value of `true` in that environment).

Now it uses `StreamrClient#getConfig()`, and which contains the full config with all defaults applied to it. 