### PR TITLE
refactor: Remove .prettierrc (unused)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-    "tabWidth": 4,
-    "semi": false
-}


### PR DESCRIPTION
This pull request removes the unused `.prettierrc` configuration file, which previously specified code formatting rules for tab width and semicolon usage.

### Changes

* Deleted `.prettierrc`, removing custom Prettier settings for `tabWidth` and `semi`.