### PR TITLE
fix(auto certifier-server): Add error handling for delete records operation

### DIFF
--- a/packages/autocertifier-server/src/AutoCertifierServer.ts
+++ b/packages/autocertifier-server/src/AutoCertifierServer.ts
@@ -119,16 +119,20 @@ export class AutoCertifierServer implements RestInterface, ChallengeManager {
             const subdomains = await this.database!.getSubdomainsByIpAndPort(ipAddress, streamrWebSocketPort)
             logger.info('Deleting all subdomains from ip: ' + ipAddress + ' port: ' 
                 + streamrWebSocketPort + ' number of subdomains: ' + subdomains.length)
-            await this.route53Api.deleteRecords(
-                RRType.A,
-                subdomains.map((subdomain) => {
-                    return {
-                        fqdn: subdomain.subdomainName + '.' + this.domainName,
-                        value: ipAddress,
-                    }
-                }),
-                300
-            )
+            try {
+                await this.route53Api.deleteRecords(
+                    RRType.A,
+                    subdomains.map((subdomain) => {
+                        return {
+                            fqdn: subdomain.subdomainName + '.' + this.domainName,
+                            value: ipAddress,
+                        }
+                    }),
+                    300
+                )
+            } catch (err) {
+                logger.warn('Error deleting records from route53: ' + ipAddress + ' error: ' + err)
+            }
             logger.info('Upserting record to route53: ' + fqdn + ' with ip: ' + ipAddress)
             await this.route53Api.upsertRecord(RRType.A, fqdn, ipAddress, 300)
         }


### PR DESCRIPTION
## Summary

Add error handling for route53 delete records operation. This ensures that the subdomain creation is continued after the delete call has been made. If the Route53 API does not hold a given domain it now throws but it should still delete everything that it does hold. Quick fix for now.