### PR TITLE
refactor: Drop `"dom"` lib from SDK's TypeScript config and clarify environment usage

### DIFF
--- a/packages/sdk/src/encryption/RSAKeyPair.ts
+++ b/packages/sdk/src/encryption/RSAKeyPair.ts
@@ -1,3 +1,10 @@
+/**
+ * @todo This file contains code for both browser and Node.js environments. Consider
+ * making it environment-specific (using separate files or conditional exports), and
+ * remove the following "dom" lib reference when done.
+ */
+/// <reference lib="dom" />
+
 import crypto from 'crypto'
 import { promisify } from 'util'
 import { KeyExchangeKeyPair } from './KeyExchangeKeyPair'

--- a/packages/sdk/src/identity/ECDSAKeyPairIdentity.ts
+++ b/packages/sdk/src/identity/ECDSAKeyPairIdentity.ts
@@ -2,6 +2,7 @@ import { hexToBinary, EcdsaSecp256r1 } from '@streamr/utils'
 import { KeyPairIdentity } from './KeyPairIdentity'
 import { SignatureType } from '@streamr/trackerless-network'
 import { StrictStreamrClientConfig } from '../Config'
+import type { webcrypto } from 'crypto'
 
 const signingUtil = new EcdsaSecp256r1()
 
@@ -10,7 +11,7 @@ const signingUtil = new EcdsaSecp256r1()
  */
 export class ECDSAKeyPairIdentity extends KeyPairIdentity {
 
-    private cachedJWK: JsonWebKey | undefined
+    private cachedJWK: webcrypto.JsonWebKey | undefined
 
     assertValidKeyPair(): void {
         signingUtil.assertValidKeyPair(this.publicKey, this.privateKey)

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
-    "lib": ["es2021", "dom"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noImplicitOverride": false

--- a/packages/sdk/tsconfig.jest.json
+++ b/packages/sdk/tsconfig.jest.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.jest.json",
   "compilerOptions": {
+    "lib": ["es2021"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noImplicitOverride": false

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": "dist/types",
-    "lib": ["es2021", "dom"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noImplicitOverride": false

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "declarationDir": "dist/types",
+    "lib": ["es2021"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noImplicitOverride": false


### PR DESCRIPTION
This PR removes `"dom"` from SDK's TypeScript `lib` configuration to avoid pulling browser-specific types into the default scope. The SDK is not primarily a browser environment, and having DOM types globally available was masking environment boundaries and weakening type safety.

The remaining changes are necessary follow-ups to keep the codebase compiling and to make environment assumptions more explicit.

### Changes

**TypeScript configuration:**

* Removed `"dom"` from the `lib` array in both `tsconfig.json` and `tsconfig.jest.json` to better reflect the intended runtime environment and prevent accidental reliance on browser-only APIs.

**Type safety and cryptographic key handling:**

* Updated `cachedJWK` in `ECDSAKeyPairIdentity` from `JsonWebKey` to `webcrypto.JsonWebKey`.

* Explicitly imported the `webcrypto` type from Node’s `crypto` module to avoid relying on DOM-provided global types and to clarify the source of the API.

This ensures cryptographic types are correctly scoped and remain available after removing the DOM lib.

**Documentation and environment targeting:**

* Added a `@todo` comment and a local `dom` lib reference in `RSAKeyPair.ts` to document that the file currently mixes browser and Node.js code.

* This makes the environment dependency explicit and flags the file for future refactoring into environment-specific implementations.
