### PR TITLE
refactor: Reformat tsconfigs for consistency

### DIFF
--- a/packages/dht/tsconfig.jest.json
+++ b/packages/dht/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "noEmit": true,
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/dht/tsconfig.karma.json
+++ b/packages/dht/tsconfig.karma.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "dist",
     "noImplicitOverride": false,
-    "types": ["jest", "jest-extended"]
+    "types": [
+      "jest",
+      "jest-extended"
+    ]
   },
-  "include": ["src", "package.json"]
+  "include": [
+    "src",
+    "package.json"
+  ]
 }

--- a/packages/proto-rpc/tsconfig.jest.json
+++ b/packages/proto-rpc/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "noEmit": true,
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -1,11 +1,9 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "noEmit": true,
     "lib": ["es2021", "dom"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "resolveJsonModule": true,
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -6,7 +6,6 @@
     "lib": ["es2021", "dom"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "resolveJsonModule": true,
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/test-utils/tsconfig.node.json
+++ b/packages/test-utils/tsconfig.node.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "outDir": "dist",
-    "types": ["node", "jest"]
+    "types": [
+      "node",
+      "jest"
+    ]
   },
   "include": [
     "src"

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -1,8 +1,11 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "noEmit": true,
-    "types": ["node", "jest", "@streamr/test-utils/customMatcherTypes"],
+    "types": [
+      "node",
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
+    ],
     "noImplicitOverride": false
   },
   "include": [

--- a/packages/trackerless-network/tsconfig.karma.json
+++ b/packages/trackerless-network/tsconfig.karma.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "outDir": "dist",
     "noImplicitOverride": false,
-    "types": ["jest", "@streamr/test-utils/customMatcherTypes"]
+    "types": [
+      "jest",
+      "@streamr/test-utils/customMatcherTypes"
+    ]
   },
-  "include": ["src", "generated"]
+  "include": [
+    "src",
+    "generated"
+  ]
 }

--- a/packages/utils/tsconfig.karma.json
+++ b/packages/utils/tsconfig.karma.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "outDir": "dist",
     "noImplicitOverride": false,
-    "types": ["jest", "jest-extended"]
+    "types": [
+      "jest",
+      "jest-extended"
+    ]
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
This pull request mainly makes formatting and minor configuration changes to various TypeScript configuration files across several packages. The changes primarily involve expanding single-line arrays for `types` and `include` fields into multi-line arrays for improved readability, and removing some unused or redundant compiler options.

### Changes

These changes do not affect application logic but help keep configuration files clean and maintainable.

**Configuration formatting improvements:**

* Reformatted the `types` and `include` arrays in multiple `tsconfig.*.json` files (such as `tsconfig.karma.json` and `tsconfig.jest.json`) across `dht`, `proto-rpc`, `trackerless-network`, `test-utils`, and `utils` packages to use multi-line arrays for better readability. [[1]](diffhunk://#diff-ee756c159139fc121c7690550bbdedebbe93f791e29c68f80247e93b46a72287L6-R14) [[2]](diffhunk://#diff-274ea2b48801446350fe2f58d96391b905f2ad57ae138a9b998c5602ab2f873dL5-R8) [[3]](diffhunk://#diff-c14c2d64f2874f18ecea49d8f61528f5d0a7064ce5e125b3807f2c1dc3491d30L4-R8) [[4]](diffhunk://#diff-5c2698258694c8934a41c50bf6374b3340732bfc80bd5eb9a407c89d8b46d0b7L6-R14) [[5]](diffhunk://#diff-a9339bd6577b7c530e347d4f43de35b290cc6536979b7edf04bbd809a63a68a7L6-R13)

**Removal of unused or redundant compiler options:**

* Removed the `noEmit` compiler option from several `tsconfig.jest.json` files where it was unnecessary, such as in `dht`, `proto-rpc`, `sdk`, and `trackerless-network` packages. [[1]](diffhunk://#diff-57fd489a6641c04408b02f51816e203938c2d4d819f96f2aee228814678e7d9fL4) [[2]](diffhunk://#diff-1f70c1f766410506b8ac4d72e9e2cdf43c0dd3a95837202876180763d02093e2L4) [[3]](diffhunk://#diff-24db07be3ce94f0c29f9b1cdb5eb169b812640e615757b63168ec8eb28d605c6L4-L8) [[4]](diffhunk://#diff-c14c2d64f2874f18ecea49d8f61528f5d0a7064ce5e125b3807f2c1dc3491d30L4-R8)
* Removed the `resolveJsonModule` compiler option from `sdk/tsconfig.jest.json` and `sdk/tsconfig.node.json` as it was defined upstream. [[1]](diffhunk://#diff-24db07be3ce94f0c29f9b1cdb5eb169b812640e615757b63168ec8eb28d605c6L4-L8) [[2]](diffhunk://#diff-da4b27143d8b704c97435b2267bc2d9781d587007709041f823c4409fbb9001fL9)