### PR TITLE
NET-1457: Define explicit "exports" for SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,6 +15,13 @@
     "./src/utils/persistence/ServerPersistence.ts": "./src/utils/persistence/BrowserPersistence.mts",
     "./dist/src/utils/persistence/ServerPersistence.js": "./dist/src/utils/persistence/BrowserPersistence.mjs"
   },
+  "exports": {
+    "default": {
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/src/exports-esm.mjs",
+      "require": "./dist/src/exports-commonjs.js"
+    }
+  },
   "files": [
     "dist",
     "!*.tsbuildinfo",


### PR DESCRIPTION
## Summary

We've encountered a strange behaviour where if you run `node script.js` and it's a esm script then node's module resolver will try to import the cjs sdk and not the esm one.

Since we're targeting newer node versions anyway, it'd seem important to prioritise "exports" field over "main"/"module". In this PR I populate "exports" field but also keep the legacy fields for good measure (won't hurt).

IIRC the SDK is the only package that distinguishes between _require_ and _import_ exports.

## Changes

Add an explicit "exports" field into SDK's package.json.

## Limitations and future improvements

In the future we may consider using the "exports" field exclusively, and drop "main" and "module". We target newer tools after all, and the legacy fields are mainly for older envs.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
