### PR TITLE
fix: Fix geoip tests reference latitude and longitude

### DIFF
--- a/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
+++ b/packages/dht/test/integration/GeoIpConnectivityChecking.test.ts
@@ -13,7 +13,7 @@ const testIp = '128.214.222.50'
 
 // Helsinki, Finland
 const testLatitude = 60.1719
-const testLongitude = 24.9347
+const testLongitude = 25.1127
 
 const dbPath = '/tmp/geoipdatabasesintegration'
 

--- a/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-intervals.test.ts
@@ -102,6 +102,6 @@ describe('GeoIpLocator', () => {
 
         // Helsinki, Finland
         expect(location!.latitude).toBeCloseTo(60.1719, 1)
-        expect(location!.longitude).toBeCloseTo(24.9347, 1)
+        expect(location!.longitude).toBeCloseTo(25.1127, 1)
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator-no-network-at-monthly.test.ts
@@ -49,7 +49,7 @@ describe('GeoIpLocatorNoNetworkAtMonthly', () => {
 
         // Helsinki, Finland
         expect(location!.latitude).toBeCloseTo(60.1719, 1)
-        expect(location!.longitude).toBeCloseTo(24.9347, 1)
+        expect(location!.longitude).toBeCloseTo(25.1127, 1)
 
     }, 60000)
 })

--- a/packages/geoip-location/test/unit/GeoIpLocator.test.ts
+++ b/packages/geoip-location/test/unit/GeoIpLocator.test.ts
@@ -40,7 +40,7 @@ describe('GeoIpLocator', () => {
     
             // Helsinki, Finland
             expect(location!.latitude).toBeCloseTo(60.1719, 1)
-            expect(location!.longitude).toBeCloseTo(24.9347, 1)
+            expect(location!.longitude).toBeCloseTo(25.1127, 1)
         
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -76,7 +76,7 @@ describe('GeoIpLocator', () => {
     
             // Helsinki, Finland
             expect(location!.latitude).toBeCloseTo(60.1719, 1)
-            expect(location!.longitude).toBeCloseTo(24.9347, 1)
+            expect(location!.longitude).toBeCloseTo(25.1127, 1)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')
@@ -98,7 +98,7 @@ describe('GeoIpLocator', () => {
     
             // Helsinki, Finland
             expect(location!.latitude).toBeCloseTo(60.1719, 1)
-            expect(location!.longitude).toBeCloseTo(24.9347, 1)
+            expect(location!.longitude).toBeCloseTo(25.1127, 1)
     
             locator.stop()
             fs.unlinkSync(dbDir + '/GeoLite2-City.mmdb')


### PR DESCRIPTION
## Summary

Apparently lat/long of example has changed again, fixing tests to account for this.