### PR TITLE
refactor(sdk): Use addresses instead of contract objects in `operatorContractUtils`

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-operator-delegate.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-delegate.ts
@@ -5,13 +5,13 @@ import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 import { parseEther } from 'ethers'
 
-createClientCommand(async (client: StreamrClient, operatorAddress: string, dataTokenAmount: string) => {
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, dataTokenAmount: string) => {
     await _operatorContractUtils.delegate(
         await client.getSigner(),
-        operatorAddress,
+        operatorContractAddress,
         parseEther(dataTokenAmount)
     )
 })
     .description('delegate funds to an operator')
-    .arguments('<operatorAddress> <dataTokenAmount>')
+    .arguments('<operatorContractAddress> <dataTokenAmount>')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-stake.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-stake.ts
@@ -5,14 +5,14 @@ import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 import { parseEther } from 'ethers'
 
-createClientCommand(async (client: StreamrClient, operatorContractAddress: string, sponsorshipAddress: string, dataTokenAmount: string) => {
-    const operatorContract = _operatorContractUtils.getOperatorContract(operatorContractAddress).connect(await client.getSigner())
+createClientCommand(async (client: StreamrClient, operatorAddress: string, sponsorshipAddress: string, dataTokenAmount: string) => {
     await _operatorContractUtils.stake(
-        operatorContract,
+        await client.getSigner(),
+        operatorAddress,
         sponsorshipAddress,
         parseEther(dataTokenAmount)
     )
 })
     .description('stake funds to a sponsorship')
-    .arguments('<operatorContractAddress> <sponsorshipAddress> <dataTokenAmount>')
+    .arguments('<operatorAddress> <sponsorshipAddress> <dataTokenAmount>')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-stake.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-stake.ts
@@ -5,14 +5,14 @@ import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 import { parseEther } from 'ethers'
 
-createClientCommand(async (client: StreamrClient, operatorAddress: string, sponsorshipAddress: string, dataTokenAmount: string) => {
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, sponsorshipAddress: string, dataTokenAmount: string) => {
     await _operatorContractUtils.stake(
         await client.getSigner(),
-        operatorAddress,
+        operatorContractAddress,
         sponsorshipAddress,
         parseEther(dataTokenAmount)
     )
 })
     .description('stake funds to a sponsorship')
-    .arguments('<operatorAddress> <sponsorshipAddress> <dataTokenAmount>')
+    .arguments('<operatorContractAddress> <sponsorshipAddress> <dataTokenAmount>')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-undelegate.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-undelegate.ts
@@ -5,13 +5,13 @@ import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 import { parseEther } from 'ethers'
 
-createClientCommand(async (client: StreamrClient, operatorAddress: string, dataTokenAmount: string) => {
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, dataTokenAmount: string) => {
     await _operatorContractUtils.undelegate(
         await client.getSigner(),
-        operatorAddress,
+        operatorContractAddress,
         parseEther(dataTokenAmount)
     )
 })
     .description('undelegate funds from an operator')
-    .arguments('<operatorAddress> <dataTokenAmount>')
+    .arguments('<operatorContractAddress> <dataTokenAmount>')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-undelegate.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-undelegate.ts
@@ -8,7 +8,7 @@ import { parseEther } from 'ethers'
 createClientCommand(async (client: StreamrClient, operatorAddress: string, dataTokenAmount: string) => {
     await _operatorContractUtils.undelegate(
         await client.getSigner(),
-        _operatorContractUtils.getOperatorContract(operatorAddress),
+        operatorAddress,
         parseEther(dataTokenAmount)
     )
 })

--- a/packages/cli-tools/bin/streamr-internal-operator-unstake.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-unstake.ts
@@ -4,13 +4,13 @@ import '../src/logLevel'
 import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 
-createClientCommand(async (client: StreamrClient, operatorContractAddress: string, sponsorshipAddress: string) => {
-    const operatorContract = _operatorContractUtils.getOperatorContract(operatorContractAddress).connect(await client.getSigner())
+createClientCommand(async (client: StreamrClient, operatorAddress: string, sponsorshipAddress: string) => {
     await _operatorContractUtils.unstake(
-        operatorContract,
+        await client.getSigner(),
+        operatorAddress,
         sponsorshipAddress
     )
 })
-    .arguments('<operatorContractAddress> <sponsorshipAddress>')
+    .arguments('<operatorAddress> <sponsorshipAddress>')
     .description('unstake all funds from a sponsorship')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-operator-unstake.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-unstake.ts
@@ -4,13 +4,13 @@ import '../src/logLevel'
 import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
 import { createClientCommand } from '../src/command'
 
-createClientCommand(async (client: StreamrClient, operatorAddress: string, sponsorshipAddress: string) => {
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, sponsorshipAddress: string) => {
     await _operatorContractUtils.unstake(
         await client.getSigner(),
-        operatorAddress,
+        operatorContractAddress,
         sponsorshipAddress
     )
 })
-    .arguments('<operatorAddress> <sponsorshipAddress>')
+    .arguments('<operatorContractAddress> <sponsorshipAddress>')
     .description('unstake all funds from a sponsorship')
     .parseAsync()

--- a/packages/cli-tools/test/internal-operator.test.ts
+++ b/packages/cli-tools/test/internal-operator.test.ts
@@ -25,29 +25,29 @@ describe('operator', () => {
         })
         await _operatorContractUtils.delegate(operator, await operatorContract.getAddress(), parseEther(SELF_DELEGATION_AMOUNT))
         const delegator = await createTestWallet({ gas: true, tokens: true })
-        const operatorAddress: string = await operatorContract.getAddress()
+        const operatorContractAddress: string = await operatorContract.getAddress()
 
         // delegate
-        await runCommand(`internal operator-delegate ${operatorAddress} ${DELEGATION_AMOUNT}`, {
+        await runCommand(`internal operator-delegate ${operatorContractAddress} ${DELEGATION_AMOUNT}`, {
             privateKey: delegator.privateKey
         })
         expect(await operatorContract.balanceInData(await delegator.getAddress())).toEqual(parseEther(DELEGATION_AMOUNT))
 
         // stake
-        await runCommand(`internal operator-stake ${operatorAddress} ${sponsorshipAddress} ${STAKE_AMOUNT}`, {
+        await runCommand(`internal operator-stake ${operatorContractAddress} ${sponsorshipAddress} ${STAKE_AMOUNT}`, {
             privateKey: operator.privateKey
         })
         expect(await operatorContract.totalStakedIntoSponsorshipsWei()).toEqual(parseEther(STAKE_AMOUNT))
 
         // unstake
-        await runCommand(`internal operator-unstake ${operatorAddress} ${sponsorshipAddress}`, {
+        await runCommand(`internal operator-unstake ${operatorContractAddress} ${sponsorshipAddress}`, {
             privateKey: operator.privateKey
         })
         expect(await operatorContract.totalStakedIntoSponsorshipsWei()).toEqual(0n)
 
         // undelegate
         await wait(MINIMUM_DELEGATION_SECONDS)
-        await runCommand(`internal operator-undelegate ${operatorAddress} ${DELEGATION_AMOUNT}`, {
+        await runCommand(`internal operator-undelegate ${operatorContractAddress} ${DELEGATION_AMOUNT}`, {
             privateKey: delegator.privateKey
         })
         expect(await operatorContract.balanceInData(await delegator.getAddress())).toEqual(0n)

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -1,4 +1,3 @@
-import type { Operator } from '@streamr/network-contracts'
 import {
     ProxyDirection,
     SignerWithProvider,
@@ -28,7 +27,7 @@ describe('OperatorPlugin', () => {
 
     let broker: Broker
     let brokerWallet: Wallet
-    let operatorContract: Operator
+    let operatorContractAddress: EthereumAddress
     let operatorWallet: Wallet & SignerWithProvider
 
     beforeAll(async () => {
@@ -38,7 +37,7 @@ describe('OperatorPlugin', () => {
         }))
         brokerWallet = deployment.nodeWallets[0]
         operatorWallet = deployment.operatorWallet
-        operatorContract = deployment.operatorContract
+        operatorContractAddress = deployment.operatorContractAddress
     }, 30 * 1000)
 
     afterEach(async () => {
@@ -59,8 +58,8 @@ describe('OperatorPlugin', () => {
         const sponsorer = await createTestWallet({ gas: true, tokens: true })
         const sponsorship1 = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
         await sponsor(sponsorer, await sponsorship1.getAddress(), parseEther('10000'))
-        await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('10000'))
-        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship1.getAddress(), parseEther('10000'))
+        await delegate(operatorWallet, operatorContractAddress, parseEther('10000'))
+        await stake(operatorWallet, operatorContractAddress, await sponsorship1.getAddress(), parseEther('10000'))
 
         const publisher = createClient()
         await stream.grantPermissions({
@@ -74,7 +73,7 @@ describe('OperatorPlugin', () => {
             privateKey: brokerWallet.privateKey,
             extraPlugins: {
                 operator: {
-                    operatorContractAddress: await operatorContract.getAddress()
+                    operatorContractAddress: operatorContractAddress
                 }
             }
         })
@@ -98,7 +97,7 @@ describe('OperatorPlugin', () => {
                 privateKey: brokerWallet.privateKey,
                 extraPlugins: {
                     operator: {
-                        operatorContractAddress: await operatorContract.getAddress()
+                        operatorContractAddress
                     }
                 }
             })
@@ -117,10 +116,9 @@ describe('OperatorPlugin', () => {
         const sponsorer = await createTestWallet({ gas: true, tokens: true })
         const sponsorship = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
         await sponsor(sponsorer, await sponsorship.getAddress(), parseEther('10000'))
-        await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('10000'))
-        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship.getAddress(), parseEther('10000'))
+        await delegate(operatorWallet, operatorContractAddress, parseEther('10000'))
+        await stake(operatorWallet, operatorContractAddress, await sponsorship.getAddress(), parseEther('10000'))
 
-        const operatorContractAddress = await operatorContract.getAddress()
         broker = await startBroker({
             privateKey: brokerWallet.privateKey,
             extraPlugins: {

--- a/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
+++ b/packages/node/test/integration/plugins/operator/OperatorPlugin.test.ts
@@ -60,7 +60,7 @@ describe('OperatorPlugin', () => {
         const sponsorship1 = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
         await sponsor(sponsorer, await sponsorship1.getAddress(), parseEther('10000'))
         await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('10000'))
-        await stake(operatorContract, await sponsorship1.getAddress(), parseEther('10000'))
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship1.getAddress(), parseEther('10000'))
 
         const publisher = createClient()
         await stream.grantPermissions({
@@ -118,7 +118,7 @@ describe('OperatorPlugin', () => {
         const sponsorship = await deploySponsorshipContract({ streamId: stream.id, deployer: sponsorer })
         await sponsor(sponsorer, await sponsorship.getAddress(), parseEther('10000'))
         await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('10000'))
-        await stake(operatorContract, await sponsorship.getAddress(), parseEther('10000'))
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship.getAddress(), parseEther('10000'))
 
         const operatorContractAddress = await operatorContract.getAddress()
         broker = await startBroker({

--- a/packages/node/test/integration/plugins/operator/announceNodeToContract.test.ts
+++ b/packages/node/test/integration/plugins/operator/announceNodeToContract.test.ts
@@ -1,5 +1,5 @@
 import { Operator, _operatorContractUtils } from '@streamr/sdk'
-import { toEthereumAddress, until } from '@streamr/utils'
+import { until } from '@streamr/utils'
 import { announceNodeToContract } from '../../../../src/plugins/operator/announceNodeToContract'
 import { createClient } from '../../../utils'
 import { createTestWallet } from '@streamr/test-utils'
@@ -11,11 +11,11 @@ describe('announceNodeToContract', () => {
     let operator: Operator
 
     beforeEach(async () => {
-        const { operatorContract, nodeWallets } = await _operatorContractUtils.setupOperatorContract({
+        const { operatorContractAddress, nodeWallets } = await _operatorContractUtils.setupOperatorContract({
             nodeCount: 1,
             createTestWallet
         })
-        operator = createClient(nodeWallets[0].privateKey).getOperator(toEthereumAddress(await operatorContract.getAddress()))
+        operator = createClient(nodeWallets[0].privateKey).getOperator(operatorContractAddress)
     }, TIMEOUT)
 
     it('read empty heartbeat, then write heartbeat then read timestamp', async () => {

--- a/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
+++ b/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
@@ -1,6 +1,6 @@
 import { _operatorContractUtils } from '@streamr/sdk'
 import { createTestWallet } from '@streamr/test-utils'
-import { collect, toEthereumAddress } from '@streamr/utils'
+import { collect } from '@streamr/utils'
 import { version as applicationVersion } from '../../../../package.json'
 import { announceNodeToStream } from '../../../../src/plugins/operator/announceNodeToStream'
 import { formCoordinationStreamId } from '../../../../src/plugins/operator/formCoordinationStreamId'
@@ -11,11 +11,10 @@ const TIMEOUT = 40 * 1000
 describe('announceNodeToStream', () => {
 
     it('publishes to stream', async () => {
-        const { operatorContract, nodeWallets } = await _operatorContractUtils.setupOperatorContract({
+        const { operatorContractAddress, nodeWallets } = await _operatorContractUtils.setupOperatorContract({
             nodeCount: 1,
             createTestWallet
         })
-        const operatorContractAddress = toEthereumAddress(await operatorContract.getAddress())
         const nodeWallet = nodeWallets[0]
         const client = createClient(nodeWallet.privateKey)
         const streamId = formCoordinationStreamId(operatorContractAddress)

--- a/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
+++ b/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
@@ -58,7 +58,7 @@ describe('checkOperatorValueBreach', () => {
         const sponsorship2 = await deploySponsorshipContract({ earningsPerSecond: parseEther('200'), streamId, deployer: operatorWallet })
         await sponsor(sponsorer, await sponsorship2.getAddress(), parseEther('25000'))
         await stake(operatorWallet, operatorContractAddress, await sponsorship2.getAddress(), parseEther('10000'))
-        const operatorContract = getOperatorContract(operatorContractAddress)
+        const operatorContract = getOperatorContract(operatorContractAddress).connect(operatorWallet)
         const valueBeforeWithdraw = await operatorContract.valueWithoutEarnings()
         const streamrConfigAddress = await operatorContract.streamrConfig()
         const streamrConfig = new Contract(streamrConfigAddress, streamrConfigABI, getProvider()) as unknown as StreamrConfig

--- a/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
+++ b/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
@@ -53,10 +53,10 @@ describe('checkOperatorValueBreach', () => {
         await delegate(operatorWallet, await operatorContract.getAddress(), parseEther('20000'))
         const sponsorship1 = await deploySponsorshipContract({ earningsPerSecond: parseEther('100'), streamId, deployer: operatorWallet })
         await sponsor(sponsorer, await sponsorship1.getAddress(), parseEther('25000'))
-        await stake(operatorContract, await sponsorship1.getAddress(), parseEther('10000'))
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship1.getAddress(), parseEther('10000'))
         const sponsorship2 = await deploySponsorshipContract({ earningsPerSecond: parseEther('200'), streamId, deployer: operatorWallet })
         await sponsor(sponsorer, await sponsorship2.getAddress(), parseEther('25000'))
-        await stake(operatorContract, await sponsorship2.getAddress(), parseEther('10000'))
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship2.getAddress(), parseEther('10000'))
         const valueBeforeWithdraw = await operatorContract.valueWithoutEarnings()
         const streamrConfigAddress = await operatorContract.streamrConfig()
         const streamrConfig = new Contract(streamrConfigAddress, streamrConfigABI, getProvider()) as unknown as StreamrConfig

--- a/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
+++ b/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
@@ -47,7 +47,7 @@ describe('maintainOperatorValue', () => {
         const sponsorship = await deploySponsorshipContract({ earningsPerSecond: parseEther('100'), streamId, deployer: operatorWallet })
         await sponsor(sponsorer, await sponsorship.getAddress(), parseEther('25000'))
         await delegate(operatorWallet, await operatorContract.getAddress(), STAKE_AMOUNT)
-        await stake(operatorContract, await sponsorship.getAddress(), STAKE_AMOUNT)
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship.getAddress(), STAKE_AMOUNT)
         const operator = createClient(nodeWallets[0].privateKey).getOperator(toEthereumAddress(await operatorContract.getAddress()))
         const { maxAllowedEarnings } = await operator.getEarnings(1n, 20)
         const triggerWithdrawLimit = multiplyWeiAmount(maxAllowedEarnings, 1 - SAFETY_FRACTION)

--- a/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
+++ b/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
@@ -56,7 +56,7 @@ describe('maintainOperatorValue', () => {
             const { sum } = await operator.getEarnings(1n, 20)
             return sum > triggerWithdrawLimit
         }, 10000, 1000)
-        const operatorContract = getOperatorContract(operatorContractAddress)
+        const operatorContract = getOperatorContract(operatorContractAddress).connect(operatorWallet)
         const valueBeforeWithdraw = await operatorContract.valueWithoutEarnings()
 
         await maintainOperatorValue(

--- a/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
+++ b/packages/node/test/integration/plugins/operator/maintainOperatorValue.test.ts
@@ -10,7 +10,8 @@ const {
     deploySponsorshipContract,
     setupOperatorContract,
     sponsor,
-    stake
+    stake,
+    getOperatorContract
 } = _operatorContractUtils
 
 const logger = new Logger(module)
@@ -36,7 +37,7 @@ describe('maintainOperatorValue', () => {
      * in network-contracts), and the configured safe limit in this test is 50%, i.e. 2.5 tokens.
      */
     it('withdraws sponsorship earnings when earnings are above the safe threshold', async () => {
-        const { operatorWallet, operatorContract, nodeWallets } = await setupOperatorContract({
+        const { operatorWallet, operatorContractAddress, nodeWallets } = await setupOperatorContract({
             nodeCount: 1,
             operatorConfig: {
                 operatorsCutPercentage: 10
@@ -46,15 +47,16 @@ describe('maintainOperatorValue', () => {
         const sponsorer = await createTestWallet({ gas: true, tokens: true })
         const sponsorship = await deploySponsorshipContract({ earningsPerSecond: parseEther('100'), streamId, deployer: operatorWallet })
         await sponsor(sponsorer, await sponsorship.getAddress(), parseEther('25000'))
-        await delegate(operatorWallet, await operatorContract.getAddress(), STAKE_AMOUNT)
-        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorship.getAddress(), STAKE_AMOUNT)
-        const operator = createClient(nodeWallets[0].privateKey).getOperator(toEthereumAddress(await operatorContract.getAddress()))
+        await delegate(operatorWallet, operatorContractAddress, STAKE_AMOUNT)
+        await stake(operatorWallet, operatorContractAddress, await sponsorship.getAddress(), STAKE_AMOUNT)
+        const operator = createClient(nodeWallets[0].privateKey).getOperator(toEthereumAddress(operatorContractAddress))
         const { maxAllowedEarnings } = await operator.getEarnings(1n, 20)
         const triggerWithdrawLimit = multiplyWeiAmount(maxAllowedEarnings, 1 - SAFETY_FRACTION)
         await until(async () => {
             const { sum } = await operator.getEarnings(1n, 20)
             return sum > triggerWithdrawLimit
         }, 10000, 1000)
+        const operatorContract = getOperatorContract(operatorContractAddress)
         const valueBeforeWithdraw = await operatorContract.valueWithoutEarnings()
 
         await maintainOperatorValue(

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -97,20 +97,19 @@ const createOperator = async (
         },
         createTestWallet
     })
-    await delegate(operator.operatorWallet, await operator.operatorContract.getAddress(), DELEGATE_AMOUNT)
-    await stake(operator.operatorWallet, await operator.operatorContract.getAddress(), sponsorshipAddress, STAKE_AMOUNT)
+    await delegate(operator.operatorWallet, operator.operatorContractAddress, DELEGATE_AMOUNT)
+    await stake(operator.operatorWallet, operator.operatorContractAddress, sponsorshipAddress, STAKE_AMOUNT)
     const node = await createBroker(formConfig({
         privateKey: operator.nodeWallets[0].privateKey,
         extraPlugins: {
             operator: {
-                operatorContractAddress: await operator.operatorContract.getAddress(),
+                operatorContractAddress: operator.operatorContractAddress,
                 ...pluginConfig
             }
         }
     }))
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    logger.info(`Operator: ${(await operator.operatorContract.getAddress()).toLowerCase()} freerider=${isFreerider}`)
-    return { node, contractAddress: await operator.operatorContract.getAddress() }
+    logger.info(`Operator: ${operator.operatorContractAddress} freerider=${isFreerider}`)
+    return { node, contractAddress: operator.operatorContractAddress }
 }
 
 const createTheGraphClient = (): TheGraphClient => {

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,6 +1,6 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamrConfig, streamrConfigABI } from '@streamr/network-contracts'
-import { _operatorContractUtils } from '@streamr/sdk'
+import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
 import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { Logger, multiplyWeiAmount, StreamID, TheGraphClient, until, wait } from '@streamr/utils'
 import { Contract, JsonRpcProvider, parseEther, Wallet } from 'ethers'
@@ -41,9 +41,9 @@ const {
     deploySponsorshipContract,
     delegate,
     stake,
+    unstake,
     getTestTokenContract,
-    getTestAdminWallet,
-    getOperatorContract
+    getTestAdminWallet
 } = _operatorContractUtils
 
 interface Operator {
@@ -98,7 +98,7 @@ const createOperator = async (
         createTestWallet
     })
     await delegate(operator.operatorWallet, await operator.operatorContract.getAddress(), DELEGATE_AMOUNT)
-    await stake(operator.operatorContract, sponsorshipAddress, STAKE_AMOUNT)
+    await stake(operator.operatorWallet, await operator.operatorContract.getAddress(), sponsorshipAddress, STAKE_AMOUNT)
     const node = await createBroker(formConfig({
         privateKey: operator.nodeWallets[0].privateKey,
         extraPlugins: {
@@ -250,8 +250,7 @@ describe('inspect', () => {
         // select only offline nodes, but because of ETH-784 the reviewer set won't change).
         logger.info('Unstake pre-baked operators')
         for (const operator of PRE_BAKED_OPERATORS) {
-            const contract = getOperatorContract(operator.contractAddress).connect(new Wallet(operator.privateKey, getProvider())) as any
-            await (await contract.unstake(PRE_BAKED_SPONSORSHIP)).wait()
+            unstake(new Wallet(operator.privateKey, getProvider()) as SignerWithProvider, operator.contractAddress, PRE_BAKED_SPONSORSHIP)
         }
 
         startTimestamp = Date.now()

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -126,7 +126,7 @@ describe('profit', () => {
         await sponsor(sponsorWallet, await sponsorshipContract.getAddress(), SPONSOR_AMOUNT)
         await delegate(operatorWallet, await operatorContract.getAddress(), OPERATOR_DELEGATED_AMOUNT)
         await delegate(delegatorWallet, await operatorContract.getAddress(), EXTERNAL_DELEGATED_AMOUNT)
-        await stake(operatorContract, await sponsorshipContract.getAddress(), OPERATOR_DELEGATED_AMOUNT + EXTERNAL_DELEGATED_AMOUNT)
+        await stake(operatorWallet, await operatorContract.getAddress(), await sponsorshipContract.getAddress(), TOTAL_DELEGATED)
  
         const broker = await startBroker({
             privateKey: operatorNodeWallet.privateKey,
@@ -152,7 +152,7 @@ describe('profit', () => {
         })
         await broker.stop()
 
-        await unstake(operatorContract, await sponsorshipContract.getAddress())
+        await unstake(operatorWallet, await operatorContract.getAddress(), await sponsorshipContract.getAddress())
         await undelegate(
             delegatorWallet,
             await operatorContract.getAddress(),

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -155,12 +155,12 @@ describe('profit', () => {
         await unstake(operatorContract, await sponsorshipContract.getAddress())
         await undelegate(
             delegatorWallet,
-            operatorContract,
+            await operatorContract.getAddress(),
             EXTERNAL_DELEGATED_AMOUNT + DELEGATOR_PROFIT_WHEN_NO_WITHDRAWALS
         )
         await undelegate(
             operatorWallet,
-            operatorContract,
+            await operatorContract.getAddress(),
             OPERATOR_DELEGATED_AMOUNT + OPERATOR_PROFIT_WHEN_NO_WITHDRAWALS + PROFIT_INACCURACY
         )
         const afterBalances = await getBalances()

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -181,20 +181,24 @@ export const undelegate = async (
 }
 
 export const stake = async (
-    operatorContract: OperatorContract,
+    staker: SignerWithProvider,
+    operatorContractAddress: string,
     sponsorshipContractAddress: string,
     amount: WeiAmount
 ): Promise<void> => {
     logger.debug('Stake', { amount: amount.toString() })
-    await (await operatorContract.stake(sponsorshipContractAddress, amount)).wait()
+    const contract = getOperatorContract(operatorContractAddress).connect(staker)
+    await (await contract.stake(sponsorshipContractAddress, amount)).wait()
 }
 
 export const unstake = async (
-    operatorContract: OperatorContract,
+    staker: SignerWithProvider,
+    operatorContractAddress: string,
     sponsorshipContractAddress: string
 ): Promise<void> => {
     logger.debug('Unstake')
-    await (await operatorContract.unstake(sponsorshipContractAddress)).wait()
+    const contract = getOperatorContract(operatorContractAddress).connect(staker)
+    await (await contract.unstake(sponsorshipContractAddress)).wait()
 }
 
 export const sponsor = async (

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -1,5 +1,5 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { Logger, multiplyWeiAmount, WeiAmount } from '@streamr/utils'
+import { EthereumAddress, Logger, multiplyWeiAmount, toEthereumAddress, WeiAmount } from '@streamr/utils'
 import { Contract, EventLog, JsonRpcProvider, parseEther, Provider, Wallet, ZeroAddress } from 'ethers'
 import range from 'lodash/range'
 import { SignerWithProvider } from '../Authentication'
@@ -36,7 +36,7 @@ export interface SetupOperatorContractOpts {
  */
 export interface SetupOperatorContractReturnType {
     operatorWallet: Wallet & SignerWithProvider
-    operatorContract: OperatorContract
+    operatorContractAddress: EthereumAddress
     nodeWallets: (Wallet & SignerWithProvider)[]
 }
 
@@ -58,7 +58,7 @@ export async function setupOperatorContract(
         }
         await (await operatorContract.setNodeAddresses(nodeWallets.map((w) => w.address))).wait()
     }
-    return { operatorWallet, operatorContract, nodeWallets }
+    return { operatorWallet, operatorContractAddress: toEthereumAddress(await operatorContract.getAddress()), nodeWallets }
 }
 
 /**

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -173,11 +173,11 @@ export const delegate = async (
 
 export const undelegate = async (
     delegator: SignerWithProvider,
-    operatorContract: OperatorContract,
+    operatorContractAddress: string,
     amount: WeiAmount
 ): Promise<void> => {    
     logger.debug('Undelegate', { amount: amount.toString() })
-    await (await operatorContract.connect(delegator).undelegate(amount)).wait()
+    await (await getOperatorContract(operatorContractAddress).connect(delegator).undelegate(amount)).wait()
 }
 
 export const stake = async (

--- a/packages/sdk/test/end-to-end/Operator.test.ts
+++ b/packages/sdk/test/end-to-end/Operator.test.ts
@@ -79,8 +79,9 @@ describe('Operator', () => {
     }, 90 * 1000)
 
     it('getStakedOperators', async () => {
-        await delegate(deployedOperator.operatorWallet, await deployedOperator.operatorContract.getAddress(), parseEther('20000'))
-        await stake(deployedOperator.operatorContract, await sponsorship1.getAddress(), parseEther('10000'))
+        const operatorContractAddress = await deployedOperator.operatorContract.getAddress()
+        await delegate(deployedOperator.operatorWallet, operatorContractAddress, parseEther('20000'))
+        await stake(deployedOperator.operatorWallet, operatorContractAddress, await sponsorship1.getAddress(), parseEther('10000'))
         const dummyOperator = await getOperator(deployedOperator.nodeWallets[0], deployedOperator)
         const randomOperatorAddress = sample(await dummyOperator.getStakedOperators())
         expect(randomOperatorAddress).toBeDefined()
@@ -103,10 +104,10 @@ describe('Operator', () => {
     }, 30 * 1000)
 
     it('getSponsorships, getOperatorsInSponsorship', async () => {
-        const operatorContractAddress = toEthereumAddress(await deployedOperator.operatorContract.getAddress())
+        const operatorContractAddress = await deployedOperator.operatorContract.getAddress()
         await delegate(deployedOperator.operatorWallet, operatorContractAddress, parseEther('20000'))
-        await stake(deployedOperator.operatorContract, await sponsorship1.getAddress(), parseEther('10000'))
-        await stake(deployedOperator.operatorContract, await sponsorship2.getAddress(), parseEther('10000'))
+        await stake(deployedOperator.operatorWallet, operatorContractAddress, await sponsorship1.getAddress(), parseEther('10000'))
+        await stake(deployedOperator.operatorWallet, operatorContractAddress, await sponsorship2.getAddress(), parseEther('10000'))
 
         const operator = await getOperator(undefined, deployedOperator)
 
@@ -143,8 +144,8 @@ describe('Operator', () => {
 
         await delegate(flagger.operatorWallet, await flagger.operatorContract.getAddress(), parseEther('20000'))
         await delegate(target.operatorWallet, await target.operatorContract.getAddress(), parseEther('30000'))
-        await stake(flagger.operatorContract, await sponsorship2.getAddress(), parseEther('15000'))
-        await stake(target.operatorContract, await sponsorship2.getAddress(), parseEther('25000'))
+        await stake(flagger.operatorWallet, await flagger.operatorContract.getAddress(), await sponsorship2.getAddress(), parseEther('15000'))
+        await stake(target.operatorWallet, await target.operatorContract.getAddress(), await sponsorship2.getAddress(), parseEther('25000'))
 
         const contractFacade = await getOperator(deployedOperator.nodeWallets[0], flagger)
         await contractFacade.flag(


### PR DESCRIPTION
Refactored functions in `operatorContractUtils` so that we give contract address as an argument instead of `OperatorContract` object:
- `delegate()`
- `stake()`
- `unstake()`

Also refactored `SetupOperatorContractReturnType` so that it contains address instead of the contract object.

## Other changes

- unified argument names in cli-tool command. Now operator contract address is always named as `operatorContractAddress`
- using `unstake()` from contract utils instead of calling contract directly in some tests