### PR TITLE
chore: Update browser test runner dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10224,9 +10224,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.11",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-            "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+            "version": "2.8.23",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
+            "integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
@@ -28832,7 +28832,6 @@
             "devDependencies": {
                 "@electron/rebuild": "^4.0.1",
                 "@jest/fake-timers": "^30.0.5",
-                "baseline-browser-mapping": "^2.9.11",
                 "buffer": "^6.0.3",
                 "electron": "^34.0.0",
                 "expect": "^30.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10224,9 +10224,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.23",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
-            "integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
+            "version": "2.9.11",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+            "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10224,9 +10224,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.23",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
-            "integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
+            "version": "2.9.11",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+            "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
@@ -28832,6 +28832,7 @@
             "devDependencies": {
                 "@electron/rebuild": "^4.0.1",
                 "@jest/fake-timers": "^30.0.5",
+                "baseline-browser-mapping": "^2.9.11",
                 "buffer": "^6.0.3",
                 "electron": "^34.0.0",
                 "expect": "^30.0.5",

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",
     "@jest/fake-timers": "^30.0.5",
-    "baseline-browser-mapping": "^2.9.11",
     "buffer": "^6.0.3",
     "electron": "^34.0.0",
     "expect": "^30.0.5",

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",
     "@jest/fake-timers": "^30.0.5",
+    "baseline-browser-mapping": "^2.9.11",
     "buffer": "^6.0.3",
     "electron": "^34.0.0",
     "expect": "^30.0.5",


### PR DESCRIPTION
Resolves the following warnings without adding `baseline-browser-mapping` as our own dev dep.

```
[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
```