### PR TITLE
feat(cli-tools): Add internal `operator-create` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-operator-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-create.ts
@@ -12,6 +12,12 @@ interface Options extends BaseOptions {
 }
 
 createClientCommand(async (client: StreamrClient, options: Options) => {
+    if (client.getConfig().environment !== 'dev2') {
+        // currently the deployOperatorContract uses TEST_CHAIN_CONFIG and therefore only "dev2" is supported
+        // TODO add e.g. "environment" parameter to that function so that other environments are also supported 
+        console.error('only "dev2" environment is supported')
+        process.exit(1)
+    }
     const metadata = (options.redundancyFactor !== undefined) ? JSON.stringify({ redundancyFactor: options.redundancyFactor }) : ''
     const contract = await _operatorContractUtils.deployOperatorContract({
         deployer: await client.getSigner(),

--- a/packages/cli-tools/bin/streamr-internal-operator-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-create.ts
@@ -1,25 +1,32 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 
-import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
+import { EthereumAddress, StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
+import { createFnParseEthereumAddressList } from '../src/common'
 
 interface Options extends BaseOptions {
     cut: number
     redundancyFactor?: number
+    nodeAddresses?: EthereumAddress[]
 }
 
 createClientCommand(async (client: StreamrClient, options: Options) => {
     const metadata = (options.redundancyFactor !== undefined) ? JSON.stringify({ redundancyFactor: options.redundancyFactor }) : ''
-    await _operatorContractUtils.deployOperatorContract({
+    const contract = await _operatorContractUtils.deployOperatorContract({
         deployer: await client.getSigner(),
         // TODO maybe we could change the operatorsCutPercentage type in _operatorContractUtils.deployOperatorContract so that the percentages
         // aren't affected by floating point numbers (now e.g. input 12.3 stores the value as 12.3000000000000016)
         operatorsCutPercentage: options.cut,
         metadata
     })
+    if (options.nodeAddresses !== undefined) {
+        await (await contract.setNodeAddresses(options.nodeAddresses)).wait()
+    }
 })
     .description('create operator')
     .requiredOption('-c, --cut <number>', 'Operator\'s cut in percentage')
     .option('-r, --redundancyFactor <number>', 'Redundancy factor')
+    .option('-n, --nodeAddresses <addresses>', 'Node addresses (comma separated list of Ethereum addresses)', 
+        createFnParseEthereumAddressList('nodeAddresses'))
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-create.ts
@@ -33,7 +33,7 @@ createClientCommand(async (client: StreamrClient, options: Options) => {
 })
     .description('create operator')
     .requiredOption('-c, --cut <number>', 'Operator\'s cut in percentage')
-    .option('-r, --redundancyFactor <number>', 'Redundancy factor')
-    .option('-n, --nodeAddresses <addresses>', 'Node addresses (comma separated list of Ethereum addresses)', 
+    .option('-r, --redundancy-factor <number>', 'Redundancy factor')
+    .option('-n, --node-addresses <addresses>', 'Node addresses (comma separated list of Ethereum addresses)', 
         createFnParseEthereumAddressList('nodeAddresses'))
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-create.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import '../src/logLevel'
+
+import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
+
+interface Options extends BaseOptions {
+    cut: number
+    redundancyFactor?: number
+}
+
+createClientCommand(async (client: StreamrClient, options: Options) => {
+    const metadata = (options.redundancyFactor !== undefined) ? JSON.stringify({ redundancyFactor: options.redundancyFactor }) : ''
+    await _operatorContractUtils.deployOperatorContract({
+        deployer: await client.getSigner(),
+        // TODO maybe we could change the operatorsCutPercentage type in _operatorContractUtils.deployOperatorContract so that the percentages
+        // aren't affected by floating point numbers (now e.g. input 12.3 stores the value as 12.3000000000000016)
+        operatorsCutPercentage: options.cut,
+        metadata
+    })
+})
+    .description('create operator')
+    .requiredOption('-c, --cut <number>', 'Operator\'s cut in percentage')
+    .option('-r, --redundancyFactor <number>', 'Redundancy factor')
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-create.ts
@@ -23,6 +23,7 @@ createClientCommand(async (client: StreamrClient, options: Options) => {
     if (options.nodeAddresses !== undefined) {
         await (await contract.setNodeAddresses(options.nodeAddresses)).wait()
     }
+    console.info(JSON.stringify({ address: await contract.getAddress() }, undefined, 4))
 })
     .description('create operator')
     .requiredOption('-c, --cut <number>', 'Operator\'s cut in percentage')

--- a/packages/cli-tools/bin/streamr-internal.ts
+++ b/packages/cli-tools/bin/streamr-internal.ts
@@ -10,6 +10,7 @@ program
     .command('visualize-topology', 'visualize network topology')
     .command('show-sdk-config', 'show config used by internal StreamrClient')
     .command('sponsorship-sponsor', 'sponsor a sponsorship')
+    .command('operator-create', 'create operator')
     .command('operator-delegate', 'delegate funds to an operator')
     .command('operator-undelegate', 'undelegate funds from an operator')
     .command('operator-stake', 'stake operator\'s funds to a sponsorship')

--- a/packages/cli-tools/src/common.ts
+++ b/packages/cli-tools/src/common.ts
@@ -1,3 +1,5 @@
+import { EthereumAddress, toEthereumAddress } from '@streamr/utils'
+
 export enum OptionType {
     FLAG, // e.g. "--enable"
     ARGUMENT  // e.g. "--private-key 0x1234"
@@ -41,3 +43,19 @@ export const formEnumArgValueDescription = (allowedValues: string[], defaultValu
 export const wrapWithQuotes = (str: string): string => {
     return `"${str}"`
 }
+
+export function createFnParseEthereumAddressList(name: string): (s: string) => EthereumAddress[] {
+    return (value: string) => {
+        const items = value.split(',').map((item)=> item.trim())
+        const result: EthereumAddress[] = []
+        for (const item of items) {
+            try {
+                result.push(toEthereumAddress(item))
+            } catch {
+                console.error(`${name} has invalid Ethereum address: "${item}"`)
+                process.exit(1)
+            }
+        }
+        return result
+    }
+} 

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -66,7 +66,7 @@ export async function setupOperatorContract(
  * @hidden
  */
 export interface DeployOperatorContractOpts {
-    deployer: Wallet
+    deployer: SignerWithProvider
     operatorsCutPercentage?: number
     metadata?: string
     operatorTokenName?: string
@@ -80,7 +80,7 @@ export async function deployOperatorContract(opts: DeployOperatorContractOpts): 
     logger.debug('Deploying OperatorContract')
     const abi = OperatorFactoryArtifact
     const operatorFactory = new Contract(TEST_CHAIN_CONFIG.contracts.OperatorFactory, abi, opts.deployer) as unknown as OperatorFactoryContract
-    const contractAddress = await operatorFactory.operators(opts.deployer.address)
+    const contractAddress = await operatorFactory.operators(await opts.deployer.getAddress())
     if (contractAddress !== ZeroAddress) {
         throw new Error('Operator already has a contract')
     }


### PR DESCRIPTION
Added an internal command for creating operator contracts. Supports only `dev2` environment.

## Usage

```
streamr internal operator-create --cut 12.3 --redundancy-factor 2 --node-addresses  '...,...' --env dev2 --private-key ...
```

## Other changes

Small refactoring to `operatorContractUtils` so that `StreamrClient#client.getSigner()` is supported as `deployer`.

## Future improvements

Could promote this to be non-internal command. Currently `operatorContractUtils#deployOperatorContract()` always uses `TEST_CHAIN_CONFIG`, but we could pass e.g. environment ID as a parameter to support also other environments.