### PR TITLE
feat(Autocertifier-server): Add indexing to the Database

### DIFF
--- a/packages/autocertifier-server/src/Database.ts
+++ b/packages/autocertifier-server/src/Database.ts
@@ -159,6 +159,8 @@ export class Database {
                 createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
             );
             CREATE INDEX subdomain_index on subdomains(subdomainName);
+            CREATE INDEX ip_port_index on subdomains(ip, port);
+            CREATE INDEX subdomain_token_index on subdomains(subdomainName, token);
             COMMIT;
         `
         await this.db!.exec(query)


### PR DESCRIPTION
## Summary

Add indexing to the Autocertifier-server database:

`CREATE INDEX ip_port_index on subdomains(ip, port);`
`CREATE INDEX subdomain_token_index on subdomains(subdomainName, token);`