### PR TITLE
fix(cli-tools): Signature output in `subscribe --with-metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
+- Signature output in `subscribe --with-metadata` (https://github.com/streamr-dev/network/pull/3245)
+
 #### Security
 
 

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -3,11 +3,11 @@ import '../src/logLevel'
 
 import omit from 'lodash/omit'
 import isString from 'lodash/isString'
+import mapValues from 'lodash/mapValues'
 import { StreamrClient, MessageMetadata } from '@streamr/sdk'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
 import { createFnParseInt } from '../src/common'
 import { binaryToHex } from '@streamr/utils'
-import { mapValues } from 'lodash'
 
 interface Options extends BaseOptions {
     partition: number
@@ -23,7 +23,10 @@ const withBinaryFieldsAsHex = (metadata: Record<string, any>) => {
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
     const formContent = (content: unknown) => content instanceof Uint8Array ? binaryToHex(content) : content
     const formMessage = options.withMetadata
-        ? (content: unknown, metadata: MessageMetadata) => ({ content: formContent(content), metadata: withBinaryFieldsAsHex(omit(metadata, 'streamMessage')) })
+        ? (content: unknown, metadata: MessageMetadata) => ({ 
+            content: formContent(content),
+            metadata: withBinaryFieldsAsHex(omit(metadata, 'streamMessage'))
+        })
         : (content: unknown) => formContent(content)
     await client.subscribe({
         streamId,

--- a/packages/cli-tools/test/stream-publish-subscribe.test.ts
+++ b/packages/cli-tools/test/stream-publish-subscribe.test.ts
@@ -78,6 +78,7 @@ describe('publish and subscribe', () => {
                 streamPartition: 0,
                 timestamp: expect.any(Number),
                 sequenceNumber: 0,
+                signature: expect.any(String),
                 publisherId: new Wallet(publisherPrivateKey).address.toLowerCase(),
                 msgChainId: expect.stringMatching(/[0-9a-zA-Z]+/)
             }
@@ -100,6 +101,7 @@ describe('publish and subscribe', () => {
                 streamPartition: 0,
                 timestamp: expect.any(Number),
                 sequenceNumber: 0,
+                signature: expect.any(String),
                 publisherId: new Wallet(publisherPrivateKey).address.toLowerCase(),
                 msgChainId: expect.stringMatching(/[0-9a-zA-Z]+/)
             }


### PR DESCRIPTION
Signature values were incorrectly printed as byte arrays in `subscribe` command output when `--with-metadata` was used. Now the values are printed as hex strings.