### PR TITLE
feat(autocertifier-server): Delete unused DNS records in batches from Route53

### DIFF
--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -118,7 +118,7 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
         if (this.route53Api !== undefined) {
             const subdomains = await this.database!.getSubdomainsByIpAndPort(ipAddress, streamrWebSocketPort)
             logger.info('Deleting all subdomains from ip: ' + ipAddress + ' port: ' 
-                + streamrWebSocketPort + ' number of subdomains: ' + subdomains.length, { subdomains })
+                + streamrWebSocketPort + ' number of subdomains: ' + subdomains.length)
             await this.route53Api.deleteRecords(
                 RRType.A,
                 subdomains.map((subdomain) => {

--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -129,10 +129,12 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
                 }),
                 300
             )
+            logger.info('Upserting record to route53: ' + fqdn + ' with ip: ' + ipAddress)
             await this.route53Api.upsertRecord(RRType.A, fqdn, ipAddress, 300)
         }
-
+        logger.info('Creating certificate for ' + fqdn + ' with ip: ' + ipAddress)
         const certificate = await this.certificateCreator!.createCertificate(fqdn)
+        logger.info('Certificate created for ' + fqdn + ' with ip: ' + ipAddress)
         return {
             fqdn,
             authenticationToken,

--- a/packages/autocertifier-server/src/Route53Api.ts
+++ b/packages/autocertifier-server/src/Route53Api.ts
@@ -56,8 +56,12 @@ export class Route53Api {
         return this.changeRecords(ChangeAction.UPSERT, recordType, [ { fqdn, value } ], ttl)
     }
 
-    public async deleteRecord(recordType: RRType, fqdn: string, value: string, ttl: number): Promise<ChangeResourceRecordSetsCommandOutput> {
-        return this.changeRecords(ChangeAction.DELETE, recordType, [ { fqdn, value } ], ttl)
+    public async deleteRecords(
+        recordType: RRType,
+        records: { fqdn: string, value: string }[],
+        ttl: number
+    ): Promise<ChangeResourceRecordSetsCommandOutput> {
+        return this.changeRecords(ChangeAction.DELETE, recordType, records, ttl)
     }
 
     // Debugging tool to list all records in a zone


### PR DESCRIPTION
## Summary

We are hitting rate limits with Route53 in the autocertifier server. We used to send individual queries to delete records from Route53. Now instead the records to delete are sent in a single request. The changes also include increased logging to make debugging of failing creation of subdomains and certificates more apparent.
