### PR TITLE
feat(node) [NET-1477]: changes to autostaker plugin adjustment phase

### DIFF
--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -165,7 +165,7 @@ export const adjustStakes: AdjustStakesFn = ({
         const unstakings = adjustments.filter((a) => a.difference < 0)
         const stakingSum = sum(stakings.map((a) => a.difference))
         const availableSum = abs(sum(unstakings.map((a) => a.difference))) + myUnstakedAmount - undelegationQueueAmount
-        if (stakingSum > availableSum) {
+        if (stakingSum > availableSum && stakings.length > 0) {
             const smallestStaking = minBy(stakings, (a) => a.difference)!
             const newDifference = smallestStaking.difference - (stakingSum - availableSum)
             const hasAlreadyStaked = myCurrentStakes.has(smallestStaking.sponsorshipId)

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -155,35 +155,27 @@ export const adjustStakes: AdjustStakesFn = ({
         }))
         .filter(({ difference: difference }) => difference !== 0n)
 
-    const targetAdjustmentDifference = myUnstakedAmount - undelegationQueueAmount
-
-    // fix rounding errors by forcing the net staking to equal myUnstakedAndUndelegationQueueAmount: adjust the largest staking
-    const netStakingAmount = sum(adjustments.map((a) => a.difference))
-    if (netStakingAmount !== targetAdjustmentDifference && stakeableSponsorships.size > 0 && adjustments.length > 0) {
-        const largestDifference = maxBy(adjustments, (a) => a.difference)!
-        largestDifference.difference += targetAdjustmentDifference - netStakingAmount
-        if (largestDifference.difference === 0n) {
-            pull(adjustments, largestDifference)
-        }
-    }
-
     const tooSmallAdjustments = adjustments.filter(
         // note the edge case: expired sponsorships can be unstaked, even if the transaction amount is considered "too small"
         (a) => (abs(a.difference) < minTransactionAmount) && stakeableSponsorships.has(a.sponsorshipId)
     )
-    if (tooSmallAdjustments.length > 0) {
-        pull(adjustments, ...tooSmallAdjustments)
-        while (true) {
-            const stakings = adjustments.filter((a) => a.difference > 0)
-            const unstakings = adjustments.filter((a) => a.difference < 0)
-            const stakingSum = sum(stakings.map((a) => a.difference))
-            const availableSum = abs(sum(unstakings.map((a) => a.difference))) + targetAdjustmentDifference
-            if (stakingSum > availableSum) {
-                const smallestStaking = minBy(stakings, (a) => a.difference)!
-                pull(adjustments, smallestStaking)
+    pull(adjustments, ...tooSmallAdjustments)
+    while (true) {
+        const stakings = adjustments.filter((a) => a.difference > 0)
+        const unstakings = adjustments.filter((a) => a.difference < 0)
+        const stakingSum = sum(stakings.map((a) => a.difference))
+        const availableSum = abs(sum(unstakings.map((a) => a.difference))) + myUnstakedAmount - undelegationQueueAmount
+        if (stakingSum > availableSum) {
+            const smallestStaking = minBy(stakings, (a) => a.difference)!
+            const newDifference = smallestStaking.difference - (stakingSum - availableSum)
+            const hasAlreadyStaked = myCurrentStakes.has(smallestStaking.sponsorshipId)
+            if (newDifference >= minTransactionAmount && (hasAlreadyStaked || newDifference >= minStakePerSponsorship)) {
+                smallestStaking.difference = newDifference
             } else {
-                break
+                pull(adjustments, smallestStaking)
             }
+        } else {
+            break
         }
     }
 

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -1,6 +1,5 @@
 import { WeiAmount } from '@streamr/utils'
 import crypto from 'crypto'
-import maxBy from 'lodash/maxBy'
 import minBy from 'lodash/minBy'
 import partition from 'lodash/partition'
 import pull from 'lodash/pull'

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -373,4 +373,21 @@ describe('payoutProportionalStrategy', () => {
             ])
         })
     })
+
+    it('not enough to stake (below minStakePerSponsorship) after undelegation queue is handled', () => {
+        expect(adjustStakes({
+            myUnstakedAmount: 1000n,
+            myCurrentStakes: new Map([
+                ['a', 4000n]
+            ]),
+            stakeableSponsorships: new Map([
+                ['a', { payoutPerSec: 10n }]
+            ]),
+            undelegationQueueAmount: 4900n,
+            operatorContractAddress: '',
+            maxSponsorshipCount: 100,
+            minTransactionAmount: 50n,
+            minStakePerSponsorship: 500n
+        })).toIncludeSameMembers([])
+    })
 })

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -181,7 +181,7 @@ describe('payoutProportionalStrategy', () => {
         ])
     })
 
-    it('handles rounding errors', async () => {
+    it('some tokens may stay unstaked as result of rounding', async () => {
         expect(adjustStakes({
             myUnstakedAmount: 1000n,
             myCurrentStakes: new Map(),
@@ -198,29 +198,8 @@ describe('payoutProportionalStrategy', () => {
         })).toIncludeSameMembers([
             { type: 'stake', sponsorshipId: 'a', amount: 166n },
             { type: 'stake', sponsorshipId: 'b', amount: 166n },
-            { type: 'stake', sponsorshipId: 'c', amount: 668n },
-        ])
-    })
-
-    it('rounding error no-op case', async () => {
-        expect(adjustStakes({
-            myUnstakedAmount: 0n,
-            myCurrentStakes: new Map([
-                ['a', 166n ],
-                ['b', 166n ],
-                ['c', 668n ],
-            ]),
-            stakeableSponsorships: new Map([
-                ['a', { payoutPerSec: 100n }],
-                ['b', { payoutPerSec: 100n }],
-                ['c', { payoutPerSec: 400n }],
-            ]),
-            undelegationQueueAmount: 0n,
-            operatorContractAddress: '',
-            maxSponsorshipCount: 100,
-            minTransactionAmount: 0n,
-            minStakePerSponsorship: 0n
-        })).toEqual([])
+            { type: 'stake', sponsorshipId: 'c', amount: 666n },
+        ]) // 2 tokens stay unstaked
     })
 
     it('handles greater than MAX_SAFE_INTEGER payout values correctly', () => {
@@ -304,11 +283,11 @@ describe('payoutProportionalStrategy', () => {
                 minTransactionAmount: 20n,
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
-                { type: 'stake', sponsorshipId: 'c', amount: 972n }
+                { type: 'stake', sponsorshipId: 'c', amount: 970n }
             ])
         })
 
-        it('one small transaction is balanced by removing one staking', () => {
+        it('one small transaction is balanced by adjusting another staking', () => {
             expect(adjustStakes({
                 myUnstakedAmount: 820n,
                 myCurrentStakes: new Map([
@@ -325,11 +304,12 @@ describe('payoutProportionalStrategy', () => {
                 minTransactionAmount: 20n,
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
-                { type: 'stake', sponsorshipId: 'c', amount: 668n }
+                { type: 'stake', sponsorshipId: 'c', amount: 666n },
+                { type: 'stake', sponsorshipId: 'b', amount: 154n }
             ])
         })
 
-        it('multiple small transactions are balanced with by removing multiple stakings', () => {
+        it('multiple small transactions are balanced by adjusting / removing other stakings', () => {
             expect(adjustStakes({
                 myUnstakedAmount: 740n,
                 myCurrentStakes: new Map([
@@ -350,32 +330,9 @@ describe('payoutProportionalStrategy', () => {
                 minTransactionAmount: 50n,
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
-                { type: 'stake', sponsorshipId: 'e', amount: 381n }
+                { type: 'stake', sponsorshipId: 'd', amount: 361n },
+                { type: 'stake', sponsorshipId: 'e', amount: 378n }
             ])
-        })
-
-        it('multiple small transactions are balanced with by removing all stakings', () => {
-            expect(adjustStakes({
-                myUnstakedAmount: 359n, 
-                myCurrentStakes: new Map([
-                    ['a', 180n],
-                    ['b', 200n],
-                    ['c', 295n],
-                    ['e', 381n]
-                ]),
-                stakeableSponsorships: new Map([
-                    ['a', { payoutPerSec: 100n }],
-                    ['b', { payoutPerSec: 100n }],
-                    ['c', { payoutPerSec: 210n }],
-                    ['d', { payoutPerSec: 220n }],
-                    ['e', { payoutPerSec: 230n }]
-                ]),
-                undelegationQueueAmount: 0n,
-                operatorContractAddress: '',
-                maxSponsorshipCount: 100,
-                minTransactionAmount: 50n,
-                minStakePerSponsorship: 0n
-            })).toEqual([])
         })
 
         it('very small expiration unstake and nothing to stake', () => {


### PR DESCRIPTION
## Summary

Introduces a change (2nd in the **Changes** list below) that attempts to be more efficient in overall token allocation.

## Changes

- Remove rounding error adjustment phase. The amounts are minuscule and not worth the additional logic.
- When adjusting the staking plan to stay below the available token amount, attempt to reduce staking amount instead of immediately jumping to remove the entire staking.

## Limitations and future improvements

- The adjustment phase logic could be made even more efficient w.r.t. token allocation and/or sponsorship coverage. One way is to take into account excess allocations above the minimum staking amount and checking whether by reducing the excesses we can get the staking plan below the available token amount.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
