### PR TITLE
fix(autocertifier-server): Wait for acme-challenge record to propagate

### DIFF
--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -4,7 +4,7 @@ import { RestInterface } from './RestInterface'
 import { RestServer } from './RestServer'
 import { v4 } from 'uuid'
 import { CertifiedSubdomain, Session } from '@streamr/autocertifier-client'
-import { Logger } from '@streamr/utils'
+import { Logger, wait } from '@streamr/utils'
 import { CertificateCreator } from './CertificateCreator'
 import { runStreamrChallenge } from './StreamrChallenger'
 import 'dotenv/config'
@@ -200,6 +200,7 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
             logger.trace(`Creating acme challenge for ${fqdn} with value ${value} to Route53`)
             await this.route53Api.upsertRecord(RRType.TXT, '_acme-challenge' + '.' + fqdn, `"${value}"`, 300)
         }
+        await wait(15000)
     }
 
     // ChallengeManager implementation


### PR DESCRIPTION
## Summary

Wait for 15 seconds after adding an acme-challenge record to wait for the change to propagate. This fixes the following errors:
`Failed to create certificate for 12b93fa1-2eb1-4540-a64b-84829f9cc507.streamr-nodes.xyz with ip: 95.216.15.80 error: Error: Error while resolving DNS TXT records for _acme-challenge.12b93fa1-2eb1-4540-a64b-84829f9cc507.streamr-nodes.xyz.`

`Failed to create certificate for 827b7512-342d-48f2-9481-bdcdb1e05597.streamr-nodes.xyz with ip: 95.216.15.80 error: Error: Did not find challenge value in TXT record.`
