### PR TITLE
refactor: Unify Karma tsconfigs

### DIFF
--- a/packages/dht/tsconfig.karma.json
+++ b/packages/dht/tsconfig.karma.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "types": [
-      "jest",
-      "jest-extended"
-    ]
+    "outDir": "dist"
   },
   "include": [
     "src",

--- a/packages/proto-rpc/tsconfig.karma.json
+++ b/packages/proto-rpc/tsconfig.karma.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "types": [
-      "jest"
-    ]
+    "outDir": "dist"
   },
   "include": [
     "src"

--- a/packages/trackerless-network/tsconfig.karma.json
+++ b/packages/trackerless-network/tsconfig.karma.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "types": [
-      "jest",
-      "@streamr/test-utils/customMatcherTypes"
-    ]
+    "outDir": "dist"
   },
   "include": [
     "src",

--- a/packages/utils/tsconfig.karma.json
+++ b/packages/utils/tsconfig.karma.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.karma.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "types": [
-      "jest",
-      "jest-extended"
-    ]
+    "outDir": "dist"
   },
   "include": [
     "src"

--- a/tsconfig.karma.json
+++ b/tsconfig.karma.json
@@ -7,14 +7,6 @@
     "allowJs": true,
     "declaration": true,
     "lib": [
-      "ES5",
-      "ES2015",
-      "ES2016",
-      "ES2017",
-      "ES2018",
-      "ES2019",
-      "ES2020",
-      "ES2021",
       "ESNext",
       "DOM"
     ],

--- a/tsconfig.karma.json
+++ b/tsconfig.karma.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Browser – Streamr",
+  "display": "Browser - Streamr",
   "compilerOptions": {
     "target": "ES2015",
     "module": "commonjs",

--- a/tsconfig.karma.json
+++ b/tsconfig.karma.json
@@ -23,7 +23,11 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "isolatedModules": true,
-    "types": [],
+    "types": [
+      "jest",
+      "jest-extended",
+      "@streamr/test-utils/customMatcherTypes"
+    ],
     "sourceMap": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This pull request updates TypeScript configuration files related to testing, mainly by centralizing the configuration of type definitions for Karma tests. The main change is moving the specification of test-related type definitions from individual package-level `tsconfig.karma.json` files into the root `tsconfig.karma.json`, simplifying and unifying the configuration across packages.

### Changes

**Centralization and simplification of test type definitions:**

* The root `tsconfig.karma.json` now includes all necessary test-related type definitions (`jest`, `jest-extended`, and `@streamr/test-utils/customMatcherTypes`) in its `types` array, ensuring consistent type support for tests across all packages.
* The `display` field in the root `tsconfig.karma.json` was updated to use a hyphen instead of an en dash for consistency.

**Cleanup of package-level configurations:**

* Removed the `types` arrays from the `tsconfig.karma.json` files in `packages/dht`, `packages/proto-rpc`, `packages/trackerless-network`, and `packages/utils`, as these are now inherited from the root config. [[1]](diffhunk://#diff-ee756c159139fc121c7690550bbdedebbe93f791e29c68f80247e93b46a72287L4-R4) [[2]](diffhunk://#diff-07b674f7bfb21f19369939a17a7a6ae2623d3b6de78fc89e1214d07764ef38c5L4-R4) [[3]](diffhunk://#diff-5c2698258694c8934a41c50bf6374b3340732bfc80bd5eb9a407c89d8b46d0b7L4-R4)

**Other minor updates:**

* The root `tsconfig.karma.json` now only includes the latest ECMAScript and DOM libraries in its `lib` array, removing older versions for clarity and modernity[^1].

[^1]: `lib` field is cumulative – including `ESNext` (bleeding edge) means we implicitly include all previous.