### PR TITLE
chore(sdk): Add `StreamrClient#getTheGraphClient()` internal method

### DIFF
--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -760,6 +760,14 @@ export class StreamrClient {
     }
 
     /**
+     * @deprecated This in an internal method
+     * @hidden
+     */
+    getTheGraphClient(): TheGraphClient {
+        return this.theGraphClient
+    }
+
+    /**
      * Get overrides for transaction options. Use as a parameter when submitting
      * transactions via ethers library.
      *


### PR DESCRIPTION
Added a method which provides a client for querying The Graph. All entities of the Streamr graph can be queried using this client, e.g.:
- `Stream`
- `StreamPermission`
- `Operator` 
- `Sponsorship`
- `Stake`
- `Vote`
- ...

This method is currently internal, but it can be made public if needed.

Needed in https://github.com/streamr-dev/network/pull/3086.