### PR TITLE
refactor: Bundle `browser-test-runner`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29987,6 +29987,7 @@
             "devDependencies": {
                 "@electron/rebuild": "^4.0.1",
                 "@jest/fake-timers": "^30.0.5",
+                "@rollup/plugin-node-resolve": "^16.0.3",
                 "buffer": "^6.0.3",
                 "electron": "^34.0.0",
                 "expect": "^30.0.5",
@@ -30000,8 +30001,93 @@
                 "karma-spec-reporter": "^0.0.36",
                 "karma-webpack": "^5.0.1",
                 "node-polyfill-webpack-plugin": "^4.1.0",
+                "rimraf": "^6.1.2",
+                "rollup": "^4.55.1",
+                "rollup-plugin-dts": "^6.3.0",
+                "tsx": "^4.21.0",
                 "webpack": "^5.103.0",
                 "webpack-cli": "^6.0.1"
+            }
+        },
+        "packages/browser-test-runner/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/browser-test-runner/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/browser-test-runner/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "packages/browser-test-runner/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/browser-test-runner/node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/cdn-location": {

--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -b",
     "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc --noEmit",
-    "reset-self": "rimraf --glob '**/*.tsbuildinfo'",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "clean": "rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -14,6 +14,7 @@
   "files": [
     "dist/exports.*",
     "dist/preload.cjs",
+    "dist/karma-setup.js",
     "!*.tsbuildinfo",
     "LICENSE"
   ],

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -8,18 +8,21 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/browser-test-runner"
   },
-  "main": "./dist/src/exports.js",
-  "browser": {
-    "./dist/src/exports.js": false
-  },
+  "main": "./dist/exports.cjs",
+  "module": "./dist/exports.js",
+  "types": "./dist/exports.d.ts",
   "files": [
-    "dist",
+    "dist/exports.*",
+    "dist/preload.cjs",
     "!*.tsbuildinfo",
     "LICENSE"
   ],
   "scripts": {
+    "prebuild": "npm run reset-self",
     "build": "tsc -b",
+    "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc --noEmit",
+    "reset-self": "rimraf --glob '**/*.tsbuildinfo'",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.network>",
@@ -27,6 +30,7 @@
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",
     "@jest/fake-timers": "^30.0.5",
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "buffer": "^6.0.3",
     "electron": "^34.0.0",
     "expect": "^30.0.5",
@@ -40,6 +44,10 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webpack": "^5.0.1",
     "node-polyfill-webpack-plugin": "^4.1.0",
+    "rimraf": "^6.1.2",
+    "rollup": "^4.55.1",
+    "rollup-plugin-dts": "^6.3.0",
+    "tsx": "^4.21.0",
     "webpack": "^5.103.0",
     "webpack-cli": "^6.0.1"
   }

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -22,7 +22,7 @@
     "build": "tsc -b",
     "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc --noEmit",
-    "reset-self": "rimraf --glob '**/*.tsbuildinfo'",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '**/*.{js,ts}'"
   },
   "author": "Streamr Network AG <contact@streamr.network>",

--- a/packages/browser-test-runner/package.json
+++ b/packages/browser-test-runner/package.json
@@ -14,7 +14,9 @@
   "files": [
     "dist/exports.*",
     "dist/preload.cjs",
+    "dist/preload.cjs.map",
     "dist/karma-setup.js",
+    "dist/karma-setup.js.map",
     "!*.tsbuildinfo",
     "LICENSE"
   ],

--- a/packages/browser-test-runner/rollup.config.mts
+++ b/packages/browser-test-runner/rollup.config.mts
@@ -42,6 +42,7 @@ function nodejs(): RollupOptions[] {
                 {
                     format: 'cjs',
                     file: './dist/preload.cjs',
+                    sourcemap: true,
                 },
             ],
         },
@@ -54,6 +55,7 @@ function nodejs(): RollupOptions[] {
                 {
                     format: 'es',
                     file: './dist/karma-setup.js',
+                    sourcemap: true,
                 },
             ],
             plugins: [

--- a/packages/browser-test-runner/rollup.config.mts
+++ b/packages/browser-test-runner/rollup.config.mts
@@ -1,0 +1,89 @@
+import { defineConfig, type RollupOptions } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+
+export default defineConfig([
+    ...nodejs(),
+    nodejsTypes(),
+])
+
+function nodejs(): RollupOptions[] {
+    return [
+        {
+            input: './dist/src/exports.js',
+            output: [
+                {
+                    format: 'es',
+                    file: './dist/exports.js',
+                    sourcemap: true,
+                },
+                {
+                    format: 'cjs',
+                    file: './dist/exports.cjs',
+                    sourcemap: true,
+                },
+            ],
+            plugins: [
+                nodeResolve({
+                    preferBuiltins: true,
+                }),
+            ],
+            external: [
+                /node_modules/,
+                /@streamr\//,
+            ],
+        },
+        {
+            /**
+             * We need a CJS preload file for Electron apps - that's the only format they support.
+             */
+            input: './dist/src/preload.js',
+            output: [
+                {
+                    format: 'cjs',
+                    file: './dist/preload.cjs',
+                },
+            ],
+        },
+        {
+            /**
+             * For Karma test runner. We only need ES module format here.
+             */
+            input: './dist/src/karma-setup.js',
+            output: [
+                {
+                    format: 'es',
+                    file: './dist/karma-setup.js',
+                },
+            ],
+            plugins: [
+                nodeResolve({
+                    preferBuiltins: true,
+                }),
+            ],
+            external: [
+                /node_modules/,
+                /@streamr\//,
+            ],
+        },
+    ]
+}
+
+function nodejsTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports.d.ts',
+        output: [
+            {
+                file: './dist/exports.d.ts',
+            },
+        ],
+        plugins: [
+            nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}

--- a/packages/browser-test-runner/rollup.config.mts
+++ b/packages/browser-test-runner/rollup.config.mts
@@ -45,6 +45,10 @@ function nodejs(): RollupOptions[] {
                     sourcemap: true,
                 },
             ],
+            external: [
+                /node_modules/,
+                /@streamr\//,
+            ],
         },
         {
             /**

--- a/packages/browser-test-runner/src/createKarmaConfig.ts
+++ b/packages/browser-test-runner/src/createKarmaConfig.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { fileURLToPath } from 'url'
 import type { Configuration, ExternalItem } from 'webpack'
 
 const DEBUG_MODE = process.env.BROWSER_TEST_DEBUG_MODE ?? false
@@ -6,7 +7,7 @@ const DEBUG_MODE = process.env.BROWSER_TEST_DEBUG_MODE ?? false
 export const createKarmaConfig = (
     testPaths: string[], webpackConfig: () => Configuration, localDirectory?: string
 ): (config: any) => any => {
-    const setupFiles = [__dirname + '/karma-setup.js']
+    const setupFiles = [fileURLToPath(new URL('./karma-setup.js', import.meta.url))]
 
     if (localDirectory !== undefined) {
         const localSetupFile = localDirectory + '/karma-setup.js'
@@ -58,7 +59,7 @@ export const createKarmaConfig = (
                     browserWindowOptions: {
                         webPreferences: {
                             contextIsolation: false,
-                            preload: __dirname + '/preload.js',
+                            preload: fileURLToPath(new URL('./preload.cjs', import.meta.url)),
                             webSecurity: false,
                             sandbox: false,
                             nodeIntegration: true

--- a/packages/browser-test-runner/src/createWebpackConfig.ts
+++ b/packages/browser-test-runner/src/createWebpackConfig.ts
@@ -44,7 +44,10 @@ export const createWebpackConfig = (
             resolve: {
                 extensions: ['.ts', '.js'],
                 alias,
-                fallback,
+                fallback: {
+                    timers: false,
+                    ...fallback
+                },
             },
             output: {
                 sourceMapFilename: `[name].[contenthash].js.map`,

--- a/packages/browser-test-runner/src/karma-setup.js
+++ b/packages/browser-test-runner/src/karma-setup.js
@@ -3,7 +3,7 @@
 
 import * as jestMock from 'jest-mock'
 
-const expect = require('expect').default
+import expect from 'expect'
 
 import { ModernFakeTimers } from '@jest/fake-timers'
 

--- a/packages/browser-test-runner/tsconfig.json
+++ b/packages/browser-test-runner/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+
+    /* Resolution */
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": "."
   },
   "include": [
     "src"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -b",
     "postbuild": "NODE_OPTIONS=\"--import tsx\" rollup -c rollup.config.mts",
     "check": "tsc -b tsconfig.jest.json",
-    "reset-self": "rimraf --glob '**/*.tsbuildinfo'",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest",


### PR DESCRIPTION
This pull request refactors the build and packaging process for the `browser-test-runner` package, introducing Rollup for bundling, improving module resolution, and updating various scripts and dependencies. The changes make the package outputs more consistent, enhance compatibility (especially for Electron and Karma), and modernize the codebase with ES module syntax and improved path handling.

## Changes

**Build & packaging improvements:**

* Added a new `rollup.config.mts` configuration to bundle outputs for CommonJS, ES modules, Electron preload, and type declarations using Rollup.
* Updated `package.json` to define `main`, `module`, and `types` entry points, specify more granular files for publishing, and add build scripts (`prebuild`, `postbuild`, `reset-self`).
* Added new devDependencies for Rollup, plugins, and build tooling in `package.json`.
* Updated `tsconfig.json` to use `"module": "preserve"` and `"moduleResolution": "bundler"` for better compatibility with modern bundlers.

**Code modernization & compatibility:**

* Switched from CommonJS `require` to ES module `import` syntax in `karma-setup.js` for `expect`.
* Improved path resolution in `createKarmaConfig.ts` to use `fileURLToPath` and `import.meta.url` for locating setup and preload files, ensuring compatibility with ESM and Electron environments. [[1]](diffhunk://#diff-ce10c51de1f8215dc5ff71f630122f7f6ed1d768f3c0e83f0978654b3ac3701fR2-R10) [[2]](diffhunk://#diff-ce10c51de1f8215dc5ff71f630122f7f6ed1d768f3c0e83f0978654b3ac3701fL61-R62)
* Updated `createWebpackConfig.ts` to explicitly set `timers: false` in the `fallback` object for module resolution.