### PR TITLE
refactor: Unbind `Logger` from NodeJS `module` object (by type)

### DIFF
--- a/packages/utils/src/Logger.ts
+++ b/packages/utils/src/Logger.ts
@@ -72,6 +72,8 @@ function wrappedMethodCall(
     }
 }
 
+type Scope = string | { id: string }
+
 export class Logger {
     static NAME_LENGTH = 25
 
@@ -84,13 +86,13 @@ export class Logger {
     trace: (msg: string, metadata?: Record<string, unknown>) => void
 
     constructor(
-        module: NodeJS.Module,
+        scope: Scope,
         contextBindings?: Record<string, unknown>,
         defaultLogLevel: LogLevel = 'info',
         parentLogger: pino.Logger = rootLogger
     ) {
         this.logger = parentLogger.child({
-            name: Logger.createName(module),
+            name: Logger.createName(scope),
             ...contextBindings
         }, {
             level: process.env.LOG_LEVEL ?? defaultLogLevel
@@ -103,8 +105,9 @@ export class Logger {
         this.trace = wrappedMethodCall(this.logger.trace.bind(this.logger))
     }
 
-    static createName(module: NodeJS.Module): string {
-        const parsedPath = path.parse(String(module.id))
+    static createName(scope: Scope): string {
+        const scopeId = typeof scope === 'string' ? scope : scope.id
+        const parsedPath = path.parse(scopeId)
         let fileId = parsedPath.name
         if (fileId === 'index') {
             // file with name "foobar/index.ts" -> "foobar"

--- a/packages/utils/src/Logger.ts
+++ b/packages/utils/src/Logger.ts
@@ -72,7 +72,7 @@ function wrappedMethodCall(
     }
 }
 
-type Scope = string | { id: string }
+type LoggerModule = string | { id: string }
 
 export class Logger {
     static NAME_LENGTH = 25
@@ -86,13 +86,13 @@ export class Logger {
     trace: (msg: string, metadata?: Record<string, unknown>) => void
 
     constructor(
-        scope: Scope,
+        loggerModule: LoggerModule,
         contextBindings?: Record<string, unknown>,
         defaultLogLevel: LogLevel = 'info',
         parentLogger: pino.Logger = rootLogger
     ) {
         this.logger = parentLogger.child({
-            name: Logger.createName(scope),
+            name: Logger.createName(loggerModule),
             ...contextBindings
         }, {
             level: process.env.LOG_LEVEL ?? defaultLogLevel
@@ -105,9 +105,9 @@ export class Logger {
         this.trace = wrappedMethodCall(this.logger.trace.bind(this.logger))
     }
 
-    static createName(scope: Scope): string {
-        const scopeId = typeof scope === 'string' ? scope : scope.id
-        const parsedPath = path.parse(scopeId)
+    static createName(loggerModule: LoggerModule): string {
+        const loggerModuleId = typeof loggerModule === 'string' ? loggerModule : loggerModule.id
+        const parsedPath = path.parse(loggerModuleId)
         let fileId = parsedPath.name
         if (fileId === 'index') {
             // file with name "foobar/index.ts" -> "foobar"


### PR DESCRIPTION
This pull request updates the `Logger` utility to make its scoping more flexible and less dependent on NodeJS `module` objects.[^1] The changes allow the logger to be initialized with either a string or an object containing an `id`, making it easier to use in different contexts beyond just files or modules.

It is backward compatible.

### Changes

**Logger scope improvements:**

* Changed the `Logger` constructor to accept a `scope` parameter, which can be either a string or an object with an `id` property, instead of a `NodeJS.Module`. (`packages/utils/src/Logger.ts`)
* Updated the `Logger.createName` static method to handle the new `scope` type, extracting the identifier appropriately whether it's a string or an object. (`packages/utils/src/Logger.ts`)
* Introduced the `Scope` type alias for clarity and type safety. (`packages/utils/src/Logger.ts`)

### Future steps

* `module` is a Node-specific object and is not available in ES and browser making the logger hard to use in other environments without a polyfill. Next steps would be to stop initializing `Logger` with `module`, esp. in files targetting multiple environments – subject for a separate PR.

[^1]: Extracted (with changes) from #3279.