### PR TITLE
feat(node) [NET-1499]: add `autostakerEnabled` status field to operator heartbeats

### DIFF
--- a/packages/node/src/plugins/operator/OperatorPlugin.ts
+++ b/packages/node/src/plugins/operator/OperatorPlugin.ts
@@ -125,7 +125,8 @@ export class OperatorPlugin extends Plugin<OperatorPluginConfig> {
                 (async () => {
                     await announceNodeToStream(
                         toEthereumAddress(this.pluginConfig.operatorContractAddress),
-                        streamrClient
+                        streamrClient,
+                        this.brokerConfig
                     )
                 })()
             }, this.pluginConfig.heartbeatUpdateIntervalInMs, this.abortController.signal)

--- a/packages/node/src/plugins/operator/announceNodeToStream.ts
+++ b/packages/node/src/plugins/operator/announceNodeToStream.ts
@@ -2,17 +2,19 @@ import { EthereumAddress, Logger } from '@streamr/utils'
 import { StreamrClient } from '@streamr/sdk'
 import { createHeartbeatMessage } from './heartbeatUtils'
 import { formCoordinationStreamId } from './formCoordinationStreamId'
+import { StrictConfig } from '../../config/config'
 
 const logger = new Logger(module)
 
 export const announceNodeToStream = async (
     operatorContractAddress: EthereumAddress,
-    streamrClient: StreamrClient
+    streamrClient: StreamrClient,
+    brokerConfig: Pick<StrictConfig, 'plugins'>
 ): Promise<void> => {
     const coordinationStream = formCoordinationStreamId(operatorContractAddress)
     try {
         const peerDescriptor = await streamrClient.getPeerDescriptor()
-        await streamrClient.publish(coordinationStream, createHeartbeatMessage(peerDescriptor))
+        await streamrClient.publish(coordinationStream, createHeartbeatMessage(peerDescriptor, brokerConfig))
         logger.debug('Published heartbeat to coordination stream', {
             streamId: coordinationStream
         })

--- a/packages/node/src/plugins/operator/heartbeatUtils.ts
+++ b/packages/node/src/plugins/operator/heartbeatUtils.ts
@@ -16,7 +16,7 @@ export const HeartbeatMessageSchema = z.object({
         region: z.optional(z.number())
     }),
     applicationVersion: z.optional(z.string()),  // optional for backward compatibility (written from v102 onward)
-    autostakerEnabled: z.optional(z.boolean()) // optional for backward compatibilit)
+    autostakerEnabled: z.optional(z.boolean()) // optional for backward compatibility
 })
 
 export type HeartbeatMessage = z.infer<typeof HeartbeatMessageSchema>

--- a/packages/node/src/plugins/operator/heartbeatUtils.ts
+++ b/packages/node/src/plugins/operator/heartbeatUtils.ts
@@ -1,6 +1,7 @@
 import { NetworkNodeType, NetworkPeerDescriptor } from '@streamr/sdk'
 import { z } from 'zod'
 import { version as applicationVersion } from '../../../package.json'
+import { StrictConfig } from '../../config/config'
 
 export const HeartbeatMessageSchema = z.object({
     msgType: z.enum(['heartbeat']),
@@ -14,15 +15,20 @@ export const HeartbeatMessageSchema = z.object({
         })),
         region: z.optional(z.number())
     }),
-    applicationVersion: z.optional(z.string())  // optional for backward compatibility (written from v102 onward)
+    applicationVersion: z.optional(z.string()),  // optional for backward compatibility (written from v102 onward)
+    autostakerEnabled: z.optional(z.boolean()) // optional for backward compatibilit)
 })
 
 export type HeartbeatMessage = z.infer<typeof HeartbeatMessageSchema>
 
-export function createHeartbeatMessage(peerDescriptor: NetworkPeerDescriptor): HeartbeatMessage {
+export function createHeartbeatMessage(
+    peerDescriptor: NetworkPeerDescriptor,
+    brokerConfig: Pick<StrictConfig, 'plugins'>
+): HeartbeatMessage {
     return {
         msgType: 'heartbeat',
         peerDescriptor,
-        applicationVersion
+        applicationVersion,
+        autostakerEnabled: brokerConfig.plugins.autostaker !== undefined,
     }
 }

--- a/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
+++ b/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
@@ -4,6 +4,7 @@ import { version as applicationVersion } from '../../../../package.json'
 import { announceNodeToStream } from '../../../../src/plugins/operator/announceNodeToStream'
 import { formCoordinationStreamId } from '../../../../src/plugins/operator/formCoordinationStreamId'
 import { createClient, deployTestOperatorContract } from '../../../utils'
+import { StrictConfig } from '../../../../src/config/config'
 
 const TIMEOUT = 40 * 1000
 
@@ -20,13 +21,14 @@ describe('announceNodeToStream', () => {
         const anonymousClient = createClient()
         const subscription = await anonymousClient.subscribe(streamId)
 
-        await announceNodeToStream(operatorContractAddress, client)
+        await announceNodeToStream(operatorContractAddress, client, { plugins: {} })
 
         const [{ content }] = await collect(subscription, 1)
         expect(content).toEqual({
             msgType: 'heartbeat',
             peerDescriptor: await client.getPeerDescriptor(),
-            applicationVersion
+            applicationVersion,
+            autostakerEnabled: false
         })
 
         await anonymousClient.destroy()

--- a/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
+++ b/packages/node/test/integration/plugins/operator/announceNodeToStream.test.ts
@@ -4,7 +4,6 @@ import { version as applicationVersion } from '../../../../package.json'
 import { announceNodeToStream } from '../../../../src/plugins/operator/announceNodeToStream'
 import { formCoordinationStreamId } from '../../../../src/plugins/operator/formCoordinationStreamId'
 import { createClient, deployTestOperatorContract } from '../../../utils'
-import { StrictConfig } from '../../../../src/config/config'
 
 const TIMEOUT = 40 * 1000
 

--- a/packages/node/test/unit/plugins/operator/OperatorFleetState.test.ts
+++ b/packages/node/test/unit/plugins/operator/OperatorFleetState.test.ts
@@ -14,7 +14,7 @@ const READY_WAIT_MS = 500
 const JITTER = 100
 
 function createHeartbeatMsg(nodeId: string): Record<string, unknown> {
-    return createHeartbeatMessage({ nodeId })
+    return createHeartbeatMessage({ nodeId }, { plugins: {} })
 }
 
 describe(OperatorFleetState, () => {

--- a/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
+++ b/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
@@ -2,30 +2,41 @@ import omit from 'lodash/omit'
 import { ZodError } from 'zod'
 import { createHeartbeatMessage, HeartbeatMessageSchema } from '../../../../src/plugins/operator/heartbeatUtils'
 
+const PEER_DESCRIPTOR = Object.freeze({
+    nodeId: 'nodeId',
+    websocket: {
+        port: 31313,
+        host: '127.0.0.1',
+        tls: false
+    }
+})
+
 describe('heartbeatUtils', () => {
     it('messages created with createHeartbeatMessage pass validation', () => {
-        const msg = createHeartbeatMessage({
-            nodeId: 'nodeId',
-            websocket: {
-                port: 31313,
-                host: '127.0.0.1',
-                tls: false
-            }
-        })
+        const msg = createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} })
         expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrow()
     })
 
-    it('messages without version pass validation', () => {
+    it('messages with extra fields pass validation', () => {
+        const msg = {
+            foobar: 'foobar',
+            ...createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} })
+        }
+        expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrow()
+    })
+
+    it('messages without applicationVersion pass validation', () => {
         const msg = omit(
-            createHeartbeatMessage({
-                nodeId: 'nodeId',
-                websocket: {
-                    port: 31313,
-                    host: '127.0.0.1',
-                    tls: false
-                }
-            }),
+            createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} }),
             'applicationVersion'
+        )
+        expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrow()
+    })
+
+    it('messages without autostakerEnabled pass validation', () => {
+        const msg = omit(
+            createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} }),
+            'autostakerEnabled'
         )
         expect(() => HeartbeatMessageSchema.parse(msg)).not.toThrow()
     })
@@ -33,7 +44,15 @@ describe('heartbeatUtils', () => {
     it('invalid message does not pass validation', () => {
         const msg = createHeartbeatMessage({
             foo: 'bar'
-        } as any)
+        } as any, { plugins: {} })
         expect(() => HeartbeatMessageSchema.parse(msg)).toThrow(ZodError)
+    })
+
+    it('applicationEnabled is true if and only if autostaker plugin is enabled', () => {
+        const msg1 = createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} })
+        expect(msg1.autostakerEnabled).toBeFalse()
+
+        const msg2 = createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: { autostaker: {} } })
+        expect(msg2.autostakerEnabled).toBeTrue()
     })
 })

--- a/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
+++ b/packages/node/test/unit/plugins/operator/heartbeatUtils.test.ts
@@ -48,7 +48,7 @@ describe('heartbeatUtils', () => {
         expect(() => HeartbeatMessageSchema.parse(msg)).toThrow(ZodError)
     })
 
-    it('applicationEnabled is true if and only if autostaker plugin is enabled', () => {
+    it('autostakerEnabled is true if and only if autostaker plugin is enabled', () => {
         const msg1 = createHeartbeatMessage(PEER_DESCRIPTOR, { plugins: {} })
         expect(msg1.autostakerEnabled).toBeFalse()
 


### PR DESCRIPTION
## Summary

Add field `autostakerEnabled` to operator heartbeat messages. This is to allow a future feature in the Hub where we can detect whether the operator is running autostaker(s) and then display a warning about changing stakes manually.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.
