### PR TITLE
feat(cli-tools): Add internal `operator-grant-controller-role` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-operator-grant-controller-role.ts
+++ b/packages/cli-tools/bin/streamr-internal-operator-grant-controller-role.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import '../src/logLevel'
+
+import { StreamrClient, _operatorContractUtils } from '@streamr/sdk'
+import { createClientCommand } from '../src/command'
+
+createClientCommand(async (client: StreamrClient, operatorContractAddress: string, userId: string) => {
+    const contract = _operatorContractUtils.getOperatorContract(operatorContractAddress).connect(await client.getSigner())
+    await (await contract.grantRole(await contract.CONTROLLER_ROLE(), userId)).wait()
+})
+    .description('grant controller role to a user')
+    .arguments('<operatorContractAddress> <user>')
+    .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal.ts
+++ b/packages/cli-tools/bin/streamr-internal.ts
@@ -16,5 +16,6 @@ program
     .command('operator-undelegate', 'undelegate funds from an operator')
     .command('operator-stake', 'stake operator\'s funds to a sponsorship')
     .command('operator-unstake', 'unstake all operator\'s funds from a sponsorship')
+    .command('operator-grant-controller-role', 'grant controller role to a user')
     .command('token-mint', 'mint test tokens')
     .parse()

--- a/packages/cli-tools/test/internal-operator.test.ts
+++ b/packages/cli-tools/test/internal-operator.test.ts
@@ -52,6 +52,13 @@ describe('operator', () => {
         })
         expect(await operatorContract.balanceInData(await delegator.getAddress())).toEqual(0n)
 
+        // grant controller role
+        const controller = await createTestWallet()
+        await runCommand(`internal operator-grant-controller-role ${operatorContractAddress} ${controller.address}`, {
+            privateKey: operator.privateKey
+        })
+        expect(await operatorContract.hasRole(await operatorContract.CONTROLLER_ROLE(), controller.address)).toBeTrue()
+
         await client.destroy()
     }, 30 * 1000)
 })


### PR DESCRIPTION
Added a new command for granting the operator controller role. This is currently an internal command, like the other operator-related commands. If needed, we can promote this to a public command later (no modifications needed).