### PR TITLE
fix(Autocertifier-server): Fix error when cleaning up subdomains

### DIFF
--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -119,7 +119,7 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
             const subdomains = await this.database!.getSubdomainsByIpAndPort(ipAddress, streamrWebSocketPort)
             logger.info('Deleting all subdomains from ip: ' + ipAddress + ' port: ' 
                 + streamrWebSocketPort + ' number of subdomains: ' + subdomains.length, { subdomains })
-            await Promise.all(subdomains.map((subdomain) => 
+            await Promise.allSettled(subdomains.map((subdomain) => 
                 this.route53Api!.deleteRecord(
                     RRType.A,
                     subdomain.subdomainName + '.' + this.domainName,


### PR DESCRIPTION
## Summary

Added `Promise.allSettled` instead of `Promise.all` to get rid of failing `createNewCertificateForSubdomain` requests
