### PR TITLE
test(dht): Equality check in `Mock-Layer1-Layer0.test.ts`

### DIFF
--- a/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
+++ b/packages/dht/test/integration/Mock-Layer1-Layer0.test.ts
@@ -76,10 +76,10 @@ describe('Layer 1 on Layer 0 with mocked connections', () => {
         expect(layer1Node3.getNeighborCount()).toEqual(layer0Node3.getNeighborCount())
         expect(layer1Node4.getNeighborCount()).toEqual(layer0Node4.getNeighborCount())
 
-        expect(layer1Node1.getNeighbors()).toContainValues(layer0Node1.getNeighbors())
-        expect(layer1Node2.getNeighbors()).toContainValues(layer0Node2.getNeighbors())
-        expect(layer1Node3.getNeighbors()).toContainValues(layer0Node3.getNeighbors())
-        expect(layer1Node4.getNeighbors()).toContainValues(layer0Node4.getNeighbors())
+        expect(layer1Node1.getNeighbors()).toIncludeSameMembers(layer0Node1.getNeighbors())
+        expect(layer1Node2.getNeighbors()).toIncludeSameMembers(layer0Node2.getNeighbors())
+        expect(layer1Node3.getNeighbors()).toIncludeSameMembers(layer0Node3.getNeighbors())
+        expect(layer1Node4.getNeighbors()).toIncludeSameMembers(layer0Node4.getNeighbors())
 
     }, 60000)
 })


### PR DESCRIPTION
Use `toIncludeSameMembers()` instead of `toContainValues()`.

The `toIncludeSameMembers()` is better check as both arrays should match exactly. In a previous line already check that there are equal items in the list, i.e. the lists won't contain additional values (which would be tolerated by `toContainValues()` but not by `toIncludeSameMembers()` )
```ts
expect(layer1Node1.getNeighborCount()).toEqual(layer0Node1.getNeighborCount())
```

This should resolve the test failure in https://github.com/streamr-dev/network/pull/3127.