### PR TITLE
refactor: Import `WebSocketServer` properly

### DIFF
--- a/packages/dht/src/connection/websocket/WebsocketServer.ts
+++ b/packages/dht/src/connection/websocket/WebsocketServer.ts
@@ -1,7 +1,7 @@
 import { createServer as createHttpServer, Server as HttpServer, IncomingMessage, ServerResponse } from 'http'
 import { createServer as createHttpsServer, Server as HttpsServer } from 'https'
 import EventEmitter from 'eventemitter3'
-import WebSocket from 'ws'
+import WebSocket, { WebSocketServer } from 'ws'
 import { WebsocketServerConnection } from './WebsocketServerConnection'
 import { Logger, asAbortable } from '@streamr/utils'
 import { createSelfSignedCertificate } from '@streamr/autocertifier-client' 
@@ -29,7 +29,7 @@ interface Events {
 export class WebsocketServer extends EventEmitter<Events> {
 
     private httpServer?: HttpServer | HttpsServer
-    private wsServer?: WebSocket.Server
+    private wsServer?: WebSocketServer
     private readonly abortController = new AbortController()
     private readonly options: WebsocketServerOptions
 
@@ -154,9 +154,9 @@ export class WebsocketServer extends EventEmitter<Events> {
         })
     }
 
-    private createWsServer(): WebSocket.Server {
+    private createWsServer(): WebSocketServer {
         const maxPayload = this.options.maxMessageSize ?? 1048576
-        return this.wsServer = new WebSocket.Server({
+        return this.wsServer = new WebSocketServer({
             noServer: true,
             maxPayload
         })


### PR DESCRIPTION
Updates the `dht` package’s `WebsocketServer` to correctly use the named `WebSocketServer` export introduced in ws v8+, improving clarity and type consistency.

> [!NOTE]
> The current `WebSocket.Server` way works as long as we target CJS and not ESM. The new way works for both.

### Changes

- Updated `WebsocketServer.ts` (mind the low-key "s") to import the server using the proper `import { WebSocketServer } from 'ws'` syntax, distinguishing it from the WebSocket client type.
- Replaced all `WebSocket.Server` type references and instantiations with `WebSocketServer` for consistent and accurate typing.

