### PR TITLE
fix(cli-tools): Value required for `--partition` in `stream subscribe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Changes before Tatum release are not documented in this file.
 #### Fixed
 
 - Signature output in `subscribe --with-metadata` (https://github.com/streamr-dev/network/pull/3245)
+- Error handling of `--partition` flag in `subscribe` (https://github.com/streamr-dev/network/pull/3263)
 
 #### Security
 

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -44,7 +44,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
 })
     .arguments('<streamId>')
     .description('subscribe to a stream, prints JSON messages to stdout line-by-line')
-    .option('-p, --partition [partition]', 'partition', createFnParseInt('--partition'), 0)
+    .option('-p, --partition <partition>', 'partition', createFnParseInt('--partition'), 0)
     .option('-d, --disable-ordering', 'disable ordering of messages by OrderingUtil', false)
     .option('-r, --raw', 'subscribe raw', false)
     .option('-m, --with-metadata', 'print each message with its metadata included', false)


### PR DESCRIPTION
Users must provide a partition value when using the `--partition` flag. If the value is omitted, the command now shows a descriptive error message.

There are no changes to the optionality of the flag: it is still ok to leave it out, in which case the command defaults to partition `0`, just like before this PR.

## Error

Before this PR we got this error like this when using the flag without a value:

```
Error: invalid streamPartition value: true
    at ensureValidStreamPartitionIndex (.../network/packages/utils/dist/src/partition.js:10:15)
```

Now we show standard `commander` error:
```
error: option '-p, --partition <partition>' argument missing
```