### PR TITLE
chore: Upgrade `eslint` project config for compatibility with `typescript-eslint` v8.46.4

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ export default [
     {
         name: 'streamr-network-typescript',
         languageOptions: {
-            globals: globals.node,
+            globals: globals.node
         },
         settings: {
             'import/resolver': {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,7 @@
-import tsParser from '@typescript-eslint/parser'
 import streamr from 'eslint-config-streamr-ts'
 import importPlugin from 'eslint-plugin-import'
 import jestPlugin from 'eslint-plugin-jest'
 import globals from 'globals'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename);
 
 export default [
     {
@@ -24,20 +18,11 @@ export default [
         name: 'streamr-network-typescript',
         languageOptions: {
             globals: globals.node,
-            parser: tsParser,
-            parserOptions: {
-                project: ['./tsconfig.jest.json'],
-                tsconfigRootDir: __dirname
-            }
         },
         settings: {
             'import/resolver': {
                 typescript: {
-                    alwaysTryTypes: true,
-                    project: [
-                        'packages/*/tsconfig.jest.json',
-                        'packages/browser-test-runner/tsconfig.node.json'
-                    ]
+                    alwaysTryTypes: true
                 },
                 node: true
             }


### PR DESCRIPTION
Improved our config compatibility with `typescript-eslint` v8.46.4, which introduced a parser error when both `parserOptions.project` and `parserOptions.projectService` are set. See https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.46.4

By removing the explicit project config and relying solely on projectService, we avoid the error and remain fully compatible with this release.

Also removed redundant parser definition (it is the default value in `typescript-eslint`).

## Related PR

This is needed for https://github.com/streamr-dev/network/pull/3231