### PR TITLE
refactor [NET-1647]: Clean-up tsconfigs for the `dht` package

### DIFF
--- a/packages/autocertifier-server/tsconfig.node.json
+++ b/packages/autocertifier-server/tsconfig.node.json
@@ -12,6 +12,6 @@
     { "path": "../utils/tsconfig.node.json" },
     { "path": "../test-utils/tsconfig.node.json" },
     { "path": "../proto-rpc/tsconfig.node.json" },
-    { "path": "../dht/tsconfig.node.json" }
+    { "path": "../dht" }
   ]
 }

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -24,9 +24,9 @@
   "scripts": {
     "prebuild": "./proto.sh",
     "postbuild": "./scripts/postbuild.sh",
-    "build": "tsc -b tsconfig.node.json",
+    "build": "tsc -b",
     "build-browser": "webpack --mode=development --progress",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -5,18 +5,10 @@
     "noImplicitOverride": false
   },
   "include": [
-    "src",
-    "generated",
-    "test",
-    "package.json",
-    "scripts"
+    "test"
   ],
   "references": [
-    { "path": "../utils/tsconfig.node.json" },
-    { "path": "../test-utils/tsconfig.node.json" },
-    { "path": "../proto-rpc/tsconfig.node.json" },
-    { "path": "../autocertifier-client" },
-    { "path": "../cdn-location" },
-    { "path": "../geoip-location/tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../test-utils/tsconfig.node.json" }
   ]
 }

--- a/packages/dht/tsconfig.json
+++ b/packages/dht/tsconfig.json
@@ -4,6 +4,8 @@
     "composite": true
   },
   "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.karma.json" },
     { "path": "./tsconfig.jest.json" }
   ]
 }

--- a/packages/dht/tsconfig.karma.json
+++ b/packages/dht/tsconfig.karma.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "dist",
     "noImplicitOverride": false,
-    "types": ["jest", "jest-extended"]
+    "types": [
+      "jest",
+      "jest-extended"
+    ]
   },
-  "include": ["src", "package.json"]
+  "include": [
+    "src",
+    "package.json"
+  ]
 }

--- a/packages/dht/tsconfig.node.json
+++ b/packages/dht/tsconfig.node.json
@@ -7,7 +7,8 @@
   "include": [
     "src",
     "generated",
-    "package.json"
+    "package.json",
+    "scripts"
   ],
   "references": [
     { "path": "../utils/tsconfig.node.json" },

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -23,7 +23,7 @@
   ],
   "references": [
     { "path": "../test-utils/tsconfig.node.json" },
-    { "path": "../dht/tsconfig.node.json" },
+    { "path": "../dht" },
     { "path": "../trackerless-network/tsconfig.node.json" }
   ]
 }

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -19,7 +19,7 @@
   "references": [
     { "path": "../test-utils/tsconfig.node.json" },
     { "path": "../trackerless-network/tsconfig.node.json" },
-    { "path": "../dht/tsconfig.node.json" }
+    { "path": "../dht" }
     
   ]
 }

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["node", "jest", "@streamr/test-utils/customMatcherTypes"],
+    "types": [
+      "node",
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
+    ],
     "noImplicitOverride": false
   },
   "include": [
@@ -13,6 +17,6 @@
   ],
   "references": [
     { "path": "../proto-rpc/tsconfig.node.json" },
-    { "path": "../dht/tsconfig.node.json" }
+    { "path": "../dht" }
   ]
 }

--- a/packages/trackerless-network/tsconfig.node.json
+++ b/packages/trackerless-network/tsconfig.node.json
@@ -12,6 +12,8 @@
     "package.json"
   ],
   "references": [
-    { "path": "../dht/tsconfig.node.json" }
+    { "path": "../dht" },
+    { "path": "../proto-rpc/tsconfig.node.json" },
+    { "path": "../utils/tsconfig.node.json" }
   ]
 }


### PR DESCRIPTION
This pull request updates TypeScript configuration files across several packages to improve project references and build consistency, especially for the `dht` package and its dependents. The main changes involve simplifying and correcting TypeScript project references, updating build scripts, and making includes and references more precise.

### Changes

**TypeScript project references and configuration updates:**

* Updated all references to the `dht` package's TypeScript configuration from `../dht/tsconfig.node.json` to simply `../dht` in multiple packages, streamlining project references and aligning with TypeScript's project reference resolution. * Added and reorganized references within `dht/tsconfig.json` to include `tsconfig.node.json` and `tsconfig.karma.json`, ensuring all relevant configs are part of the composite project.
* Updated `dht/tsconfig.jest.json` references to point to the local `tsconfig.node.json` and removed unnecessary references to unrelated packages, narrowing the scope for Jest builds.

**Build script and inclusion improvements:**

* Modified the `dht` package's `build` script to use `tsc -b` (building all referenced projects) and enhanced the `check` script to also type-check `tsconfig.node.json`.
* Expanded the `include` array in `dht/tsconfig.node.json` to add the `scripts` directory, ensuring scripts are included in the build.

**Test and browser configuration adjustments:**

* Reformatted the `types` array in `trackerless-network/tsconfig.jest.json` for better readability.