### PR TITLE
refactor: Bundle `autocertifier-client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7361,9 +7361,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-            "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+            "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
             "cpu": [
                 "arm"
             ],
@@ -7375,9 +7375,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-            "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+            "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
             "cpu": [
                 "arm64"
             ],
@@ -7389,9 +7389,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-            "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+            "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
             "cpu": [
                 "arm64"
             ],
@@ -7403,9 +7403,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-            "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+            "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
             "cpu": [
                 "x64"
             ],
@@ -7417,9 +7417,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-            "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+            "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
             "cpu": [
                 "arm64"
             ],
@@ -7431,9 +7431,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-            "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+            "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
             "cpu": [
                 "x64"
             ],
@@ -7445,9 +7445,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-            "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+            "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
             "cpu": [
                 "arm"
             ],
@@ -7459,9 +7459,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-            "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+            "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
             "cpu": [
                 "arm"
             ],
@@ -7473,9 +7473,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-            "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+            "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7487,9 +7487,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-            "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+            "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
             "cpu": [
                 "arm64"
             ],
@@ -7501,9 +7501,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-            "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+            "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+            "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
             "cpu": [
                 "loong64"
             ],
@@ -7515,9 +7529,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-            "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+            "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+            "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
             "cpu": [
                 "ppc64"
             ],
@@ -7529,9 +7557,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-            "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+            "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
             "cpu": [
                 "riscv64"
             ],
@@ -7543,9 +7571,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-            "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+            "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
             "cpu": [
                 "riscv64"
             ],
@@ -7557,9 +7585,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-            "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+            "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
             "cpu": [
                 "s390x"
             ],
@@ -7571,9 +7599,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+            "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
             "cpu": [
                 "x64"
             ],
@@ -7585,9 +7613,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-            "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+            "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
             "cpu": [
                 "x64"
             ],
@@ -7598,10 +7626,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+            "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-            "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+            "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
             "cpu": [
                 "arm64"
             ],
@@ -7613,9 +7655,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-            "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+            "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
             "cpu": [
                 "arm64"
             ],
@@ -7627,9 +7669,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-            "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+            "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
             "cpu": [
                 "ia32"
             ],
@@ -7641,9 +7683,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+            "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
             "cpu": [
                 "x64"
             ],
@@ -7655,9 +7697,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-            "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+            "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
             "cpu": [
                 "x64"
             ],
@@ -25318,9 +25360,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-            "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+            "version": "4.55.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+            "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -25334,28 +25376,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.53.3",
-                "@rollup/rollup-android-arm64": "4.53.3",
-                "@rollup/rollup-darwin-arm64": "4.53.3",
-                "@rollup/rollup-darwin-x64": "4.53.3",
-                "@rollup/rollup-freebsd-arm64": "4.53.3",
-                "@rollup/rollup-freebsd-x64": "4.53.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-                "@rollup/rollup-linux-arm64-musl": "4.53.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-musl": "4.53.3",
-                "@rollup/rollup-openharmony-arm64": "4.53.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-                "@rollup/rollup-win32-x64-gnu": "4.53.3",
-                "@rollup/rollup-win32-x64-msvc": "4.53.3",
+                "@rollup/rollup-android-arm-eabi": "4.55.1",
+                "@rollup/rollup-android-arm64": "4.55.1",
+                "@rollup/rollup-darwin-arm64": "4.55.1",
+                "@rollup/rollup-darwin-x64": "4.55.1",
+                "@rollup/rollup-freebsd-arm64": "4.55.1",
+                "@rollup/rollup-freebsd-x64": "4.55.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+                "@rollup/rollup-linux-arm64-musl": "4.55.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+                "@rollup/rollup-linux-loong64-musl": "4.55.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+                "@rollup/rollup-linux-x64-gnu": "4.55.1",
+                "@rollup/rollup-linux-x64-musl": "4.55.1",
+                "@rollup/rollup-openbsd-x64": "4.55.1",
+                "@rollup/rollup-openharmony-arm64": "4.55.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+                "@rollup/rollup-win32-x64-gnu": "4.55.1",
+                "@rollup/rollup-win32-x64-msvc": "4.55.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -29817,7 +29862,93 @@
                 "node-forge": "^1.3.2"
             },
             "devDependencies": {
-                "@types/node-forge": "^1.3.14"
+                "@rollup/plugin-node-resolve": "^16.0.3",
+                "@types/node-forge": "^1.3.14",
+                "rimraf": "^6.1.2",
+                "rollup": "^4.55.1",
+                "rollup-plugin-dts": "^6.3.0",
+                "tsx": "^4.21.0"
+            }
+        },
+        "packages/autocertifier-client/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/autocertifier-client/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/autocertifier-client/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "packages/autocertifier-client/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/autocertifier-client/node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/autocertifier-server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30380,7 +30380,7 @@
                 "@types/md5": "^2.3.6",
                 "@types/secp256k1": "^4.0.7",
                 "rimraf": "^6.1.2",
-                "rollup": "^4.53.3",
+                "rollup": "^4.55.1",
                 "rollup-plugin-dts": "^6.3.0",
                 "tsx": "^4.21.0"
             }

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/autocertifier-client"
   },
   "main": "./dist/src/exports.cjs",
-  "module": "./dist/src/exports.js",
+  "module": "./dist/src/exports.mjs",
   "types": "./dist/src/exports.d.ts",
   "files": [
     "dist/src/exports.*",

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/autocertifier-client"
   },
   "main": "./dist/exports.cjs",
-  "module": "./dist/exports.mjs",
+  "module": "./dist/exports.js",
   "types": "./dist/exports.d.ts",
   "files": [
     "dist/exports.*",

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -7,15 +7,9 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/autocertifier-client"
   },
-  "exports": {
-    ".": {
-      "default": {
-        "types": "./dist/src/exports.d.ts",
-        "import": "./dist/src/exports.js",
-        "require": "./dist/src/exports.cjs"
-      }
-    }
-  },
+  "main": "./dist/src/exports.cjs",
+  "module": "./dist/src/exports.js",
+  "types": "./dist/src/exports.d.ts",
   "files": [
     "dist/src/exports.*",
     "!*.tsbuildinfo"

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -7,18 +7,27 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/autocertifier-client"
   },
-  "main": "dist/src/exports.js",
-  "types": "dist/src/exports.d.ts",
+  "exports": {
+    ".": {
+      "default": {
+        "types": "./dist/src/exports.d.ts",
+        "import": "./dist/src/exports.js",
+        "require": "./dist/src/exports.cjs"
+      }
+    }
+  },
   "files": [
-    "dist",
+    "dist/src/exports.*",
     "!*.tsbuildinfo"
   ],
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
-    "prebuild": "./proto.sh",
+    "prebuild": "npm run reset-self && ./proto.sh",
     "build": "tsc -b",
+    "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc --noEmit",
+    "reset-self": "rimraf --glob '**/*.tsbuildinfo'",
     "clean": "rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },
@@ -29,6 +38,11 @@
     "node-forge": "^1.3.2"
   },
   "devDependencies": {
-    "@types/node-forge": "^1.3.14"
+    "@rollup/plugin-node-resolve": "^16.0.3",
+    "@types/node-forge": "^1.3.14",
+    "rimraf": "^6.1.2",
+    "rollup": "^4.55.1",
+    "rollup-plugin-dts": "^6.3.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -7,11 +7,11 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/autocertifier-client"
   },
-  "main": "./dist/src/exports.cjs",
-  "module": "./dist/src/exports.mjs",
-  "types": "./dist/src/exports.d.ts",
+  "main": "./dist/exports.cjs",
+  "module": "./dist/exports.mjs",
+  "types": "./dist/exports.d.ts",
   "files": [
-    "dist/src/exports.*",
+    "dist/exports.*",
     "!*.tsbuildinfo"
   ],
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -9,16 +9,16 @@ export default defineConfig([
 
 function nodejs(): RollupOptions {
     return {
-        input: './dist/src/exports.js',
+        input: './dist/js/src/exports.js',
         output: [
             {
                 format: 'es',
-                file: './dist/src/exports.mjs',
+                file: './dist/exports.mjs',
                 sourcemap: true,
             },
             {
                 format: 'cjs',
-                file: './dist/src/exports.cjs',
+                file: './dist/exports.cjs',
                 sourcemap: true,
             },
         ],
@@ -36,10 +36,10 @@ function nodejs(): RollupOptions {
 
 function nodejsTypes(): RollupOptions {
     return {
-        input: './dist/src/exports.d.ts',
+        input: './dist/types/src/exports.d.ts',
         output: [
             {
-                file: './dist/src/exports.d.ts',
+                file: './dist/exports.d.ts',
             },
         ],
         plugins: [

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -13,7 +13,7 @@ function nodejs(): RollupOptions {
         output: [
             {
                 format: 'es',
-                file: './dist/exports.mjs',
+                file: './dist/exports.js',
                 sourcemap: true,
             },
             {

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -9,7 +9,7 @@ export default defineConfig([
 
 function nodejs(): RollupOptions {
     return {
-        input: './dist/js/src/exports.js',
+        input: './dist/src/exports.js',
         output: [
             {
                 format: 'es',
@@ -36,7 +36,7 @@ function nodejs(): RollupOptions {
 
 function nodejsTypes(): RollupOptions {
     return {
-        input: './dist/types/src/exports.d.ts',
+        input: './dist/src/exports.d.ts',
         output: [
             {
                 file: './dist/exports.d.ts',

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -1,0 +1,54 @@
+import { defineConfig, type RollupOptions } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+
+export default defineConfig([
+    nodejs(),
+    nodejsTypes(),
+])
+
+function nodejs(): RollupOptions {
+    return {
+        input: './dist/src/exports.js',
+        output: [
+            {
+                format: 'es',
+                file: './dist/src/exports.js',
+                sourcemap: true,
+            },
+            {
+                format: 'cjs',
+                file: './dist/src/exports.cjs',
+                sourcemap: true,
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: true,
+            }),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function nodejsTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports.d.ts',
+        output: [
+            {
+                file: './dist/src/exports.d.ts',
+            },
+        ],
+        plugins: [
+            nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -13,7 +13,7 @@ function nodejs(): RollupOptions {
         output: [
             {
                 format: 'es',
-                file: './dist/src/exports.js',
+                file: './dist/src/exports.mjs',
                 sourcemap: true,
             },
             {

--- a/packages/autocertifier-client/tsconfig.json
+++ b/packages/autocertifier-client/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+
+    /* Resolution */
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": "."
   },
   "include": [
     "src"

--- a/packages/autocertifier-client/tsconfig.json
+++ b/packages/autocertifier-client/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "dist/js",
+    "declarationDir": "dist/types",
 
     /* Resolution */
     "module": "preserve",

--- a/packages/autocertifier-client/tsconfig.json
+++ b/packages/autocertifier-client/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist/js",
-    "declarationDir": "dist/types",
+    "outDir": "dist",
 
     /* Resolution */
     "module": "preserve",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,18 +8,18 @@
     "directory": "packages/utils"
   },
   "main": "./dist/exports-nodejs.cjs",
-  "module": "./dist/exports-nodejs.mjs",
+  "module": "./dist/exports-nodejs.js",
   "types": "./dist/exports-nodejs.d.ts",
   "exports": {
     ".": {
       "browser": {
         "types": "./dist/exports-browser.d.ts",
-        "import": "./dist/exports-browser.mjs",
+        "import": "./dist/exports-browser.js",
         "require": "./dist/exports-browser.cjs"
       },
       "default": {
         "types": "./dist/exports-nodejs.d.ts",
-        "import": "./dist/exports-nodejs.mjs",
+        "import": "./dist/exports-nodejs.js",
         "require": "./dist/exports-nodejs.cjs"
       }
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -67,7 +67,7 @@
     "@types/md5": "^2.3.6",
     "@types/secp256k1": "^4.0.7",
     "rimraf": "^6.1.2",
-    "rollup": "^4.53.3",
+    "rollup": "^4.55.1",
     "rollup-plugin-dts": "^6.3.0",
     "tsx": "^4.21.0"
   }

--- a/packages/utils/rollup.config.mts
+++ b/packages/utils/rollup.config.mts
@@ -53,7 +53,7 @@ function nodejs(): RollupOptions {
         output: [
             {
                 format: 'es',
-                file: './dist/exports-nodejs.mjs',
+                file: './dist/exports-nodejs.js',
                 sourcemap: true,
             },
             {
@@ -83,7 +83,7 @@ function browser(): RollupOptions {
         output: [
             {
                 format: 'es',
-                file: './dist/exports-browser.mjs',
+                file: './dist/exports-browser.js',
                 sourcemap: true,
             },
             {


### PR DESCRIPTION
This pull request introduces a new bundling workflow for the `autocertifier-client` package, adding Rollup-based builds for both JavaScript and TypeScript types. It also updates the package configuration to support both CommonJS and ES module outputs, improves build script management, and refines the package's file exports for better distribution.

### Build system integration

* Added a new `rollup.config.mts` file to bundle both CommonJS (`exports.cjs`) and ES module (`exports.mjs`) outputs, as well as generate TypeScript type definitions using Rollup and relevant plugins.
* Updated `tsconfig.json` to use `module: preserve` and `moduleResolution: bundler` for compatibility with the new bundling setup.

### Package configuration improvements

* Modified `package.json` to specify both `main` (CommonJS) and `module` (ESM) entry points, and refined the `files` field to export only the necessary bundle outputs.
* Added new build scripts (`postbuild`, `reset-self`) and improved the build pipeline to include cleaning up build artifacts and running Rollup after TypeScript compilation.

### Dependency updates

* Added Rollup, plugins for node resolution and type definitions, `tsx`, and `rimraf` as development dependencies to support the new build process.