### PR TITLE
refactor: Clear jest's cache without validating jest configs

### DIFF
--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit test/integration",
     "test-unit": "jest test/unit",

--- a/packages/autocertifier-server/package.json
+++ b/packages/autocertifier-server/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit test/integration",
     "test-unit": "jest test/unit",

--- a/packages/cdn-location/package.json
+++ b/packages/cdn-location/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/integration",
     "test-integration": "jest test/integration",

--- a/packages/cdn-location/package.json
+++ b/packages/cdn-location/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/integration",
     "test-integration": "jest test/integration",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run build && jest --bail --forceExit"
   },

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run build && jest --bail --forceExit"
   },

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -27,7 +27,7 @@
     "build": "tsc -b",
     "build-browser": "webpack --mode=development --progress",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-browser": "karma start karma.config.ts",

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -27,7 +27,7 @@
     "build": "tsc -b",
     "build-browser": "webpack --mode=development --progress",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",
     "test-browser": "karma start karma.config.ts",

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit",
     "test-unit": "jest test/unit"

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit",
     "test-unit": "jest test/unit"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-sequential",
     "test-unit": "jest test/unit",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-sequential",
     "test-unit": "jest test/unit",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -22,7 +22,7 @@
     "build": "tsc -b",
     "build-browser": "webpack --mode=development --progress",
     "check": "./test-proto.sh && tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "./test-proto.sh && eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "./test-proto.sh && npm run test-unit && npm run test-integration",
     "test-browser": "./test-proto.sh && karma start karma.config.ts",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -22,7 +22,7 @@
     "build": "tsc -b",
     "build-browser": "webpack --mode=development --progress",
     "check": "./test-proto.sh && tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "./test-proto.sh && eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "./test-proto.sh && npm run test-unit && npm run test-integration",
     "test-browser": "./test-proto.sh && karma start karma.config.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,7 +37,7 @@
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist src/generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist src/generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts,mts}'",
     "generate-protoc-code": "./proto.sh",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,7 +37,7 @@
     "build-browser-development": "NODE_ENV=development webpack --mode=development --progress",
     "build-browser-production": "NODE_ENV=production webpack --mode=production --progress",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist src/generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist src/generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts,mts}'",
     "generate-protoc-code": "./proto.sh",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "test": "jest",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "test": "jest",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -21,7 +21,7 @@
     "build-browser": "webpack --mode=development --progress",
     "prebuild": "./proto.sh",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -21,7 +21,7 @@
     "build-browser": "webpack --mode=development --progress",
     "prebuild": "./proto.sh",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "coverage": "jest --coverage",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "npm run test-unit && npm run test-integration && npm run test-end-to-end",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",
     "test-browser": "karma start karma.config.ts"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -p tsconfig.jest.json",
-    "clean": "jest --clearCache --config '{}'; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
+    "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",
     "test-browser": "karma start karma.config.ts"


### PR DESCRIPTION
This pull request updates the `clean` script in the `package.json` files across multiple packages to improve how Jest's cache is cleared. The script now explicitly provides an empty config to the `jest --clearCache` command, which helps prevent issues if a local or default Jest config is missing or incompatible.

> [!IMPORTANT]
> It still clears the default cache directory, but! it does not care about config file validity.[^1]

### Changes

**Script improvements across all packages:**

* Updated the `clean` script in the following `package.json` files to use `jest --clearCache --config '{}'` instead of just `jest --clearCache`, ensuring Jest does not look for a config file when clearing its cache:
  - `packages/autocertifier-server/package.json`
  - `packages/cdn-location/package.json`
  - `packages/cli-tools/package.json`
  - `packages/dht/package.json`
  - `packages/geoip-location/package.json`
  - `packages/node/package.json`
  - `packages/proto-rpc/package.json`
  - `packages/sdk/package.json`
  - `packages/test-utils/package.json`
  - `packages/trackerless-network/package.json`
  - `packages/utils/package.json`

This also noticeably speeds up the cleanup process.

[^1]: Configs can \*become* invalid due to the processing order of the `npm run … --workspaces` command – `clean` command of the most "shared" test package (like `test-utils`) gets called first which may (will) in the future cause deletion of its jest setup files used by some packages in their jest setups (like custom matchers).