### PR TITLE
refactor: Unify `types` for jest tsconfigs

### DIFF
--- a/packages/cli-tools/tsconfig.jest.json
+++ b/packages/cli-tools/tsconfig.jest.json
@@ -1,12 +1,5 @@
 {
   "extends": "../../tsconfig.jest.json",
-  "compilerOptions": {
-    "types": [
-      "node",
-      "jest",
-      "@streamr/test-utils/customMatcherTypes"
-    ]
-  },
   "include": [
     "package.json",
     "src",

--- a/packages/trackerless-network/tsconfig.jest.json
+++ b/packages/trackerless-network/tsconfig.jest.json
@@ -1,11 +1,6 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "types": [
-      "node",
-      "jest",
-      "@streamr/test-utils/customMatcherTypes"
-    ],
     "noImplicitOverride": false
   },
   "include": [

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -3,6 +3,11 @@
   "compilerOptions": {
     "noEmit": true,
     "isolatedModules": true,
-    "types": ["node", "jest", "jest-extended"]
+    "types": [
+      "node",
+      "jest",
+      "jest-extended",
+      "@streamr/test-utils/customMatcherTypes"
+    ]
   }
 }


### PR DESCRIPTION
This pull request updates TypeScript Jest configuration files to centralize and standardize the declaration of custom test utility types. The main change is moving the inclusion of `@streamr/test-utils/customMatcherTypes` from package-level configurations into the root `tsconfig.jest.json`, ensuring all packages consistently include these types during testing.

### Changes

**TypeScript Jest configuration updates:**

* Added `@streamr/test-utils/customMatcherTypes` to the `types` array in the root `tsconfig.jest.json` so that custom matcher types are available project-wide.
* Removed redundant `types` declarations from `packages/cli-tools/tsconfig.jest.json` and `packages/trackerless-network/tsconfig.jest.json` to rely on the centralized configuration. [[1]](diffhunk://#diff-198e2b7b2035fa308d0d3c58fddc55ee01229e98c40f7c40ac11cffb40092f83L3-L9) [[2]](diffhunk://#diff-c14c2d64f2874f18ecea49d8f61528f5d0a7064ce5e125b3807f2c1dc3491d30L4-L8)