### PR TITLE
refactor(sdk): Operator contract utils without token ABI

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-operator-delegate.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-delegate.ts
@@ -9,8 +9,7 @@ createClientCommand(async (client: StreamrClient, operatorAddress: string, dataT
     await _operatorContractUtils.delegate(
         await client.getSigner(),
         operatorAddress,
-        parseEther(dataTokenAmount),
-        _operatorContractUtils.getTestTokenContract()
+        parseEther(dataTokenAmount)
     )
 })
     .description('delegate funds to an operator')

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-sponsor.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-sponsor.ts
@@ -9,8 +9,7 @@ createClientCommand(async (client: StreamrClient, sponsorshipAddress: string, da
     await _operatorContractUtils.sponsor(
         await client.getSigner(),
         sponsorshipAddress,
-        parseEther(dataTokenAmount),
-        _operatorContractUtils.getTestTokenContract()
+        parseEther(dataTokenAmount)
     )
 })
     .description('sponsor a stream')

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -207,17 +207,6 @@ export const sponsor = async (
     await (await sponsorshipContract.sponsor(amount)).wait()
 }
 
-export const transferTokens = async (
-    from: SignerWithProvider,
-    to: string,
-    amount: WeiAmount,
-    data?: string,
-    token?: DATATokenContract
-): Promise<void> => {
-    const tx = await ((token ?? getTestTokenContract()).connect(from).transferAndCall(to, amount, data ?? '0x'))
-    await tx.wait()
-}
-
 export const getOperatorContract = (operatorAddress: string): OperatorContract => {
     return new Contract(operatorAddress, OperatorArtifact) as unknown as OperatorContract
 }

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -171,7 +171,7 @@ export const delegate = async (
     // onTokenTransfer: the tokens are delegated on behalf of the given data address
     // eslint-disable-next-line max-len
     // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol#L233
-    await transferTokens(delegator, operatorContractAddress, amount, undefined, tokenAddress)
+    await transferTokens(delegator, operatorContractAddress, amount, tokenAddress)
 }
 
 export const undelegate = async (
@@ -209,18 +209,17 @@ export const sponsor = async (
     const tokenAddress = await getSponsorshipContract(sponsorshipContractAddress).connect(sponsorer.provider).token()
     // eslint-disable-next-line max-len
     // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol#L139
-    await transferTokens(sponsorer, sponsorshipContractAddress, amount, undefined, tokenAddress)
+    await transferTokens(sponsorer, sponsorshipContractAddress, amount, tokenAddress)
 }
 
 export const transferTokens = async (
     from: SignerWithProvider,
     to: string,
     amount: WeiAmount,
-    data: string | undefined,
     tokenAddress: string
 ): Promise<void> => {
     const token = new Contract(tokenAddress, DATATokenArtifact) as unknown as DATATokenContract
-    const tx = await token.connect(from).transferAndCall(to, amount, data ?? '0x')
+    const tx = await token.connect(from).transferAndCall(to, amount, '0x')
     await tx.wait()
 }
 

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -207,6 +207,17 @@ export const sponsor = async (
     await (await sponsorshipContract.sponsor(amount)).wait()
 }
 
+export const transferTokens = async (
+    from: SignerWithProvider,
+    to: string,
+    amount: WeiAmount,
+    data?: string,
+    token?: DATATokenContract
+): Promise<void> => {
+    const tx = await ((token ?? getTestTokenContract()).connect(from).transferAndCall(to, amount, data ?? '0x'))
+    await tx.wait()
+}
+
 export const getOperatorContract = (operatorAddress: string): OperatorContract => {
     return new Contract(operatorAddress, OperatorArtifact) as unknown as OperatorContract
 }

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -168,11 +168,10 @@ export const delegate = async (
 ): Promise<void> => {
     logger.debug('Delegate', { amount: amount.toString() })
     const tokenAddress = await getOperatorContract(operatorContractAddress).connect(delegator.provider).token()
-    // TODO can we remove the data argument?
     // onTokenTransfer: the tokens are delegated on behalf of the given data address
     // eslint-disable-next-line max-len
     // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol#L233
-    await transferTokens(delegator, operatorContractAddress, amount, await delegator.getAddress(), tokenAddress)
+    await transferTokens(delegator, operatorContractAddress, amount, undefined, tokenAddress)
 }
 
 export const undelegate = async (

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -179,6 +179,7 @@ export const undelegate = async (
     operatorContract: OperatorContract,
     amount: WeiAmount
 ): Promise<void> => {
+    logger.debug('Undelegate', { amount: amount.toString() })
     await (await operatorContract.connect(delegator).undelegate(amount)).wait()
 }
 

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -164,14 +164,11 @@ export const getTestAdminWallet = (adminKey?: string, provider?: Provider): Wall
 export const delegate = async (
     delegator: SignerWithProvider,
     operatorContractAddress: string,
-    amount: WeiAmount,
-    token?: DATATokenContract
+    amount: WeiAmount
 ): Promise<void> => {
     logger.debug('Delegate', { amount: amount.toString() })
-    // onTokenTransfer: the tokens are delegated on behalf of the given data address
-    // eslint-disable-next-line max-len
-    // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol#L233
-    await transferTokens(delegator, operatorContractAddress, amount, await delegator.getAddress(), token)
+    const operatorContract = getOperatorContract(operatorContractAddress).connect(delegator)
+    await (await operatorContract.delegate(amount)).wait()
 }
 
 export const undelegate = async (
@@ -204,12 +201,10 @@ export const sponsor = async (
     sponsorer: SignerWithProvider,
     sponsorshipContractAddress: string,
     amount: WeiAmount,
-    token?: DATATokenContract
 ): Promise<void> => {
     logger.debug('Sponsor', { amount: amount.toString() })
-    // eslint-disable-next-line max-len
-    // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol#L139
-    await transferTokens(sponsorer, sponsorshipContractAddress, amount, undefined, token)
+    const sponsorshipContract = getSponsorshipContract(sponsorshipContractAddress).connect(sponsorer)
+    await (await sponsorshipContract.sponsor(amount)).wait()
 }
 
 export const transferTokens = async (
@@ -225,4 +220,8 @@ export const transferTokens = async (
 
 export const getOperatorContract = (operatorAddress: string): OperatorContract => {
     return new Contract(operatorAddress, OperatorArtifact) as unknown as OperatorContract
+}
+
+const getSponsorshipContract = (sponsorshipAddress: string): SponsorshipContract => {
+    return new Contract(sponsorshipAddress, SponsorshipArtifact) as unknown as SponsorshipContract
 }

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -168,9 +168,6 @@ export const delegate = async (
 ): Promise<void> => {
     logger.debug('Delegate', { amount: amount.toString() })
     const tokenAddress = await getOperatorContract(operatorContractAddress).connect(delegator.provider).token()
-    // onTokenTransfer: the tokens are delegated on behalf of the given data address
-    // eslint-disable-next-line max-len
-    // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol#L233
     await transferTokens(delegator, operatorContractAddress, amount, tokenAddress)
 }
 
@@ -207,8 +204,6 @@ export const sponsor = async (
 ): Promise<void> => {
     logger.debug('Sponsor', { amount: amount.toString() })
     const tokenAddress = await getSponsorshipContract(sponsorshipContractAddress).connect(sponsorer.provider).token()
-    // eslint-disable-next-line max-len
-    // https://github.com/streamr-dev/network-contracts/blob/01ec980cfe576e25e8c9acc08a57e1e4769f3e10/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol#L139
     await transferTokens(sponsorer, sponsorshipContractAddress, amount, tokenAddress)
 }
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -244,24 +244,7 @@ const getTestProvider = (): Provider => {
 }
 
 const getTestTokenContract = (adminWallet: Wallet): { mint: (targetAddress: string, amountWei: bigint) => Promise<TransactionResponse> } => {
-    const ABI = [{
-        inputs: [
-            {
-                internalType: 'address',
-                name: 'to',
-                type: 'address'
-            },
-            {
-                internalType: 'uint256',
-                name: 'amount',
-                type: 'uint256'
-            }
-        ],
-        name: 'mint',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function'
-    }]
+    const ABI = ['function mint(address to, uint256 amount)']
     return new Contract(TEST_CHAIN_CONFIG.contracts.DATA, ABI).connect(adminWallet) as unknown as { mint: () => Promise<TransactionResponse> }
 }
 


### PR DESCRIPTION
Refactored `delegate()` and `sponsor()` so that the token argument is not needed. The token address is now queried via a `Operator`/`Sponsorship` contract instance.

## Other changes

- removed obsolete `delegator` parameter from `transferAndCall()`
- simplified ABI definition in `getTestTokenContract()`
- added logging for `undelegate()`

## Future improvements

As we no longer need to pass the `token` argument for `delegate()` and `sponsor()` functions it should be possible to promote the related internal cli-tool command to non-internal commands. 
