### PR TITLE
bugfix: getting subtle in web workers

### DIFF
--- a/packages/sdk/test/unit/ECDSAKeyPairIdentity.test.ts
+++ b/packages/sdk/test/unit/ECDSAKeyPairIdentity.test.ts
@@ -28,10 +28,11 @@ describe('ECDSAKeyPairIdentity', () => {
         })
         it('throws if the given publicKey does not match the publicKey', async () => {
             const keyPair = signingUtil.generateKeyPair()
+            const wrongPublicKey = new Uint8Array(keyPair.publicKey.length)
 
             expect(() => ECDSAKeyPairIdentity.fromConfig({
                 auth: {
-                    publicKey: binaryToHex(keyPair.publicKey).replace('b', 'd'),
+                    publicKey: binaryToHex(wrongPublicKey),
                     privateKey: binaryToHex(keyPair.privateKey),
                 }
             })).toThrow()

--- a/packages/utils/src/crossPlatformCrypto.ts
+++ b/packages/utils/src/crossPlatformCrypto.ts
@@ -1,9 +1,12 @@
 import crypto from 'crypto'
 
-declare const window: any
+declare const self: any
 
 export function getSubtle(): crypto.webcrypto.SubtleCrypto {
-    const subtle = typeof window !== 'undefined' ? window?.crypto?.subtle : crypto.webcrypto.subtle
+    // in browser main thread, self === window
+    // in web workers, self is defined but window is not
+    // in node.js, self is undefined
+    const subtle = typeof self !== 'undefined' ? self?.crypto?.subtle : crypto.webcrypto.subtle
     if (!subtle) {
         const url = 'https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto'
         throw new Error(`SubtleCrypto not supported. This feature is available only in secure contexts (HTTPS) & Node 16+. ${url}`)


### PR DESCRIPTION
`window` is not available inside web workers, and this was used for getting access to SubtleCrypto API in browsers.

Instead, use `self` - which in browser main thread is the same as `window`, but also grants access to `self.crypto.subtle` in web workers.

Also fixes an unrelated flaky test I happened to notice in the CI run.