### PR TITLE
feat(utils): Add `Cache#invalidate()`

### DIFF
--- a/packages/utils/src/Cache.ts
+++ b/packages/utils/src/Cache.ts
@@ -18,4 +18,9 @@ export class Cache<V> {
         }
         return this.value!
     }
+
+    invalidate(): void {
+        this.value = undefined
+        this.valueTimestamp = undefined
+    }
 }

--- a/packages/utils/test/Cache.test.ts
+++ b/packages/utils/test/Cache.test.ts
@@ -21,4 +21,16 @@ describe('Cache', () => {
         expect(await cache.get()).toEqual('bar')
         expect(valueFactory).toHaveBeenCalledTimes(2)
     })
+
+    it('invalidate', async () => {
+        const valueFactory = jest.fn().mockImplementation(async () => 'foo')
+        const cache = new Cache(valueFactory, MAX_AGE)
+        expect(await cache.get()).toEqual('foo')
+        expect(valueFactory).toHaveBeenCalledTimes(1)
+        cache.invalidate()
+        expect(await cache.get()).toEqual('foo')
+        expect(valueFactory).toHaveBeenCalledTimes(2)
+        expect(await cache.get()).toEqual('foo')
+        expect(valueFactory).toHaveBeenCalledTimes(2)
+    })
 })


### PR DESCRIPTION
Add a method to `Cache` which allows us to invalidate the value. The actual invalidation is done just by setting `valueTimestamp` to `undefined`. We also set `value` to `undefined` so that garbage collector can clean up the previous value.