### PR TITLE
refactor: Clean-up karma setup

### DIFF
--- a/packages/browser-test-runner/src/createKarmaConfig.ts
+++ b/packages/browser-test-runner/src/createKarmaConfig.ts
@@ -56,7 +56,6 @@ export const createKarmaConfig = (
             singleRun: !DEBUG_MODE,  //set to false to leave electron window open
             webpack: {
                 ...baseWebpack,
-                entry: {},
                 externals: {
                     ...(baseWebpack.externals ?? {}),
                     'expect': 'commonjs2 expect',

--- a/packages/browser-test-runner/src/createKarmaConfig.ts
+++ b/packages/browser-test-runner/src/createKarmaConfig.ts
@@ -24,7 +24,7 @@ export const createKarmaConfig = (
                 'karma-sourcemap-loader'
             ],
             basePath: '.',
-            frameworks: ['jasmine'],
+            frameworks: ['webpack', 'jasmine'],
             reporters: ['spec'],
             files: [
                 ...setupFiles,

--- a/packages/browser-test-runner/src/createWebpackConfig.ts
+++ b/packages/browser-test-runner/src/createWebpackConfig.ts
@@ -3,7 +3,6 @@ import webpack from 'webpack'
 import NodePolyfillPlugin from 'node-polyfill-webpack-plugin'
 
 interface CreateWebpackConfigOptions {
-    entry: string
     libraryName: string
     alias?: Record<string, string>
     fallback?: Record<string, string>
@@ -11,7 +10,7 @@ interface CreateWebpackConfigOptions {
 }
 
 export const createWebpackConfig = (
-    { entry, libraryName, alias = {}, fallback = {}, externals = {} }: CreateWebpackConfigOptions
+    { libraryName, alias = {}, fallback = {}, externals = {} }: CreateWebpackConfigOptions
 ): Record<string, any> => {
     return () => {
         return {
@@ -19,7 +18,6 @@ export const createWebpackConfig = (
                 type: 'filesystem',
             },
             mode: 'development',
-            entry,
             devtool: 'eval-source-map',
             module: {
                 rules: [

--- a/packages/browser-test-runner/src/createWebpackConfig.ts
+++ b/packages/browser-test-runner/src/createWebpackConfig.ts
@@ -45,7 +45,6 @@ export const createWebpackConfig = (
                 fallback,
             },
             output: {
-                filename: `${libraryName}.js`,
                 sourceMapFilename: `[name].[contenthash].js.map`,
                 chunkFilename: '[id].[contenthash].js',
                 path: path.resolve('.', 'dist'),

--- a/packages/dht/karma.config.js
+++ b/packages/dht/karma.config.js
@@ -16,7 +16,6 @@ const BrowserWebsocketClientConnection = path.resolve(__dirname, 'src/connection
 module.exports = createKarmaConfig(
     TEST_PATHS,
     createWebpackConfig({
-        entry: './src/exports.ts',
         libraryName: 'dht',
         alias: {
             [NodeWebrtcConnection]: BrowserWebrtcConnection,

--- a/packages/proto-rpc/karma.config.js
+++ b/packages/proto-rpc/karma.config.js
@@ -4,7 +4,6 @@ const { createKarmaConfig, createWebpackConfig } = require('@streamr/browser-tes
 const TEST_PATHS = ['test/**/*.ts']
 
 module.exports = createKarmaConfig(TEST_PATHS, createWebpackConfig({
-    entry: './src/exports.ts',
     libraryName: 'proto-rpc',
     fallback: {
         module: false

--- a/packages/trackerless-network/karma.config.js
+++ b/packages/trackerless-network/karma.config.js
@@ -9,7 +9,6 @@ const TEST_PATHS = [
 ]
 
 module.exports = createKarmaConfig(TEST_PATHS, createWebpackConfig({
-    entry: './src/exports.ts',
     libraryName: 'trackerless-network',
     alias: {
         [path.resolve(__dirname, '../dht/src/connection/webrtc/NodeWebrtcConnection.ts')]:

--- a/packages/utils/karma.config.js
+++ b/packages/utils/karma.config.js
@@ -4,7 +4,6 @@ const { createKarmaConfig, createWebpackConfig } = require('@streamr/browser-tes
 const TEST_PATHS = ['test/**/*.ts']
 
 module.exports = createKarmaConfig(TEST_PATHS, createWebpackConfig({
-    entry: './src/exports.ts',
     libraryName: 'utils',
     fallback: {
         module: false


### PR DESCRIPTION
This PR removes unused Webpack config fields from `createWebpackConfig` and `createKarmaConfig` utils and fixes Karma warnings about implicit configuration.

## Changes

* Removes `entry` and output `filename` from `createWebpackConfig`, since Karma ignores them and only warns about their presence.
* Adds the `webpack` framework to Karma configs to avoid Karma’s warning that it had to add it implicitly.

Overall, this cleans up redundant settings and silences unnecessary Karma warnings.

## Limitations and future improvements

None.

## Checklist before requesting a review

- [x] Is this a breaking change? If it is, be clear in summary.
- [x] Read through code myself one more time.
- [x] Make sure any and all `TODO` comments left behind are meant to be left in.
- [x] Has reasonable passing test coverage?
- [x] Updated changelog if applicable.
- [x] Updated documentation if applicable.

---

Before

```
npm run test-browser -w packages/proto-rpc

> @streamr/proto-rpc@103.1.2 test-browser
> ./test-proto.sh && karma start karma.config.js

webpack was not included as a framework in karma configuration, setting this automatically...

karma-webpack does not currently support custom entries, if this is something you need,
consider opening an issue.
ignoring attempt to set the entry option...

karma-webpack does not currently support customized filenames via
webpack output.filename, if this is something you need consider opening an issue.
defaulting proto-rpc.js to [name].js.
Webpack bundling...
```

After

```
npm run test-browser -w packages/proto-rpc

> @streamr/proto-rpc@103.1.2 test-browser
> ./test-proto.sh && karma start karma.config.js

Webpack bundling...
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused Webpack entry/filename and explicitly adds the `webpack` framework to Karma, updating package configs accordingly.
> 
> - **Browser test runner**:
>   - `createKarmaConfig`: adds `webpack` to `frameworks`; drops overriding `webpack.entry`.
>   - `createWebpackConfig`: removes `entry` option and output `filename`.
> - **Package configs**:
>   - Updates `karma.config.js` in `packages/dht`, `packages/proto-rpc`, `packages/trackerless-network`, and `packages/utils` to stop passing `entry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b3032d19fe95808bf34cca8ab0e38790ebd0ddb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->