### PR TITLE
fix: Fix incorrect header image URL in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes before Tatum release are not documented in this file.
 
 #### Fixed
 
-- Fix outdated GitHub URLs referencing old `network-monorepo` repository instead of `network`
+- Fix outdated GitHub URLs referencing old `network-monorepo` repository instead of `network` (https://github.com/streamr-dev/network/pull/3348)
 
 ### @streamr/sdk
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changes before Tatum release are not documented in this file.
 
 ## [Unreleased]
 
+### General
+
+#### Fixed
+
+- Fix outdated GitHub URLs referencing old `network-monorepo` repository instead of `network`
+
 ### @streamr/sdk
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://streamr.network">
-    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network-monorepo/main/packages/sdk/readme-header.png" width="1320" />
+    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network/main/packages/sdk/readme-header.png" width="1320" />
   </a>
 </p>
 

--- a/docs/docs/guides/use-any-language-or-device.md
+++ b/docs/docs/guides/use-any-language-or-device.md
@@ -148,7 +148,7 @@ For URL authentication, for example `mqtt://"":ApiKey@1.2.3.4:1883`. Some MQTT l
 
 :::note
 If you're connecting to the MQTT interface over the open internet, please remember to make sure the port is open.
-Technical information about the plugin interface can be found in the [Streamr node plugin docs](https://github.com/streamr-dev/network-monorepo/blob/main/packages/broker/plugins.md).
+Technical information about the plugin interface can be found in the [Streamr node plugin docs](https://github.com/streamr-dev/network/blob/main/packages/node/plugins.md).
 :::
 
 #### Start pushing data
@@ -168,7 +168,7 @@ await mqttClient.publish(StreamId, JSON.stringify({ foo: bar }))
 
 If everything has been configured correctly so far then the data should now be flowing to the Streamr node, which will receive and sign the data, then publish it to the to the Streamr Network stream.
 
-At this point, you could use the Streamr [CLI tool](https://github.com/streamr-dev/network-monorepo/tree/main/packages/cli-tools) to subscribe to stream and observe the message flow:
+At this point, you could use the Streamr [CLI tool](https://github.com/streamr-dev/network/tree/main/packages/cli-tools) to subscribe to stream and observe the message flow:
 
 ```shell
 $ npm install -g @streamr/cli-tools

--- a/docs/docs/usage/cli-tool.md
+++ b/docs/docs/usage/cli-tool.md
@@ -196,7 +196,7 @@ The `--config` argument tries to read a configuration file from the current work
 
 If no `--config` argument is specified, default settings are read from `~/.streamr/config/default.json`, if that file exists.
 
-The configuration file is a JSON. It has one root-level property `client`, which contains any configuration properties for the [streamr-sdk-javascript](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/) client. Example:
+The configuration file is a JSON. It has one root-level property `client`, which contains any configuration properties for the [streamr-sdk-javascript](https://github.com/streamr-dev/network/blob/main/packages/sdk/) client. Example:
 
 ```
 {

--- a/packages/cli-tools/README.md
+++ b/packages/cli-tools/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://streamr.network">
-    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network-monorepo/main/packages/client/readme-header.png" width="1320" />
+    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network/main/packages/sdk/readme-header.png" width="1320" />
   </a>
 </p>
 
@@ -175,7 +175,7 @@ The `--config` argument tries to read a configuration file from the current work
 
 If no `--config` argument is specified, default settings are read from `~/.streamr/config/default.json`, if that file exists.
 
-The configuration file is a JSON. It has one root-level property `client`, which contains any configuration properties for the [@streamr/sdk](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/). Example:
+The configuration file is a JSON. It has one root-level property `client`, which contains any configuration properties for the [@streamr/sdk](https://github.com/streamr-dev/network/blob/main/packages/sdk/). Example:
 ```
 {
     "client": {

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://streamr.network">
-    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network-monorepo/main/packages/client/readme-header.png" width="1320" />
+    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network/main/packages/sdk/readme-header.png" width="1320" />
   </a>
 </p>
 

--- a/packages/node/plugins.md
+++ b/packages/node/plugins.md
@@ -122,7 +122,7 @@ If you want to publish or subscribe to a specific partition of a stream, you can
 
 - `/streams/:streamId/subscribe?partitions=0,2,5`: subscribes to given partition numbers
 - `/streams/:streamId/publish?partition=2`: publishes to given partition number
-- `/streams/:streamId/publish?partitionKey=foo`: use the given key to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams))
+- `/streams/:streamId/publish?partitionKey=foo`: use the given key to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network/blob/main/packages/sdk/README.md#publishing-to-partitioned-streams))
 - `/streams/:streamId/publish?partitionKeyField=customerId`: use the given field in a JSON to choose the `paritionKey` (e.g. `{ "customerId": "foo", ...  }` -> `paritionKey` is `foo`)
 
 By default, partition `0` is selected.
@@ -292,7 +292,7 @@ http://localhost:7171/streams/foo.eth%2fbar
 The endpoint supports the following optional query parameters:
 
 - `timestamp` can be used to set the message timestamp explicitly. The timestamp should be passed in ISO-8601 string (e.g. `2001-02-03T04:05:06Z`), or as milliseconds since epoch, e.g. `1234567890000`
-- `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network-monorepo/blob/main/packages/client/README.md#publishing-to-partitioned-streams)). The default (in case neither is provided) is to select a random partition for each message.
+- `partition` (explicit partition number) or `partitionKey` (a string which used to calculate the partition number, [see JS-client for details](https://github.com/streamr-dev/network/blob/main/packages/sdk/README.md#publishing-to-partitioned-streams)). The default (in case neither is provided) is to select a random partition for each message.
 
 #### Port
 

--- a/packages/node/src/broker.ts
+++ b/packages/node/src/broker.ts
@@ -66,7 +66,7 @@ export const createBroker = async (configWithoutDefaults: Config): Promise<Broke
             if (!streamrClient.getConfig().network.controlLayer.webrtcAllowPrivateAddresses) {
                 logger.warn('WebRTC private address probing is disabled. ' +
                     'This makes it impossible to create network layer connections directly via local routers ' +
-                    'More info: https://github.com/streamr-dev/network-monorepo/wiki/WebRTC-private-addresses')
+                    'More info: https://github.com/streamr-dev/network/wiki/WebRTC-private-addresses')
             }
         },
         stop: async () => {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://streamr.network">
-    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network-monorepo/main/packages/client/readme-header.png" width="600" />
+    <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/network/main/packages/sdk/readme-header.png" width="600" />
   </a>
 </p>
 
@@ -9,7 +9,7 @@
 </h1>
 
 ![latest npm package version](https://img.shields.io/npm/v/@streamr/sdk?label=latest)
-![GitHub stars](https://img.shields.io/github/stars/streamr-dev/network-monorepo?style=social)
+![GitHub stars](https://img.shields.io/github/stars/streamr-dev/network?style=social)
 [![Discord Chat](https://img.shields.io/discord/801574432350928907.svg?label=Discord&logo=Discord&colorB=7289da)](https://discord.gg/FVtAph9cvz)
 
 The Streamr SDK allows you to interact with the [Streamr Network](https://streamr.network) from JavaScript-based environments, such as browsers and [Node.js](https://nodejs.org). This library contains convenience functions for creating and managing streams on the Streamr Network.

--- a/packages/trackerless-network/package.json
+++ b/packages/trackerless-network/package.json
@@ -4,7 +4,7 @@
   "description": "Minimal and extendable implementation of the Streamr Network node.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/streamr-dev/network-monorepo.git",
+    "url": "git+https://github.com/streamr-dev/network.git",
     "directory": "packages/trackerless-network"
   },
   "main": "dist/src/exports.js",


### PR DESCRIPTION
This pull request updates documentation and metadata references throughout the codebase to point to the new `streamr-dev/network` repository, replacing outdated references to `network-monorepo`. The changes primarily affect README files, documentation, and code comments, ensuring consistency and accuracy for users and developers.

**Repository and asset references:**

* Updated all image and asset URLs in `README.md` files (`packages/sdk/README.md`, `packages/node/README.md`, `packages/cli-tools/README.md`, and root `README.md`) to point to the new repository structure and correct asset locations. [[1]](diffhunk://#diff-fb389a13c110d5b92cb85e2a1eb937b649ff8adc09a19626ab6cbc9218bb6d83L3-R3) [[2]](diffhunk://#diff-28333700bd7300f8ced1811261b0deb467d583021c08e658ad82f0134a08d25fL3-R3) [[3]](diffhunk://#diff-3c4d1a5ee1333e9210e8774c0f5d67695ad9c409cbee0d43cb368ae443cf2dd5L3-R3) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3)

**Documentation links:**

* Changed all documentation links in markdown files (`docs/docs/guides/use-any-language-or-device.md`, `docs/docs/usage/cli-tool.md`, `packages/node/plugins.md`, `packages/cli-tools/README.md`) to reference the updated repository and directory structure. [[1]](diffhunk://#diff-a5ff983d372be965158bc6a2803874015f87ed46921cfb56386e439f86fbce18L151-R151) [[2]](diffhunk://#diff-a5ff983d372be965158bc6a2803874015f87ed46921cfb56386e439f86fbce18L171-R171) [[3]](diffhunk://#diff-23f4f563592c7d42eb886fa58e5756bf97d0b28568ac836d5299a0424c8c818eL199-R199) [[4]](diffhunk://#diff-3c4d1a5ee1333e9210e8774c0f5d67695ad9c409cbee0d43cb368ae443cf2dd5L178-R178) [[5]](diffhunk://#diff-25c8e4e9c25343cd6cf286d359fad01e70e5f36bb07a28c7476ad2bc0343db51L125-R125) [[6]](diffhunk://#diff-25c8e4e9c25343cd6cf286d359fad01e70e5f36bb07a28c7476ad2bc0343db51L295-R295)

**Metadata updates:**

* Updated the repository URL in `packages/trackerless-network/package.json` to point to the new GitHub repository.

**Badge and social links:**

* Fixed badge and social links in `packages/sdk/README.md` to reflect the new repository name.

**Code comments:**

* Updated a code comment in `packages/node/src/broker.ts` to reference the correct Wiki location.