### PR TITLE
deps: Bump `webpack` to v5.103.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20077,13 +20077,17 @@
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/locate-path": {
@@ -28770,9 +28774,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.102.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
-            "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
+            "version": "5.103.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
+            "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -28793,7 +28797,7 @@
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
@@ -29813,7 +29817,7 @@
                 "karma-spec-reporter": "^0.0.36",
                 "karma-webpack": "^5.0.1",
                 "node-polyfill-webpack-plugin": "^4.1.0",
-                "webpack": "^5.102.1",
+                "webpack": "^5.103.0",
                 "webpack-cli": "^6.0.1"
             }
         },
@@ -30087,7 +30091,7 @@
                 "ts-node": "^10.9.2",
                 "util": "^0.12.4",
                 "weak-napi": "^2.0.2",
-                "webpack": "^5.102.1",
+                "webpack": "^5.103.0",
                 "webpack-bundle-analyzer": "^4.10.1",
                 "webpack-cli": "^6.0.1",
                 "webpack-merge": "^6.0.1"

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -34,7 +34,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webpack": "^5.0.1",
     "node-polyfill-webpack-plugin": "^4.1.0",
-    "webpack": "^5.102.1",
+    "webpack": "^5.103.0",
     "webpack-cli": "^6.0.1"
   }
 }

--- a/packages/browser-test-runner/src/createKarmaConfig.ts
+++ b/packages/browser-test-runner/src/createKarmaConfig.ts
@@ -13,6 +13,7 @@ export const createKarmaConfig = (
     const preprocessors: Record<string, string[]> = {}
     setupFiles.forEach((f) => preprocessors[f] = ['webpack'])
     testPaths.forEach((f) => preprocessors[f] = ['webpack', 'sourcemap'])
+    const baseWebpack = webpackConfig()
     return (config: any) => {
         config.set({
             plugins: [
@@ -38,7 +39,8 @@ export const createKarmaConfig = (
                             contextIsolation: false,
                             preload: __dirname + '/preload.js',
                             webSecurity: false,
-                            sandbox: false
+                            sandbox: false,
+                            nodeIntegration: true
                         },
                         show: DEBUG_MODE  // set to true to show the electron window
                     }
@@ -53,8 +55,15 @@ export const createKarmaConfig = (
             },
             singleRun: !DEBUG_MODE,  //set to false to leave electron window open
             webpack: {
-                ...webpackConfig(),
-                entry: {}
+                ...baseWebpack,
+                entry: {},
+                externals: {
+                    ...(baseWebpack.externals ?? {}),
+                    'expect': 'commonjs2 expect',
+                    '@jest/expect-utils': 'commonjs2 @jest/expect-utils',
+                    'pretty-format': 'commonjs2 pretty-format',
+                    'jest-diff': 'commonjs2 jest-diff',
+                },
             }
         })
     }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -85,7 +85,7 @@
     "ts-node": "^10.9.2",
     "util": "^0.12.4",
     "weak-napi": "^2.0.2",
-    "webpack": "^5.102.1",
+    "webpack": "^5.103.0",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^6.0.1",
     "webpack-merge": "^6.0.1"


### PR DESCRIPTION
Upgraded webpack version and modified karma config to be compatible with the upgrade.

## Error

After the upgrade browser test runs, e.g. `npm run test-browser-unit `in the `sdk` package, failed like this:

```
Electron 34.2.0 (Node 20.18.2) ERROR
  Uncaught TypeError: __webpack_modules__[moduleId] is not a function
  at /tmp/_karma_webpack_665134/commons.js:3032:41
  
  TypeError: __webpack_modules__[moduleId] is not a function
      at __nested_webpack_require_24761__ (/tmp/_karma_webpack_665134/commons.js:3032:41)
      at ./src/utils.ts (/tmp/_karma_webpack_665134/commons.js:2661:16)
      at __nested_webpack_require_24761__ (/tmp/_karma_webpack_665134/commons.js:3032:41)
      at ./src/index.ts (/tmp/_karma_webpack_665134/commons.js:2430:14)
      at __nested_webpack_require_24761__ (/tmp/_karma_webpack_665134/commons.js:3032:41)
      at /tmp/_karma_webpack_665134/commons.js:3043:44
      at ../../node_modules/@jest/expect-utils/build/index.js (/tmp/_karma_webpack_665134/commons.js:3046:12)
      at __webpack_require__ (/tmp/_karma_webpack_665134/runtime.js:23:42)
      at /tmp/_karma_webpack_665134/commons.js:111126:20
      at /tmp/_karma_webpack_665134/commons.js:111366:3
``` 

## Changes to browser runner karma configuration

Webpack’s [recent change](https://github.com/webpack/webpack/releases/tag/v5.103.0) of `"Rename single nested __webpack_export__ and __webpack_require__ in already bundled code"` is likely causing this issue. Because our Karma test setup imports several Jest packages that are themselves pre-bundled, webpack’s re-bundling breaks their internal runtime. We fix this by declaring those Jest packages as externals in the Karma webpack config so they’re not re-bundled.

In this PR three dependencies have been defined as externals:
- @jest/expect-utils
- pretty-format
- jest-diff

Also added `nodeIntegration: true` definition to the webpack config so that Electron can use these external packages. Without this addition the run fails like this: `Uncaught ReferenceError: require is not defined`.

We may need externalize also `jest-matcher-utils` in the future as it is a similar dependency to these three packages. But as there is no error about that package, it hasn't been externalized in this PR