### PR TITLE
feat: `requiredBlockNumber` callback parameter in `TheGraphClient` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
-- Transaction timeouts in Autostaker (https://github.com/streamr-dev/network/pull/3236)
+Autostaker changes:
+- transaction timeouts (https://github.com/streamr-dev/network/pull/3236)
+- queries filter by required block number (https://github.com/streamr-dev/network/pull/3238)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Added
 
+- Transaction timeouts in Autostaker (https://github.com/streamr-dev/network/pull/3236)
+
 #### Changed
 
 #### Deprecated

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -233,32 +233,33 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
         stakes: Map<SponsorshipID, WeiAmount>,
         streamrClient: StreamrClient
     ): Promise<Map<SponsorshipID, SponsorshipConfig>> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<SponsorshipQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
-            // TODO add support spnsorships which have non-zero minimumStakingPeriodSeconds (i.e. implement some loggic in the 
-            // payoutPropotionalStrategy so that we ensure that unstaking doesn't happen too soon)
-            return {
-                query: `
-                    {
-                        sponsorships (
-                            where: {
-                                projectedInsolvency_gt: ${Math.floor(Date.now() / 1000)}
-                                minimumStakingPeriodSeconds: "0"
-                                minOperators_lte: ${this.pluginConfig.maxAcceptableMinOperatorCount}
-                                totalPayoutWeiPerSec_gte: "${MIN_SPONSORSHIP_TOTAL_PAYOUT_PER_SECOND.toString()}"
-                                id_gt: "${lastId}"
-                            },
-                            first: ${pageSize}
-                            block: { number_gte: ${requiredBlockNumber} }
-                        ) {
-                            id
-                            totalPayoutWeiPerSec
-                            operatorCount
-                            maxOperators
+        const queryResult = streamrClient.getTheGraphClient()
+            .queryEntities<SponsorshipQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
+                // TODO add support spnsorships which have non-zero minimumStakingPeriodSeconds (i.e. implement some loggic in the 
+                // payoutPropotionalStrategy so that we ensure that unstaking doesn't happen too soon)
+                return {
+                    query: `
+                        {
+                            sponsorships (
+                                where: {
+                                    projectedInsolvency_gt: ${Math.floor(Date.now() / 1000)}
+                                    minimumStakingPeriodSeconds: "0"
+                                    minOperators_lte: ${this.pluginConfig.maxAcceptableMinOperatorCount}
+                                    totalPayoutWeiPerSec_gte: "${MIN_SPONSORSHIP_TOTAL_PAYOUT_PER_SECOND.toString()}"
+                                    id_gt: "${lastId}"
+                                },
+                                first: ${pageSize}
+                                block: { number_gte: ${requiredBlockNumber} }
+                            ) {
+                                id
+                                totalPayoutWeiPerSec
+                                operatorCount
+                                maxOperators
+                            }
                         }
-                    }
-                `
-            }
-        })
+                    `
+                }
+            })
         const sponsorships = await collect(queryResult)
         const hasAcceptableOperatorCount = (item: SponsorshipQueryResultItem) => {
             if (stakes.has(item.id)) {
@@ -277,52 +278,54 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
     }
 
     private async getMyCurrentStakes(streamrClient: StreamrClient): Promise<Map<SponsorshipID, WeiAmount>> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<StakeQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
-            return {
-                query: `
-                    {
-                        stakes (
-                            where: {
-                                operator: "${this.pluginConfig.operatorContractAddress.toLowerCase()}",
-                                id_gt: "${lastId}"
-                            },
-                            first: ${pageSize}
-                            block: { number_gte: ${requiredBlockNumber} }
-                        ) {
-                            id
-                            sponsorship {
+        const queryResult = streamrClient.getTheGraphClient()
+            .queryEntities<StakeQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
+                return {
+                    query: `
+                        {
+                            stakes (
+                                where: {
+                                    operator: "${this.pluginConfig.operatorContractAddress.toLowerCase()}",
+                                    id_gt: "${lastId}"
+                                },
+                                first: ${pageSize}
+                                block: { number_gte: ${requiredBlockNumber} }
+                            ) {
                                 id
+                                sponsorship {
+                                    id
+                                }
+                                amountWei
                             }
-                            amountWei
                         }
-                    }
-                `
-            }
-        })
+                    `
+                }
+            })
         const stakes = await collect(queryResult)
         return new Map(stakes.map((stake) => [stake.sponsorship.id, BigInt(stake.amountWei) ]))
     }
 
     private async getUndelegationQueueAmount(streamrClient: StreamrClient): Promise<WeiAmount> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<UndelegationQueueQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
-            return {
-                query: `
-                    {
-                        queueEntries (
-                             where:  {
-                                operator: "${this.pluginConfig.operatorContractAddress.toLowerCase()}",
-                                id_gt: "${lastId}"
-                            },
-                            first: ${pageSize}
-                            block: { number_gte: ${requiredBlockNumber} }
-                        ) {
-                            id
-                            amount
+        const queryResult = streamrClient.getTheGraphClient()
+            .queryEntities<UndelegationQueueQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
+                return {
+                    query: `
+                        {
+                            queueEntries (
+                                where:  {
+                                    operator: "${this.pluginConfig.operatorContractAddress.toLowerCase()}",
+                                    id_gt: "${lastId}"
+                                },
+                                first: ${pageSize}
+                                block: { number_gte: ${requiredBlockNumber} }
+                            ) {
+                                id
+                                amount
+                            }
                         }
-                    }
-                `
-            }
-        })
+                    `
+                }
+            })
         const entries = await collect(queryResult)
         return sum(entries.map((entry) => BigInt(entry.amount)))
     }

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -233,7 +233,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
         stakes: Map<SponsorshipID, WeiAmount>,
         streamrClient: StreamrClient
     ): Promise<Map<SponsorshipID, SponsorshipConfig>> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<SponsorshipQueryResultItem>((lastId: string, pageSize: number) => {
+        const queryResult = streamrClient.getTheGraphClient().queryEntities<SponsorshipQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
             // TODO add support spnsorships which have non-zero minimumStakingPeriodSeconds (i.e. implement some loggic in the 
             // payoutPropotionalStrategy so that we ensure that unstaking doesn't happen too soon)
             return {
@@ -248,6 +248,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                                 id_gt: "${lastId}"
                             },
                             first: ${pageSize}
+                            block: { number_gte: ${requiredBlockNumber} }
                         ) {
                             id
                             totalPayoutWeiPerSec
@@ -276,7 +277,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
     }
 
     private async getMyCurrentStakes(streamrClient: StreamrClient): Promise<Map<SponsorshipID, WeiAmount>> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<StakeQueryResultItem>((lastId: string, pageSize: number) => {
+        const queryResult = streamrClient.getTheGraphClient().queryEntities<StakeQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
             return {
                 query: `
                     {
@@ -286,6 +287,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                                 id_gt: "${lastId}"
                             },
                             first: ${pageSize}
+                            block: { number_gte: ${requiredBlockNumber} }
                         ) {
                             id
                             sponsorship {
@@ -302,7 +304,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
     }
 
     private async getUndelegationQueueAmount(streamrClient: StreamrClient): Promise<WeiAmount> {
-        const queryResult = streamrClient.getTheGraphClient().queryEntities<UndelegationQueueQueryResultItem>((lastId: string, pageSize: number) => {
+        const queryResult = streamrClient.getTheGraphClient().queryEntities<UndelegationQueueQueryResultItem>((lastId: string, pageSize: number, requiredBlockNumber: number) => {
             return {
                 query: `
                     {
@@ -312,6 +314,7 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                                 id_gt: "${lastId}"
                             },
                             first: ${pageSize}
+                            block: { number_gte: ${requiredBlockNumber} }
                         ) {
                             id
                             amount

--- a/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
+++ b/packages/node/src/plugins/autostaker/AutostakerPlugin.ts
@@ -53,6 +53,7 @@ const MIN_SPONSORSHIP_TOTAL_PAYOUT_PER_SECOND = 1000000000000n
 const ACTION_SUBMIT_RETRY_COUNT = 5
 const ACTION_SUBMIT_RETRY_DELAY_MS = 5000
 const ACTION_GAS_LIMIT_BUMP_PCT = 20
+const TRANSACTION_TIMEOUT = 60 * 1000
 
 const fetchMinStakePerSponsorship = async (theGraphClient: TheGraphClient): Promise<bigint> => {
     const queryResult = await theGraphClient.queryEntity<{ network: { minimumStakeWei: string } }>({
@@ -73,7 +74,8 @@ const getStakeOrUnstakeFunction = (action: Action): (
     sponsorshipContractAddress: string,
     amount: WeiAmount,
     bumpGasLimitPct: number,
-    onSubmit: (tx: ContractTransactionResponse) => void
+    onSubmit: (tx: ContractTransactionResponse) => void,
+    transactionTimeout?: number
 ) => Promise<ContractTransactionReceipt | null> => {
     switch (action.type) {
         case 'stake':
@@ -148,7 +150,8 @@ export class AutostakerPlugin extends Plugin<AutostakerPluginConfig> {
                 // be staking/unstaking at the same time, so we bump the gas limit to be safe
                 ACTION_GAS_LIMIT_BUMP_PCT,
                 // resolve on the onSubmit callback (=tx is broadcasted) instead of when the stakeOrUnstakeFunction resolves (=tx is mined)
-                (tx) => resolve(tx) 
+                (tx) => resolve(tx),
+                TRANSACTION_TIMEOUT 
             ).catch(reject)
         })
     }

--- a/packages/utils/src/TheGraphClient.ts
+++ b/packages/utils/src/TheGraphClient.ts
@@ -51,7 +51,7 @@ export class TheGraphClient {
     }
 
     async* queryEntities<T extends { id: string }>(
-        createQuery: (lastId: string, pageSize: number) => GraphQLQuery,
+        createQuery: (lastId: string, pageSize: number, requiredBlockNumber: number) => GraphQLQuery,
         /*
          * For simple queries there is one root level property, e.g. "streams" or "permissions"
          * which contain array of items. If the query contains more than one root level property
@@ -68,7 +68,7 @@ export class TheGraphClient {
         let lastResultSet: T[] | undefined
         do {
             const lastId = (lastResultSet !== undefined) ? lastResultSet[lastResultSet.length - 1].id : ''
-            const query = createQuery(lastId, pageSize)
+            const query = createQuery(lastId, pageSize, this.requiredBlockNumber)
             const response = await this.sendQuery(query)
             const items: T[] = parseItems(response)
             yield* items

--- a/packages/utils/test/TheGraphClient.test.ts
+++ b/packages/utils/test/TheGraphClient.test.ts
@@ -36,6 +36,11 @@ class EmulatedTheGraphIndex {
     }
 }
 
+const nextValue = async <T>(source: AsyncIterator<T>): Promise<T | undefined> => {
+    const item = source.next()
+    return (await item).value
+}
+
 describe('TheGraphClient', () => {
 
     let theGraphIndex: EmulatedTheGraphIndex
@@ -182,5 +187,17 @@ describe('TheGraphClient', () => {
         expect(await responsePromise2).toEqual({
             foo: 'result-7'
         })
+    })
+
+    it('required block number in callback', async () => {
+        theGraphIndex.start()
+        const callback1 = jest.fn().mockReturnValue(MOCK_QUERY)
+        await nextValue(client.queryEntities(callback1))
+        expect(callback1).toHaveBeenCalledWith('', expect.any(Number), 0)
+
+        client.updateRequiredBlockNumber(2)
+        const callback2 = jest.fn().mockReturnValue(MOCK_QUERY)
+        await nextValue(client.queryEntities(callback2))
+        expect(callback2).toHaveBeenCalledWith('', expect.any(Number), 2)
     })
 })


### PR DESCRIPTION
`TheGraphClient#queryEntities` callback now has extra parameter which delivers the information about required block number.

We already had a poller in TheGraphClient, but it seems that that approach doesn't always work (maybe the latest block number and the actual query are be fetched from different indexers, maybe because there is a load balancer in The Graph).

Also modified Autostaker to use that feature in the queries.

## Future improvements

- Implement the support also in `TheGraphClient#queryEntity` (which doesn't currently use callbacks)