### PR TITLE
feat: Bundle a limited version of `autocertifier-client` for the browser

### DIFF
--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -7,11 +7,25 @@
     "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/autocertifier-client"
   },
-  "main": "./dist/exports.cjs",
-  "module": "./dist/exports.js",
-  "types": "./dist/exports.d.ts",
+  "main": "./dist/exports-nodejs.cjs",
+  "module": "./dist/exports-nodejs.js",
+  "types": "./dist/exports-nodejs.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/exports-nodejs.d.ts",
+      "browser": {
+        "types": "./dist/exports-browser.d.ts",
+        "import": "./dist/exports-browser.js",
+        "require": "./dist/exports-browser.cjs"
+      },
+      "import": "./dist/exports-nodejs.js",
+      "require": "./dist/exports-nodejs.cjs",
+      "default": "./dist/exports-nodejs.js"
+    }
+  },
   "files": [
-    "dist/exports.*",
+    "dist/exports-nodejs.*",
+    "dist/exports-browser.*",
     "!*.tsbuildinfo"
   ],
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",

--- a/packages/autocertifier-client/rollup.config.mts
+++ b/packages/autocertifier-client/rollup.config.mts
@@ -5,6 +5,8 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 export default defineConfig([
     nodejs(),
     nodejsTypes(),
+    browser(),
+    browserTypes(),
 ])
 
 function nodejs(): RollupOptions {
@@ -13,12 +15,12 @@ function nodejs(): RollupOptions {
         output: [
             {
                 format: 'es',
-                file: './dist/exports.js',
+                file: './dist/exports-nodejs.js',
                 sourcemap: true,
             },
             {
                 format: 'cjs',
-                file: './dist/exports.cjs',
+                file: './dist/exports-nodejs.cjs',
                 sourcemap: true,
             },
         ],
@@ -39,11 +41,61 @@ function nodejsTypes(): RollupOptions {
         input: './dist/src/exports.d.ts',
         output: [
             {
-                file: './dist/exports.d.ts',
+                file: './dist/exports-nodejs.d.ts',
             },
         ],
         plugins: [
             nodeResolve(),
+            dts(),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function browser(): RollupOptions {
+    return {
+        input: './dist/src/exports-browser.js',
+        output: [
+            {
+                format: 'es',
+                file: './dist/exports-browser.js',
+                sourcemap: true,
+            },
+            {
+                format: 'cjs',
+                file: './dist/exports-browser.cjs',
+                sourcemap: true,
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: false,
+                browser: true,
+            }),
+        ],
+        external: [
+            /node_modules/,
+            /@streamr\//,
+        ],
+    }
+}
+
+function browserTypes(): RollupOptions {
+    return {
+        input: './dist/src/exports-browser.d.ts',
+        output: [
+            {
+                file: './dist/exports-browser.d.ts',
+            },
+        ],
+        plugins: [
+            nodeResolve({
+                preferBuiltins: false,
+                browser: true,
+            }),
             dts(),
         ],
         external: [

--- a/packages/autocertifier-client/src/AutoCertifierClient.ts
+++ b/packages/autocertifier-client/src/AutoCertifierClient.ts
@@ -8,6 +8,7 @@ import { CertifiedSubdomain } from './data/CertifiedSubdomain'
 import fs from 'fs'
 import path from 'path'
 import * as forge from 'node-forge'
+import { SERVICE_ID } from './consts'
 
 interface AutoCertifierClientEvents {
     updatedCertificate: (domain: CertifiedSubdomain) => void
@@ -35,7 +36,6 @@ const getBaseDirectory = (directory: string): string => {
     return path.sep
 }
 
-export const SERVICE_ID = 'system/auto-certificer'
 const ONE_DAY = 1000 * 60 * 60 * 24
 const MAX_INT_32 = 2147483647
 

--- a/packages/autocertifier-client/src/consts.ts
+++ b/packages/autocertifier-client/src/consts.ts
@@ -1,0 +1,1 @@
+export const SERVICE_ID = 'system/auto-certificer'

--- a/packages/autocertifier-client/src/exports-browser.ts
+++ b/packages/autocertifier-client/src/exports-browser.ts
@@ -1,0 +1,3 @@
+export { SERVICE_ID } from './consts'
+export type { CertifiedSubdomain } from './data/CertifiedSubdomain'
+export type { AutoCertifierClient } from './AutoCertifierClient'

--- a/packages/autocertifier-client/src/exports.ts
+++ b/packages/autocertifier-client/src/exports.ts
@@ -1,5 +1,5 @@
 export { AutoCertifierClient, type HasSession } from './AutoCertifierClient'
-export { SERVICE_ID } from './consts' 
+export { SERVICE_ID } from './consts'
 export type { CertifiedSubdomain } from './data/CertifiedSubdomain'
 export type { Session } from './data/Session'
 export type { UpdateIpAndPortRequest } from './data/UpdateIpAndPortRequest'

--- a/packages/autocertifier-client/src/exports.ts
+++ b/packages/autocertifier-client/src/exports.ts
@@ -1,4 +1,5 @@
-export { AutoCertifierClient, SERVICE_ID, type HasSession } from './AutoCertifierClient'
+export { AutoCertifierClient, type HasSession } from './AutoCertifierClient'
+export { SERVICE_ID } from './consts' 
 export type { CertifiedSubdomain } from './data/CertifiedSubdomain'
 export type { Session } from './data/Session'
 export type { UpdateIpAndPortRequest } from './data/UpdateIpAndPortRequest'

--- a/packages/dht/karma.config.ts
+++ b/packages/dht/karma.config.ts
@@ -13,6 +13,12 @@ export default createKarmaConfig(
         libraryName: 'dht',
         alias: {
             /**
+             * Our "browser" tests use the Node.js build of `autocertifier-client` package – needed
+             * for certifications stuff, but still, very confusing.
+             */
+            '@streamr/autocertifier-client': resolve(__dirname, '../autocertifier-client/dist/exports-nodejs.cjs'),
+
+            /**
              * Selectively alias only browser-specific implementations here. The rest stays in `nodejs/`
              * because these (like WebsocketServer) are needed for testing and running WebSocket-based
              * code in Electron environment.

--- a/packages/dht/rollup.config.mts
+++ b/packages/dht/rollup.config.mts
@@ -114,7 +114,6 @@ function browser(): RollupOptions {
             /node_modules/,
             /@streamr\//,
         ],
-
     }
 }
 

--- a/packages/dht/src/browser/defaultAutoCertifierClientFactory.ts
+++ b/packages/dht/src/browser/defaultAutoCertifierClientFactory.ts
@@ -1,4 +1,4 @@
-import { AutoCertifierClient } from '@streamr/autocertifier-client'
+import type { AutoCertifierClient } from '@streamr/autocertifier-client'
 import { ListeningRpcCommunicator } from '../transport/ListeningRpcCommunicator'
 
 export const defaultAutoCertifierClientFactory = (


### PR DESCRIPTION
This pull request updates the `autocertifier-client` package to provide separate builds and type definitions for Node.js and browser environments, and refactors how the `SERVICE_ID` constant is exported. The changes improve compatibility, allow for better tree-shaking, and clarify the package's entry points for different platforms.

> [!note]
> This adds a very minimalistic set of features used by browser bundles of other packages.

## Changes

**Multi-platform build and exports:**

* The `package.json` now defines separate entry points and type definitions for Node.js (`exports-nodejs.*`) and browser (`exports-browser.*`) builds, and introduces an `exports` map to clarify usage in different environments.

* The Rollup configuration (`rollup.config.mts`) is updated to produce both Node.js and browser bundles and their corresponding type definitions, using separate output files for each platform. [[1]](diffhunk://#diff-aa7340f6df268dc8fead031bb0c353a91b48aaba1de3a92f4453e889522380baR8-R9) [[2]](diffhunk://#diff-aa7340f6df268dc8fead031bb0c353a91b48aaba1de3a92f4453e889522380baL16-R23) [[3]](diffhunk://#diff-aa7340f6df268dc8fead031bb0c353a91b48aaba1de3a92f4453e889522380baL42-R44) [[4]](diffhunk://#diff-aa7340f6df268dc8fead031bb0c353a91b48aaba1de3a92f4453e889522380baR57-R106)

**Exports and type improvements:**

* A new `exports-browser.ts` file is added to explicitly export `SERVICE_ID`, `CertifiedSubdomain`, and `AutoCertifierClient` types for browser consumers.

* The main `exports.ts` file now imports `SERVICE_ID` from a new `consts.ts` file, rather than directly from `AutoCertifierClient.ts`, improving modularity. [[1]](diffhunk://#diff-863c50d9a2d9e6354ead53c9a0774fc7b77195d1a0c810fccfbf8e7927003accL1-R2) [[2]](diffhunk://#diff-b305f800b166c6cb29b81990e96817430b44b06cca6151f539758e0d4255c468R1)

* The `SERVICE_ID` constant is moved from `AutoCertifierClient.ts` to a new `consts.ts` module and is imported where needed, clarifying its source and reducing coupling. [[1]](diffhunk://#diff-eb1e0fd9ae3d2c3a37ffef96ff63e73956c8926dcbe11a391e39d9c83d9aefd0R11) [[2]](diffhunk://#diff-eb1e0fd9ae3d2c3a37ffef96ff63e73956c8926dcbe11a391e39d9c83d9aefd0L38) [[3]](diffhunk://#diff-b305f800b166c6cb29b81990e96817430b44b06cca6151f539758e0d4255c468R1)

**Minor improvements:**

* The DHT package updates its imports to use `type`-only imports for `AutoCertifierClient`, improving type safety and clarity.

* Minor formatting cleanup in the DHT browser Rollup config.

## Things to know

* It may not be clear to the team that the Karma tests are a mixture of browser and NodeJS environments. Although Karma is meant to aim at the browser testing, there are 2 Karma setups now that explicitly point to NodeJS versions of other packages in order to work.

   1. `trackerless-network` points to NodeJS build of `dht`.
   2. `dht` points to NodeJS build of `autocertifier-client`.

   This does work, and is way easier to grasp if we talk about it openly and explicitly. And that's how the setups are now.

   We may want to address it as an issue in the future, and come up with much better separation though.   