### PR TITLE
feat(cli-tools): Add internal `sponsorship-create` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -27,6 +27,6 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .description('create sponsorship')
     .arguments('<streamId>')
-    .requiredOption('-e, --earningsPerSecond <number>', 'Earnings per second')
-    .requiredOption('-c, --minOperatorCount <number>', 'Minimum operator count')
+    .requiredOption('-e, --earnings-per-second <number>', 'Earnings per second')
+    .requiredOption('-c, --min-operator-count <number>', 'Minimum operator count')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import '../src/logLevel'
+
+import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
+import { createClientCommand, Options as BaseOptions } from '../src/command'
+import { toEthereumAddress, toStreamID } from '@streamr/utils'
+import { parseEther } from 'ethers'
+
+interface Options extends BaseOptions {
+    earningsPerSecond: string
+    minOperatorCount: number
+}
+
+createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
+    await _operatorContractUtils.deploySponsorshipContract({
+        streamId: toStreamID(streamId, toEthereumAddress(await client.getUserId())),
+        earningsPerSecond: parseEther(options.earningsPerSecond),
+        deployer: await client.getSigner(),
+        minOperatorCount: options.minOperatorCount
+    })
+})
+    .description('create sponsorship')
+    .arguments('<streamId>')
+    .requiredOption('-e, --earningsPerSecond <number>', 'Earnings per second')
+    .requiredOption('-c, --minOperatorCount <number>', 'Minimum operator count')
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -12,6 +12,12 @@ interface Options extends BaseOptions {
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
+    if (client.getConfig().environment !== 'dev2') {
+        // currently the deploySponsorshipContract uses TEST_CHAIN_CONFIG and therefore only "dev2" is supported
+        // TODO add e.g. "environment" parameter to that function so that other environments are also supported 
+        console.error('only "dev2" environment is supported')
+        process.exit(1)
+    }
     await _operatorContractUtils.deploySponsorshipContract({
         streamId: toStreamID(streamId, toEthereumAddress(await client.getUserId())),
         earningsPerSecond: parseEther(options.earningsPerSecond),

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -18,12 +18,13 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
         console.error('only "dev2" environment is supported')
         process.exit(1)
     }
-    await _operatorContractUtils.deploySponsorshipContract({
+    const contract = await _operatorContractUtils.deploySponsorshipContract({
         streamId: toStreamID(streamId, toEthereumAddress(await client.getUserId())),
         earningsPerSecond: parseEther(options.earningsPerSecond),
         deployer: await client.getSigner(),
         minOperatorCount: options.minOperatorCount
     })
+    console.info(JSON.stringify({ address: await contract.getAddress() }, undefined, 4))
 })
     .description('create sponsorship')
     .arguments('<streamId>')

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -8,7 +8,7 @@ import { parseEther } from 'ethers'
 
 interface Options extends BaseOptions {
     earningsPerSecond: string
-    minOperatorCount: number
+    minOperatorCount?: number
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
@@ -29,5 +29,5 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
     .description('create sponsorship')
     .arguments('<streamId>')
     .requiredOption('-e, --earnings-per-second <number>', 'Earnings per second')
-    .requiredOption('-c, --min-operator-count <number>', 'Minimum operator count')
+    .option('-c, --min-operator-count <number>', 'Minimum operator count')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal.ts
+++ b/packages/cli-tools/bin/streamr-internal.ts
@@ -9,6 +9,7 @@ program
     .command('node-info', 'info about a node')
     .command('visualize-topology', 'visualize network topology')
     .command('show-sdk-config', 'show config used by internal StreamrClient')
+    .command('sponsorship-create', 'create sponsorship')
     .command('sponsorship-sponsor', 'sponsor a sponsorship')
     .command('operator-delegate', 'delegate funds to an operator')
     .command('operator-undelegate', 'undelegate funds from an operator')

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -111,7 +111,7 @@ export async function deployOperatorContract(opts: DeployOperatorContractOpts): 
  */
 export interface DeploySponsorshipContractOpts {
     streamId: string
-    deployer: Wallet
+    deployer: SignerWithProvider
     metadata?: string
     minOperatorCount?: number
     earningsPerSecond?: WeiAmount


### PR DESCRIPTION
Added an internal command for creating sponsorship contracts. Supports only `dev2` environment.

## Usage

```
streamr internal sponsorship-create /foo --earnings-per-second 123 --min-operator-count 4 --env dev2 --private-key ...
```

## Other changes

Small refactoring to `operatorContractUtils` so that `StreamrClient#client.getSigner()` is supported as `deployer`.

## Future improvements

Could promote this to be non-internal command. Currently `operatorContractUtils#deploySponsorshipContract()` always uses `TEST_CHAIN_CONFIG`, but we could pass e.g. environment ID as a parameter to support also other environments.