### PR TITLE
refactor: Restore strict `noImplicitOverride` for packages with no protobuf code

### DIFF
--- a/packages/autocertifier-server/tsconfig.node.json
+++ b/packages/autocertifier-server/tsconfig.node.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "noImplicitOverride": false
+    "outDir": "dist"
   },
   "include": [
     "src",

--- a/packages/cdn-location/tsconfig.node.json
+++ b/packages/cdn-location/tsconfig.node.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "noImplicitOverride": false
+    "outDir": "dist"
   },
   "include": [
     "src"

--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -5,8 +5,7 @@
       "node",
       "jest",
       "@streamr/test-utils/customMatcherTypes"
-    ],
-    "noImplicitOverride": false
+    ]
   },
   "include": [
     "package.json",

--- a/packages/dht/tsconfig.karma.json
+++ b/packages/dht/tsconfig.karma.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
     "outDir": "dist",
-    "noImplicitOverride": false,
     "types": [
       "jest",
       "jest-extended"

--- a/packages/geoip-location/tsconfig.node.json
+++ b/packages/geoip-location/tsconfig.node.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "noImplicitOverride": false
+    "outDir": "dist"
   },
   "include": [
     "src"

--- a/packages/proto-rpc/tsconfig.karma.json
+++ b/packages/proto-rpc/tsconfig.karma.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
     "outDir": "dist",
-    "noImplicitOverride": false,
     "types": [
       "jest"
     ]

--- a/packages/trackerless-network/tsconfig.karma.json
+++ b/packages/trackerless-network/tsconfig.karma.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
     "outDir": "dist",
-    "noImplicitOverride": false,
     "types": [
       "jest",
       "@streamr/test-utils/customMatcherTypes"

--- a/packages/utils/tsconfig.karma.json
+++ b/packages/utils/tsconfig.karma.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
     "outDir": "dist",
-    "noImplicitOverride": false,
     "types": [
       "jest",
       "jest-extended"


### PR DESCRIPTION
This pull request removes the `noImplicitOverride` option from several TypeScript configuration files across multiple packages.

> [!NOTE]
> Previously, `noImplicitOverride` was explicitly set to `false` across the app. This was not a design choice, but a workaround: the auto-generated protobuf types were incompatible with `noImplicitOverride`, and there was no proper isolation at the tsconfig level to scope that limitation. As a result, stricter typing guarantees were relaxed&nbsp;globally.
>
> Change in this PR is a step towards bringing the restriction back, making the types stricter again.

### Changes

**TypeScript configuration cleanup:**

* Removed the `noImplicitOverride` option from `tsconfig.node.json` files in `autocertifier-server`, `cdn-location`, and `geoip-location` packages. [[1]](diffhunk://#diff-b8ca01c11975250ba2d1cf703ecb4dfb3a3197b14d1e0fb1c92cab47c0f393efL4-R4) [[2]](diffhunk://#diff-829757d9b00ea7fbff093ee2e216391cd3edcd5f46ddf05bde89e75eae6bfe83L4-R4) [[3]](diffhunk://#diff-12d458a7541ce0f79df26b4a0912690fb4f49f715022716a14e166027152cb5cL4-R4)
* Removed the `noImplicitOverride` option from `tsconfig.karma.json` files in `dht`, `proto-rpc`, `trackerless-network`, and `utils` packages. [[1]](diffhunk://#diff-ee756c159139fc121c7690550bbdedebbe93f791e29c68f80247e93b46a72287L5) [[2]](diffhunk://#diff-07b674f7bfb21f19369939a17a7a6ae2623d3b6de78fc89e1214d07764ef38c5L5) [[3]](diffhunk://#diff-5c2698258694c8934a41c50bf6374b3340732bfc80bd5eb9a407c89d8b46d0b7L5) [[4]](diffhunk://#diff-a9339bd6577b7c530e347d4f43de35b290cc6536979b7edf04bbd809a63a68a7L5)
* Removed the `noImplicitOverride` option from `tsconfig.jest.json` in the `cli-tools` package.