### PR TITLE
feat: Support create-and-fund pattern in sponsorship deployment

### DIFF
--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -8,11 +8,20 @@ import {
     OperatorFactory as OperatorFactoryContract,
     SponsorshipABI,
     Sponsorship as SponsorshipContract,
-    SponsorshipFactoryABI,
-    SponsorshipFactory as SponsorshipFactoryContract
+    SponsorshipFactoryABI
 } from '@streamr/network-contracts'
 import { Logger, multiplyWeiAmount, WeiAmount } from '@streamr/utils'
-import { Contract, ContractTransactionReceipt, ContractTransactionResponse, EventLog, formatEther, parseEther, ZeroAddress } from 'ethers'
+import {
+    AbiCoder,
+    Contract,
+    ContractTransactionReceipt,
+    ContractTransactionResponse,
+    EventLog,
+    formatEther,
+    Interface,
+    parseEther,
+    ZeroAddress
+} from 'ethers'
 import { EnvironmentId } from '../Config'
 import { SignerWithProvider } from '../identity/Identity'
 
@@ -85,11 +94,6 @@ export interface DeploySponsorshipContractOpts {
 
 export async function deploySponsorshipContract(opts: DeploySponsorshipContractOpts): Promise<SponsorshipContract> {
     logger.debug('Deploying SponsorshipContract')
-    const sponsorshipFactory = new Contract(
-        CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipFactory,
-        SponsorshipFactoryABI,
-        opts.deployer
-    ) as unknown as SponsorshipFactoryContract
     const policies: { contractAddress: string, param: number | bigint }[] = [{
         contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipStakeWeightedAllocationPolicy,
         param: opts.earningsPerSecond
@@ -106,19 +110,35 @@ export async function deploySponsorshipContract(opts: DeploySponsorshipContractO
             param: opts.maxOperatorCount
         })
     }
-    const sponsorshipDeployTx = await sponsorshipFactory.deploySponsorship(
-        (opts.minOperatorCount ?? 1).toString(),
-        opts.streamId,
-        opts.metadata ?? '{}',
-        policies.map((p) => p.contractAddress),
-        policies.map((p) => p.param)
+    const sponsorshipContractParams = AbiCoder.defaultAbiCoder().encode(
+        ['uint32', 'string', 'string', 'address[]', 'uint[]'],
+        [
+            (opts.minOperatorCount ?? 1).toString(),
+            opts.streamId,
+            opts.metadata ?? '{}',
+            policies.map((p) => p.contractAddress),
+            policies.map((p) => p.param),
+        ],
     )
-    const sponsorshipDeployReceipt = await sponsorshipDeployTx.wait()
-    const newSponsorshipEvent = sponsorshipDeployReceipt!.logs.find((l: any) => l.fragment?.name === 'NewSponsorship') as EventLog
-    const newSponsorshipAddress = newSponsorshipEvent.args.sponsorshipContract
-    const newSponsorship = new Contract(newSponsorshipAddress, SponsorshipABI, opts.deployer) as unknown as SponsorshipContract
-    logger.debug('Deployed SponsorshipContract', { address: newSponsorshipAddress })
-    return newSponsorship
+    const deployTx = await getTokenContract(CHAIN_CONFIG[opts.environmentId].contracts.DATA)
+        .connect(opts.deployer)
+        .transferAndCall(
+            CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipFactory,
+            0n,
+            sponsorshipContractParams,
+        )
+    const deployReceipt = await deployTx.wait()
+    const factoryInterface = new Interface(SponsorshipFactoryABI)
+    const newSponsorshipEvent = deployReceipt!.logs
+        .map((log) => factoryInterface.parseLog(log))
+        .find((p) => p?.name === 'NewSponsorship')!
+    const sponsorshipAddress = newSponsorshipEvent.args.sponsorshipContract
+    logger.debug('Deployed SponsorshipContract', { address: sponsorshipAddress })
+    return new Contract(
+        sponsorshipAddress,
+        SponsorshipABI,
+        opts.deployer,
+    ) as unknown as SponsorshipContract
 }
 
 export const delegate = async (
@@ -207,7 +227,7 @@ export const transferTokens = async (
     amount: WeiAmount,
     tokenAddress: string
 ): Promise<void> => {
-    const token = new Contract(tokenAddress, DATATokenABI) as unknown as DATATokenContract
+    const token = getTokenContract(tokenAddress)
     const tx = await token.connect(from).transferAndCall(to, amount, '0x')
     await tx.wait()
 }
@@ -218,6 +238,10 @@ export const getOperatorContract = (operatorAddress: string): OperatorContract =
 
 const getSponsorshipContract = (sponsorshipAddress: string): SponsorshipContract => {
     return new Contract(sponsorshipAddress, SponsorshipABI) as unknown as SponsorshipContract
+}
+
+const getTokenContract = (tokenAddress: string): DATATokenContract => {
+    return new Contract(tokenAddress, DATATokenABI) as unknown as DATATokenContract
 }
 
 const bumpGasLimit = (gasEstimate: bigint, increasePercentage: number): bigint => {

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -99,7 +99,7 @@ export async function deploySponsorshipContract(opts: DeploySponsorshipContractO
         param: opts.earningsPerSecond
     }, {
         contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipDefaultLeavePolicy,
-        param: opts.minStakeDuration ?? 0,
+        param: opts.minStakeDuration ?? 0
     }, {
         contractAddress: CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipVoteKickPolicy,
         param: 0
@@ -155,7 +155,7 @@ export const undelegate = async (
     delegator: SignerWithProvider,
     operatorContractAddress: string,
     amount: WeiAmount
-): Promise<void> => {    
+): Promise<void> => {
     logger.debug('Undelegate', { amount: amount.toString() })
     await (await getOperatorContract(operatorContractAddress).connect(delegator).undelegate(amount)).wait()
 }
@@ -170,7 +170,7 @@ export const stake = async (
 ): Promise<ContractTransactionReceipt | null> => {
     logger.debug('Stake', { amount: formatEther(amount), sponsorshipContractAddress })
     const operatorContract = getOperatorContract(operatorContractAddress).connect(staker)
-    
+
     let gasLimit = await operatorContract.stake.estimateGas(sponsorshipContractAddress, amount)
     if (bumpGasLimitPct > 0) {
         gasLimit = bumpGasLimit(gasLimit, bumpGasLimitPct)

--- a/packages/sdk/src/contracts/operatorContractUtils.ts
+++ b/packages/sdk/src/contracts/operatorContractUtils.ts
@@ -90,6 +90,7 @@ export interface DeploySponsorshipContractOpts {
     maxOperatorCount?: number
     minStakeDuration?: number
     environmentId: EnvironmentId
+    sponsorAmount?: WeiAmount
 }
 
 export async function deploySponsorshipContract(opts: DeploySponsorshipContractOpts): Promise<SponsorshipContract> {
@@ -124,7 +125,7 @@ export async function deploySponsorshipContract(opts: DeploySponsorshipContractO
         .connect(opts.deployer)
         .transferAndCall(
             CHAIN_CONFIG[opts.environmentId].contracts.SponsorshipFactory,
-            0n,
+            opts.sponsorAmount ?? 0n,
             sponsorshipContractParams,
         )
     const deployReceipt = await deployTx.wait()

--- a/packages/sdk/test/end-to-end/operatorContractUtils.test.ts
+++ b/packages/sdk/test/end-to-end/operatorContractUtils.test.ts
@@ -1,0 +1,65 @@
+import { createTestWallet } from '@streamr/test-utils'
+import { _operatorContractUtils } from '../../src'
+import { createTestClient, createTestStream } from '../test-utils/utils'
+import { Logger, TheGraphClient, until } from '@streamr/utils'
+import { config as CHAIN_CONFIG } from '@streamr/config'
+
+const createTheGraphClient = (): TheGraphClient => {
+    return new TheGraphClient({
+        serverUrl: CHAIN_CONFIG.dev2.theGraphUrl,
+        fetch,
+        logger: new Logger(module)
+    })
+}
+
+// It will take some time until The Graph indexes the entity: here we re-query the entity until it appears in the index
+const queryTheGraphUntilSuccess = async (query: string): Promise<any> => {
+    const TIMEOUT = 4000
+    const client = createTheGraphClient()
+    let result
+    await until(async () => {
+        const response = await client.queryEntity<any>({ query })
+        result = Object.values(response)[0]
+        return (result !== null)
+    }, TIMEOUT)
+    return result
+}
+
+describe('operatorContractUtils', () => {
+    it('deploySponsorshipContract', async () => {
+        const stream = await createTestStream(createTestClient((await createTestWallet({ gas: true })).privateKey), module)
+        const sponsorship = await _operatorContractUtils.deploySponsorshipContract({
+            streamId: stream.id,
+            deployer: await createTestWallet({ gas: true }),
+            metadata: JSON.stringify({ foo: 'bar' }),
+            earningsPerSecond: 123n,
+            minOperatorCount: 1,
+            maxOperatorCount: 2,
+            minStakeDuration: 456,
+            environmentId: 'dev2'
+        })
+        const contractAddress = await sponsorship.getAddress()
+        const result = await queryTheGraphUntilSuccess(`{
+            sponsorship(id: "${contractAddress.toLowerCase()}") {
+                stream {
+                    id
+                }
+                totalPayoutWeiPerSec
+                metadata
+                minOperators
+                maxOperators
+                minimumStakingPeriodSeconds
+            }
+        }`)
+        expect(result).toEqual({
+            stream: {
+                id: stream.id
+            },
+            totalPayoutWeiPerSec: '123',
+            metadata: '{"foo":"bar"}',
+            minOperators: 1,
+            maxOperators: 2,
+            minimumStakingPeriodSeconds: '456'
+        })
+    })
+})

--- a/packages/sdk/test/end-to-end/operatorContractUtils.test.ts
+++ b/packages/sdk/test/end-to-end/operatorContractUtils.test.ts
@@ -1,4 +1,4 @@
-import { createTestWallet } from '@streamr/test-utils'
+import { createTestWallet, describeOnlyInNodeJs } from '@streamr/test-utils'
 import { _operatorContractUtils } from '../../src'
 import { createTestClient, createTestStream } from '../test-utils/utils'
 import { Logger, TheGraphClient, until } from '@streamr/utils'
@@ -25,7 +25,7 @@ const queryTheGraphUntilSuccess = async (query: string): Promise<any> => {
     return result
 }
 
-describe('operatorContractUtils', () => {
+describeOnlyInNodeJs('operatorContractUtils', () => {
     it('deploySponsorshipContract', async () => {
         const stream = await createTestStream(createTestClient((await createTestWallet({ gas: true })).privateKey), module)
         const deployer = await createTestWallet({ gas: true, tokens: true })


### PR DESCRIPTION
There is now an optional `sponsorAmount` option in `deploySponsorshipContract()`. By using this option, deployment and sponsoring can be performed in the same transaction.

## Changes

We now use `transferAndCall` instead of `SponsorshipFactory#deploySponsorship()`. This allows us to pass both pieces of information in a single transaction: the deployment options as the `data` argument and the sponsor amount as the `value` argument.

If `sponsorAmount` is not defined, we simply transfer 0 wei. In that case, a non-sponsored sponsorship is deployed, meaning the behavior is identical to how it worked before this PR.