### PR TITLE
refactor [NET-1645]: Clean-up tsconfigs for the `cdn-location` package

### DIFF
--- a/packages/cdn-location/package.json
+++ b/packages/cdn-location/package.json
@@ -18,8 +18,8 @@
   "license": "Apache-2.0",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
-    "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "build": "tsc -b",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json && tsc --noEmit -p ./tsconfig.data-generation.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/integration",

--- a/packages/cdn-location/tsconfig.data-generation.json
+++ b/packages/cdn-location/tsconfig.data-generation.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "data-generation"
+  ]
+}

--- a/packages/cdn-location/tsconfig.jest.json
+++ b/packages/cdn-location/tsconfig.jest.json
@@ -1,14 +1,10 @@
 {
   "extends": "../../tsconfig.jest.json",
   "include": [
-    "src",
-    "data-generation",
     "test"
   ],
   "references": [
-    { "path": "../utils/tsconfig.node.json" },
-    { "path": "../test-utils/tsconfig.node.json" },
-    { "path": "../proto-rpc/tsconfig.node.json" },
-    { "path": "../autocertifier-client" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../test-utils/tsconfig.node.json" }
   ]
 }

--- a/packages/cdn-location/tsconfig.json
+++ b/packages/cdn-location/tsconfig.json
@@ -4,6 +4,8 @@
     "composite": true
   },
   "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.data-generation.json" },
     { "path": "./tsconfig.jest.json" }
   ]
 }

--- a/packages/cdn-location/tsconfig.node.json
+++ b/packages/cdn-location/tsconfig.node.json
@@ -8,7 +8,6 @@
     "src"
   ],
   "references": [
-    { "path": "../utils/tsconfig.node.json" },
-    { "path": "../test-utils/tsconfig.node.json" }
+    { "path": "../utils/tsconfig.node.json" }
   ]
 }

--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -16,7 +16,7 @@
     { "path": "../test-utils/tsconfig.node.json" },
     { "path": "../proto-rpc/tsconfig.node.json" },
     { "path": "../autocertifier-client" },
-    { "path": "../cdn-location/tsconfig.node.json" },
+    { "path": "../cdn-location" },
     { "path": "../geoip-location/tsconfig.node.json" }
   ]
 }

--- a/packages/dht/tsconfig.node.json
+++ b/packages/dht/tsconfig.node.json
@@ -14,7 +14,7 @@
     { "path": "../test-utils/tsconfig.node.json" },
     { "path": "../proto-rpc/tsconfig.node.json" },
     { "path": "../autocertifier-client" },
-    { "path": "../cdn-location/tsconfig.node.json" },
+    { "path": "../cdn-location" },
     { "path": "../geoip-location/tsconfig.node.json" }
   ]
 }


### PR DESCRIPTION
This pull request updates TypeScript configuration and build scripts for the `cdn-location` (primarily) and `dht` packages to improve type checking, project references, and test configuration. The main focus is on refining how different parts of the codebase are built and checked, especially for data generation and testing.

### Changes

**TypeScript configuration improvements:**

* Added a new `tsconfig.data-generation.json` in `cdn-location` for type-checking the `data-generation` directory without emitting output, and updated the main `tsconfig.json` to reference it.
* Updated `tsconfig.jest.json` in `cdn-location` to only include the `test` directory, and changed project references to point to the local `tsconfig.node.json` and `test-utils`.
* Adjusted `tsconfig.node.json` in `cdn-location` to remove the reference to `test-utils`, keeping only `utils` as a reference.

**Build and check script enhancements:**

* Improved the `check` script in `cdn-location/package.json` to run type checks for both test and data generation configs, ensuring stricter type safety across the project.

**Project references update for `dht` package:**

* Changed `dht` package TypeScript configs to reference the entire `cdn-location` project instead of just its `tsconfig.node.json`, simplifying dependency management.