### PR TITLE
hotfix: autostaker changes

### DIFF
--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -117,6 +117,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                 running = false
             }
         }
+        logger.info(`First activation in approximately ${this.pluginConfig.runIntervalInMs / (1000 * 60) } minutes`)
         scheduleAtApproximateInterval(triggerRun, this.pluginConfig.runIntervalInMs, 0.1, false, this.abortController.signal)
         streamrClient.on('sponsorshipCreated', triggerRun)
         this.abortController.signal.addEventListener('abort', () => {

--- a/packages/node/src/plugins/autostaker/config.schema.json
+++ b/packages/node/src/plugins/autostaker/config.schema.json
@@ -34,7 +34,7 @@
     "runIntervalInMs": {
       "type": "integer",
       "description": "The interval (in milliseconds) at which autostaking possibilities are analyzed and executed",
-      "minimum": 0,
+      "minimum": 300000,
       "default": 3600000
     },
     "fleetState": {

--- a/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
+++ b/packages/node/src/plugins/autostaker/payoutProportionalStrategy.ts
@@ -119,11 +119,15 @@ const getTargetStakes = (
         id,
         minStakePerSponsorship + payoutProportionalAmount * stakeableSponsorships.get(id)!.payoutPerSec / payoutPerSecSum
     ])
+    const targetsForFullUnstake: TargetStake[] = [...myCurrentStakes.keys()].filter((id) => !selectedSponsorships.includes(id)).map((id) => [
+        id,
+        0n
+    ])
     const targetsForExpired: TargetStake[] = getExpiredSponsorships(myCurrentStakes, stakeableSponsorships).map((id) => [
         id,
         0n
     ])
-    return new Map([...targetsForSelected, ...targetsForExpired])
+    return new Map([...targetsForSelected, ...targetsForFullUnstake, ...targetsForExpired])
 }
 
 /**

--- a/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
+++ b/packages/node/test/unit/plugins/autostaker/payoutProportionalStrategy.test.ts
@@ -389,6 +389,33 @@ describe('payoutProportionalStrategy', () => {
             maxSponsorshipCount: 100,
             minTransactionAmount: 50n,
             minStakePerSponsorship: 500n
-        })).toIncludeSameMembers([])
+        })).toIncludeSameMembers([
+            { type: 'unstake', sponsorshipId: 'a', amount: 4000n }
+        ])
+    })
+
+    it('unstakes to match maxSponsorchipCount if has more current sponsorships', () => {
+        expect(adjustStakes({
+            myUnstakedAmount: 0n,
+            myCurrentStakes: new Map([
+                ['a', 10000n],
+                ['b', 5000n],
+                ['c', 5000n]
+            ]),
+            stakeableSponsorships: new Map([
+                ['a', { payoutPerSec: 4n }],
+                ['b', { payoutPerSec: 2n }],
+                ['c', { payoutPerSec: 2n }],
+            ]),
+            undelegationQueueAmount: 0n,
+            operatorContractAddress: '',
+            maxSponsorshipCount: 1,
+            minTransactionAmount: 0n,
+            minStakePerSponsorship: 5000n
+        })).toIncludeSameMembers([
+            { type: 'stake', sponsorshipId: 'a', amount: 10000n },
+            { type: 'unstake', sponsorshipId: 'b', amount: 5000n },
+            { type: 'unstake', sponsorshipId: 'c', amount: 5000n }
+        ])
     })
 })


### PR DESCRIPTION
## Summary

Tweaks to autostaker plugin based on real-world testing.

## Changes
- Handle situations where there are more current sponsorships joined to than the maximum limit set. 
- Log message about first activation
- Set a minimum of 5 minutes for timer-based activation