### PR TITLE
refactor: Tweak & tighten types for `@streamr/utils`

### DIFF
--- a/packages/utils/src/Defer.ts
+++ b/packages/utils/src/Defer.ts
@@ -2,7 +2,7 @@ import once from 'lodash/once'
 
 type ResolveFn<T> = (value: T | PromiseLike<T>) => void
 
-type RejectFn = (reason?: Error) => void
+type RejectFn = (reason?: unknown) => void
 
 const noopExecutor = () => {}
 
@@ -44,7 +44,7 @@ export class Defer<T> extends Promise<T> {
         }
     }
 
-    reject(error: Error): void {
+    reject(error: unknown): void {
         this.ensureNoopCatchAttached()
         if (!this.settled) {
             this.settled = true

--- a/packages/utils/src/ENSName.ts
+++ b/packages/utils/src/ENSName.ts
@@ -1,4 +1,4 @@
-import { BrandedString } from './types'
+import type { BrandedString } from './types'
 
 export function isENSNameFormatIgnoreCase(str: string): boolean {
     return str.indexOf('.') > 0

--- a/packages/utils/src/EthereumAddress.ts
+++ b/packages/utils/src/EthereumAddress.ts
@@ -1,4 +1,4 @@
-import { BrandedString } from './types'
+import type { BrandedString } from './types'
 
 const REGEX = /^0x[a-fA-F0-9]{40}$/
 export const PREFIXED_STRING_LENGTH = 42

--- a/packages/utils/src/Metric.ts
+++ b/packages/utils/src/Metric.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'eventemitter3'
+import { EventEmitter } from 'eventemitter3'
 import set from 'lodash/set'
 import { scheduleAtFixedRate } from './scheduleAtFixedRate'
 

--- a/packages/utils/src/ObservableEventEmitter.ts
+++ b/packages/utils/src/ObservableEventEmitter.ts
@@ -1,5 +1,5 @@
-import EventEmitter3 from 'eventemitter3'
-import { Events } from './types'
+import { EventEmitter } from 'eventemitter3'
+import type { Events } from './types'
 
 interface ObserverEvents<E extends Events<E>> {
     addEventListener: (eventName: keyof E) => void
@@ -12,8 +12,8 @@ interface ObserverEvents<E extends Events<E>> {
  */
 export class ObservableEventEmitter<E extends Events<E>> {
 
-    private delegate: EventEmitter3<any> = new EventEmitter3()
-    private observer: EventEmitter3<ObserverEvents<E>> = new EventEmitter3()
+    private delegate: EventEmitter<any> = new EventEmitter()
+    private observer: EventEmitter<ObserverEvents<E>> = new EventEmitter()
 
     on<T extends keyof E>(eventName: T, listener: E[T]): void {
         this.delegate.on(eventName, listener)
@@ -50,7 +50,7 @@ export class ObservableEventEmitter<E extends Events<E>> {
         return this.delegate.listenerCount(eventName)
     }
 
-    getObserver(): EventEmitter3<ObserverEvents<E>, any> {
+    getObserver(): EventEmitter<ObserverEvents<E>> {
         return this.observer
     }
 }

--- a/packages/utils/src/SigningUtil.ts
+++ b/packages/utils/src/SigningUtil.ts
@@ -5,9 +5,9 @@ import { ml_dsa87 } from '@noble/post-quantum/ml-dsa'
 import { randomBytes } from '@noble/post-quantum/utils'
 import { p256 } from '@noble/curves/p256'
 import { areEqualBinaries, binaryToHex } from './binaryUtils'
-import { UserIDRaw } from './UserID'
+import type { UserIDRaw } from './UserID'
 import { getSubtle } from './crossPlatformCrypto'
-import { webcrypto } from 'crypto'
+import type { webcrypto } from 'crypto'
 
 export const KEY_TYPES = [
     'ECDSA_SECP256K1_EVM', 

--- a/packages/utils/src/StreamID.ts
+++ b/packages/utils/src/StreamID.ts
@@ -1,7 +1,7 @@
-import { ENSName } from './ENSName'
-import { EthereumAddress } from './EthereumAddress'
+import type { ENSName } from './ENSName'
+import type { EthereumAddress } from './EthereumAddress'
 import { toEthereumAddressOrENSName } from './toEthereumAddressOrENSName'
-import { BrandedString } from './types'
+import type { BrandedString } from './types'
 
 export type StreamID = BrandedString<'StreamID'>
 

--- a/packages/utils/src/StreamPartID.ts
+++ b/packages/utils/src/StreamPartID.ts
@@ -1,6 +1,6 @@
-import { StreamID, toStreamID } from './StreamID'
+import { type StreamID, toStreamID } from './StreamID'
 import { ensureValidStreamPartitionIndex } from './partition'
-import { BrandedString } from './types'
+import type { BrandedString } from './types'
 
 const DELIMITER = '#'
 

--- a/packages/utils/src/TheGraphClient.ts
+++ b/packages/utils/src/TheGraphClient.ts
@@ -144,7 +144,7 @@ class IndexingState {
             try {
                 return await getCurrentBlockNumber()
             } catch (err) {
-                logger.warn('Failed to get current block number', { reason: err?.reason })
+                logger.warn('Failed to get current block number', { reason: err instanceof Error ? err.message : String(err) })
                 return undefined
             }
         }

--- a/packages/utils/src/UserID.ts
+++ b/packages/utils/src/UserID.ts
@@ -1,6 +1,6 @@
 import { binaryToHex, hexToBinary } from './binaryUtils'
 import { PREFIXED_STRING_LENGTH } from './EthereumAddress'
-import { BrandedString } from './types'
+import type { BrandedString } from './types'
 
 const REGEX = /^0x[a-fA-F0-9]+$/
 

--- a/packages/utils/src/initEventGateway.ts
+++ b/packages/utils/src/initEventGateway.ts
@@ -1,4 +1,4 @@
-import { Events } from './types'
+import type { Events } from './types'
 import { ObservableEventEmitter } from './ObservableEventEmitter'
 
 /*

--- a/packages/utils/src/isENSName.ts
+++ b/packages/utils/src/isENSName.ts
@@ -1,5 +1,5 @@
-import { EthereumAddress } from './EthereumAddress'
-import { ENSName, isENSNameFormatIgnoreCase } from './ENSName'
+import type { EthereumAddress } from './EthereumAddress'
+import { type ENSName, isENSNameFormatIgnoreCase } from './ENSName'
 
 export function isENSName(domain: EthereumAddress | ENSName): domain is ENSName {
     return isENSNameFormatIgnoreCase(domain)

--- a/packages/utils/src/lengthPrefixedFrameUtils.ts
+++ b/packages/utils/src/lengthPrefixedFrameUtils.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformCallback } from 'stream'
+import { Transform, type TransformCallback } from 'stream'
 
 // If you change this you also need to change `writeUint32BE` and `readUInt32BE` in the code below
 const HEADER_LENGTH = 4

--- a/packages/utils/src/toEthereumAddressOrENSName.ts
+++ b/packages/utils/src/toEthereumAddressOrENSName.ts
@@ -1,5 +1,5 @@
-import { EthereumAddress, toEthereumAddress } from './EthereumAddress'
-import { ENSName, isENSNameFormatIgnoreCase, toENSName } from './ENSName'
+import { type EthereumAddress, toEthereumAddress } from './EthereumAddress'
+import { type ENSName, isENSNameFormatIgnoreCase, toENSName } from './ENSName'
 
 export function toEthereumAddressOrENSName(str: string): EthereumAddress | ENSName | never {
     return isENSNameFormatIgnoreCase(str) ? toENSName(str) : toEthereumAddress(str)

--- a/packages/utils/src/until.ts
+++ b/packages/utils/src/until.ts
@@ -1,4 +1,4 @@
-import { asAbortable } from './asAbortable'
+import { AbortError, asAbortable } from './asAbortable'
 import { wait } from './wait'
 import { composeAbortSignals } from './composeAbortSignals'
 
@@ -47,7 +47,7 @@ export const until = async (
             await wait(retryInterval, composedSignal)
         }
     } catch (e) {
-        if (e.code === 'AbortError') {
+        if (e instanceof AbortError) {
             throwError(userAborted, conditionFn, onTimeoutContext)
         }
         throw e


### PR DESCRIPTION
## Summary

This pull request focuses on improving type safety and modernizing import usage across the `packages/utils` module. The changes primarily convert regular imports to `type` imports for TypeScript type-only dependencies, update event emitter usage for consistency, and enhance error handling for better reliability.

## Changes

**Type import modernization:**

* Replaces regular imports with `type` imports for TypeScript-only types in files such as `ENSName.ts`, `EthereumAddress.ts`, `UserID.ts`, `StreamID.ts`, `StreamPartID.ts`, `SigningUtil.ts`, `toEthereumAddressOrENSName.ts`, `isENSName.ts`, `initEventGateway.ts`, and others, improving build performance and clarity.

**Event emitter consistency:**

* Standardizes all event emitter imports to use `{ EventEmitter }` from `eventemitter3`, replacing previous default and aliased imports, and updated corresponding type usages in `Metric.ts` and `ObservableEventEmitter.ts`.

**Error handling improvements:**

* Improves error logging in `TheGraphClient.ts` to correctly display error messages regardless of error type.
* Updates the abort logic in `until.ts` to use `instanceof AbortError` for more robust error detection.

**Type safety enhancements:**

* Broadenes the `RejectFn` type in `Defer.ts` from `Error` to `unknown` and updated the `reject` method accordingly, allowing for more flexible error handling.

**Minor improvements:**

* Adds missing named imports and type annotations in files such as `lengthPrefixedFrameUtils.ts` for better code clarity.

## Limitations and future improvements

N/A

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens type usage, standardizes `eventemitter3` imports, and refines error handling across `@streamr/utils`.
> 
> - **Type imports & types**:
>   - Convert numerous imports to `import type` in `ENSName.ts`, `EthereumAddress.ts`, `UserID.ts`, `StreamID.ts`, `StreamPartID.ts`, `SigningUtil.ts`, `initEventGateway.ts`, `isENSName.ts`, `toEthereumAddressOrENSName.ts`, `lengthPrefixedFrameUtils.ts`.
>   - Broaden `Defer` reject types: `RejectFn` and `reject()` now accept `unknown`.
> - **Event emitter standardization**:
>   - Use `{ EventEmitter }` from `eventemitter3` in `Metric.ts` and `ObservableEventEmitter.ts`; update related types and return types (`getObserver`).
> - **Error handling improvements**:
>   - `TheGraphClient`: safer warning logging for unknown error types.
>   - `until`: detect aborts via `instanceof AbortError` and import `AbortError`.
> - **Minor**:
>   - Misc small type-only import tweaks (e.g., `TransformCallback`, `StreamID` in `StreamPartID.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f8bbe4b7d606d60a26eec22bd9a920e6925b1f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->