### PR TITLE
refactor: Scope the usage of `disableSourceOfProjectReferenceRedirect` to packages where it's really needed

### DIFF
--- a/packages/cli-tools/tsconfig.node.json
+++ b/packages/cli-tools/tsconfig.node.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "disableSourceOfProjectReferenceRedirect": true
   },
   "include": [
     "package.json",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,8 +14,7 @@
     "sourceMap": true,
     "stripInternal": true,
     "useUnknownInCatchVariables": false,
-    "strictBindCallApply": true,
-    "disableSourceOfProjectReferenceRedirect": true
+    "strictBindCallApply": true
   }, 
   "lib": [
     "DOM"


### PR DESCRIPTION
This pull request updates TypeScript configuration to adjust how project reference redirects are handled. The main change is moving the `disableSourceOfProjectReferenceRedirect` option from the root `tsconfig.node.json` to the more specific `packages/cli-tools/tsconfig.node.json` configuration.

In essence, we don't want it enabled globally, and since the `cli-tools` is the only package that uses a private resource from another package (that it references) we can go with more accurate setup.

### Changes

**TypeScript configuration changes:**

* Removed `disableSourceOfProjectReferenceRedirect` from the root `tsconfig.node.json` to avoid globally disabling project reference redirects.
* Added `disableSourceOfProjectReferenceRedirect: true` to `packages/cli-tools/tsconfig.node.json` so that this setting only applies to the CLI tools package, providing more granular control.