### PR TITLE
fix(network): fix import of `waitForEvent3` in InspectSession.test.ts

### DIFF
--- a/packages/trackerless-network/test/unit/InspectSession.test.ts
+++ b/packages/trackerless-network/test/unit/InspectSession.test.ts
@@ -1,7 +1,6 @@
 import { InspectSession, Events } from '../../src/content-delivery-layer/inspection/InspectSession'
 import { MessageID } from '../../generated/packages/trackerless-network/protos/NetworkRpc'
-import { waitForEvent3 } from '../../../utils/dist/src/waitForEvent3'
-import { utf8ToBinary } from '@streamr/utils'
+import { utf8ToBinary, waitForEvent3 } from '@streamr/utils'
 import { DhtAddress, randomDhtAddress } from '@streamr/dht'
 
 describe('InspectSession', () => {


### PR DESCRIPTION
## Summary

Fixed bad import of `waitForEvent3` in InspectSession.test.ts
