### PR TITLE
refactor [NET-1646]: Clean-up tsconfigs for the `cli-tools` package

### DIFF
--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 
-import { convertStreamMessageToBytes, MessageMetadata, StreamMessage, StreamrClient } from '@streamr/sdk'
+import { convertStreamMessageToBytes, MessageMetadata, StreamrClient } from '@streamr/sdk'
 import { binaryToHex, toLengthPrefixedFrame } from '@streamr/utils'
 import mapValues from 'lodash/mapValues'
 import isString from 'lodash/isString'

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import '../src/logLevel'
 
-import { convertStreamMessageToBytes, MessageMetadata, StreamrClient } from '@streamr/sdk'
+import { convertStreamMessageToBytes, MessageMetadata, type StreamMessage, StreamrClient } from '@streamr/sdk'
 import { binaryToHex, toLengthPrefixedFrame } from '@streamr/utils'
 import mapValues from 'lodash/mapValues'
 import isString from 'lodash/isString'
@@ -30,7 +30,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
     for await (const msg of sub) {
         if (options.binary) {
             // @ts-expect-error private field
-            const streamMessage = msg.streamMessage
+            const streamMessage = msg.streamMessage as StreamMessage
             const binaryData = options.withMetadata    
                 ? convertStreamMessageToBytes(streamMessage)
                 : streamMessage.content

--- a/packages/cli-tools/bin/streamr-stream-subscribe.ts
+++ b/packages/cli-tools/bin/streamr-stream-subscribe.ts
@@ -30,7 +30,7 @@ createClientCommand(async (client: StreamrClient, streamId: string, options: Opt
     for await (const msg of sub) {
         if (options.binary) {
             // @ts-expect-error private field
-            const streamMessage = msg.streamMessage as StreamMessage
+            const streamMessage = msg.streamMessage
             const binaryData = options.withMetadata    
                 ? convertStreamMessageToBytes(streamMessage)
                 : streamMessage.content

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -17,8 +17,8 @@
     "streamr": "dist/bin/streamr.js"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "build": "tsc -b",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run build && jest --bail --forceExit"

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
+    "check": "tsc -p ./tsconfig.jest.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run build && jest --bail --forceExit"

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -9,10 +9,16 @@
     "noImplicitOverride": false
   },
   "include": [
+    "package.json",
+    "src",
+    "bin",
     "test"
   ],
   "references": [
-    { "path": "./tsconfig.node.json" },
+    { "path": "../utils/tsconfig.node.json" },
+    { "path": "../sdk/tsconfig.node.json" },
+    { "path": "../dht/tsconfig.node.json" },
+    { "path": "../trackerless-network/tsconfig.node.json" },
     { "path": "../test-utils/tsconfig.node.json" }
   ]
 }

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -6,8 +6,10 @@
     "noImplicitOverride": false
   },
   "include": [
-    "src",
-    "bin",
     "test"
+  ],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "../test-utils/tsconfig.node.json" }
   ]
 }

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "noEmit": true,
     "types": [
       "node",
       "jest",

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["node", "jest", "@streamr/test-utils/customMatcherTypes"],
+    "types": [
+      "node",
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
+    ],
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/cli-tools/tsconfig.json
+++ b/packages/cli-tools/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": true
   },
   "references": [
+    { "path": "./tsconfig.node.json" },
     { "path": "./tsconfig.jest.json" }
   ]
 }

--- a/packages/cli-tools/tsconfig.node.json
+++ b/packages/cli-tools/tsconfig.node.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "dist"
   },
   "include": [
@@ -11,6 +10,8 @@
   ],
   "references": [
     { "path": "../utils/tsconfig.node.json" },
-    { "path": "../sdk/tsconfig.node.json" }
+    { "path": "../sdk/tsconfig.node.json" },
+    { "path": "../dht/tsconfig.node.json" },
+    { "path": "../trackerless-network/tsconfig.node.json" }
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,7 +14,8 @@
     "sourceMap": true,
     "stripInternal": true,
     "useUnknownInCatchVariables": false,
-    "strictBindCallApply": true
+    "strictBindCallApply": true,
+    "disableSourceOfProjectReferenceRedirect": true
   }, 
   "lib": [
     "DOM"


### PR DESCRIPTION
This pull request updates TypeScript configuration for the `cli-tools` package to improve project references and build reliability. The changes primarily enhance how the package manages its dependencies and build process, ensuring better integration with related packages and more robust project setup.

### Changes

**TypeScript project configuration improvements:**

* Added additional project references in `tsconfig.node.json` and `tsconfig.jest.json` for `dht`, `trackerless-network`, and `test-utils` to ensure proper dependency tracking and type checking.
* Included `tsconfig.node.json` as a reference in the main `tsconfig.json` for `cli-tools`, clarifying the build order and dependencies.
* Added `package.json` to the `include` array in `tsconfig.jest.json` to ensure it is considered in type checking and builds.

**Build process and compiler options:**

* Simplified the `build` script in `package.json` to use the default TypeScript project references build (`tsc -b`), making the build process more consistent.
* Enabled the `disableSourceOfProjectReferenceRedirect` compiler option in the root `tsconfig.node.json` to prevent issues with source file redirection in project references.

**Other adjustments:**

* Removed the `composite` option from `cli-tools/tsconfig.node.json`, as it is now managed at a higher level.