### PR TITLE
refactor [NET-1653]: Clean-up tsconfigs for the `trackerless-network` package

### DIFF
--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -18,7 +18,6 @@
     ],
     "exclude": ["src/exports-esm.mjs"],
     "references": [
-        { "path": "../test-utils/tsconfig.node.json" },
-        { "path": "../trackerless-network/tsconfig.browser.json" }
+        { "path": "../test-utils/tsconfig.node.json" }
     ]
 }

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -27,6 +27,6 @@
     "references": [
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../dht/tsconfig.node.json" },
-        { "path": "../trackerless-network/tsconfig.node.json" }
+        { "path": "../trackerless-network" }
     ]
 }

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -20,7 +20,7 @@
     ],
     "references": [
         { "path": "../test-utils/tsconfig.node.json" },
-        { "path": "../trackerless-network/tsconfig.node.json" },
+        { "path": "../trackerless-network" },
         { "path": "../dht/tsconfig.node.json" }
 
     ]

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -18,10 +18,10 @@
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
-    "build": "tsc -b tsconfig.node.json",
-    "build-browser": "webpack --mode=development --progress",
     "prebuild": "./proto.sh",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "build": "tsc -b",
+    "build-browser": "webpack --mode=development --progress",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",

--- a/packages/trackerless-network/tsconfig.browser.json
+++ b/packages/trackerless-network/tsconfig.browser.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.browser.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "noImplicitOverride": false
-  },
-  "include": ["src", "generated"]
-}

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -1,18 +1,15 @@
 {
-    "extends": "../../tsconfig.jest.json",
-    "compilerOptions": {
-        "noEmit": true,
-        "types": ["node", "jest", "@streamr/test-utils/customMatcherTypes"],
-        "noImplicitOverride": false
-    },
-    "include": [
-        "src/**/*",
-        "generated/**/*",
-        "test/**/*",
-        "package.json"
+  "extends": "../../tsconfig.jest.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
     ],
-    "references": [
-        { "path": "../proto-rpc/tsconfig.node.json" },
-        { "path": "../dht/tsconfig.node.json" }
-    ]
+    "noImplicitOverride": false
+  },
+  "include": ["test"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/packages/trackerless-network/tsconfig.json
+++ b/packages/trackerless-network/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "./tsconfig.jest.json"
+  "files": [],
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "./tsconfig.jest.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.karma.json" }
+  ]
 }

--- a/packages/trackerless-network/tsconfig.karma.json
+++ b/packages/trackerless-network/tsconfig.karma.json
@@ -1,6 +1,15 @@
 {
-  "extends": "./tsconfig.browser.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
-    "types": ["jest", "@streamr/test-utils/customMatcherTypes"]
-  }
+    "outDir": "dist",
+    "noImplicitOverride": false,
+    "types": [
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
+    ]
+  },
+  "include": [
+    "src",
+    "generated"
+  ]
 }

--- a/packages/trackerless-network/tsconfig.node.json
+++ b/packages/trackerless-network/tsconfig.node.json
@@ -1,17 +1,20 @@
 {
-    "extends": "../../tsconfig.node.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "noImplicitOverride": false
-    },
-    "include": [
-        "src/**/*",
-        "generated/**/*",
-        "test/benchmark/first-message.ts",
-        "test/utils/utils.ts",
-        "package.json"
-    ],
-    "references": [
-        { "path": "../dht/tsconfig.node.json" }
-    ]
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noImplicitOverride": false,
+    "stripInternal": false
+  },
+  "include": [
+    "src",
+    "generated",
+    "package.json"
+  ],
+  "references": [
+    { "path": "../dht/tsconfig.node.json" },
+    { "path": "../proto-rpc/tsconfig.node.json" },
+    { "path": "../utils/tsconfig.node.json" },
+    { "path": "../browser-test-runner/tsconfig.node.json" },
+    { "path": "../test-utils/tsconfig.node.json" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/trackerless-network" }
+  ]
+}


### PR DESCRIPTION
This pull request refactors and simplifies the TypeScript configuration for the `trackerless-network` package, improving project references, build scripts, and configuration clarity. The changes remove redundant configuration files, update references to use package roots instead of specific config files, and streamline the `build` and `check` commands for better maintainability and consistency across environments.

### Changes

**TypeScript configuration and references:**

* Removed the redundant `tsconfig.browser.json` from `trackerless-network` and updated `tsconfig.karma.json` to extend the root browser config, with improved `compilerOptions` and `include` settings.
* Updated project references in multiple SDK and `trackerless-network` configs to point to package roots rather than specific config files, simplifying dependency management. 
* Added a new root `tsconfig.json` for `trackerless-network` to manage composite builds and references to environment-specific configs.

**Build and check scripts:**

* Refactored build and check scripts in `trackerless-network/package.json` to use composite builds and ensure both Jest and Node configs are checked for type errors.

**Test and environment config improvements:**

* Simplified and updated the Jest TypeScript config for `trackerless-network` to only include test files and to reference the local Node config.