### PR TITLE
feat(node) [NET-1485]: introduce more fine-grained excess token handling in autostaker algorithm

### DIFF
--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -163,6 +163,8 @@ export const adjustStakes: AdjustStakesFn = ({
         (a) => (abs(a.difference) < minTransactionAmount) && stakeableSponsorships.has(a.sponsorshipId)
     )
     pull(adjustments, ...tooSmallAdjustments)
+
+    // Balance out any excess staking we incurred by filtering out too-small adjustments
     while (true) {
         const stakings = adjustments.filter((a) => a.difference > 0)
         const unstakings = adjustments.filter((a) => a.difference < 0)

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -184,18 +184,7 @@ export const adjustStakes: AdjustStakesFn = ({
                 const smallestStaking = minBy(stakings, (a) => a.difference)!
                 pull(adjustments, smallestStaking)
             } else {
-                const stakingsSortedByEarnings = [...stakings].sort((a, b) => {
-                    const aEarnings = stakeableSponsorships.get(a.sponsorshipId)!.payoutPerSec
-                    const bEarnings = stakeableSponsorships.get(b.sponsorshipId)!.payoutPerSec
-                    if (aEarnings < bEarnings) {
-                        return -1
-                    } else if (aEarnings > bEarnings) {
-                        return 1
-                    } else {
-                        return 0
-                    }
-                })
-                for (const staking of stakingsSortedByEarnings) {
+                for (const staking of stakings) { // iterate in any order
                     const allowance = stakingReductionAllowances.get(staking.sponsorshipId)!
                     if (allowance > 0n) {
                         const reduction = bigIntMin(allowance, excess)

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -182,7 +182,7 @@ export const adjustStakes: AdjustStakesFn = ({
                 const smallestStaking = minBy(stakings, (a) => a.difference)!
                 pull(adjustments, smallestStaking)
             } else {
-                const stakingsSortedByEarnings = stakings.sort((a, b) => {
+                const stakingsSortedByEarnings = [...stakings].sort((a, b) => {
                     const aEarnings = stakeableSponsorships.get(a.sponsorshipId)!.payoutPerSec
                     const bEarnings = stakeableSponsorships.get(b.sponsorshipId)!.payoutPerSec
                     if (aEarnings < bEarnings) {

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -45,7 +45,7 @@ const abs = (n: bigint) => (n < 0n) ? -n : n
 
 const bigIntMax = (...args: bigint[]): bigint => args.reduce((m, e) => e > m ? e : m)
 
-export const bigIntMin = (...args: bigint[]): bigint => args.reduce((m, e) => e < m ? e : m)
+const bigIntMin = (...args: bigint[]): bigint => args.reduce((m, e) => e < m ? e : m)
 
 const getExpiredSponsorships = (
     myCurrentStakes: Map<SponsorshipID, WeiAmount>,

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -195,6 +195,7 @@ export const adjustStakes: AdjustStakesFn = ({
                         }
                     }
                 }
+                break
             }
         } else {
             break

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -304,8 +304,8 @@ describe('payoutProportionalStrategy', () => {
                 minTransactionAmount: 20n,
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
-                { type: 'stake', sponsorshipId: 'c', amount: 666n },
-                { type: 'stake', sponsorshipId: 'b', amount: 154n }
+                { type: 'stake', sponsorshipId: 'c', amount: 654n },
+                { type: 'stake', sponsorshipId: 'b', amount: 166n }
             ])
         })
 
@@ -331,8 +331,8 @@ describe('payoutProportionalStrategy', () => {
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
                 { type: 'stake', sponsorshipId: 'c', amount: 50n },
-                { type: 'stake', sponsorshipId: 'd', amount: 312n },
-                { type: 'stake', sponsorshipId: 'e', amount: 378n }
+                { type: 'stake', sponsorshipId: 'd', amount: 361n },
+                { type: 'stake', sponsorshipId: 'e', amount: 329n }
             ])
         })
 

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -330,7 +330,8 @@ describe('payoutProportionalStrategy', () => {
                 minTransactionAmount: 50n,
                 minStakePerSponsorship: 0n
             })).toIncludeSameMembers([
-                { type: 'stake', sponsorshipId: 'd', amount: 361n },
+                { type: 'stake', sponsorshipId: 'c', amount: 50n },
+                { type: 'stake', sponsorshipId: 'd', amount: 312n },
                 { type: 'stake', sponsorshipId: 'e', amount: 378n }
             ])
         })


### PR DESCRIPTION
## Summary

Introduce a more fine-grained excess token handling approach in the stake/unstake planning algorithm. Compared to the previous approach, this approach makes more of an effort to keep tokens staked at the cost of added complexity. 

Excess tokens appear during the algorithm when we filter out stakings/unstakings from the plan that are deemed to small (their adjustment is below `minTransactionAmount`). This can lead to there being more tokens attempted to being staked than are available for staking, a.k.a., excess tokens. Thus we need to balance this out by adjusting the stakings of the plan.

### Previous approach in a nutshell

The previous approach looked for the staking with the smallest adjustment. If the excess could be removed from this staking's adjustment while still keeping the transaction valid* it would proceed to do so. Otherwise it would remove the entire staking from the plan. This process would repeat until there was no excess.

### New approach in a nutshell
The new approach will first try to remove the excess over all the stakings. To do this, for each staking we calculate an _allowance_  (Finnish: vara, esim. turvavara), the amount we can reduce from the adjustment while still keeping the transaction valid*.  If the sum of these allowances is more than or equal to the excess, we can safely adjust the stakings and get rid of the excess without having to drop any stakings. However, if the opposite is the case, we simply remove the staking with the smallest adjustment from the plan (in similar vein to the previous approach). This process is repeated until there is no excess.

(*) a valid staking means the adjustment is above `minTransactionAmount` and that the stake as a whole after the transaction is above `minStakePerSponsorship`

## Limitations and future improvements

In the case when we do have to drop a staking from the plan (sum of allowances isn't enough to cover excess), we often end up with unstaked tokens at the end. We could add an extra step to the very end of the algorithm, in which we attempt to divide any remaining tokens with the stakings still present in the plan. However, this should be done in a way as to minimize any potential oscillation.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
