### PR TITLE
Bundle `proto-rpc`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30369,13 +30369,99 @@
                 "uuid": "^11.1.0"
             },
             "devDependencies": {
+                "@rollup/plugin-node-resolve": "^16.0.3",
                 "@streamr/browser-test-runner": "^0.0.1",
                 "@streamr/test-utils": "103.2.0",
-                "@types/lodash": "^4.17.21"
+                "@types/lodash": "^4.17.21",
+                "rimraf": "^6.1.2",
+                "rollup": "^4.55.1",
+                "rollup-plugin-dts": "^6.3.0",
+                "tsx": "^4.21.0"
             },
             "optionalDependencies": {
                 "bufferutil": "^4.0.9",
                 "utf-8-validate": "^6.0.5"
+            }
+        },
+        "packages/proto-rpc/node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/proto-rpc/node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/proto-rpc/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "packages/proto-rpc/node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "packages/proto-rpc/node_modules/rimraf": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/sdk": {

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -7,9 +7,9 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/proto-rpc"
   },
-  "main": "./dist/src/exports.cjs",
-  "module": "./dist/src/exports.js",
-  "types": "./dist/src/exports.d.ts",
+  "main": "./dist/exports.cjs",
+  "module": "./dist/exports.js",
+  "types": "./dist/exports.d.ts",
   "files": [
     "dist/exports.*",
     "!*.tsbuildinfo",

--- a/packages/proto-rpc/package.json
+++ b/packages/proto-rpc/package.json
@@ -7,10 +7,11 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/proto-rpc"
   },
-  "main": "dist/src/exports.js",
-  "types": "dist/src/exports.d.ts",
+  "main": "./dist/src/exports.cjs",
+  "module": "./dist/src/exports.js",
+  "types": "./dist/src/exports.d.ts",
   "files": [
-    "dist",
+    "dist/exports.*",
     "!*.tsbuildinfo",
     "README.md",
     "LICENSE"
@@ -18,10 +19,11 @@
   "license": "(Apache-2.0 AND BSD-3-Clause)",
   "author": "Streamr Network AG <contact@streamr.network>",
   "scripts": {
-    "prebuild": "./proto.sh",
+    "prebuild": "npm run reset-self && ./proto.sh",
     "build": "tsc -b",
-    "build-browser": "webpack --mode=development --progress",
+    "postbuild": "NODE_OPTIONS='--import tsx' rollup -c rollup.config.mts",
     "check": "./test-proto.sh && tsc -b tsconfig.jest.json",
+    "reset-self": "rimraf --glob 'dist/**/*.tsbuildinfo'",
     "clean": "jest --clearCache --config '{}' || true; rm -rf dist generated *.tsbuildinfo node_modules/.cache || true",
     "eslint": "./test-proto.sh && eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'",
     "test": "./test-proto.sh && npm run test-unit && npm run test-integration",
@@ -38,9 +40,14 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "@streamr/browser-test-runner": "^0.0.1",
     "@streamr/test-utils": "103.2.0",
-    "@types/lodash": "^4.17.21"
+    "@types/lodash": "^4.17.21",
+    "rimraf": "^6.1.2",
+    "rollup": "^4.55.1",
+    "rollup-plugin-dts": "^6.3.0",
+    "tsx": "^4.21.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.9",

--- a/packages/proto-rpc/rollup.config.mts
+++ b/packages/proto-rpc/rollup.config.mts
@@ -1,0 +1,52 @@
+import { defineConfig, type RollupOptions } from 'rollup'
+import { dts } from 'rollup-plugin-dts'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+
+export default defineConfig([
+    nodejs(),
+    nodejsTypes(),
+])
+
+function nodejs(): RollupOptions {
+    return {
+        input: './dist/src/exports.js',
+        output: [
+            {
+                format: 'es',
+                file: './dist/exports.js',
+                sourcemap: true,
+            },
+            {
+                format: 'cjs',
+                file: './dist/exports.cjs',
+                sourcemap: true,
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: true,
+            }),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function nodejsTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports.d.ts',
+        output: [
+            { file: './dist/exports.d.ts' },
+        ],
+        plugins: [
+            nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}

--- a/packages/proto-rpc/tsconfig.json
+++ b/packages/proto-rpc/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+
+    /* Resolution */
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "baseUrl": "."
   },
   "include": [
     "src"


### PR DESCRIPTION
This pull request updates the build and packaging pipeline for the `proto-rpc` package to improve module output, type bundling, and cleanup. The changes introduce Rollup for bundling, refine the output structure, and add supporting scripts and dependencies.

**Build and packaging improvements:**

* Added a new `rollup.config.mts` configuration file to bundle both CommonJS (`exports.cjs`) and ES module (`exports.js`) outputs, as well as generate bundled type definitions (`exports.d.ts`).
* Updated `package.json` to point `main` to `./dist/src/exports.cjs`, add a `module` entry for ESM, and restrict the published files to only the bundled outputs.
* Added a `postbuild` script to run Rollup after TypeScript compilation, and a `reset-self` script to clean up build artifacts before building.

**Dependency updates:**

* Added build-related devDependencies: `rollup`, `rollup-plugin-dts`, `@rollup/plugin-node-resolve`, `tsx`, and `rimraf` for improved bundling and cleanup.

**TypeScript configuration:**

* Updated `tsconfig.json` to use `module: preserve` and `moduleResolution: bundler` to better support the new bundling workflow.