### PR TITLE
feat(sdk): Raw publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes before Tatum release are not documented in this file.
 
 - Proxy connections now support bidirectionality and it is the default behavior. (https://github.com/streamr-dev/network/pull/3260)
 - Added `findProxyNodes` function to `StreamrClient` for discovering proxy nodes via Operator nodes.
+- Add `StreamrClient#publishRaw()` for publishing raw messages (https://github.com/streamr-dev/network/pull/3280)
 
 #### Changed
 

--- a/packages/sdk/test/end-to-end/publish-subscribe-raw.test.ts
+++ b/packages/sdk/test/end-to-end/publish-subscribe-raw.test.ts
@@ -1,0 +1,52 @@
+import { StreamID, toUserId } from '@streamr/utils'
+import { createTestClient, createTestStream } from '../test-utils/utils'
+import { nextValue } from '../../src/utils/iterators'
+import { EthereumKeyPairIdentity } from '../../src/identity/EthereumKeyPairIdentity'
+import { MessageSigner } from '../../src/signature/MessageSigner'
+import { Wallet } from 'ethers'
+import { MessageID } from '../../src/protocol/MessageID'
+import { ContentType, EncryptionType, SignatureType } from '@streamr/trackerless-network'
+import { StreamMessageType, StreamPermission } from '../../src'
+import { createTestWallet } from '@streamr/test-utils'
+
+describe('publish-subscribe-raw', () => {
+
+    let streamId: StreamID
+    let publisherWallet: Wallet
+
+    beforeEach(async () => {
+        const creatorWallet = await createTestWallet({ gas: true })
+        const creatorClient = createTestClient(creatorWallet.privateKey)
+        const stream = await createTestStream(creatorClient, module)
+        streamId = stream.id
+        publisherWallet = await createTestWallet()
+        stream.grantPermissions({
+            userId: publisherWallet.address.toLowerCase(),
+            permissions: [StreamPermission.PUBLISH]
+        })
+        await creatorClient.destroy()
+    })
+
+    async function createTestMessage() {
+        const messageSigner = new MessageSigner(EthereumKeyPairIdentity.fromPrivateKey(publisherWallet.privateKey))
+        return await messageSigner.createSignedMessage({
+            messageId: new MessageID(streamId, 0, 123456789, 0, toUserId(publisherWallet.address), 'mock-msgChainId'),
+            content: new Uint8Array([1, 2, 3]),
+            contentType: ContentType.BINARY,
+            encryptionType: EncryptionType.NONE,
+            messageType: StreamMessageType.MESSAGE
+        }, SignatureType.ECDSA_SECP256K1_EVM)
+    }
+
+    it('happy path', async () => {
+        const publisher = createTestClient()
+        const subscriber = createTestClient()
+        const subcription = await subscriber.subscribe({ streamId, raw: true })
+        const sentMessage = await createTestMessage()
+        await publisher.publishRaw(sentMessage)
+        const receivedMessage = await nextValue(subcription[Symbol.asyncIterator]())
+        expect(receivedMessage! .streamMessage).toEqual(sentMessage)
+        await publisher.destroy()
+        await subscriber.destroy()
+    })
+})


### PR DESCRIPTION
Added the `StreamrClient#publishRaw()` method.

It is the counterpart to the existing `StreamrClient#subscribe({ raw: true }`) method. In raw publish/subscribe mode, the SDK’s message pipeline is bypassed: e.g. validation, decryption, and message ordering are skipped.