### PR TITLE
refactor(sdk): Move test utils from `operatorContractUtils` to `test-utils`

### DIFF
--- a/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
+++ b/packages/node/test/integration/plugins/operator/checkOperatorValueBreach.test.ts
@@ -1,6 +1,6 @@
 import { Operator, StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils } from '@streamr/sdk'
-import { createTestWallet, setupTestOperatorContract, setupTestOperatorContractOpts } from '@streamr/test-utils'
+import { createTestWallet, getTestProvider, setupTestOperatorContract, setupTestOperatorContractOpts } from '@streamr/test-utils'
 import { Logger, toEthereumAddress, until } from '@streamr/utils'
 import { Contract, parseEther } from 'ethers'
 import { checkOperatorValueBreach } from '../../../../src/plugins/operator/checkOperatorValueBreach'
@@ -8,7 +8,6 @@ import { createClient, createTestStream, deployTestOperatorContract, deployTestS
 
 const {
     delegate,
-    getProvider,
     sponsor,
     stake,
     getOperatorContract
@@ -56,7 +55,7 @@ describe('checkOperatorValueBreach', () => {
         const operatorContract = getOperatorContract(operatorContractAddress).connect(operatorWallet)
         const valueBeforeWithdraw = await operatorContract.valueWithoutEarnings()
         const streamrConfigAddress = await operatorContract.streamrConfig()
-        const streamrConfig = new Contract(streamrConfigAddress, StreamrConfigABI, getProvider()) as unknown as StreamrConfig
+        const streamrConfig = new Contract(streamrConfigAddress, StreamrConfigABI, getTestProvider()) as unknown as StreamrConfig
         const allowedDifference = valueBeforeWithdraw * (await streamrConfig.maxAllowedEarningsFraction()) / ONE_ETHER
         const client = createClient(watcherWallets[0].privateKey)
         const operator = client.getOperator(toEthereumAddress(watcherOperatorContractAddress))

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,9 +1,16 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestProvider, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import {
+    createTestPrivateKey,
+    createTestWallet,
+    getTestAdminWallet,
+    getTestProvider,
+    getTestTokenContract,
+    setupTestOperatorContract
+} from '@streamr/test-utils'
 import { Logger, multiplyWeiAmount, StreamID, TheGraphClient, until, wait } from '@streamr/utils'
-import { Contract, JsonRpcProvider, parseEther, Wallet } from 'ethers'
+import { Contract, parseEther, Wallet } from 'ethers'
 import { Broker, createBroker } from '../../src/broker'
 import { createClient, createTestStream, deployTestOperatorContract, deployTestSponsorshipContract, formConfig } from '../utils'
 import { OperatorPluginConfig } from './../../src/plugins/operator/OperatorPlugin'

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestProvider, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { Logger, multiplyWeiAmount, StreamID, TheGraphClient, until, wait } from '@streamr/utils'
 import { Contract, JsonRpcProvider, parseEther, Wallet } from 'ethers'
 import { Broker, createBroker } from '../../src/broker'
@@ -36,7 +36,6 @@ import { OperatorPluginConfig } from './../../src/plugins/operator/OperatorPlugi
  */
 
 const {
-    getProvider,
     delegate,
     stake,
     unstake,
@@ -119,7 +118,7 @@ const createTheGraphClient = (): TheGraphClient => {
 const configureBlockchain = async (): Promise<void> => {
     const MINING_INTERVAL = 1100
     logger.info('Configure blockchain')
-    const provider = getProvider() as JsonRpcProvider
+    const provider = getTestProvider() as JsonRpcProvider
     await provider.send('evm_setAutomine', [true])
     await createStream()  // just some transaction
     await provider.send('evm_setAutomine', [false])
@@ -245,7 +244,7 @@ describe('inspect', () => {
         // select only offline nodes, but because of ETH-784 the reviewer set won't change).
         logger.info('Unstake pre-baked operators')
         for (const operator of PRE_BAKED_OPERATORS) {
-            unstake(new Wallet(operator.privateKey, getProvider()) as SignerWithProvider, operator.contractAddress, PRE_BAKED_SPONSORSHIP)
+            unstake(new Wallet(operator.privateKey, getTestProvider()) as SignerWithProvider, operator.contractAddress, PRE_BAKED_SPONSORSHIP)
         }
 
         startTimestamp = Date.now()
@@ -264,7 +263,7 @@ describe('inspect', () => {
             await operator.node.stop()
         }
         // revert to dev-chain default mining interval
-        await (getProvider() as JsonRpcProvider).send('evm_setIntervalMining', [DEV_CHAIN_DEFAULT_MINING_INTERVAL])
+        await (getTestProvider() as JsonRpcProvider).send('evm_setIntervalMining', [DEV_CHAIN_DEFAULT_MINING_INTERVAL])
     })
 
     /*
@@ -304,7 +303,7 @@ describe('inspect', () => {
         }
 
         // assert slashing and rewards
-        const token = getTestTokenContract().connect(getProvider())
+        const token = getTestTokenContract().connect(getTestProvider())
         expect(await getTokenBalance(freeriderOperator.contractAddress, token)).toEqual(
             DELEGATE_AMOUNT - multiplyWeiAmount(STAKE_AMOUNT, SLASHING_PERCENTAGE / 100)
         )

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -118,7 +118,7 @@ const createTheGraphClient = (): TheGraphClient => {
 const configureBlockchain = async (): Promise<void> => {
     const MINING_INTERVAL = 1100
     logger.info('Configure blockchain')
-    const provider = getTestProvider() as JsonRpcProvider
+    const provider = getTestProvider()
     await provider.send('evm_setAutomine', [true])
     await createStream()  // just some transaction
     await provider.send('evm_setAutomine', [false])
@@ -263,7 +263,7 @@ describe('inspect', () => {
             await operator.node.stop()
         }
         // revert to dev-chain default mining interval
-        await (getTestProvider() as JsonRpcProvider).send('evm_setIntervalMining', [DEV_CHAIN_DEFAULT_MINING_INTERVAL])
+        await getTestProvider().send('evm_setIntervalMining', [DEV_CHAIN_DEFAULT_MINING_INTERVAL])
     })
 
     /*

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { Logger, multiplyWeiAmount, StreamID, TheGraphClient, until, wait } from '@streamr/utils'
 import { Contract, JsonRpcProvider, parseEther, Wallet } from 'ethers'
 import { Broker, createBroker } from '../../src/broker'
@@ -40,7 +40,6 @@ const {
     delegate,
     stake,
     unstake,
-    getTestAdminWallet
 } = _operatorContractUtils
 
 interface Operator {

--- a/packages/node/test/smoke/inspect.test.ts
+++ b/packages/node/test/smoke/inspect.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { Logger, multiplyWeiAmount, StreamID, TheGraphClient, until, wait } from '@streamr/utils'
 import { Contract, JsonRpcProvider, parseEther, Wallet } from 'ethers'
 import { Broker, createBroker } from '../../src/broker'
@@ -40,7 +40,6 @@ const {
     delegate,
     stake,
     unstake,
-    getTestTokenContract,
     getTestAdminWallet
 } = _operatorContractUtils
 

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -1,7 +1,14 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { Sponsorship, StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestProvider, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import {
+    createTestPrivateKey,
+    createTestWallet,
+    getTestAdminWallet,
+    getTestProvider,
+    getTestTokenContract,
+    setupTestOperatorContract
+} from '@streamr/test-utils'
 import { EthereumAddress, multiplyWeiAmount, until, WeiAmount } from '@streamr/utils'
 import { Contract, parseEther, Wallet } from 'ethers'
 import { createClient, createTestStream, deployTestOperatorContract, deployTestSponsorshipContract, startBroker } from '../utils'

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { Sponsorship, StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { EthereumAddress, multiplyWeiAmount, until, WeiAmount } from '@streamr/utils'
 import { Contract, parseEther, Wallet } from 'ethers'
 import { createClient, createTestStream, deployTestOperatorContract, deployTestSponsorshipContract, startBroker } from '../utils'
@@ -38,7 +38,6 @@ const {
     undelegate,
     stake,
     unstake,
-    getTestTokenContract,
     getTestAdminWallet
 } = _operatorContractUtils
 

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { Sponsorship, StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestProvider, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { EthereumAddress, multiplyWeiAmount, until, WeiAmount } from '@streamr/utils'
 import { Contract, parseEther, Wallet } from 'ethers'
 import { createClient, createTestStream, deployTestOperatorContract, deployTestSponsorshipContract, startBroker } from '../utils'
@@ -32,7 +32,6 @@ import { createClient, createTestStream, deployTestOperatorContract, deployTestS
  */
 
 const {
-    getProvider,
     sponsor,
     delegate,
     undelegate,
@@ -75,7 +74,7 @@ describe('profit', () => {
         admin: WeiAmount
         operatorContract: WeiAmount
     }> => {
-        const dataToken = getTestTokenContract().connect(getProvider())
+        const dataToken = getTestTokenContract().connect(getTestProvider())
         const adminWallet = getTestAdminWallet()
         return {
             operator: await dataToken.balanceOf(operatorWallet.address),

--- a/packages/node/test/smoke/profit.test.ts
+++ b/packages/node/test/smoke/profit.test.ts
@@ -1,7 +1,7 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { Sponsorship, StreamrConfig, StreamrConfigABI } from '@streamr/network-contracts'
 import { _operatorContractUtils, SignerWithProvider } from '@streamr/sdk'
-import { createTestPrivateKey, createTestWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
+import { createTestPrivateKey, createTestWallet, getTestAdminWallet, getTestTokenContract, setupTestOperatorContract } from '@streamr/test-utils'
 import { EthereumAddress, multiplyWeiAmount, until, WeiAmount } from '@streamr/utils'
 import { Contract, parseEther, Wallet } from 'ethers'
 import { createClient, createTestStream, deployTestOperatorContract, deployTestSponsorshipContract, startBroker } from '../utils'
@@ -38,7 +38,6 @@ const {
     undelegate,
     stake,
     unstake,
-    getTestAdminWallet
 } = _operatorContractUtils
 
 const SPONSOR_AMOUNT = parseEther('6000')

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -10,13 +10,12 @@ import {
     SponsorshipFactory as SponsorshipFactoryContract
 } from '@streamr/network-contracts'
 import { Logger, multiplyWeiAmount, WeiAmount } from '@streamr/utils'
-import { Contract, EventLog, JsonRpcProvider, parseEther, Provider, ZeroAddress } from 'ethers'
+import { Contract, EventLog, parseEther, ZeroAddress } from 'ethers'
 import { EnvironmentId } from '../Config'
 import type { DATAv2 as DATATokenContract } from '../ethereumArtifacts/DATAv2'
 import DATATokenArtifact from '../ethereumArtifacts/DATAv2Abi.json'
 import { SignerWithProvider } from '../identity/Identity'
 
-const TEST_CHAIN_CONFIG = CHAIN_CONFIG.dev2
 const FRACTION_MAX = parseEther('1')
 
 const logger = new Logger(module)
@@ -108,13 +107,6 @@ export async function deploySponsorshipContract(opts: DeploySponsorshipContractO
     const newSponsorship = new Contract(newSponsorshipAddress, SponsorshipABI, opts.deployer) as unknown as SponsorshipContract
     logger.debug('Deployed SponsorshipContract', { address: newSponsorshipAddress })
     return newSponsorship
-}
-
-export function getProvider(): Provider {
-    return new JsonRpcProvider(TEST_CHAIN_CONFIG.rpcEndpoints[0].url, undefined, {
-        batchStallTime: 0,       // Don't batch requests, send them immediately
-        cacheTimeout: -1         // Do not employ result caching
-    })
 }
 
 export const delegate = async (

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -10,7 +10,7 @@ import {
     SponsorshipFactory as SponsorshipFactoryContract
 } from '@streamr/network-contracts'
 import { Logger, multiplyWeiAmount, WeiAmount } from '@streamr/utils'
-import { Contract, EventLog, JsonRpcProvider, parseEther, Provider, Wallet, ZeroAddress } from 'ethers'
+import { Contract, EventLog, JsonRpcProvider, parseEther, Provider, ZeroAddress } from 'ethers'
 import { EnvironmentId } from '../Config'
 import type { DATAv2 as DATATokenContract } from '../ethereumArtifacts/DATAv2'
 import DATATokenArtifact from '../ethereumArtifacts/DATAv2Abi.json'
@@ -115,10 +115,6 @@ export function getProvider(): Provider {
         batchStallTime: 0,       // Don't batch requests, send them immediately
         cacheTimeout: -1         // Do not employ result caching
     })
-}
-
-export const getTestAdminWallet = (adminKey?: string, provider?: Provider): Wallet => {
-    return new Wallet(adminKey ?? TEST_CHAIN_CONFIG.adminPrivateKey).connect(provider ?? getProvider())
 }
 
 export const delegate = async (

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -117,10 +117,6 @@ export function getProvider(): Provider {
     })
 }
 
-export function getTestTokenContract(): DATATokenContract {
-    return new Contract(TEST_CHAIN_CONFIG.contracts.DATA, DATATokenArtifact) as unknown as DATATokenContract
-}
-
 export const getTestAdminWallet = (adminKey?: string, provider?: Provider): Wallet => {
     return new Wallet(adminKey ?? TEST_CHAIN_CONFIG.adminPrivateKey).connect(provider ?? getProvider())
 }

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -104,7 +104,6 @@ import {
     sponsor,
     stake,
     unstake,
-    getProvider,
     DeploySponsorshipContractOpts,
     getOperatorContract
 } from './contracts/operatorContractUtils'
@@ -121,7 +120,6 @@ const _operatorContractUtils = {
     sponsor,
     stake,
     unstake,
-    getProvider,
     deployOperatorContract,
     getOperatorContract
 }

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -106,7 +106,6 @@ import {
     unstake,
     getProvider,
     DeploySponsorshipContractOpts,
-    getTestAdminWallet,
     getOperatorContract
 } from './contracts/operatorContractUtils'
 
@@ -124,7 +123,6 @@ const _operatorContractUtils = {
     unstake,
     getProvider,
     deployOperatorContract,
-    getTestAdminWallet,
     getOperatorContract
 }
 export { _operatorContractUtils }

--- a/packages/sdk/src/exports.ts
+++ b/packages/sdk/src/exports.ts
@@ -106,7 +106,6 @@ import {
     unstake,
     getProvider,
     DeploySponsorshipContractOpts,
-    getTestTokenContract,
     getTestAdminWallet,
     getOperatorContract
 } from './contracts/operatorContractUtils'
@@ -125,7 +124,6 @@ const _operatorContractUtils = {
     unstake,
     getProvider,
     deployOperatorContract,
-    getTestTokenContract,
     getTestAdminWallet,
     getOperatorContract
 }

--- a/packages/sdk/test/end-to-end/Operator.test.ts
+++ b/packages/sdk/test/end-to-end/Operator.test.ts
@@ -6,7 +6,7 @@ import {
     OperatorFactory as OperatorFactoryContract,
     Sponsorship as SponsorshipContract
 } from '@streamr/network-contracts'
-import { createTestPrivateKey, setupTestOperatorContract, setupTestOperatorContractReturnType } from '@streamr/test-utils'
+import { createTestPrivateKey, getTestAdminWallet, setupTestOperatorContract, setupTestOperatorContractReturnType } from '@streamr/test-utils'
 import { Logger, TheGraphClient, toEthereumAddress, until } from '@streamr/utils'
 import { Contract, parseEther, Wallet } from 'ethers'
 import sample from 'lodash/sample'
@@ -14,7 +14,6 @@ import { StreamrClient } from '../../src/StreamrClient'
 import { Operator } from '../../src/contracts/Operator'
 import {
     delegate,
-    getTestAdminWallet,
     sponsor,
     stake
 } from '../../src/contracts/operatorContractUtils'

--- a/packages/sdk/test/end-to-end/decorated-contract.test.ts
+++ b/packages/sdk/test/end-to-end/decorated-contract.test.ts
@@ -2,21 +2,19 @@ import 'reflect-metadata'
 
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamRegistryABI, StreamRegistry as StreamRegistryContract } from '@streamr/network-contracts'
-import { createTestPrivateKey } from '@streamr/test-utils'
+import { createTestPrivateKey, getTestProvider } from '@streamr/test-utils'
 import { toEthereumAddress } from '@streamr/utils'
-import { Contract, JsonRpcProvider, Wallet } from 'ethers'
+import { Contract, Wallet } from 'ethers'
 import { createDecoratedContract } from '../../src/contracts/contract'
 import { mockLoggerFactory } from '../test-utils/utils'
 
 const TEST_CHAIN_CONFIG = CHAIN_CONFIG.dev2
 
-const getProvider = () => new JsonRpcProvider(TEST_CHAIN_CONFIG.rpcEndpoints[0].url)
-
 describe('decorated contract', () => {
 
     it('read', async () => {
         const contract = createDecoratedContract<StreamRegistryContract>(
-            new Contract(toEthereumAddress(TEST_CHAIN_CONFIG.contracts.StreamRegistry), StreamRegistryABI, getProvider()),
+            new Contract(toEthereumAddress(TEST_CHAIN_CONFIG.contracts.StreamRegistry), StreamRegistryABI, getTestProvider()),
             'StreamRegisty',
             mockLoggerFactory(),
             1
@@ -28,7 +26,7 @@ describe('decorated contract', () => {
     })
 
     it('write', async () => {
-        const wallet = new Wallet(await createTestPrivateKey({ gas: true }), getProvider())
+        const wallet = new Wallet(await createTestPrivateKey({ gas: true }), getTestProvider())
         const contract = createDecoratedContract<StreamRegistryContract>(
             new Contract(toEthereumAddress(TEST_CHAIN_CONFIG.contracts.StreamRegistry), StreamRegistryABI, wallet),
             'StreamRegisty',

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,8 +1,8 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
-import { Operator as OperatorContract } from '@streamr/network-contracts'
+import { DATAv2ABI as DATATokenABI, DATAv2 as DATATokenContract, Operator as OperatorContract } from '@streamr/network-contracts'
 import { binaryToHex, EthereumAddress, Logger, retry, toEthereumAddress, toUserId, until, UserID, waitForEvent } from '@streamr/utils'
 import crypto, { randomBytes } from 'crypto'
-import { AbstractSigner, Contract, JsonRpcProvider, parseEther, Provider, TransactionResponse, Wallet } from 'ethers'
+import { AbstractSigner, Contract, JsonRpcProvider, parseEther, Provider, Wallet } from 'ethers'
 import { EventEmitter, once } from 'events'
 import express from 'express'
 import random from 'lodash/random'
@@ -245,9 +245,8 @@ const getTestProvider = (): Provider => {
     })
 }
 
-const getTestTokenContract = (adminWallet: Wallet): { mint: (targetAddress: string, amountWei: bigint) => Promise<TransactionResponse> } => {
-    const ABI = ['function mint(address to, uint256 amount)']
-    return new Contract(TEST_CHAIN_CONFIG.contracts.DATA, ABI).connect(adminWallet) as unknown as { mint: () => Promise<TransactionResponse> }
+export const getTestTokenContract = (): DATATokenContract => {
+    return new Contract(TEST_CHAIN_CONFIG.contracts.DATA, DATATokenABI) as unknown as DATATokenContract
 }
 
 const getTestAdminWallet = (provider: Provider): Wallet => {
@@ -263,7 +262,7 @@ export const createTestWallet = async (opts?: { gas?: boolean, tokens?: boolean 
     const newWallet = new Wallet(fastPrivateKey())
     if (opts?.gas || opts?.tokens) {
         const adminWallet = getTestAdminWallet(provider)
-        const token = getTestTokenContract(adminWallet)
+        const token = getTestTokenContract().connect(adminWallet)
         await retry(
             async () => {
                 if (opts?.gas) {

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -238,7 +238,7 @@ export { customMatchers }
 
 const TEST_CHAIN_CONFIG = CHAIN_CONFIG.dev2
 
-const getTestProvider = (): Provider => {
+export const getTestProvider = (): Provider => {
     return new JsonRpcProvider(TEST_CHAIN_CONFIG.rpcEndpoints[0].url, undefined, {
         batchStallTime: 0,       // Don't batch requests, send them immediately
         cacheTimeout: -1         // Do not employ result caching

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -238,7 +238,7 @@ export { customMatchers }
 
 const TEST_CHAIN_CONFIG = CHAIN_CONFIG.dev2
 
-export const getTestProvider = (): Provider => {
+export const getTestProvider = (): JsonRpcProvider => {
     return new JsonRpcProvider(TEST_CHAIN_CONFIG.rpcEndpoints[0].url, undefined, {
         batchStallTime: 0,       // Don't batch requests, send them immediately
         cacheTimeout: -1         // Do not employ result caching

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -249,8 +249,8 @@ export const getTestTokenContract = (): DATATokenContract => {
     return new Contract(TEST_CHAIN_CONFIG.contracts.DATA, DATATokenABI) as unknown as DATATokenContract
 }
 
-const getTestAdminWallet = (provider: Provider): Wallet => {
-    return new Wallet(TEST_CHAIN_CONFIG.adminPrivateKey).connect(provider)
+export const getTestAdminWallet = (provider?: Provider): Wallet => {
+    return new Wallet(TEST_CHAIN_CONFIG.adminPrivateKey).connect(provider ?? getTestProvider())
 }
 
 const fastPrivateKey = (): string => {


### PR DESCRIPTION
There was some overlap between `sdk`'s `operatorContractUtils` and the `test-utils` package. Now as the DATAv2 contract is available via `@streamr/network-contracts` that overlapping can be avoided.

These functions should now be used from `test-utils` instead of `operatorContractUtils`:
- `getTestTokenContract()`
- `getTestAdminWallet()`
- `getProvider()`

The `getProvider()` has been renamed to `getTestProvider()` and there is stricter type for that.
