### PR TITLE
feat(cli-tools): Add `--max-operator-count` flag to `sponsorship-create` command

### DIFF
--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -24,5 +24,5 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
     .description('create sponsorship')
     .arguments('<streamId>')
     .requiredOption('-e, --earnings-per-second <number>', 'Earnings per second')
-    .option('-c, --min-operator-count <number>', 'Minimum operator count')
+    .option('--min-operator-count <number>', 'Minimum operator count')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -9,6 +9,7 @@ import { parseEther } from 'ethers'
 interface Options extends BaseOptions {
     earningsPerSecond: string
     minOperatorCount?: number
+    maxOperatorCount?: number
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
@@ -17,6 +18,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
         earningsPerSecond: parseEther(options.earningsPerSecond),
         deployer: await client.getSigner(),
         minOperatorCount: options.minOperatorCount,
+        maxOperatorCount: options.maxOperatorCount,
         environmentId: client.getConfig().environment
     })
     console.info(JSON.stringify({ address: await contract.getAddress() }, undefined, 4))

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-create.ts
@@ -23,6 +23,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .description('create sponsorship')
     .arguments('<streamId>')
-    .requiredOption('-e, --earnings-per-second <number>', 'Earnings per second')
+    .requiredOption('-e, --earnings-per-second <number>', 'Earnings per second in data tokens')
     .option('--min-operator-count <number>', 'Minimum operator count')
+    .option('--max-operator-count <number>', 'Maximum operator count')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-internal-sponsorship-sponsor.ts
+++ b/packages/cli-tools/bin/streamr-internal-sponsorship-sponsor.ts
@@ -13,5 +13,5 @@ createClientCommand(async (client: StreamrClient, sponsorshipAddress: string, da
     )
 })
     .description('sponsor a stream')
-    .arguments('<sponsorshipAddress> <tokenAmount>')
+    .arguments('<sponsorshipAddress> <dataTokenAmount>')
     .parseAsync()

--- a/packages/cli-tools/test/internal-sponsorship-create.test.ts
+++ b/packages/cli-tools/test/internal-sponsorship-create.test.ts
@@ -1,0 +1,58 @@
+import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
+import { until } from '@streamr/utils'
+import { parseEther } from 'ethers'
+import { createTestClient, runCommand } from './utils'
+
+interface QueryResultItem {
+    sponsorships: [{
+        totalPayoutWeiPerSec: string
+        minOperators: number
+    }]
+}
+
+const EARNINGS_PER_SECOND = 123
+const MIN_OPERATOR_COUNT = 10
+
+describe('sponsorship-create', () => {
+
+    it('happy path', async () => {
+        const client = createTestClient(await createTestPrivateKey({ gas: true }))
+        const stream = await client.createStream('/test')
+
+        const sponsorer = await createTestWallet({ gas: true, tokens: true })
+        // eslint-disable-next-line max-len
+        const command = `internal sponsorship-create ${stream.id} --earnings-per-second ${EARNINGS_PER_SECOND} --min-operator-count ${MIN_OPERATOR_COUNT}`
+        await runCommand(command, {
+            privateKey: sponsorer.privateKey
+        })
+
+        // wait for The Graph to index it
+        let queryResult
+        await until(async () => {
+            queryResult = await client.getTheGraphClient().queryEntity<QueryResultItem>({ 
+                query: `
+                    {
+                        sponsorships (
+                            where: { 
+                                stream_: { 
+                                    id: "${stream.id}"
+                                }
+                            }
+                        ) {
+                            totalPayoutWeiPerSec
+                            minOperators
+                        }
+                    }
+                `
+            })
+            return queryResult.sponsorships.length > 0
+        })
+
+        expect(queryResult!.sponsorships[0]).toEqual({ 
+            totalPayoutWeiPerSec: parseEther(String(EARNINGS_PER_SECOND)).toString(),
+            minOperators: MIN_OPERATOR_COUNT
+        })
+
+        await client.destroy()
+    })
+})

--- a/packages/cli-tools/test/internal-sponsorship-create.test.ts
+++ b/packages/cli-tools/test/internal-sponsorship-create.test.ts
@@ -12,6 +12,7 @@ interface QueryResultItem {
 
 const EARNINGS_PER_SECOND = 123
 const MIN_OPERATOR_COUNT = 10
+const MAX_OPERATOR_COUNT = 20
 
 describe('sponsorship-create', () => {
 
@@ -21,7 +22,7 @@ describe('sponsorship-create', () => {
 
         const sponsorer = await createTestWallet({ gas: true, tokens: true })
         // eslint-disable-next-line max-len
-        const command = `internal sponsorship-create ${stream.id} --earnings-per-second ${EARNINGS_PER_SECOND} --min-operator-count ${MIN_OPERATOR_COUNT}`
+        const command = `internal sponsorship-create ${stream.id} --earnings-per-second ${EARNINGS_PER_SECOND} --min-operator-count ${MIN_OPERATOR_COUNT} --max-operator-count ${MAX_OPERATOR_COUNT}`
         await runCommand(command, {
             privateKey: sponsorer.privateKey
         })
@@ -41,6 +42,7 @@ describe('sponsorship-create', () => {
                         ) {
                             totalPayoutWeiPerSec
                             minOperators
+                            maxOperators
                         }
                     }
                 `
@@ -50,7 +52,8 @@ describe('sponsorship-create', () => {
 
         expect(queryResult!.sponsorships[0]).toEqual({ 
             totalPayoutWeiPerSec: parseEther(String(EARNINGS_PER_SECOND)).toString(),
-            minOperators: MIN_OPERATOR_COUNT
+            minOperators: MIN_OPERATOR_COUNT,
+            maxOperators: MAX_OPERATOR_COUNT
         })
 
         await client.destroy()

--- a/packages/cli-tools/test/internal-sponsorship-create.test.ts
+++ b/packages/cli-tools/test/internal-sponsorship-create.test.ts
@@ -7,6 +7,7 @@ interface QueryResultItem {
     sponsorships: [{
         totalPayoutWeiPerSec: string
         minOperators: number
+        maxOperators: number
     }]
 }
 

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -54,10 +54,11 @@ export async function deployOperatorContract(opts: DeployOperatorContractOpts): 
             CHAIN_CONFIG[opts.environmentId].contracts.OperatorDefaultDelegationPolicy,
             CHAIN_CONFIG[opts.environmentId].contracts.OperatorDefaultExchangeRatePolicy,
             CHAIN_CONFIG[opts.environmentId].contracts.OperatorDefaultUndelegationPolicy,
-        ], [
+        ],
+        [
             0,
             0,
-            0,
+            0
         ]
     )).wait()
     const newSponsorshipEvent = operatorReceipt!.logs.find((l: any) => l.fragment?.name === 'NewOperator') as EventLog

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -76,6 +76,7 @@ export interface DeploySponsorshipContractOpts {
     deployer: SignerWithProvider
     metadata?: string
     minOperatorCount?: number
+    maxOperatorCount?: number
     earningsPerSecond?: WeiAmount
     environmentId: EnvironmentId
 }
@@ -87,19 +88,28 @@ export async function deploySponsorshipContract(opts: DeploySponsorshipContractO
         SponsorshipFactoryABI,
         opts.deployer
     ) as unknown as SponsorshipFactoryContract
+    const policies: { contractAddress: string, param: number | bigint }[] = [{
+        contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipStakeWeightedAllocationPolicy,
+        param: opts.earningsPerSecond ?? parseEther('1')
+    }, {
+        contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipDefaultLeavePolicy,
+        param: 0,
+    }, {
+        contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipVoteKickPolicy,
+        param: 0
+    }]
+    if (opts.maxOperatorCount !== undefined) {
+        policies.push({
+            contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipMaxOperatorsJoinPolicy,
+            param: opts.maxOperatorCount
+        })
+    }
     const sponsorshipDeployTx = await sponsorshipFactory.deploySponsorship(
         (opts.minOperatorCount ?? 1).toString(),
         opts.streamId,
         opts.metadata ?? '{}',
-        [
-            CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipStakeWeightedAllocationPolicy,
-            CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipDefaultLeavePolicy,
-            CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipVoteKickPolicy,
-        ], [
-            opts.earningsPerSecond ?? parseEther('1'),
-            '0',
-            '0',
-        ]
+        policies.map((p) => p.contractAddress),
+        policies.map((p) => p.param)
     )
     const sponsorshipDeployReceipt = await sponsorshipDeployTx.wait()
     const newSponsorshipEvent = sponsorshipDeployReceipt!.logs.find((l: any) => l.fragment?.name === 'NewSponsorship') as EventLog


### PR DESCRIPTION
**Note that this PR contains breaking changes to internal commands. But as there are no changes for public API, this is not a breaking change in semver sense.**

Added new flag to the internal `sponsorship-create` command.

Also removed support for the short flag `-c` which was an alias to `--min-operator-count` . Now neither of the operator count flags have a short alias.

## Related changes

SDK's internal `operatorContractUtils#deploySponsorshipContract()` now supports `maxOperatorCount` option. Some refactoring was needed there to support dynamic policy count (as we need to have additional policy if `maxOperatorCount`  is defined).

## Other changes

- explicit wording about the unit of token amount in two CLI tool commands
- small stylistic fix in `operatorContractUtils#deployOperatorContract()`
