### PR TITLE
fix(autocertifier-server): Only delete existing records from route53

### DIFF
--- a/packages/autocertifier-server/src/Route53Api.ts
+++ b/packages/autocertifier-server/src/Route53Api.ts
@@ -7,7 +7,7 @@ import {
     RRType,
     ChangeResourceRecordSetsCommandOutput
 } from '@aws-sdk/client-route-53'
-import chunk from 'lodash/chunk'
+
 interface Record {
     fqdn: string 
     value: string
@@ -60,12 +60,12 @@ export class Route53Api {
         recordType: RRType,
         records: { fqdn: string, value: string }[],
         ttl: number
-    ): Promise<void> {
-        const chunks = chunk(records, 25)
-        for (const chunk of chunks) {
-            const response = await this.changeRecords(ChangeAction.DELETE, recordType, chunk, ttl)
-            console.log(response)
+    ): Promise<ChangeResourceRecordSetsCommandOutput> {
+        const uniqueRecords = [...new Set(records.map((record) => record.fqdn))]
+        if (uniqueRecords.length !== records.length) {
+            throw new Error('Duplicate records found')
         }
+        return this.changeRecords(ChangeAction.DELETE, recordType, records, ttl)
     }
 
     // Debugging tool to list all records in a zone

--- a/packages/autocertifier-server/src/Route53Api.ts
+++ b/packages/autocertifier-server/src/Route53Api.ts
@@ -62,10 +62,10 @@ export class Route53Api {
         ttl: number
     ): Promise<void> {
         const chunks = chunk(records, 25)
-        const responses = await Promise.all(chunks.map(async (chunk) => 
-            this.changeRecords(ChangeAction.DELETE, recordType, chunk, ttl)
-        ))
-        console.log(responses)
+        for (const chunk of chunks) {
+            const response = await this.changeRecords(ChangeAction.DELETE, recordType, chunk, ttl)
+            console.log(response)
+        }
     }
 
     // Debugging tool to list all records in a zone

--- a/packages/autocertifier-server/src/Route53Api.ts
+++ b/packages/autocertifier-server/src/Route53Api.ts
@@ -60,12 +60,26 @@ export class Route53Api {
         recordType: RRType,
         records: { fqdn: string, value: string }[],
         ttl: number
-    ): Promise<ChangeResourceRecordSetsCommandOutput> {
-        const uniqueRecords = [...new Set(records.map((record) => record.fqdn))]
-        if (uniqueRecords.length !== records.length) {
-            throw new Error('Duplicate records found')
+    ): Promise<void> {
+        if (records.length === 0) {
+            return
         }
-        return this.changeRecords(ChangeAction.DELETE, recordType, records, ttl)
+        // Filter to only records that actually exist in Route53
+        const existingRecords = await this.listRecords()
+        const existingNames = new Set(
+            existingRecords.ResourceRecordSets
+                ?.filter((rrs) => rrs.Type === recordType)
+                .map((rrs) => rrs.Name) ?? []
+        )
+        // Route53 returns names with trailing dot, normalize for comparison
+        const recordsToDelete = records.filter((record) => {
+            const normalizedFqdn = record.fqdn.endsWith('.') ? record.fqdn : record.fqdn + '.'
+            return existingNames.has(normalizedFqdn)
+        })
+        if (recordsToDelete.length === 0) {
+            return
+        }
+        await this.changeRecords(ChangeAction.DELETE, recordType, recordsToDelete, ttl)
     }
 
     // Debugging tool to list all records in a zone

--- a/packages/autocertifier-server/src/Route53Api.ts
+++ b/packages/autocertifier-server/src/Route53Api.ts
@@ -7,7 +7,7 @@ import {
     RRType,
     ChangeResourceRecordSetsCommandOutput
 } from '@aws-sdk/client-route-53'
-
+import chunk from 'lodash/chunk'
 interface Record {
     fqdn: string 
     value: string
@@ -60,8 +60,12 @@ export class Route53Api {
         recordType: RRType,
         records: { fqdn: string, value: string }[],
         ttl: number
-    ): Promise<ChangeResourceRecordSetsCommandOutput> {
-        return this.changeRecords(ChangeAction.DELETE, recordType, records, ttl)
+    ): Promise<void> {
+        const chunks = chunk(records, 25)
+        const responses = await Promise.all(chunks.map(async (chunk) => 
+            this.changeRecords(ChangeAction.DELETE, recordType, chunk, ttl)
+        ))
+        console.log(responses)
     }
 
     // Debugging tool to list all records in a zone


### PR DESCRIPTION
## Summary

Added logic to filter out records that do not exist in Route53 to get rid of errors during delete records queries.
