### PR TITLE
feat(cli-tools): Add `--partition` flag to `stream publish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Changes before Tatum release are not documented in this file.
 
 ### @streamr/cli-tools
 
+- Add `--partition` flag to `stream publish` (https://github.com/streamr-dev/network/pull/3262)
+
 #### Added
 
 #### Changed

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -45,7 +45,7 @@ const publishStream = (
                 }
             }
             const partitionKey = (partitionKeyField !== undefined && typeof message === 'object') ? message[partitionKeyField] : undefined
-            client.publish({ id: streamId, partition }, message, { partitionKey }).then(
+            client.publish({ streamId, partition }, message, { partitionKey }).then(
                 () => done(),
                 (err) => done(err)
             )

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -6,8 +6,10 @@ import { StreamrClient } from '@streamr/sdk'
 import { hexToBinary, wait } from '@streamr/utils'
 import es from 'event-stream'
 import { createClientCommand, Options as BaseOptions } from '../src/command'
+import { createFnParseInt } from '../src/common'
 
 interface Options extends BaseOptions {
+    partition?: number
     partitionKeyField?: string
 }
 
@@ -16,7 +18,8 @@ const isHexadecimal = (str: string): boolean => {
 }
 
 const publishStream = (
-    stream: string,
+    streamId: string,
+    partition: number | undefined,
     partitionKeyField: string | undefined,
     client: StreamrClient
 ): Writable => {
@@ -42,7 +45,7 @@ const publishStream = (
                 }
             }
             const partitionKey = (partitionKeyField !== undefined && typeof message === 'object') ? message[partitionKeyField] : undefined
-            client.publish(stream, message, { partitionKey }).then(
+            client.publish({ id: streamId, partition }, message, { partitionKey }).then(
                 () => done(),
                 (err) => done(err)
             )
@@ -52,7 +55,7 @@ const publishStream = (
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
-    const ps = publishStream(streamId, options.partitionKeyField, client)
+    const ps = publishStream(streamId, options.partition, options.partitionKeyField, client)
     return new Promise((resolve, reject) => {
         process.stdin
             .pipe(es.split())
@@ -73,6 +76,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .arguments('<streamId>')
     .description('publish to a stream by reading JSON messages from stdin line-by-line or hexadecimal strings for binary data')
+    .option('-p, --partition [partition]', 'partition', createFnParseInt('--partition'), undefined)
     // eslint-disable-next-line max-len
     .option('-k, --partition-key-field <string>', 'field name in each message to use for assigning the message to a stream partition (only for JSON data)')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -76,7 +76,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .arguments('<streamId>')
     .description('publish to a stream by reading JSON messages from stdin line-by-line or hexadecimal strings for binary data')
-    .option('-p, --partition [partition]', 'partition', createFnParseInt('--partition'), undefined)
+    .option('-p, --partition <partition>', 'partition', createFnParseInt('--partition'))
     // eslint-disable-next-line max-len
     .option('-k, --partition-key-field <string>', 'field name in each message to use for assigning the message to a stream partition (only for JSON data)')
     .parseAsync()

--- a/packages/cli-tools/bin/streamr-stream-publish.ts
+++ b/packages/cli-tools/bin/streamr-stream-publish.ts
@@ -55,6 +55,10 @@ const publishStream = (
 }
 
 createClientCommand(async (client: StreamrClient, streamId: string, options: Options) => {
+    if ((options.partition !== undefined) && (options.partitionKeyField !== undefined)) {
+        console.error('Invalid combination of "partition" and "partition-key-field"')
+        process.exit(1)
+    }
     const ps = publishStream(streamId, options.partition, options.partitionKeyField, client)
     return new Promise((resolve, reject) => {
         process.stdin

--- a/packages/cli-tools/test/stream-publish.test.ts
+++ b/packages/cli-tools/test/stream-publish.test.ts
@@ -1,0 +1,74 @@
+import StreamrClient, { StreamPermission } from '@streamr/sdk'
+import { createTestPrivateKey } from '@streamr/test-utils'
+import { keyToArrayIndex, StreamID } from '@streamr/utils'
+import range from 'lodash/range'
+import { createTestClient, nextValue, runCommand } from './utils'
+import { Wallet } from 'ethers'
+
+const PARTITION_COUNT = 10
+
+describe('stream-publish', () => {
+
+    let streamId: StreamID
+    let publisherPrivateKey: string
+    let subscriberPrivateKey: string
+
+    function createSubscriber(): StreamrClient {
+        return createTestClient(subscriberPrivateKey)
+    }
+
+    beforeEach(async () => {
+        publisherPrivateKey = await createTestPrivateKey({ gas: true })
+        subscriberPrivateKey = await createTestPrivateKey({ gas: true })
+        const client = createTestClient(await createTestPrivateKey({ gas: true }))
+        const stream = await client.createStream({ id: `/${Date.now()}`, partitions: PARTITION_COUNT })
+        await stream.grantPermissions({
+            userId: new Wallet(publisherPrivateKey).address,
+            permissions: [StreamPermission.PUBLISH]
+        }, {
+            userId: new Wallet(subscriberPrivateKey).address,
+            permissions: [StreamPermission.SUBSCRIBE]
+        })
+        streamId = stream.id
+        await client.destroy()
+    })
+
+    function publishViaCliCommand(additionalArgs: string[] = []) {
+        const args = [streamId, ...additionalArgs]
+        setImmediate(async () => {
+            await runCommand(`stream publish ${args.join(' ')}`, {
+                inputLines: [JSON.stringify({ foo: 123 })],
+                privateKey: publisherPrivateKey
+            })
+        })
+    }
+
+    it('happy path', async () => {
+        const subscriber = createSubscriber()
+        const subscriptions = await Promise.all(range(PARTITION_COUNT).map((partition) => subscriber.subscribe({ id: streamId, partition })))
+        publishViaCliCommand()
+        const receivedMessage = await Promise.race(subscriptions.map((s) => nextValue(s[Symbol.asyncIterator]())))
+        expect(receivedMessage!.content).toEqual({ foo: 123 })
+        await subscriber.destroy()
+    })
+
+    it('explicit partition', async () => {
+        const PARTITION = 5
+        const subscriber = createSubscriber()
+        const subscription = await subscriber.subscribe({ id: streamId, partition: PARTITION })
+        publishViaCliCommand([`--partition ${PARTITION}`])
+        const receivedMessage = await nextValue(subscription[Symbol.asyncIterator]())
+        expect(receivedMessage!.content).toEqual({ foo: 123 })
+        await subscriber.destroy()
+    })
+
+    it('partition key field', async () => {
+        const partition = keyToArrayIndex(PARTITION_COUNT, 123)
+        const subscriber = createSubscriber()
+        const subscription = await subscriber.subscribe({ id: streamId, partition })
+        publishViaCliCommand(['--partition-key-field foo'])
+        const receivedMessage = await nextValue(subscription[Symbol.asyncIterator]())
+        expect(receivedMessage!.content).toEqual({ foo: 123 })
+        await subscriber.destroy()
+    })    
+})

--- a/packages/cli-tools/test/utils.ts
+++ b/packages/cli-tools/test/utils.ts
@@ -96,3 +96,8 @@ export const deployTestOperatorContract = async (opts: Omit<DeployOperatorContra
 export const deployTestSponsorshipContract = async (opts: Omit<DeploySponsorshipContractOpts, 'environmentId'>): Promise<SponsorshipContract> => {
     return _operatorContractUtils.deploySponsorshipContract({ ...opts, 'environmentId': 'dev2' })
 }
+
+export const nextValue = async <T>(source: AsyncIterator<T>): Promise<T | undefined> => {
+    const item = source.next()
+    return (await item).value
+}


### PR DESCRIPTION
Added an optional flag to `stream publish` to control the target partition.

## Default partition

Note that the default value for the partition is `undefined`, i.e. it publishes to random partition (just like before this PR). In `stream-subscribe` there is similar flag, which has a default value of `0` (i.e. it subscribes to the first partition). 

## Test

Improved test coverage by adding tests for partition-related functionality of `stream-publish` command. Also renamed existing `stream-publish-subscribe.test.ts` to `stream-subscribe.test.ts` as those test cases are asserting the subscribe outputs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--partition` to `stream publish` with validation against `--partition-key-field`, updates tests, and notes change in changelog.
> 
> - **CLI (`packages/cli-tools`)**
>   - `stream publish`: Add `--partition` option and parse via `createFnParseInt`; pass `{ streamId, partition }` to `client.publish`.
>   - Validate mutually exclusive use of `--partition` and `--partition-key-field` (exit with error on conflict).
> - **Tests**
>   - New `stream-publish.test.ts`: covers default publish, explicit `--partition`, and `--partition-key-field` routing.
>   - Refactor `stream-subscribe.test.ts`: publish via SDK helper instead of CLI; minor renames and typings.
>   - Test utils: add `nextValue()` helper.
> - **Docs**
>   - `CHANGELOG.md`: document new `--partition` flag under `@streamr/cli-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf70088e223f9f69555c47fcbb53e58f637a64e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




