### PR TITLE
refactor: Bundle `cdn-location`

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -6,6 +6,7 @@ RUN --mount=type=cache,target=/root/.npm \
 	npm run bootstrap-pkg --package=@streamr/utils && \
 	npm run bootstrap-pkg --package=@streamr/proto-rpc && \
 	npm run bootstrap-pkg --package=@streamr/autocertifier-client && \
+	npm run bootstrap-pkg --package=@streamr/cdn-location && \
 	npm run bootstrap-pkg --package=@streamr/dht && \
 	npm run bootstrap-pkg --package=@streamr/trackerless-network && \
 	npm run bootstrap-pkg --package=@streamr/sdk && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -30099,7 +30099,93 @@
                 "haversine": "^1.1.1"
             },
             "devDependencies": {
-                "@types/haversine": "^1.1.8"
+                "@rollup/plugin-node-resolve": "^16.0.3",
+                "@types/haversine": "^1.1.8",
+                "rimraf": "^6.1.2",
+                "rollup": "^4.55.1",
+                "rollup-plugin-dts": "^6.3.0",
+                "tsx": "^4.21.0"
+            }
+        },
+        "packages/cdn-location/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/cdn-location/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/cdn-location/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "packages/cdn-location/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/cdn-location/node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/cli-tools": {

--- a/packages/cdn-location/package.json
+++ b/packages/cdn-location/package.json
@@ -7,10 +7,11 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/cdn-location"
   },
-  "main": "dist/src/exports.js",
-  "types": "dist/src/exports.d.ts",
+  "main": "./dist/exports.cjs",
+  "module": "./dist/exports.js",
+  "types": "./dist/exports.d.ts",
   "files": [
-    "dist",
+    "dist/exports.*",
     "!*.tsbuildinfo",
     "README.md",
     "LICENSE"
@@ -18,8 +19,11 @@
   "license": "Apache-2.0",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
+    "prebuild": "npm run reset-self",
     "build": "tsc -b",
+    "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc -p tsconfig.jest.json",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/integration",
@@ -32,6 +36,11 @@
     "haversine": "^1.1.1"
   },
   "devDependencies": {
-    "@types/haversine": "^1.1.8"
+    "@rollup/plugin-node-resolve": "^16.0.3",
+    "@types/haversine": "^1.1.8",
+    "rimraf": "^6.1.2",
+    "rollup": "^4.55.1",
+    "rollup-plugin-dts": "^6.3.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/packages/cdn-location/rollup.config.mts
+++ b/packages/cdn-location/rollup.config.mts
@@ -1,0 +1,54 @@
+import { defineConfig, type RollupOptions } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+
+export default defineConfig([
+    nodejs(),
+    nodejsTypes(),
+])
+
+function nodejs(): RollupOptions {
+    return {
+        input: './dist/src/exports.js',
+        output: [
+            {
+                format: 'es',
+                file: './dist/exports.js',
+                sourcemap: true,
+            },
+            {
+                format: 'cjs',
+                file: './dist/exports.cjs',
+                sourcemap: true,
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: true,
+            }),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function nodejsTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports.d.ts',
+        output: [
+            {
+                file: './dist/exports.d.ts',
+            },
+        ],
+        plugins: [
+            nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}

--- a/packages/cdn-location/tsconfig.json
+++ b/packages/cdn-location/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+
+    /* Resolution */
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": "."
   },
   "include": [
     "src"


### PR DESCRIPTION
> [!NOTE]
> Looks like #3332 is too much at once - lotta failing tests and what not. I will deal with each of them packages separately.

This pull request updates the build and packaging setup for the `@streamr/cdn-location` package. The main improvements are the introduction of a Rollup build process to generate both CommonJS and ES module outputs, refined output file structure, and enhancements to the development workflow.

## Changes

**Build system and packaging improvements:**

* Added a new `rollup.config.mts` file to configure Rollup to bundle the package into both ES module (`exports.js`) and CommonJS (`exports.cjs`) formats, as well as to generate type declarations (`exports.d.ts`). This setup also marks dependencies as external to avoid bundling them.
* Updated `package.json` to point to the new output files, specify both `main` (CommonJS) and `module` (ESM) entry points, and restrict the published files to only the relevant outputs.
* Added Rollup and related plugins (`@rollup/plugin-node-resolve`, `rollup-plugin-dts`, `tsx`) as dev dependencies, and introduced a `postbuild` script to run Rollup after TypeScript compilation. Also added a `prebuild` script to clean up build info files.
* Updated `tsconfig.json` to use `"module": "preserve"` and `"moduleResolution": "bundler"` for better compatibility with the new bundling process.

**Monorepo integration:**

* Included `@streamr/cdn-location` in the monorepo bootstrap process in the root `Dockerfile.node`, ensuring it is built alongside other packages.