### PR TITLE
feat(node): Leader check in Autostaker

### DIFF
--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -1,11 +1,14 @@
 import { _operatorContractUtils, SignerWithProvider, StreamrClient } from '@streamr/sdk'
-import { collect, Logger, scheduleAtApproximateInterval, TheGraphClient, WeiAmount } from '@streamr/utils'
+import { collect, Logger, scheduleAtApproximateInterval, TheGraphClient, toEthereumAddress, WeiAmount } from '@streamr/utils'
 import { Schema } from 'ajv'
 import { formatEther, parseEther } from 'ethers'
 import { Plugin } from '../../Plugin'
 import PLUGIN_CONFIG_SCHEMA from './config.schema.json'
 import { adjustStakes } from './payoutProportionalStrategy'
 import { Action, SponsorshipConfig, SponsorshipID } from './types'
+import { formCoordinationStreamId } from '../operator/formCoordinationStreamId'
+import { OperatorFleetState } from '../operator/OperatorFleetState'
+import { createIsLeaderFn } from '../operator/createIsLeaderFn'
 
 export interface AutostakerPluginConfig {
     operatorContractAddress: string
@@ -13,6 +16,13 @@ export interface AutostakerPluginConfig {
     minTransactionDataTokenAmount: number
     maxAcceptableMinOperatorCount: number
     runIntervalInMs: number
+    fleetState: {
+        heartbeatUpdateIntervalInMs: number
+        pruneAgeInMs: number
+        pruneIntervalInMs: number
+        latencyExtraInMs: number
+        warmupPeriodInMs: number
+    }
 }
 
 interface SponsorshipQueryResultItem {
@@ -71,9 +81,23 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
     async start(streamrClient: StreamrClient): Promise<void> {
         logger.info('Start autostaker plugin')
         const minStakePerSponsorship = await fetchMinStakePerSponsorship(streamrClient.getTheGraphClient())
+        const fleetState = new OperatorFleetState(
+            streamrClient,
+            formCoordinationStreamId(toEthereumAddress(this.pluginConfig.operatorContractAddress)),
+            this.pluginConfig.fleetState.heartbeatUpdateIntervalInMs,
+            this.pluginConfig.fleetState.pruneAgeInMs,
+            this.pluginConfig.fleetState.pruneIntervalInMs,
+            this.pluginConfig.fleetState.latencyExtraInMs,
+            this.pluginConfig.fleetState.warmupPeriodInMs
+        )
+        await fleetState.start()
+        await fleetState.waitUntilReady()
+        const isLeader = await createIsLeaderFn(streamrClient, fleetState, logger)
         scheduleAtApproximateInterval(async () => {
             try {
-                await this.runActions(streamrClient, minStakePerSponsorship)
+                if (isLeader()) {
+                    await this.runActions(streamrClient, minStakePerSponsorship)
+                }
             } catch (err) {
                 logger.warn('Error while running autostaker actions', { err })
             }

--- a/packages/node/src/plugins/autostaker/config.schema.json
+++ b/packages/node/src/plugins/autostaker/config.schema.json
@@ -36,6 +36,44 @@
       "description": "The interval (in milliseconds) at which autostaking possibilities are analyzed and executed",
       "minimum": 0,
       "default": 3600000
+    },
+    "fleetState": {
+      "type": "object",
+      "description": "Operator fleet state settings",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "heartbeatUpdateIntervalInMs": {
+          "type": "integer",
+          "description": "The interval (in milliseconds) at which heartbeats get published to coordination stream",
+          "minimum": 0,
+          "default": 10000
+        },
+        "pruneAgeInMs": {
+          "type": "integer",
+          "description": "The maximum time (in milliseconds) of a heartbeat to count towards a node being online",
+          "minimum": 0,
+          "default": 180000
+        },
+        "pruneIntervalInMs": {
+          "type": "integer",
+          "description": "The interval (in milliseconds) at which to prune old heartbeats",
+          "minimum": 0,
+          "default": 30000
+        },
+        "latencyExtraInMs": {
+          "type": "integer",
+          "description": "Account for extra latency (milliseconds) due to networking",
+          "minimum": 0,
+          "default": 2000
+        },
+        "warmupPeriodInMs": {
+          "type": "integer",
+          "description": "The time (in milliseconds) to wait before starting to count heartbeats",
+          "minimum": 0,
+          "default": 10000
+        }
+      }
     }
   }
 }

--- a/packages/node/src/plugins/operator/OperatorFleetState.ts
+++ b/packages/node/src/plugins/operator/OperatorFleetState.ts
@@ -56,7 +56,7 @@ export class OperatorFleetState extends EventEmitter<OperatorFleetStateEvents> {
         )
     }
 
-    private constructor(
+    constructor(
         streamrClient: StreamrClient,
         coordinationStreamId: StreamID,
         heartbeatIntervalInMs: number,

--- a/packages/node/test/smoke/autostaker.test.ts
+++ b/packages/node/test/smoke/autostaker.test.ts
@@ -157,6 +157,10 @@ describe('autostaker', () => {
                 autostaker: {
                     operatorContractAddress,
                     runIntervalInMs: RUN_INTERVAL
+                },
+                // start operator plugin so that heartbeats are published for the fleet state leader analysis
+                operator: {
+                    operatorContractAddress
                 }
             }
         }))


### PR DESCRIPTION
## Summary

Only the leader node runs Autostaker.

## Related changes

Also modified the smoke test to use `setupTestOperatorContract()`. That setup includes a call to `setNodeAddresses()`, which grants the operator plugin publish rights to the coordination stream.

## Future improvements

The fleet state implementation is now under operator plugin directory. Maybe it would make sense to move to some generic place=
