### PR TITLE
feat(Autocertifier-server): Keep track of modification times for subdomain updates

### DIFF
--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -26,7 +26,8 @@ export class Database {
 
     public async createSubdomain(subdomain: string, ip: string, port: string, token: string): Promise<void> {
         try {
-            await this.createSubdomainStatement!.run(subdomain, ip, port, token)
+            const now = new Date().toISOString()
+            await this.createSubdomainStatement!.run(subdomain, ip, port, token, now, now)
         } catch (e) {
             throw new DatabaseError('Failed to create subdomain ' + subdomain, e)
         }
@@ -79,7 +80,8 @@ export class Database {
             throw new InvalidSubdomainOrToken('Invalid subdomain or token ' + subdomain, e)
         }
         try {
-            await this.updateSubdomainIpStatement!.run(ip, port, new Date().toISOString(), subdomain, token)
+            const now = new Date().toISOString()
+            await this.updateSubdomainIpStatement!.run(ip, port, now, subdomain, token)
         } catch (e) {
             throw new DatabaseError('Failed to update subdomain ' + subdomain, e)
         }
@@ -108,7 +110,7 @@ export class Database {
             await this.createTables()
         }
 
-        this.createSubdomainStatement = await this.db.prepare("INSERT INTO subdomains (subdomainName, ip, port, token) VALUES (?, ?, ?, ?)")
+        this.createSubdomainStatement = await this.db.prepare("INSERT INTO subdomains (subdomainName, ip, port, token, createdAt, modifiedAt) VALUES (?, ?, ?, ?, ?, ?)")
         this.getSubdomainStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ?")
         this.getAllSubdomainsStatement = await this.db.prepare("SELECT * FROM subdomains")
         this.getSubdomainWithTokenStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ? AND token = ?")

--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -79,7 +79,7 @@ export class Database {
             throw new InvalidSubdomainOrToken('Invalid subdomain or token ' + subdomain, e)
         }
         try {
-            await this.updateSubdomainIpStatement!.run(ip, port, subdomain, token)
+            await this.updateSubdomainIpStatement!.run(ip, port, new Date().toISOString(), subdomain, token)
         } catch (e) {
             throw new DatabaseError('Failed to update subdomain ' + subdomain, e)
         }
@@ -112,7 +112,7 @@ export class Database {
         this.getSubdomainStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ?")
         this.getAllSubdomainsStatement = await this.db.prepare("SELECT * FROM subdomains")
         this.getSubdomainWithTokenStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ? AND token = ?")
-        this.updateSubdomainIpStatement = await this.db.prepare("UPDATE subdomains SET ip = ?, port = ? WHERE subdomainName = ? AND token = ?")
+        this.updateSubdomainIpStatement = await this.db.prepare("UPDATE subdomains SET ip = ?, port = ?, modifiedAt = ? WHERE subdomainName = ? AND token = ?")
         this.getSubdomainAcmeChallengeStatement = await this.db.prepare("SELECT acmeChallenge FROM subdomains WHERE subdomainName = ?")
         this.updateSubdomainAcmeChallengeStatement = await this.db.prepare("UPDATE subdomains SET acmeChallenge = ? WHERE subdomainName = ?")
 
@@ -156,7 +156,8 @@ export class Database {
                 port TEXT NOT NULL,
                 token TEXT NOT NULL,
                 acmeChallenge TEXT,
-                createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
+                createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+                modifiedAt DATETIME
             );
             CREATE INDEX subdomain_index on subdomains(subdomainName);
             COMMIT;
@@ -174,6 +175,7 @@ export interface Subdomain {
     port: string
     token: string
     acmeChallenge?: string
-    createdAt?: Date
+    createdAt?: string // ISO format
+    modifiedAt?: string // ISO format
     id?: number
 }

--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -109,11 +109,12 @@ export class Database {
         if (!result) {
             await this.createTables()
         }
-
+        // eslint-disable-next-line max-len
         this.createSubdomainStatement = await this.db.prepare("INSERT INTO subdomains (subdomainName, ip, port, token, createdAt, modifiedAt) VALUES (?, ?, ?, ?, ?, ?)")
         this.getSubdomainStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ?")
         this.getAllSubdomainsStatement = await this.db.prepare("SELECT * FROM subdomains")
         this.getSubdomainWithTokenStatement = await this.db.prepare("SELECT * FROM subdomains WHERE subdomainName = ? AND token = ?")
+        // eslint-disable-next-line max-len
         this.updateSubdomainIpStatement = await this.db.prepare("UPDATE subdomains SET ip = ?, port = ?, modifiedAt = ? WHERE subdomainName = ? AND token = ?")
         this.getSubdomainAcmeChallengeStatement = await this.db.prepare("SELECT acmeChallenge FROM subdomains WHERE subdomainName = ?")
         this.updateSubdomainAcmeChallengeStatement = await this.db.prepare("UPDATE subdomains SET acmeChallenge = ? WHERE subdomainName = ?")

--- a/packages/autocertifier-server/test/unit/Database.test.ts
+++ b/packages/autocertifier-server/test/unit/Database.test.ts
@@ -14,6 +14,7 @@ describe('Database', () => {
 
     describe('createSubdomain()', () => {
         it('should create a new subdomain', async () => {
+            const testStartTimestamp = new Date()
             const subdomain: Subdomain = {
                 subdomainName: 'example.com',
                 ip: '127.0.0.1',
@@ -26,6 +27,8 @@ describe('Database', () => {
             const result = await db.getSubdomain(subdomain.subdomainName)
 
             expect(result).toEqual(expect.objectContaining(subdomain))
+            expect(new Date(result!.createdAt!).getTime()).toBeGreaterThanOrEqual(testStartTimestamp.getTime())
+            expect(new Date(result!.modifiedAt!).getTime()).toBeGreaterThanOrEqual(testStartTimestamp.getTime())
         })
     })
 

--- a/packages/autocertifier-server/test/unit/Database.test.ts
+++ b/packages/autocertifier-server/test/unit/Database.test.ts
@@ -32,6 +32,7 @@ describe('Database', () => {
     describe('updateSubdomainIp()', () => {
         // TODO: remove storing port in the data base
         it('should update the IP and port of an existing subdomain', async () => {
+            const testStartTimestamp = new Date()
             const subdomain: Subdomain = {
                 subdomainName: 'example.com',
                 ip: '127.0.0.1',
@@ -50,6 +51,7 @@ describe('Database', () => {
 
             expect(result?.ip).toEqual(newIp)
             expect(result?.port).toEqual(newPort)
+            expect(new Date(result!.modifiedAt!).getTime()).toBeGreaterThanOrEqual(testStartTimestamp.getTime())
         })
 
         it('should throw if a IP and PORT update is tried with wrong token', async () => {
@@ -77,8 +79,7 @@ describe('Database', () => {
                 ip: '127.0.0.1',
                 port: '8080',
                 token: 'abc123',
-                acmeChallenge: '',
-                createdAt: new Date()
+                acmeChallenge: ''
             }
 
             await db.createSubdomain(subdomain.subdomainName, subdomain.ip, subdomain.port, subdomain.token)
@@ -88,7 +89,6 @@ describe('Database', () => {
             await db.updateSubdomainAcmeChallenge(subdomain.subdomainName, newChallenge)
 
             const result = await db.getSubdomain(subdomain.subdomainName)
-
             expect(result?.acmeChallenge).toEqual(newChallenge)
         })
     })


### PR DESCRIPTION
## Summary

Added a new field to the subdomains table. The field is updated when calling the `/certificates`, `/certificates/:subdomain`, `/certificates/:subdomain/ip` endpoints. The field can be used to check if subdomains are being actively used once data has been gathered in the database.