### PR TITLE
chore(node): Remove `OperatorServiceConfig` interface

### DIFF
--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -1,12 +1,10 @@
 import {
     ReviewRequestEvent,
-    SignerWithProvider,
     StreamrClient
 } from '@streamr/sdk'
 import {
     addManagedEventListener,
     Cache,
-    EthereumAddress,
     Logger,
     scheduleAtInterval,
     setAbortableInterval,
@@ -14,7 +12,6 @@ import {
     toEthereumAddress
 } from '@streamr/utils'
 import { Schema } from 'ajv'
-import { Overrides } from 'ethers'
 import { Plugin } from '../../Plugin'
 import { MaintainTopologyHelper } from './MaintainTopologyHelper'
 import { MaintainTopologyService } from './MaintainTopologyService'
@@ -64,13 +61,6 @@ export interface OperatorPluginConfig {
         intervalInMs: number
         maxAgeInMs: number
     }
-}
-
-export interface OperatorServiceConfig {
-    signer: SignerWithProvider
-    operatorContractAddress: EthereumAddress
-    theGraphUrl: string
-    getEthersOverrides: () => Promise<Overrides>
 }
 
 const STAKED_OPERATORS_CACHE_MAX_AGE = 2 * 24 * 60 * 60 * 1000

--- a/packages/sdk/src/contracts/Operator.ts
+++ b/packages/sdk/src/contracts/Operator.ts
@@ -404,7 +404,7 @@ export class Operator {
 
     /**
      * Find the sum of earnings in Sponsorships (that the Operator must withdraw before the sum reaches a limit),
-     * SUBJECT TO the constraints, set in the OperatorServiceConfig:
+     * SUBJECT TO the constraints:
      *  - only take at most maxSponsorshipsInWithdraw addresses (those with most earnings), or all if undefined
      *  - only take sponsorships that have more than minSponsorshipEarningsInWithdraw, or all if undefined
      */


### PR DESCRIPTION
Removed obsolete interface. All usage was removed in https://github.com/streamr-dev/network/pull/2601.

Also updated a comment in `Operator#getEarnings()`. It nowadays gets the constraints via the function arguments.