### PR TITLE
bugfix: fix ecdsa verification on safari

### DIFF
--- a/packages/utils/src/SigningUtil.ts
+++ b/packages/utils/src/SigningUtil.ts
@@ -240,7 +240,7 @@ export class EcdsaSecp256r1 extends SigningUtil {
         try {
             key = await this.importKey(publicKey)
         } catch (err) {
-            // On some browsers (Safari), uncompressed keys are not supported for some reason!
+            // On some browsers (Safari), compressed keys are not supported for some reason!
             // If that might be the case, retry with an uncompressed key
             if (publicKey.length === 33) {
                 key = await this.importKey(this.getUncompressedPublicKey(publicKey))

--- a/packages/utils/src/SigningUtil.ts
+++ b/packages/utils/src/SigningUtil.ts
@@ -124,9 +124,9 @@ export class EcdsaSecp256k1Evm extends SigningUtil {
  * Signing scheme using ECDSA with secp256r1 curve and SHA-256, natively supported by browsers
  */
 export class EcdsaSecp256r1 extends SigningUtil {
-    generateKeyPair(): KeyPair {
+    generateKeyPair(compressPublicKey: boolean = true): KeyPair {
         const privateKey = randomBytes(32)
-        const publicKey = this.getPublicKeyFromPrivateKey(privateKey)
+        const publicKey = this.getPublicKeyFromPrivateKey(privateKey, compressPublicKey)
 
         return {
             publicKey,
@@ -140,6 +140,23 @@ export class EcdsaSecp256r1 extends SigningUtil {
 
     getPublicKeyFromPrivateKey(privateKey: Uint8Array, compressed: boolean = true): Uint8Array {
         return p256.getPublicKey(privateKey, compressed)
+    }
+
+    getUncompressedPublicKey(publicKey: Uint8Array): Uint8Array {
+        if (publicKey.length == 33) {
+            // Decode compressed public key to an elliptic curve point
+            const point = p256.ProjectivePoint.fromHex(publicKey)
+
+            // Convert the point to an uncompressed public key
+            return point.toRawBytes(false)
+        }
+
+        // No-op if called with already uncompressed key
+        if (publicKey.length == 65) {
+            return publicKey
+        }
+
+        throw new Error(`Unexpected public key length: ${publicKey.length}`)
     }
 
     privateKeyToJWK(privateKey: Uint8Array): webcrypto.JsonWebKey {
@@ -204,8 +221,8 @@ export class EcdsaSecp256r1 extends SigningUtil {
         return new Uint8Array(signature)
     }
 
-    async verifySignature(publicKey: UserIDRaw, payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
-        const key = await subtleCrypto.importKey(
+    private async importKey(publicKey: Uint8Array): Promise<webcrypto.CryptoKey> {
+        return subtleCrypto.importKey(
             'raw',
             publicKey,
             {
@@ -215,6 +232,22 @@ export class EcdsaSecp256r1 extends SigningUtil {
             false,
             ['verify']
         )
+    }
+
+    async verifySignature(publicKey: UserIDRaw, payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
+        let key: webcrypto.CryptoKey
+
+        try {
+            key = await this.importKey(publicKey)
+        } catch (err) {
+            // On some browsers (Safari), uncompressed keys are not supported for some reason!
+            // If that might be the case, retry with an uncompressed key
+            if (publicKey.length === 33) {
+                key = await this.importKey(this.getUncompressedPublicKey(publicKey))
+            } else {
+                throw err
+            }
+        }
 
         const isValid = await subtleCrypto.verify(
             {

--- a/packages/utils/src/SigningUtil.ts
+++ b/packages/utils/src/SigningUtil.ts
@@ -221,7 +221,7 @@ export class EcdsaSecp256r1 extends SigningUtil {
         return new Uint8Array(signature)
     }
 
-    private async importKey(publicKey: Uint8Array): Promise<webcrypto.CryptoKey> {
+    private async publicKeyToCryptoKey(publicKey: Uint8Array): Promise<webcrypto.CryptoKey> {
         return subtleCrypto.importKey(
             'raw',
             publicKey,
@@ -238,12 +238,12 @@ export class EcdsaSecp256r1 extends SigningUtil {
         let key: webcrypto.CryptoKey
 
         try {
-            key = await this.importKey(publicKey)
+            key = await this.publicKeyToCryptoKey(publicKey)
         } catch (err) {
             // On some browsers (Safari), compressed keys are not supported for some reason!
             // If that might be the case, retry with an uncompressed key
             if (publicKey.length === 33) {
-                key = await this.importKey(this.getUncompressedPublicKey(publicKey))
+                key = await this.publicKeyToCryptoKey(this.getUncompressedPublicKey(publicKey))
             } else {
                 throw err
             }

--- a/packages/utils/test/SigningUtil.test.ts
+++ b/packages/utils/test/SigningUtil.test.ts
@@ -125,9 +125,15 @@ describe('EcdsaSecp256r1', () => {
     const validSignature2 = '3a804164f19baf0f52bc34d03be8090ea7957dabf340a9b220bf680d36e5ccd9a2d6423fa14d0ccfd1efcca3044ac788516de703fe28e4f23b644ad482275ea2'
 
     describe('generateKeyPair', () => {
-        it('generates keys of correct length', async () => {
+        it('generates keys of correct length (default)', async () => {
             const keyPair = util.generateKeyPair()
-            expect(keyPair.publicKey.length).toBe(33) // compressed. uncompressed would be 65 bytes
+            expect(keyPair.publicKey.length).toBe(33) // compressed
+            expect(keyPair.privateKey.length).toBe(32)
+        })
+
+        it('generates keys of correct length (uncompressed)', async () => {
+            const keyPair = util.generateKeyPair(false)
+            expect(keyPair.publicKey.length).toBe(65) // uncompressed
             expect(keyPair.privateKey.length).toBe(32)
         })
 
@@ -150,6 +156,15 @@ describe('EcdsaSecp256r1', () => {
         })
         it('passes on known valid pair with uncompressed public key', () => {
             util.assertValidKeyPair(publicKey2, privateKey2)
+        })
+    })
+
+    describe('getUncompressedPublicKey', () => {
+        it('produces the correct uncompressed public key', () => {
+            const compressed = util.getPublicKeyFromPrivateKey(privateKey1, true)
+            const uncompressed = util.getPublicKeyFromPrivateKey(privateKey1, false)
+
+            expect(util.getUncompressedPublicKey(compressed)).toEqual(uncompressed)
         })
     })
 


### PR DESCRIPTION
On some browsers (Safari), trying to import a compressed public key on the webcrypto API fails for some reason! This PR introduces a workaround whereby a failed import is retried with an uncompressed key, which is computed from the compressed one.