### PR TITLE
refactor: Explicit `node` exports for jest (mainly)

### DIFF
--- a/packages/autocertifier-client/package.json
+++ b/packages/autocertifier-client/package.json
@@ -18,6 +18,7 @@
         "import": "./dist/exports-browser.js",
         "require": "./dist/exports-browser.cjs"
       },
+      "node": "./dist/exports-nodejs.cjs",
       "import": "./dist/exports-nodejs.js",
       "require": "./dist/exports-nodejs.cjs",
       "default": "./dist/exports-nodejs.js"

--- a/packages/dht/package.json
+++ b/packages/dht/package.json
@@ -18,6 +18,7 @@
         "import": "./dist/exports-browser.js",
         "require": "./dist/exports-browser.cjs"
       },
+      "node": "./dist/exports-nodejs.cjs",
       "import": "./dist/exports-nodejs.js",
       "require": "./dist/exports-nodejs.cjs",
       "default": "./dist/exports-nodejs.js"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,18 +13,21 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "node": "./dist/index.cjs",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./setupCustomMatchers": {
       "types": "./dist/setupCustomMatchers.d.ts",
+      "node": "./dist/setupCustomMatchers.cjs",
       "import": "./dist/setupCustomMatchers.js",
       "require": "./dist/setupCustomMatchers.cjs",
       "default": "./dist/setupCustomMatchers.js"
     },
     "./customMatchers": {
       "types": "./dist/customMatchers.d.ts",
+      "node": "./dist/customMatchers.cjs",
       "import": "./dist/customMatchers.js",
       "require": "./dist/customMatchers.cjs",
       "default": "./dist/customMatchers.js"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,8 @@
       "browser": {
         "types": "./dist/exports-browser.d.ts",
         "import": "./dist/exports-browser.js",
-        "require": "./dist/exports-browser.cjs"
+        "require": "./dist/exports-browser.cjs",
+        "default": "./dist/exports-browser.js"
       },
       "node": "./dist/exports-nodejs.cjs",
       "import": "./dist/exports-nodejs.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,10 @@
         "import": "./dist/exports-browser.js",
         "require": "./dist/exports-browser.cjs"
       },
+      "node": "./dist/exports-nodejs.cjs",
       "import": "./dist/exports-nodejs.js",
-      "require": "./dist/exports-nodejs.cjs"
+      "require": "./dist/exports-nodejs.cjs",
+      "default": "./dist/exports-nodejs.js"
     }
   },
   "files": [


### PR DESCRIPTION
This pull request updates the `exports` fields in several `package.json` files to explicitly add a `"node"` export condition for Node.js-specific builds. This improves compatibility and clarity when these packages are imported in different environments, ensuring that the correct entry points are used for Node.js.

**Package export improvements:**

* Added a `"node"` export condition pointing to the Node.js CommonJS build in `packages/autocertifier-client/package.json`, `packages/dht/package.json`, and `packages/utils/package.json` to clarify and standardize Node.js entry points. [[1]](diffhunk://#diff-ce36aa2971623458d0b35543ec3caf4e8df12445e570d4c599e3142a79b87de5R21) [[2]](diffhunk://#diff-48deceddbbe98a41ff1d0f560db132548031fbd96d790c09ffeed924a20e8a05R21) [[3]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053R21-R24)
* Updated `packages/test-utils/package.json` to add `"node"` export conditions for the main entry and sub-exports (`./setupCustomMatchers`, `./customMatchers`), ensuring correct resolution in Node.js environments.