### PR TITLE
refactor: Use explicit module names instead of `module` for logging (round 2)

### DIFF
--- a/packages/dht/src/connection/webrtc/WebrtcConnector.ts
+++ b/packages/dht/src/connection/webrtc/WebrtcConnector.ts
@@ -21,7 +21,7 @@ import { acceptHandshake, createIncomingHandshaker, createOutgoingHandshaker, re
 import { isMaybeSupportedProtocolVersion } from '../../helpers/version'
 import { PendingConnection } from '../PendingConnection'
 
-const logger = new Logger(module)
+const logger = new Logger('WebrtcConnector')
 
 export const replaceInternalIpWithExternalIp = (candidate: string, ip: string): string => {
     const parsed = candidate.split(' ')

--- a/packages/sdk/test/browser-smoke-test/server.js
+++ b/packages/sdk/test/browser-smoke-test/server.js
@@ -3,7 +3,7 @@ const path = require('path')
 const express = require('express')
 const { Logger } = require('@streamr/utils')
 
-const logger = new Logger(module)
+const logger = new Logger('browser-smoke-test/server')
 const app = express()
 
 app.use('/static', express.static(path.join(__dirname, '/../../dist')))

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -90,7 +90,7 @@ describe('Logger', () => {
                 ? 'APP:Logger.test          '
                 : 'APP:Logger.test'
             process.env.STREAMR_APPLICATION_ID = 'APP'
-            expect(Logger.createName(module)).toBe(expected)
+            expect(Logger.createName('Logger.test')).toBe(expected)
             delete process.env.STREAMR_APPLICATION_ID
         })
         it('index', () => {

--- a/packages/utils/test/Logger.test.ts
+++ b/packages/utils/test/Logger.test.ts
@@ -17,7 +17,7 @@ describe('Logger', () => {
                 logs.push(pick(JSON.parse(data), ['level', 'msg']))
             }
         }
-        logger = new Logger('Logger', undefined, 'trace', pino({
+        logger = new Logger('Logger.test', undefined, 'trace', pino({
             level: 'trace',
             browser: {
                 write: (o) => {
@@ -83,14 +83,14 @@ describe('Logger', () => {
             const expected = typeof _streamr_electron_test === 'undefined'
                 ? 'Logger.test              '
                 : 'Logger.test'
-            expect(Logger.createName(module)).toBe(expected)
+            expect(Logger.createName('Logger.test.ts')).toBe(expected)
         })
         it('application id', () => {
             const expected = typeof _streamr_electron_test === 'undefined'
                 ? 'APP:Logger.test          '
                 : 'APP:Logger.test'
             process.env.STREAMR_APPLICATION_ID = 'APP'
-            expect(Logger.createName('Logger.test')).toBe(expected)
+            expect(Logger.createName('Logger.test.ts')).toBe(expected)
             delete process.env.STREAMR_APPLICATION_ID
         })
         it('index', () => {


### PR DESCRIPTION
This pull request primarily standardizes how loggers are initialized across the codebase by using explicit string names instead of the `module` object. This change improves clarity and consistency in log output, making it easier to identify log sources. Additionally, a related test has been updated to match the new logger initialization approach.

### Changes

**Logger initialization standardization:**

* Changed logger initialization in `WebrtcConnector.ts` to use the explicit string `'WebrtcConnector'` instead of passing the `module` object.
* Changed logger initialization in `browser-smoke-test/server.js` to use the explicit string `'browser-smoke-test/server'` instead of passing the `module` object.

**Test updates:**

* Updated the `Logger` test in `Logger.test.ts` to expect logger names created from strings instead of the `module` object.

### Future steps

* We may want to stick to string-based scopes/modules to be explicit. This way we could also simplify `Logger#createName`.