### PR TITLE
refactor [NET-1654]: Clean-up tsconfigs for the `utils` package

### DIFF
--- a/packages/autocertifier-client/tsconfig.jest.json
+++ b/packages/autocertifier-client/tsconfig.jest.json
@@ -6,6 +6,6 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/autocertifier-client/tsconfig.node.json
+++ b/packages/autocertifier-client/tsconfig.node.json
@@ -9,6 +9,6 @@
         "generated/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/autocertifier-server/tsconfig.jest.json
+++ b/packages/autocertifier-server/tsconfig.jest.json
@@ -6,7 +6,7 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json"}

--- a/packages/autocertifier-server/tsconfig.node.json
+++ b/packages/autocertifier-server/tsconfig.node.json
@@ -9,7 +9,7 @@
         "bin/**/*",
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../dht/tsconfig.node.json"}

--- a/packages/cdn-location/tsconfig.jest.json
+++ b/packages/cdn-location/tsconfig.jest.json
@@ -6,7 +6,7 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json"}

--- a/packages/cdn-location/tsconfig.node.json
+++ b/packages/cdn-location/tsconfig.node.json
@@ -8,7 +8,7 @@
         "src/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" }
     ]
 }

--- a/packages/cli-tools/tsconfig.node.json
+++ b/packages/cli-tools/tsconfig.node.json
@@ -10,7 +10,7 @@
         "bin/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../sdk/tsconfig.node.json" }
     ]
 }

--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -12,7 +12,7 @@
         "scripts"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json" },

--- a/packages/dht/tsconfig.node.json
+++ b/packages/dht/tsconfig.node.json
@@ -10,7 +10,7 @@
         "package.json"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../proto-rpc/tsconfig.node.json" },
         { "path": "../autocertifier-client/tsconfig.node.json" },

--- a/packages/geoip-location/tsconfig.jest.json
+++ b/packages/geoip-location/tsconfig.jest.json
@@ -5,6 +5,6 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/geoip-location/tsconfig.node.json
+++ b/packages/geoip-location/tsconfig.node.json
@@ -8,6 +8,6 @@
         "src/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" }
     ]
 }

--- a/packages/node/tsconfig.jest.json
+++ b/packages/node/tsconfig.jest.json
@@ -8,7 +8,7 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../sdk/tsconfig.node.json" }
     ]

--- a/packages/node/tsconfig.node.json
+++ b/packages/node/tsconfig.node.json
@@ -10,7 +10,7 @@
         "package.json"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" },
         { "path": "../sdk/tsconfig.node.json" }
     ]

--- a/packages/proto-rpc/tsconfig.jest.json
+++ b/packages/proto-rpc/tsconfig.jest.json
@@ -10,7 +10,7 @@
         "test/**/*",
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" },
+        { "path": "../utils" },
         { "path": "../test-utils/tsconfig.node.json" }
     ]
 }

--- a/packages/proto-rpc/tsconfig.node.json
+++ b/packages/proto-rpc/tsconfig.node.json
@@ -9,6 +9,6 @@
         "generated/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/test-utils/tsconfig.jest.json
+++ b/packages/test-utils/tsconfig.jest.json
@@ -5,6 +5,6 @@
         "test/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/test-utils/tsconfig.node.json
+++ b/packages/test-utils/tsconfig.node.json
@@ -8,6 +8,6 @@
         "src/**/*"
     ],
     "references": [
-        { "path": "../utils/tsconfig.node.json" }
+        { "path": "../utils" }
     ]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,8 +16,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.node.json",
-    "check": "tsc -p ./tsconfig.jest.json",
+    "build": "tsc -b",
+    "check": "tsc -p ./tsconfig.jest.json && tsc --noEmit -p ./tsconfig.node.json",
     "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",

--- a/packages/utils/tsconfig.browser.json
+++ b/packages/utils/tsconfig.browser.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.browser.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "noImplicitOverride": false
-  },
-  "include": ["src"]
-}

--- a/packages/utils/tsconfig.jest.json
+++ b/packages/utils/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.jest.json",
-  "include": [
-    "src/**/*",
-    "test/**/*"
+  "include": ["test"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
   ]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,3 +1,11 @@
 {
-  "extends": "./tsconfig.jest.json"
+  "files": [],
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "./tsconfig.jest.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.karma.json" }
+  ]
 }

--- a/packages/utils/tsconfig.karma.json
+++ b/packages/utils/tsconfig.karma.json
@@ -1,6 +1,12 @@
 {
-  "extends": "./tsconfig.browser.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
-    "types": ["jest", "jest-extended"]
-  }
+    "outDir": "dist",
+    "noImplicitOverride": false,
+    "types": [
+      "jest",
+      "jest-extended"
+    ]
+  },
+  "include": ["src"]
 }

--- a/packages/utils/tsconfig.node.json
+++ b/packages/utils/tsconfig.node.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
+    "stripInternal": false,
     "outDir": "dist"
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/utils" }
+  ]
+}


### PR DESCRIPTION
This pull request updates TypeScript configuration files across multiple packages to improve project references and build consistency. The main change is standardizing how the `utils` package is referenced in various `tsconfig` files, switching from referencing its config file directly to referencing the package directory. Additionally, the `utils` package receives several updates to its own config files and scripts to streamline builds and checks.

### Changes

**Project reference updates:**

* Updated all references to the `utils` package in `tsconfig.jest.json` and `tsconfig.node.json` files across packages (such as `autocertifier-client`, `autocertifier-server`, `cdn-location`, `dht`, `geoip-location`, `node`, `proto-rpc`, `test-utils`, and `cli-tools`) to use `{ "path": "../utils" }` instead of `{ "path": "../utils/tsconfig.node.json" }` for better compatibility with TypeScript project references.

**`utils` package configuration improvements:**

* Added a root `tsconfig.json` to the `utils` package, enabling composite builds and referencing all relevant config files (`tsconfig.jest.json`, `tsconfig.node.json`, `tsconfig.karma.json`).
* Updated `tsconfig.jest.json` in `utils` to only include the `test` directory and added a reference to its own `tsconfig.node.json` for improved separation of test and source code.

**Build and check script enhancements:**

* Modified the `build` script in `utils/package.json` to use `tsc -b` for composite builds, and updated the `check` script to run both Jest and Node TypeScript checks for stricter type safety.

**Cleanup:**

* Removed the unused `tsconfig.browser.json` file from the `utils` package, reducing clutter.