### PR TITLE
feat(node): Undelegation queue in Autostaker

### DIFF
--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -105,11 +105,8 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                 sponsorshipId,
                 amount: formatEther(amount)
             })),
-            undelegationQueue: formatEther(undelegationQueueAmount),
-            balance: {
-                unstaked: formatEther(myUnstakedAmount),
-                staked: formatEther(myStakedAmount)
-            }
+            myUnstakedAmount: formatEther(myUnstakedAmount),
+            undelegationQueue: formatEther(undelegationQueueAmount)
         })
         const actions = adjustStakes({
             myCurrentStakes,

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -28,7 +28,7 @@ interface StakeQueryResultItem {
     sponsorship: {
         id: SponsorshipID
     }
-    amountWei: WeiAmount
+    amountWei: string
 }
 
 const logger = new Logger(module)

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -135,7 +135,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                 query: `
                     {
                         sponsorships (
-                            where:  {
+                            where: {
                                 projectedInsolvency_gt: ${Math.floor(Date.now() / 1000)}
                                 minimumStakingPeriodSeconds: "0"
                                 minOperators_lte: ${this.pluginConfig.maxAcceptableMinOperatorCount}
@@ -176,7 +176,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                 query: `
                     {
                         stakes (
-                            where:  {
+                            where: {
                                 operator: "${this.pluginConfig.operatorContractAddress.toLowerCase()}",
                                 id_gt: "${lastId}"
                             },

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -6,6 +6,7 @@ import { Plugin } from '../../Plugin'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { adjustStakes } from './payoutProportionalStrategy'
 import { Action, SponsorshipConfig, SponsorshipID } from './types'
+import { sum } from './sum'
 
 export interface AutostakerPluginConfig {
     operatorContractAddress: string
@@ -87,7 +88,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
             .connect(provider)
         const myCurrentStakes = await this.getMyCurrentStakes(streamrClient)
         const stakeableSponsorships = await this.getStakeableSponsorships(myCurrentStakes, streamrClient)
-        const myStakedAmount = await operatorContract.totalStakedIntoSponsorshipsWei()
+        const myStakedAmount = sum([...myCurrentStakes.values()])
         const myUnstakedAmount = (await operatorContract.valueWithoutEarnings()) - myStakedAmount
         logger.debug('Analysis state', {
             stakeableSponsorships: [...stakeableSponsorships.entries()].map(([sponsorshipId, config]) => ({

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -6,6 +6,7 @@ import partition from 'lodash/partition'
 import pull from 'lodash/pull'
 import sortBy from 'lodash/sortBy'
 import { Action, AdjustStakesFn, SponsorshipConfig, SponsorshipID } from './types'
+import { sum } from './sum'
 
 /**
  * Allocate stake in proportion to the payout each sponsorship gives.
@@ -40,10 +41,6 @@ import { Action, AdjustStakesFn, SponsorshipConfig, SponsorshipID } from './type
  **/
 
 type TargetStake = [SponsorshipID, WeiAmount]
-
-const sum = (values: bigint[]): bigint =>{
-    return values.reduce((acc, value) => acc + value, 0n)
-}
 
 const abs = (n: bigint) => (n < 0n) ? -n : n
 

--- a/packages/node/src/plugins/autostaker/sum.ts
+++ b/packages/node/src/plugins/autostaker/sum.ts
@@ -1,0 +1,3 @@
+export const sum = (values: bigint[]): bigint =>{
+    return values.reduce((acc, value) => acc + value, 0n)
+}

--- a/packages/node/src/plugins/autostaker/types.ts
+++ b/packages/node/src/plugins/autostaker/types.ts
@@ -15,6 +15,7 @@ export type AdjustStakesFn = (opts: {
     myCurrentStakes: Map<SponsorshipID, WeiAmount>
     myUnstakedAmount: WeiAmount
     stakeableSponsorships: Map<SponsorshipID, SponsorshipConfig>
+    undelegationQueueAmount: WeiAmount
     operatorContractAddress: string
     maxSponsorshipCount: number
     minTransactionAmount: WeiAmount

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -12,6 +12,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 4n }],
                 ['c', { payoutPerSec: 6n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -27,6 +28,7 @@ describe('payoutProportionalStrategy', () => {
             myUnstakedAmount: 1000n,
             myCurrentStakes: new Map([[ 'a', 2000n ]]),
             stakeableSponsorships: new Map(),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -45,6 +47,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 20n }],
                 ['c', { payoutPerSec: 30n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -65,6 +68,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 20n }], // included
                 ['c', { payoutPerSec: 30n }], // included
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 2,
             minTransactionAmount: 0n,
@@ -84,6 +88,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 20n }], // not included
                 ['c', { payoutPerSec: 30n }], // included
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -98,6 +103,7 @@ describe('payoutProportionalStrategy', () => {
             myUnstakedAmount: 100n,
             myCurrentStakes: new Map(),
             stakeableSponsorships: new Map([['a', { payoutPerSec: 10n }]]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -119,6 +125,7 @@ describe('payoutProportionalStrategy', () => {
                 ['c', { payoutPerSec: 20n }], // stake here
                 ['d', { payoutPerSec: 10n }], // stake here
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -139,6 +146,7 @@ describe('payoutProportionalStrategy', () => {
             stakeableSponsorships: new Map([
                 ['a', { payoutPerSec: 10n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -161,6 +169,7 @@ describe('payoutProportionalStrategy', () => {
                 ['a', { payoutPerSec: 10n }],
                 ['b', { payoutPerSec: 10n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -181,6 +190,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 100n }],
                 ['c', { payoutPerSec: 400n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -205,6 +215,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 100n }],
                 ['c', { payoutPerSec: 400n }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -221,6 +232,7 @@ describe('payoutProportionalStrategy', () => {
                 ['b', { payoutPerSec: 4n * BigInt(Number.MAX_SAFE_INTEGER) }],
                 ['c', { payoutPerSec: 2n * BigInt(Number.MAX_SAFE_INTEGER) }],
             ]),
+            undelegationQueueAmount: 0n,
             operatorContractAddress: '',
             maxSponsorshipCount: 100,
             minTransactionAmount: 0n,
@@ -238,6 +250,7 @@ describe('payoutProportionalStrategy', () => {
                     ['a', { payoutPerSec: 100n }],
                     ['b', { payoutPerSec: 100n }],
                 ]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress,
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 0n,
@@ -253,6 +266,28 @@ describe('payoutProportionalStrategy', () => {
         expect(stakesForOperator1[0].sponsorshipId).toEqual(stakesForOperator1_rerun[0].sponsorshipId)
     })
 
+    it('undelegation queue', () => {
+        expect(adjustStakes({
+            myUnstakedAmount: 500n,
+            myCurrentStakes: new Map([
+                ['a', 2000n ],
+                ['b', 3000n ]
+            ]),
+            stakeableSponsorships: new Map([
+                ['a', { payoutPerSec: 20n }],
+                ['b', { payoutPerSec: 30n }]
+            ]),
+            undelegationQueueAmount: 1100n,
+            operatorContractAddress: '',
+            maxSponsorshipCount: 100,
+            minTransactionAmount: 0n,
+            minStakePerSponsorship: 100n
+        })).toIncludeSameMembers([
+            { type: 'unstake', sponsorshipId: 'a', amount: 220n },
+            { type: 'unstake', sponsorshipId: 'b', amount: 380n }
+        ])
+    })
+
     describe('exclude small transactions', () => {
         it('exclude small stakings', () => {
             expect(adjustStakes({
@@ -263,6 +298,7 @@ describe('payoutProportionalStrategy', () => {
                     ['b', { payoutPerSec: 20n }],
                     ['c', { payoutPerSec: 1000n }]
                 ]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 20n,
@@ -283,6 +319,7 @@ describe('payoutProportionalStrategy', () => {
                     ['b', { payoutPerSec: 100n }],
                     ['c', { payoutPerSec: 400n }],
                 ]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 20n,
@@ -307,6 +344,7 @@ describe('payoutProportionalStrategy', () => {
                     ['d', { payoutPerSec: 220n }],
                     ['e', { payoutPerSec: 230n }]
                 ]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 50n,
@@ -332,6 +370,7 @@ describe('payoutProportionalStrategy', () => {
                     ['d', { payoutPerSec: 220n }],
                     ['e', { payoutPerSec: 230n }]
                 ]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 50n,
@@ -347,6 +386,7 @@ describe('payoutProportionalStrategy', () => {
                     ['b', 1000n]
                 ]),
                 stakeableSponsorships: new Map([]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 50n,
@@ -365,6 +405,7 @@ describe('payoutProportionalStrategy', () => {
                     ['b', 20n]
                 ]),
                 stakeableSponsorships: new Map([]),
+                undelegationQueueAmount: 0n,
                 operatorContractAddress: '',
                 maxSponsorshipCount: 100,
                 minTransactionAmount: 50n,

--- a/packages/utils/src/sum.ts
+++ b/packages/utils/src/sum.ts
@@ -1,3 +1,0 @@
-export function sum(values: bigint[]): bigint {
-    return values.reduce((acc, value) => acc + value, 0n)
-}


### PR DESCRIPTION
## Summary

Entries in the undelegation queue now affect the Autostaker calculations. 

## Background
 
When a delegator undelegates some amount from an operator, the tokens aren't immediately transferred back to the delegator. Instead the amount is added to the undelegation queue. The transfer happens as soon as there are enough unstaked tokens in the operator contract.

## Changes

Modified the target stake calculation `payoutProportionalStrategy`. The rounding logic and skipping of small transactions are also affected slightly. The autostaker plugin reads the sum of undelegation queue entries from The Graph and passes the amount to the strategy function.

Also added more assertions to the `autostaker.test.ts` smoke tests.

## Other changes

- The `myStakedAmount` in calculated from the stakes instead of querying it from the contract
- Simplified logging in the plugin

## Chores

- Removed `sum.ts` from the `@streamr/utils` package
  - it was not exported
  - the file was added during the development of https://github.com/streamr-dev/network/pull/3086 (we should have removed the file in that PR)
- Fixed field type in `StakeQueryResultItem`