### PR TITLE
refactor [NET-1652]: Clean-up tsconfigs for the `test-utils` package

### DIFF
--- a/packages/autocertifier-server/tsconfig.jest.json
+++ b/packages/autocertifier-server/tsconfig.jest.json
@@ -7,7 +7,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json"}
     ]

--- a/packages/autocertifier-server/tsconfig.node.json
+++ b/packages/autocertifier-server/tsconfig.node.json
@@ -10,7 +10,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../dht/tsconfig.node.json"}
     ]

--- a/packages/cdn-location/tsconfig.jest.json
+++ b/packages/cdn-location/tsconfig.jest.json
@@ -7,7 +7,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json"}
     ]

--- a/packages/cdn-location/tsconfig.node.json
+++ b/packages/cdn-location/tsconfig.node.json
@@ -9,6 +9,6 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" }
+        { "path": "../test-utils" }
     ]
 }

--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -13,7 +13,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json" },
         { "path": "../cdn-location/tsconfig.node.json" },

--- a/packages/dht/tsconfig.node.json
+++ b/packages/dht/tsconfig.node.json
@@ -11,7 +11,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json" },
         { "path": "../cdn-location/tsconfig.node.json" },

--- a/packages/node/tsconfig.jest.json
+++ b/packages/node/tsconfig.jest.json
@@ -9,7 +9,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../sdk/tsconfig.node.json" }
     ]
 }

--- a/packages/node/tsconfig.node.json
+++ b/packages/node/tsconfig.node.json
@@ -11,7 +11,7 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../sdk/tsconfig.node.json" }
     ]
 }

--- a/packages/proto-rpc/tsconfig.jest.json
+++ b/packages/proto-rpc/tsconfig.jest.json
@@ -11,6 +11,6 @@
     ],
     "references": [
         { "path": "../utils/tsconfig.node.json" },
-        { "path": "../test-utils/tsconfig.node.json" }
+        { "path": "../test-utils" }
     ]
 }

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -18,7 +18,7 @@
     ],
     "exclude": ["src/exports-esm.mjs"],
     "references": [
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../trackerless-network/tsconfig.browser.json" }
     ]
 }

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -25,7 +25,7 @@
         "src/exports-esm.mjs"
     ],
     "references": [
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../dht/tsconfig.node.json" },
         { "path": "../trackerless-network/tsconfig.node.json" }
     ]

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -19,7 +19,7 @@
         "jest.config.ts"
     ],
     "references": [
-        { "path": "../test-utils/tsconfig.node.json" },
+        { "path": "../test-utils" },
         { "path": "../trackerless-network/tsconfig.node.json" },
         { "path": "../dht/tsconfig.node.json" }
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -16,8 +16,8 @@
     "customMatcherTypes.d.ts"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "build": "tsc -b",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "test": "jest",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"

--- a/packages/test-utils/tsconfig.jest.json
+++ b/packages/test-utils/tsconfig.jest.json
@@ -1,10 +1,7 @@
 {
-    "extends": "../../tsconfig.jest.json",
-    "include": [
-        "src/**/*",
-        "test/**/*"
-    ],
-    "references": [
-        { "path": "../utils/tsconfig.node.json" }
-    ]
+  "extends": "../../tsconfig.jest.json",
+  "include": ["test"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,3 +1,10 @@
 {
-  "extends": "./tsconfig.jest.json"
+  "files": [],
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "./tsconfig.jest.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/packages/test-utils/tsconfig.node.json
+++ b/packages/test-utils/tsconfig.node.json
@@ -1,13 +1,14 @@
 {
-    "extends": "../../tsconfig.node.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "types": ["node", "jest"]
-    },
-    "include": [
-        "src/**/*"
-    ],
-    "references": [
-        { "path": "../utils/tsconfig.node.json" }
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": [
+      "node",
+      "jest"
     ]
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../utils/tsconfig.node.json" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/test-utils" }
+  ]
+}


### PR DESCRIPTION
This pull request updates TypeScript project references and configuration for the `test-utils` package and its consumers. The main change is to simplify references to `test-utils` by pointing directly to the package directory instead of specific config files, and to clean up and clarify TypeScript config files for better project structure and build reliability.

**TypeScript project reference updates**

* Updated all consumer packages (such as `autocertifier-server`, `cdn-location`, `dht`, `node`, `proto-rpc`, and `sdk`) to reference the `test-utils` package directly instead of `test-utils/tsconfig.node.json` in their various TypeScript config files (`tsconfig.node.json`, `tsconfig.jest.json`, `tsconfig.browser.json`).

**`test-utils` package configuration improvements**

* Cleaned up and clarified the TypeScript config files in `test-utils`: added a root `tsconfig.json` with composite enabled and explicit references, reduced the `tsconfig.jest.json` include scope to only the `test` directory, and improved the formatting of `tsconfig.node.json`.

**Build and script adjustments**

* Updated the `build` and `check` scripts in `test-utils/package.json` to use the root build and to ensure both jest and node configs are checked for type correctness.