### PR TITLE
refactor: Bundle `geoip-location`

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/root/.npm \
 	npm run bootstrap-pkg --package=@streamr/proto-rpc && \
 	npm run bootstrap-pkg --package=@streamr/autocertifier-client && \
 	npm run bootstrap-pkg --package=@streamr/cdn-location && \
+	npm run bootstrap-pkg --package=@streamr/geoip-location && \
 	npm run bootstrap-pkg --package=@streamr/dht && \
 	npm run bootstrap-pkg --package=@streamr/trackerless-network && \
 	npm run bootstrap-pkg --package=@streamr/sdk && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -30282,9 +30282,95 @@
                 "uuid": "^11.1.0"
             },
             "devDependencies": {
+                "@rollup/plugin-node-resolve": "^16.0.3",
                 "@types/long-timeout": "^0.1.2",
                 "@types/tar": "^6.1.11",
-                "express": "^5.2.0"
+                "express": "^5.2.0",
+                "rimraf": "^6.1.2",
+                "rollup": "^4.55.1",
+                "rollup-plugin-dts": "^6.3.0",
+                "tsx": "^4.21.0"
+            }
+        },
+        "packages/geoip-location/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/geoip-location/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/geoip-location/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "packages/geoip-location/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/geoip-location/node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/node": {

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -11,11 +11,10 @@
   "module": "./dist/exports.js",
   "types": "./dist/exports.d.ts",
   "browser": {
-    "dist/exports.js": false
+    "./dist/exports.js": false
   },
   "files": [
-    "dist",
-    "!dist/src",
+    "dist/exports.*",
     "!*.tsbuildinfo",
     "README.md",
     "LICENSE"

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -10,6 +10,9 @@
   "main": "./dist/exports.cjs",
   "module": "./dist/exports.js",
   "types": "./dist/exports.d.ts",
+  "browser": {
+    "dist/exports.js": false
+  },
   "files": [
     "dist",
     "!dist/src",

--- a/packages/geoip-location/package.json
+++ b/packages/geoip-location/package.json
@@ -7,15 +7,12 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/geoip-location"
   },
-  "main": "dist/src/exports.js",
-  "browser": {
-    "dist/src/exports.js": false,
-    "dist/src/GeoIpLocator.js": false,
-    "dist/src/downloadGeoIpDatabase.js": false
-  },
-  "types": "dist/src/exports.d.ts",
+  "main": "./dist/exports.cjs",
+  "module": "./dist/exports.js",
+  "types": "./dist/exports.d.ts",
   "files": [
     "dist",
+    "!dist/src",
     "!*.tsbuildinfo",
     "README.md",
     "LICENSE"
@@ -23,8 +20,11 @@
   "license": "Apache-2.0",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
+    "prebuild": "npm run reset-self",
     "build": "tsc -b",
+    "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "tsc -p tsconfig.jest.json",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "clean": "jest --clearCache --config '{}' || true; rm -rf dist *.tsbuildinfo node_modules/.cache || true",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "jest test/unit",
@@ -39,8 +39,13 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/long-timeout": "^0.1.2",
     "@types/tar": "^6.1.11",
-    "express": "^5.2.0"
+    "express": "^5.2.0",
+    "rimraf": "^6.1.2",
+    "rollup": "^4.55.1",
+    "rollup-plugin-dts": "^6.3.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/packages/geoip-location/rollup.config.mts
+++ b/packages/geoip-location/rollup.config.mts
@@ -1,0 +1,52 @@
+import { defineConfig, type RollupOptions } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+
+export default defineConfig([
+    nodejs(),
+    nodejsTypes(),
+])
+
+function nodejs(): RollupOptions {
+    return {
+        input: './dist/src/exports.js',
+        output: [
+            {
+                format: 'es',
+                file: './dist/exports.js',
+                sourcemap: true,
+            },
+            {
+                format: 'cjs',
+                file: './dist/exports.cjs',
+                sourcemap: true,
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: true,
+            }),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function nodejsTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports.d.ts',
+        output: [
+            { file: './dist/exports.d.ts' },
+        ],
+        plugins: [
+            nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}

--- a/packages/geoip-location/tsconfig.json
+++ b/packages/geoip-location/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+
+    /* Resolution */
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": "."
   },
   "include": [
     "src"


### PR DESCRIPTION
This pull request introduces significant improvements to the build and packaging process for the `@streamr/geoip-location` package, including the addition of a Rollup build step, updates to the package entry points, and enhancements to development dependencies. These changes ensure better compatibility and distribution of the package in both CommonJS and ES module formats, streamline type definitions, and improve build script reliability.

**Build and packaging improvements:**

* Added a new Rollup configuration (`rollup.config.mts`) to bundle output files in both ES and CommonJS formats and to generate type definitions, improving compatibility and distribution.
* Updated the `package.json` entry points to explicitly specify CommonJS (`main`), ES module (`module`), and type definitions (`types`) outputs; adjusted the `files` field to exclude unnecessary files from the published package.
* Enhanced build scripts in `package.json` by adding `prebuild`, `postbuild`, and `reset-self` steps to automate cleaning and bundling, improving reliability and developer experience.

**Dependency and configuration updates:**

* Added development dependencies for Rollup, its plugins, and related utilities (`@rollup/plugin-node-resolve`, `rollup`, `rollup-plugin-dts`, `tsx`, `rimraf`) to support the new build process.
* Updated TypeScript configuration (`tsconfig.json`) to use `moduleResolution: bundler` and `module: preserve`, aligning with the new bundling approach.

**Integration:**

* Included the `@streamr/geoip-location` package in the Docker build process to ensure it is bootstrapped along with other packages.