### PR TITLE
refactor: Address feedback on bundles + minor tweaks

### DIFF
--- a/packages/dht/src/browser/createDefaultAutocertifierClient.ts
+++ b/packages/dht/src/browser/createDefaultAutocertifierClient.ts
@@ -1,7 +1,7 @@
 import type { AutoCertifierClient } from '@streamr/autocertifier-client'
 import { ListeningRpcCommunicator } from '../transport/ListeningRpcCommunicator'
 
-export const defaultAutoCertifierClientFactory = (
+export const createDefaultAutocertifierClient = (
     _configFile: string,
     _autoCertifierUrl: string,
     _autoCertifierRpcCommunicator: ListeningRpcCommunicator,

--- a/packages/dht/src/connection/websocket/AutoCertifierClientFacade.ts
+++ b/packages/dht/src/connection/websocket/AutoCertifierClientFacade.ts
@@ -5,7 +5,7 @@ import {
 import { ListeningRpcCommunicator } from '../../transport/ListeningRpcCommunicator'
 import { Logger, waitForEvent } from '@streamr/utils'
 import { ITransport } from '../../transport/ITransport' 
-import { defaultAutoCertifierClientFactory } from '@/defaultAutoCertifierClientFactory'
+import { createDefaultAutocertifierClient } from '@/createDefaultAutocertifierClient'
 
 const START_TIMEOUT = 60 * 1000
 
@@ -40,7 +40,7 @@ export class AutoCertifierClientFacade {
         this.options = options
         this.rpcCommunicator = new ListeningRpcCommunicator(AUTO_CERTIFIER_SERVICE_ID, options.transport)
         this.autoCertifierClient = options.createClientFactory ? options.createClientFactory() 
-            : defaultAutoCertifierClientFactory(
+            : createDefaultAutocertifierClient(
                 options.configFile,
                 options.url,
                 this.rpcCommunicator,

--- a/packages/dht/src/nodejs/createDefaultAutocertifierClient.ts
+++ b/packages/dht/src/nodejs/createDefaultAutocertifierClient.ts
@@ -6,7 +6,7 @@ import {
 } from '@streamr/autocertifier-client'
 import { ListeningRpcCommunicator } from '../transport/ListeningRpcCommunicator'
 
-export const defaultAutoCertifierClientFactory = (
+export const createDefaultAutocertifierClient = (
     configFile: string,
     autoCertifierUrl: string,
     autoCertifierRpcCommunicator: ListeningRpcCommunicator,

--- a/packages/utils/src/browser/crypto.ts
+++ b/packages/utils/src/browser/crypto.ts
@@ -6,6 +6,7 @@ import {
 import aesModes from 'browserify-aes/modes'
 import { sha1 } from '@noble/hashes/legacy.js'
 import type { Transform } from 'readable-stream'
+import { utf8ToBinary } from 'src/binaryUtils'
 
 export function getSubtle(): SubtleCrypto {
     const { crypto } = globalThis
@@ -26,7 +27,7 @@ export function computeMd5(input: string): Buffer {
 }
 
 export function computeSha1(input: string): Buffer {
-    return Buffer.from(sha1(new TextEncoder().encode(input)))
+    return Buffer.from(sha1(utf8ToBinary(input)))
 }
 
 export type Jwk = JsonWebKey

--- a/packages/utils/src/browser/crypto.ts
+++ b/packages/utils/src/browser/crypto.ts
@@ -6,7 +6,7 @@ import {
 import aesModes from 'browserify-aes/modes'
 import { sha1 } from '@noble/hashes/legacy.js'
 import type { Transform } from 'readable-stream'
-import { utf8ToBinary } from 'src/binaryUtils'
+import { utf8ToBinary } from '../binaryUtils'
 
 export function getSubtle(): SubtleCrypto {
     const { crypto } = globalThis


### PR DESCRIPTION
This pull request primarily refactors the naming and usage of the default AutoCertifier client factory functions for clarity and consistency, and makes a minor cryptographic utility update. The most important changes are grouped below.

### Refactoring and Consistency Improvements

* Renamed `defaultAutoCertifierClientFactory` to `createDefaultAutocertifierClient` in both `browser` and `nodejs` implementations, and updated all imports and usages accordingly for clarity and consistency. [[1]](diffhunk://#diff-acea4cfec95dcee32462af3b41a61f06b65b43b29d9aec7fba9af92b75afc309L4-R4) [[2]](diffhunk://#diff-3564c07adda6cca35da167730df18b4a93073619cad8b132a840fa129c2924f5L9-R9) [[3]](diffhunk://#diff-05c4f4f30929641c70e23ccb069dfaa5bd450bab1643a0f91fadaea4be72dddaL8-R8) [[4]](diffhunk://#diff-05c4f4f30929641c70e23ccb069dfaa5bd450bab1643a0f91fadaea4be72dddaL43-R43)

### Utility and Cryptography Updates

* Updated the `computeSha1` function in `crypto.ts` to use `utf8ToBinary` for string-to-binary conversion, improving encoding reliability. Also imported `utf8ToBinary` from `src/binaryUtils`. [[1]](diffhunk://#diff-285b8e8fa583afc20697242820c6adb2419720d1c2056c6ecb7d8617060c1a51R9) [[2]](diffhunk://#diff-285b8e8fa583afc20697242820c6adb2419720d1c2056c6ecb7d8617060c1a51L29-R30)