### PR TITLE
test(dht): Optimize topology tests

### DIFF
--- a/packages/dht/src/connection/ConnectionManager.ts
+++ b/packages/dht/src/connection/ConnectionManager.ts
@@ -184,7 +184,7 @@ export class ConnectionManager extends EventEmitter<TransportEvents> implements 
      * Removes connections if there are more than maxConnections: in that case we remove unlocked connections
      * which hasn't been used within maxIdleTime.
      */
-    public garbageCollectConnections(maxConnections: number, maxIdleTime: number): void {
+    private garbageCollectConnections(maxConnections: number, maxIdleTime: number): void {
         if (this.endpoints.size <= maxConnections) {
             return
         }

--- a/packages/dht/src/dht/DhtNode.ts
+++ b/packages/dht/src/dht/DhtNode.ts
@@ -129,6 +129,7 @@ type StrictDhtNodeOptions = MarkRequired<DhtNodeOptions,
 
 const logger = new Logger(module)
 
+export const NUMBER_OF_NODES_PER_KBUCKET_DEFAULT = 8
 const PERIODICAL_PING_INTERVAL = 60 * 1000
 
 // TODO move this to trackerless-network package and change serviceId to be a required paramater
@@ -159,7 +160,7 @@ export class DhtNode extends EventEmitter<Events> implements ITransport {
             serviceId: CONTROL_LAYER_NODE_SERVICE_ID,
             joinParallelism: 3,
             maxContactCount: 200,
-            numberOfNodesPerKBucket: 8,
+            numberOfNodesPerKBucket: NUMBER_OF_NODES_PER_KBUCKET_DEFAULT,
             joinNoProgressLimit: 5,
             dhtJoinTimeout: 60000,
             peerDiscoveryQueryBatchSize: 5,

--- a/packages/dht/test/benchmark/Find.test.ts
+++ b/packages/dht/test/benchmark/Find.test.ts
@@ -26,10 +26,10 @@ describe('Find correctness', () => {
     beforeEach(async () => {
 
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)), undefined)
+        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)))
 
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[i].data)), undefined)
+            const node = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[i].data)))
             nodes.push(node)
         }
     })

--- a/packages/dht/test/benchmark/KademliaCorrectness.test.ts
+++ b/packages/dht/test/benchmark/KademliaCorrectness.test.ts
@@ -28,7 +28,7 @@ describe('Kademlia correctness', () => {
 
     beforeEach(async () => {
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)), 8)
+        entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(Uint8Array.from(dhtIds[0].data)))
         nodes.push(entryPoint)
         nodeIndicesById[entryPoint.getNodeId()] = 0
 

--- a/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-WebSocket.test.ts
@@ -1,9 +1,8 @@
-import { DhtNode } from '../../src/dht/DhtNode'
+import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 const STREAM_ID = 'stream'
 const NUM_OF_NODES = 16
-const NUM_OF_NODES_PER_KBUCKET = 8
 const WEBSOCKET_PORT_RANGE = { min: 62200, max: 62200 + NUM_OF_NODES }
 
 describe('Layer1 Scale', () => {
@@ -41,7 +40,6 @@ describe('Layer1 Scale', () => {
                 websocketPortRange: WEBSOCKET_PORT_RANGE,
                 entryPoints: [epPeerDescriptor],
                 websocketServerEnableTls: false,
-                numberOfNodesPerKBucket: NUM_OF_NODES_PER_KBUCKET
             })
             await node.start()
             layer0Nodes.push(node)
@@ -50,8 +48,7 @@ describe('Layer1 Scale', () => {
                 connectionsView: node.getConnectionsView(),
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getLocalPeerDescriptor(),
-                serviceId: STREAM_ID,
-                numberOfNodesPerKBucket: NUM_OF_NODES_PER_KBUCKET
+                serviceId: STREAM_ID
             })
             await layer1.start()
             layer1Nodes.push(layer1)
@@ -73,10 +70,10 @@ describe('Layer1 Scale', () => {
     // TODO: fix flaky test in NET-1021
     it('bucket sizes', async () => {
         layer0Nodes.forEach((node) => {
-            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET - 1)
+            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT - 1)
         })
         layer1Nodes.forEach((node ) => {
-            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
+            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
         })
     })
 })

--- a/packages/dht/test/end-to-end/Layer1-Scale-Webrtc.test.ts
+++ b/packages/dht/test/end-to-end/Layer1-Scale-Webrtc.test.ts
@@ -1,9 +1,8 @@
-import { DhtNode } from '../../src/dht/DhtNode'
+import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
 import { createMockPeerDescriptor } from '../utils/utils'
 
 const STREAM_ID = 'stream'
 const NUM_OF_NODES = 16
-const NUM_OF_NODES_PER_KBUCKET = 8
 
 describe('Layer1 Scale', () => {
 
@@ -37,8 +36,7 @@ describe('Layer1 Scale', () => {
 
         for (let i = 1; i < NUM_OF_NODES; i++) {
             const node = new DhtNode({ 
-                entryPoints: [epPeerDescriptor],
-                numberOfNodesPerKBucket: NUM_OF_NODES_PER_KBUCKET
+                entryPoints: [epPeerDescriptor]
             })
             await node.start()
             layer0Nodes.push(node)
@@ -48,8 +46,7 @@ describe('Layer1 Scale', () => {
                 entryPoints: [epPeerDescriptor],
                 peerDescriptor: node.getLocalPeerDescriptor(),
                 serviceId: STREAM_ID,
-                rpcRequestTimeout: 5000,
-                numberOfNodesPerKBucket: NUM_OF_NODES_PER_KBUCKET
+                rpcRequestTimeout: 5000
             })
             await layer1.start()
             layer1Nodes.push(layer1)
@@ -67,10 +64,10 @@ describe('Layer1 Scale', () => {
 
     it('bucket sizes', async () => {
         layer0Nodes.forEach((node) => {
-            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET - 1)
+            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT - 1)
         })
         layer1Nodes.forEach((node) => {
-            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
+            expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
         })
     })
 })

--- a/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
+++ b/packages/dht/test/integration/DhtJoinPeerDiscovery.test.ts
@@ -1,30 +1,28 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
-import { DhtNode } from '../../src/dht/DhtNode'
+import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
 import { toDhtAddress } from '../../src/identifiers'
 import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
-
-const NUM_OF_NODES_PER_KBUCKET = 8
 
 const runTest = async (latencyType: LatencyType) => {
     const simulator = new Simulator(latencyType)
     const entrypointDescriptor = createMockPeerDescriptor({
         region: getRandomRegion()
     })
-    const entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(entrypointDescriptor.nodeId), NUM_OF_NODES_PER_KBUCKET)
+    const entryPoint = await createMockConnectionDhtNode(simulator, toDhtAddress(entrypointDescriptor.nodeId))
     const nodes: DhtNode[] = []
     for (let i = 1; i < 100; i++) {
-        const node = await createMockConnectionDhtNode(simulator, undefined, NUM_OF_NODES_PER_KBUCKET)
+        const node = await createMockConnectionDhtNode(simulator, undefined)
         nodes.push(node)
     }
 
     await entryPoint.joinDht([entrypointDescriptor])
     await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
     nodes.forEach((node) => {
-        expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
-        expect(node.getClosestContacts().length).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
+        expect(node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
+        expect(node.getClosestContacts().length).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
     })
-    expect(entryPoint.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
+    expect(entryPoint.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
 
     await Promise.all([
         entryPoint.stop(),

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -19,7 +19,7 @@ describe('Find correctness', () => {
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
+            const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)
         }
         await entryPoint.joinDht([entrypointDescriptor])

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -1,7 +1,7 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../generated/packages/dht/protos/DhtRpc'
-import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
+import { createMockConnectionDhtNode } from '../utils/utils'
 import { toDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 
 const NUM_NODES = 100
@@ -25,7 +25,6 @@ describe('Find correctness', () => {
         }
         await entryPoint.joinDht([entrypointDescriptor])
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
-        await waitForStableTopology(nodes, 15, 45 * 1000)
     }, 90000)
 
     afterEach(async () => {

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -3,6 +3,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { PeerDescriptor } from '../../generated/packages/dht/protos/DhtRpc'
 import { createMockConnectionDhtNode } from '../utils/utils'
 import { toDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
+import sample from 'lodash/sample'
 
 const NUM_NODES = 100
 
@@ -33,7 +34,7 @@ describe('Find correctness', () => {
     })
 
     it('Entrypoint can find a node from the network (exact match)', async () => {
-        const targetId = toDhtAddressRaw(nodes[45].getNodeId())
+        const targetId = toDhtAddressRaw(sample(nodes)!.getNodeId())
         const closestNodes = await entryPoint.findClosestNodesFromDht(toDhtAddress(targetId))
         expect(closestNodes.length).toBeGreaterThanOrEqual(5)
         expect(toDhtAddress(targetId)).toEqual(toNodeId(closestNodes[0]))

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -22,7 +22,6 @@ describe('Find correctness', () => {
             const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)
         }
-        await entryPoint.joinDht([entrypointDescriptor])
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
     }, 90000)
 

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -5,7 +5,6 @@ import { createMockConnectionDhtNode } from '../utils/utils'
 import { toDhtAddress, toNodeId, toDhtAddressRaw } from '../../src/identifiers'
 
 const NUM_NODES = 100
-const K = 8
 
 describe('Find correctness', () => {
 
@@ -16,11 +15,11 @@ describe('Find correctness', () => {
 
     beforeEach(async () => {
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator, undefined, K)
+        entryPoint = await createMockConnectionDhtNode(simulator, undefined)
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, K, 15, 60000)
+            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, 15, 60000)
             nodes.push(node)
         }
         await entryPoint.joinDht([entrypointDescriptor])

--- a/packages/dht/test/integration/Find.test.ts
+++ b/packages/dht/test/integration/Find.test.ts
@@ -19,7 +19,7 @@ describe('Find correctness', () => {
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, 15, 60000)
+            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
             nodes.push(node)
         }
         await entryPoint.joinDht([entrypointDescriptor])

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -23,13 +23,7 @@ describe('Layer1', () => {
         layer1CleanUp = []
 
         for (let i = 0; i < NODE_COUNT; i++) {
-            const node = await createMockConnectionDhtNode(
-                simulator,
-                undefined,
-                undefined,
-                undefined,
-                60000
-            )
+            const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)
         }
 

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -1,10 +1,9 @@
 import { Simulator } from '../../src/connection/simulator/Simulator'
-import { DhtNode } from '../../src/dht/DhtNode'
+import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
 import { toDhtAddress } from '../../src/identifiers'
 import { createMockConnectionDhtNode, createMockConnectionLayer1Node, createMockPeerDescriptor } from '../utils/utils'
 
 const NODE_COUNT = 48
-const NUM_OF_NODES_PER_KBUCKET = 8
 
 describe('Layer1', () => {
 
@@ -46,7 +45,7 @@ describe('Layer1', () => {
         const layer1Nodes: DhtNode[] = []
         for (let i = 0; i < NODE_COUNT; i++) {
             const layer0 = nodes[i]
-            const layer1 = await createMockConnectionLayer1Node(layer0, undefined, NUM_OF_NODES_PER_KBUCKET)
+            const layer1 = await createMockConnectionLayer1Node(layer0, undefined, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT)
             layer1Nodes.push(layer1)
             layer1CleanUp.push(layer1)
         }
@@ -58,7 +57,7 @@ describe('Layer1', () => {
             const layer1Node = layer1Nodes[i]
             expect(layer1Node.getNodeId()).toEqual(layer0Node.getNodeId())
             expect(layer1Node.getConnectionsView().getConnectionCount()).toEqual(layer0Node.getConnectionsView().getConnectionCount())
-            expect(layer1Node.getNeighborCount()).toBeGreaterThanOrEqual(NUM_OF_NODES_PER_KBUCKET / 2)
+            expect(layer1Node.getNeighborCount()).toBeGreaterThanOrEqual(NUMBER_OF_NODES_PER_KBUCKET_DEFAULT / 2)
             expect(layer1Node.getConnectionsView().getConnections()).toEqual(layer0Node.getConnectionsView().getConnections())
         }
     }, 120000)

--- a/packages/dht/test/integration/Layer1-scale.test.ts
+++ b/packages/dht/test/integration/Layer1-scale.test.ts
@@ -45,7 +45,7 @@ describe('Layer1', () => {
         const layer1Nodes: DhtNode[] = []
         for (let i = 0; i < NODE_COUNT; i++) {
             const layer0 = nodes[i]
-            const layer1 = await createMockConnectionLayer1Node(layer0, undefined, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT)
+            const layer1 = await createMockConnectionLayer1Node(layer0, undefined)
             layer1Nodes.push(layer1)
             layer1CleanUp.push(layer1)
         }

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -9,7 +9,6 @@ import { DataEntry, PeerDescriptor } from '../../generated/packages/dht/protos/D
 
 const DATA = createMockDataEntry()
 const NUM_NODES = 100
-const MAX_CONNECTIONS = 80
 const ENTRY_POINT_INDEX = 0
 
 const getDataEntries = (node: DhtNode): DataEntry[] => {
@@ -25,7 +24,7 @@ describe('Replicate data from node to node in DHT', () => {
     const simulator = new Simulator(LatencyType.FIXED, 20)
 
     beforeEach(async () => {
-        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress(), undefined, MAX_CONNECTIONS)
+        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress())
         entryPointDescriptor = entryPoint.getLocalPeerDescriptor()
         await entryPoint.joinDht([entryPointDescriptor])
         nodes = []
@@ -34,8 +33,7 @@ describe('Replicate data from node to node in DHT', () => {
             const node = await createMockConnectionDhtNode(
                 simulator,
                 randomDhtAddress(),
-                undefined,
-                MAX_CONNECTIONS
+                undefined
             )
             nodes.push(node)
         }

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -30,11 +30,7 @@ describe('Replicate data from node to node in DHT', () => {
         nodes = []
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(
-                simulator,
-                randomDhtAddress(),
-                undefined
-            )
+            const node = await createMockConnectionDhtNode(simulator, randomDhtAddress())
             nodes.push(node)
         }
     }, 60000)

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -1,6 +1,6 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
+import { createMockConnectionDhtNode } from '../utils/utils'
 import { SortedContactList } from '../../src/dht/contact/SortedContactList'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { DhtAddress, randomDhtAddress, toDhtAddress, toNodeId } from '../../src/identifiers'
@@ -70,7 +70,6 @@ describe('Replicate data from node to node in DHT', () => {
                 }
             })
         )
-        await waitForStableTopology(nodes)
 
         const data = getDataEntries(closest[0])
         expect(data).toHaveLength(1)
@@ -85,8 +84,6 @@ describe('Replicate data from node to node in DHT', () => {
                 }
             })
         )
-        await waitForStableTopology(nodes)
-
         const randomIndex = Math.floor(Math.random() * nodes.length)
         const storerDescriptors = await nodes[randomIndex].storeDataToDht(toDhtAddress(DATA.key), DATA.data!)
         const stoppedNodeIds: DhtAddress[] = []

--- a/packages/dht/test/integration/ReplicateData.test.ts
+++ b/packages/dht/test/integration/ReplicateData.test.ts
@@ -10,7 +10,6 @@ import { DataEntry, PeerDescriptor } from '../../generated/packages/dht/protos/D
 const DATA = createMockDataEntry()
 const NUM_NODES = 100
 const MAX_CONNECTIONS = 80
-const K = 8
 const ENTRY_POINT_INDEX = 0
 
 const getDataEntries = (node: DhtNode): DataEntry[] => {
@@ -26,7 +25,7 @@ describe('Replicate data from node to node in DHT', () => {
     const simulator = new Simulator(LatencyType.FIXED, 20)
 
     beforeEach(async () => {
-        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress(), K, MAX_CONNECTIONS)
+        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress(), undefined, MAX_CONNECTIONS)
         entryPointDescriptor = entryPoint.getLocalPeerDescriptor()
         await entryPoint.joinDht([entryPointDescriptor])
         nodes = []
@@ -35,7 +34,7 @@ describe('Replicate data from node to node in DHT', () => {
             const node = await createMockConnectionDhtNode(
                 simulator,
                 randomDhtAddress(),
-                K,
+                undefined,
                 MAX_CONNECTIONS
             )
             nodes.push(node)

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -25,7 +25,7 @@ describe('Storing data in DHT', () => {
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
+            const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -6,7 +6,6 @@ import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntr
 import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
 
 const NUM_NODES = 100
-const MAX_CONNECTIONS = 20
 
 describe('Storing data in DHT', () => {
 
@@ -21,14 +20,12 @@ describe('Storing data in DHT', () => {
 
     beforeEach(async () => {
         nodes = []
-        entryPoint = await createMockConnectionDhtNode(simulator,
-            undefined, undefined, MAX_CONNECTIONS)
+        entryPoint = await createMockConnectionDhtNode(simulator)
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator,
-                undefined, undefined, MAX_CONNECTIONS, 60000)
+            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -3,7 +3,7 @@ import { DhtNode } from '../../src/dht/DhtNode'
 import { toDhtAddress, toNodeId } from '../../src/identifiers'
 import { PeerDescriptor } from '../../generated/packages/dht/protos/DhtRpc'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
-import { createMockConnectionDhtNode, createMockPeerDescriptor, waitForStableTopology } from '../utils/utils'
+import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/utils'
 
 const NUM_NODES = 100
 const MAX_CONNECTIONS = 20
@@ -33,7 +33,6 @@ describe('Storing data in DHT', () => {
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))
-        await waitForStableTopology(nodes, MAX_CONNECTIONS)
     }, 90000)
 
     afterEach(async () => {

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -23,7 +23,6 @@ describe('Storing data in DHT', () => {
         entryPoint = await createMockConnectionDhtNode(simulator)
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
-        nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)

--- a/packages/dht/test/integration/Store.test.ts
+++ b/packages/dht/test/integration/Store.test.ts
@@ -7,7 +7,6 @@ import { createMockConnectionDhtNode, createMockPeerDescriptor } from '../utils/
 
 const NUM_NODES = 100
 const MAX_CONNECTIONS = 20
-const K = 4
 
 describe('Storing data in DHT', () => {
 
@@ -23,13 +22,13 @@ describe('Storing data in DHT', () => {
     beforeEach(async () => {
         nodes = []
         entryPoint = await createMockConnectionDhtNode(simulator,
-            undefined, K, MAX_CONNECTIONS)
+            undefined, undefined, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         entrypointDescriptor = entryPoint.getLocalPeerDescriptor()
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(simulator,
-                undefined, K, MAX_CONNECTIONS, 60000)
+                undefined, undefined, MAX_CONNECTIONS, 60000)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entrypointDescriptor])))

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -21,7 +21,7 @@ describe('Storing data in DHT', () => {
         const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress())
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
+            const node = await createMockConnectionDhtNode(simulator)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entryPoint.getLocalPeerDescriptor()])))

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -1,6 +1,6 @@
 import { LatencyType, Simulator } from '../../src/connection/simulator/Simulator'
 import { DhtNode } from '../../src/dht/DhtNode'
-import { createMockConnectionDhtNode, waitForStableTopology } from '../utils/utils'
+import { createMockConnectionDhtNode } from '../utils/utils'
 import { createMockDataEntry, expectEqualData } from '../utils/mock/mockDataEntry'
 import { randomDhtAddress, toDhtAddress } from '../../src/identifiers'
 import { wait } from '@streamr/utils'
@@ -29,7 +29,6 @@ describe('Storing data in DHT', () => {
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entryPoint.getLocalPeerDescriptor()])))
-        await waitForStableTopology(nodes, MAX_CONNECTIONS)
     }, 90000)
 
     afterEach(async () => {

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -7,7 +7,6 @@ import { wait } from '@streamr/utils'
 
 const NUM_NODES = 5
 const MAX_CONNECTIONS = 5
-const K = 4
 
 describe('Storing data in DHT', () => {
 
@@ -21,11 +20,11 @@ describe('Storing data in DHT', () => {
     beforeEach(async () => {
         nodes = []
         const entryPoint = await createMockConnectionDhtNode(simulator,
-            randomDhtAddress(), K, MAX_CONNECTIONS)
+            randomDhtAddress(), undefined, MAX_CONNECTIONS)
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
             const node = await createMockConnectionDhtNode(simulator, 
-                undefined, K, MAX_CONNECTIONS, 60000)
+                undefined, undefined, MAX_CONNECTIONS, 60000)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entryPoint.getLocalPeerDescriptor()])))

--- a/packages/dht/test/integration/StoreAndDelete.test.ts
+++ b/packages/dht/test/integration/StoreAndDelete.test.ts
@@ -6,7 +6,6 @@ import { randomDhtAddress, toDhtAddress } from '../../src/identifiers'
 import { wait } from '@streamr/utils'
 
 const NUM_NODES = 5
-const MAX_CONNECTIONS = 5
 
 describe('Storing data in DHT', () => {
 
@@ -19,12 +18,10 @@ describe('Storing data in DHT', () => {
 
     beforeEach(async () => {
         nodes = []
-        const entryPoint = await createMockConnectionDhtNode(simulator,
-            randomDhtAddress(), undefined, MAX_CONNECTIONS)
+        const entryPoint = await createMockConnectionDhtNode(simulator, randomDhtAddress())
         nodes.push(entryPoint)
         for (let i = 1; i < NUM_NODES; i++) {
-            const node = await createMockConnectionDhtNode(simulator, 
-                undefined, undefined, MAX_CONNECTIONS, 60000)
+            const node = await createMockConnectionDhtNode(simulator, undefined, undefined, undefined, 60000)
             nodes.push(node)
         }
         await Promise.all(nodes.map((node) => node.joinDht([entryPoint.getLocalPeerDescriptor()])))

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -74,7 +74,7 @@ export const createMockRingNode = async (
 export const createMockConnectionDhtNode = async (
     simulator: Simulator,
     nodeId?: DhtAddress,
-    numberOfNodesPerKBucket?: number,
+    numberOfNodesPerKBucket?: undefined,
     maxConnections = 80,
     dhtJoinTimeout = 45000
 ): Promise<DhtNode> => {

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -73,10 +73,7 @@ export const createMockRingNode = async (
 
 export const createMockConnectionDhtNode = async (
     simulator: Simulator,
-    nodeId?: DhtAddress,
-    numberOfNodesPerKBucket?: undefined,
-    maxConnections?: undefined,
-    dhtJoinTimeout?: undefined
+    nodeId?: DhtAddress
 ): Promise<DhtNode> => {
     const peerDescriptor: PeerDescriptor = {
         nodeId: toDhtAddressRaw(nodeId ?? randomDhtAddress()),
@@ -90,9 +87,6 @@ export const createMockConnectionDhtNode = async (
         transport: mockConnectionManager,
         connectionsView: mockConnectionManager,
         connectionLocker: mockConnectionManager,
-        numberOfNodesPerKBucket,
-        maxConnections,
-        dhtJoinTimeout,
         rpcRequestTimeout: 5000
     }
     const node = new class extends DhtNode {

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -1,4 +1,4 @@
-import { DhtNode } from '../../src/dht/DhtNode'
+import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
@@ -102,7 +102,7 @@ export const createMockConnectionDhtNode = async (
 export const createMockConnectionLayer1Node = async (
     layer0Node: DhtNode,
     serviceId?: string,
-    numberOfNodesPerKBucket = 8
+    numberOfNodesPerKBucket = NUMBER_OF_NODES_PER_KBUCKET_DEFAULT
 ): Promise<DhtNode> => {
     const descriptor: PeerDescriptor = {
         nodeId: layer0Node.getLocalPeerDescriptor().nodeId,

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -247,23 +247,3 @@ export const createMockPeers = (): PeerDescriptor[] => {
         n1, n2, n3, n4
     ]
 }
-
-/*
- * When we start multiple nodes, most of the nodes have unlocked connections. This promise will resolve when some of those 
- * unlocked connections have been garbage collected, i.e. we typically have connections only to the nodes which
- * are neighbors.
- */
-export const waitForStableTopology = async (nodes: DhtNode[], maxConnectionCount: number = 10000, waitTime = 20000): Promise<void> => {
-    const MAX_IDLE_TIME = 100
-    const connectionManagers = nodes.map((n) => n.getTransport() as ConnectionManager)
-    await Promise.all(connectionManagers.map(async (connectionManager) => {
-        connectionManager.garbageCollectConnections(maxConnectionCount, MAX_IDLE_TIME)
-        try {
-            await until(() => connectionManager.getConnections().length <= maxConnectionCount, waitTime)
-        } catch {
-            // the topology is very likely stable, but we can't be sure (maybe the node has more than maxConnectionCount
-            // locked connections and therefore it is ok to that garbage collector was not able to remove any of those
-            // connections
-        }
-    }))
-}

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -20,12 +20,11 @@ import {
     IWebsocketClientConnectorRpc
 } from '../../generated/packages/dht/protos/DhtRpc.server'
 import { Simulator } from '../../src/connection/simulator/Simulator'
-import { ConnectionManager } from '../../src/connection/ConnectionManager'
 import { v4 } from 'uuid'
 import { getRandomRegion } from '../../src/connection/simulator/pings'
 import { Empty } from '../../generated/google/protobuf/empty'
 import { Any } from '../../generated/google/protobuf/any'
-import { wait, until } from '@streamr/utils'
+import { wait } from '@streamr/utils'
 import { SimulatorTransport } from '../../src/connection/simulator/SimulatorTransport'
 import { DhtAddress, randomDhtAddress, toDhtAddressRaw } from '../../src/identifiers'
 

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -75,7 +75,7 @@ export const createMockConnectionDhtNode = async (
     simulator: Simulator,
     nodeId?: DhtAddress,
     numberOfNodesPerKBucket?: undefined,
-    maxConnections = 80,
+    maxConnections?: undefined,
     dhtJoinTimeout = 45000
 ): Promise<DhtNode> => {
     const peerDescriptor: PeerDescriptor = {
@@ -91,7 +91,7 @@ export const createMockConnectionDhtNode = async (
         connectionsView: mockConnectionManager,
         connectionLocker: mockConnectionManager,
         numberOfNodesPerKBucket,
-        maxConnections: maxConnections,
+        maxConnections,
         dhtJoinTimeout,
         rpcRequestTimeout: 5000
     }

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -76,7 +76,7 @@ export const createMockConnectionDhtNode = async (
     nodeId?: DhtAddress,
     numberOfNodesPerKBucket?: undefined,
     maxConnections?: undefined,
-    dhtJoinTimeout = 45000
+    dhtJoinTimeout?: undefined
 ): Promise<DhtNode> => {
     const peerDescriptor: PeerDescriptor = {
         nodeId: toDhtAddressRaw(nodeId ?? randomDhtAddress()),

--- a/packages/dht/test/utils/utils.ts
+++ b/packages/dht/test/utils/utils.ts
@@ -1,4 +1,4 @@
-import { DhtNode, NUMBER_OF_NODES_PER_KBUCKET_DEFAULT } from '../../src/dht/DhtNode'
+import { DhtNode } from '../../src/dht/DhtNode'
 import {
     ClosestPeersRequest,
     ClosestPeersResponse,
@@ -101,8 +101,7 @@ export const createMockConnectionDhtNode = async (
 
 export const createMockConnectionLayer1Node = async (
     layer0Node: DhtNode,
-    serviceId?: string,
-    numberOfNodesPerKBucket = NUMBER_OF_NODES_PER_KBUCKET_DEFAULT
+    serviceId?: string
 ): Promise<DhtNode> => {
     const descriptor: PeerDescriptor = {
         nodeId: layer0Node.getLocalPeerDescriptor().nodeId,
@@ -113,7 +112,6 @@ export const createMockConnectionLayer1Node = async (
         transport: layer0Node,
         connectionsView: layer0Node.getConnectionsView(),
         serviceId: serviceId ?? 'layer1',
-        numberOfNodesPerKBucket,
         rpcRequestTimeout: 10000
     })
     await node.start()


### PR DESCRIPTION
Removed obsolete `waitForStableTopology()` call. It is no longer needed. That change made tests significantly faster.

Also changed `ConnectionManager#garbageCollectConnections()` to private as that utility method was the only reason why it was kept `public`.

## Other changes

- removed `numberOfNodesPerKBucket`, `maxConnections` and `dhtJoinTimeout` parameters from `createMockConnectionDhtNode()`, all tests now use DhtNode's default values.
- removed unnecessary `createMockConnectionLayer1Node` from `createMockConnectionDhtNode()`
- tests use the new `NUMBER_OF_NODES_PER_KBUCKET_DEFAULT` constant is used instead of local constant
- removed unnecessary entry point array push in Store.test.ts
- removed unnecessary j`oinDht()` call in Find.test.ts

## Statistics

Execution time of `dht` browser tests dropped from 300s -> 200s. Also `dht` NodeJS tests are faster, but as those are run concurrently the total execution time didn't drop significantly. 