### PR TITLE
refactor(sdk): Resolve `Resends` circular dependency

### DIFF
--- a/packages/sdk/src/subscribe/MessagePipelineFactory.ts
+++ b/packages/sdk/src/subscribe/MessagePipelineFactory.ts
@@ -10,23 +10,21 @@ import { StreamMessage } from '../protocol/StreamMessage'
 import { SignatureValidator } from '../signature/SignatureValidator'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { PushPipeline } from '../utils/PushPipeline'
-import { Resends } from './Resends'
 import { MessagePipelineOptions, createMessagePipeline as _createMessagePipeline } from './messagePipeline'
 
 type MessagePipelineFactoryOptions = MarkOptional<Omit<MessagePipelineOptions,
-    'resends' |
     'groupKeyManager' |
     'streamRegistry' |
     'signatureValidator' |
     'destroySignal' |
     'loggerFactory'>,
     'getStorageNodes' |
-    'config'>
+    'config' |
+    'resends'>
 
 @scoped(Lifecycle.ContainerScoped)
 export class MessagePipelineFactory {
 
-    private readonly resends: Resends
     private readonly streamStorageRegistry: StreamStorageRegistry
     private readonly streamRegistry: StreamRegistry
     private readonly signatureValidator: SignatureValidator
@@ -37,7 +35,6 @@ export class MessagePipelineFactory {
 
     /* eslint-disable indent */
     constructor(
-        @inject(delay(() => Resends)) resends: Resends,
         streamStorageRegistry: StreamStorageRegistry,
         @inject(delay(() => StreamRegistry)) streamRegistry: StreamRegistry,
         signatureValidator: SignatureValidator,
@@ -46,7 +43,6 @@ export class MessagePipelineFactory {
         destroySignal: DestroySignal,
         loggerFactory: LoggerFactory
     ) {
-        this.resends = resends
         this.streamStorageRegistry = streamStorageRegistry
         this.streamRegistry = streamRegistry
         this.signatureValidator = signatureValidator
@@ -60,7 +56,6 @@ export class MessagePipelineFactory {
         return _createMessagePipeline({
             ...opts,
             getStorageNodes: opts.getStorageNodes ?? ((streamId: StreamID) => this.streamStorageRegistry.getStorageNodes(streamId)),
-            resends: this.resends,
             streamRegistry: this.streamRegistry,
             signatureValidator: this.signatureValidator,
             groupKeyManager: this.groupKeyManager,

--- a/packages/sdk/src/subscribe/Resends.ts
+++ b/packages/sdk/src/subscribe/Resends.ts
@@ -13,7 +13,7 @@ import {
 import random from 'lodash/random'
 import sample from 'lodash/sample'
 import without from 'lodash/without'
-import { Lifecycle, delay, inject, scoped } from 'tsyringe'
+import { Lifecycle, inject, scoped } from 'tsyringe'
 import { ConfigInjectionToken, type StrictStreamrClientConfig } from '../ConfigTypes'
 import { StreamrClientError } from '../StreamrClientError'
 import { StorageNodeRegistry } from '../contracts/StorageNodeRegistry'
@@ -127,10 +127,9 @@ export class Resends {
     private readonly config: StrictStreamrClientConfig
     private readonly logger: Logger
 
-    /* eslint-disable indent */
     constructor(
-        @inject(delay(() => StorageNodeRegistry)) storageNodeRegistry: StorageNodeRegistry,
-        @inject(delay(() => MessagePipelineFactory)) messagePipelineFactory: MessagePipelineFactory,
+        storageNodeRegistry: StorageNodeRegistry,
+        messagePipelineFactory: MessagePipelineFactory,
         @inject(ConfigInjectionToken) config: StrictStreamrClientConfig,
         loggerFactory: LoggerFactory
     ) {

--- a/packages/sdk/src/subscribe/Resends.ts
+++ b/packages/sdk/src/subscribe/Resends.ts
@@ -211,7 +211,8 @@ export class Resends {
              * in ascending order, we don't need the ordering functionality.
              */
             getStorageNodes: async () => without(nodeAddresses, nodeAddress),
-            config: (nodeAddresses.length === 1) ? { ...this.config, orderMessages: false } : this.config
+            config: (nodeAddresses.length === 1) ? { ...this.config, orderMessages: false } : this.config,
+            resends: this
         })
         const lines = transformError(fetchLengthPrefixedFrameHttpBinaryStream(url, abortSignal), getHttpErrorTransform())
         setImmediate(async () => {

--- a/packages/sdk/src/subscribe/Subscriber.ts
+++ b/packages/sdk/src/subscribe/Subscriber.ts
@@ -3,6 +3,7 @@ import { Lifecycle, delay, inject, scoped } from 'tsyringe'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
+import { Resends } from './Resends'
 import { Subscription } from './Subscription'
 import { SubscriptionSession } from './SubscriptionSession'
 
@@ -12,15 +13,18 @@ export class Subscriber {
     private readonly subSessions: Map<StreamPartID, SubscriptionSession> = new Map()
     private readonly node: NetworkNodeFacade
     private readonly messagePipelineFactory: MessagePipelineFactory
+    private readonly resends: Resends
     private readonly logger: Logger
 
     constructor(
         node: NetworkNodeFacade,
         @inject(delay(() => MessagePipelineFactory)) messagePipelineFactory: MessagePipelineFactory,
+        @inject(delay(() => Resends)) resends: Resends,
         loggerFactory: LoggerFactory,
     ) {
         this.node = node
         this.messagePipelineFactory = messagePipelineFactory
+        this.resends = resends
         this.logger = loggerFactory.createLogger('Subscriber')
     }
 
@@ -31,7 +35,8 @@ export class Subscriber {
         const subSession = new SubscriptionSession(
             streamPartId,
             this.messagePipelineFactory,
-            this.node
+            this.node,
+            this.resends
         )
 
         this.subSessions.set(streamPartId, subSession)

--- a/packages/sdk/src/subscribe/Subscriber.ts
+++ b/packages/sdk/src/subscribe/Subscriber.ts
@@ -1,5 +1,5 @@
 import { EthereumAddress, Logger, StreamPartID } from '@streamr/utils'
-import { Lifecycle, delay, inject, scoped } from 'tsyringe'
+import { Lifecycle, scoped } from 'tsyringe'
 import { NetworkNodeFacade } from '../NetworkNodeFacade'
 import { LoggerFactory } from '../utils/LoggerFactory'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
@@ -18,8 +18,8 @@ export class Subscriber {
 
     constructor(
         node: NetworkNodeFacade,
-        @inject(delay(() => MessagePipelineFactory)) messagePipelineFactory: MessagePipelineFactory,
-        @inject(delay(() => Resends)) resends: Resends,
+        messagePipelineFactory: MessagePipelineFactory,
+        resends: Resends,
         loggerFactory: LoggerFactory,
     ) {
         this.node = node
@@ -32,12 +32,12 @@ export class Subscriber {
         if (this.subSessions.has(streamPartId)) {
             return this.getSubscriptionSession(streamPartId)!
         }
-        const subSession = new SubscriptionSession(
+        const subSession = new SubscriptionSession({
             streamPartId,
-            this.messagePipelineFactory,
-            this.node,
-            this.resends
-        )
+            messagePipelineFactory: this.messagePipelineFactory,
+            node: this.node,
+            resends: this.resends
+        })
 
         this.subSessions.set(streamPartId, subSession)
         subSession.onRetired.listen(() => {

--- a/packages/sdk/src/subscribe/SubscriptionSession.ts
+++ b/packages/sdk/src/subscribe/SubscriptionSession.ts
@@ -5,6 +5,7 @@ import { PushPipeline } from '../utils/PushPipeline'
 import { Scaffold } from '../utils/Scaffold'
 import { Signal } from '../utils/Signal'
 import { MessagePipelineFactory } from './MessagePipelineFactory'
+import type { Resends } from './Resends'
 import { Subscription } from './Subscription'
 
 /**
@@ -30,14 +31,16 @@ export class SubscriptionSession {
     constructor(
         streamPartId: StreamPartID,
         messagePipelineFactory: MessagePipelineFactory,
-        node: NetworkNodeFacade
+        node: NetworkNodeFacade,
+        resends: Resends
     ) {
         this.streamPartId = streamPartId
         this.distributeMessage = this.distributeMessage.bind(this)
         this.node = node
         this.onError = this.onError.bind(this)
         this.pipeline = messagePipelineFactory.createMessagePipeline({
-            streamPartId
+            streamPartId,
+            resends
         })
         this.pipeline.onError.listen(this.onError)
         this.pipeline

--- a/packages/sdk/src/subscribe/SubscriptionSession.ts
+++ b/packages/sdk/src/subscribe/SubscriptionSession.ts
@@ -17,6 +17,13 @@ const getAnyItemFromSet = <T>(set: Set<T>): T | undefined => {
     return set.values().next().value
 }
 
+export interface SubscriptionSessionOptions {
+    streamPartId: StreamPartID
+    messagePipelineFactory: MessagePipelineFactory
+    node: NetworkNodeFacade
+    resends: Resends
+}
+
 export class SubscriptionSession {
 
     public readonly streamPartId: StreamPartID
@@ -28,19 +35,14 @@ export class SubscriptionSession {
     private readonly pipeline: PushPipeline<StreamMessage, StreamMessage>
     private readonly node: NetworkNodeFacade
 
-    constructor(
-        streamPartId: StreamPartID,
-        messagePipelineFactory: MessagePipelineFactory,
-        node: NetworkNodeFacade,
-        resends: Resends
-    ) {
-        this.streamPartId = streamPartId
+    constructor(opts: SubscriptionSessionOptions) {
+        this.streamPartId = opts.streamPartId
         this.distributeMessage = this.distributeMessage.bind(this)
-        this.node = node
+        this.node = opts.node
         this.onError = this.onError.bind(this)
-        this.pipeline = messagePipelineFactory.createMessagePipeline({
-            streamPartId,
-            resends
+        this.pipeline = opts.messagePipelineFactory.createMessagePipeline({
+            streamPartId: opts.streamPartId,
+            resends: opts.resends
         })
         this.pipeline.onError.listen(this.onError)
         this.pipeline

--- a/packages/sdk/src/subscribe/messagePipeline.ts
+++ b/packages/sdk/src/subscribe/messagePipeline.ts
@@ -24,7 +24,7 @@ import { EncryptionType } from '@streamr/trackerless-network'
 export interface MessagePipelineOptions {
     streamPartId: StreamPartID
     getStorageNodes: (streamId: StreamID) => Promise<EthereumAddress[]>
-    resends: Resends
+    resends?: Resends
     streamRegistry: StreamRegistry
     signatureValidator: SignatureValidator
     groupKeyManager: GroupKeyManager
@@ -91,7 +91,7 @@ export const createMessagePipeline = (opts: MessagePipelineOptions): PushPipelin
     // end up acting as gaps that we repeatedly try to fill.
     const ignoreMessages = new WeakSet<MessageID>()
     messageStream.onError.listen(onError)
-    if (opts.config.orderMessages) {
+    if (opts.config.orderMessages && opts.resends) {
         // order messages and fill gaps
         const orderMessages = new OrderMessages(
             opts.streamPartId,

--- a/packages/sdk/test/unit/SubscriptionSession.test.ts
+++ b/packages/sdk/test/unit/SubscriptionSession.test.ts
@@ -4,6 +4,7 @@ import { mock } from 'jest-mock-extended'
 import { Subscription } from '../../src'
 import { NetworkNodeFacade } from '../../src/NetworkNodeFacade'
 import { MessagePipelineFactory } from '../../src/subscribe/MessagePipelineFactory'
+import type { Resends } from '../../src/subscribe/Resends'
 import { SubscriptionSession } from '../../src/subscribe/SubscriptionSession'
 import { PushPipeline } from '../../src/utils/PushPipeline'
 import { ErrorSignal, Signal } from '../../src/utils/Signal'
@@ -28,7 +29,8 @@ describe('SubscriptionSession', () => {
         pushPipeline.pipe.mockReturnValue(pushPipeline as any)
         pipelineFactory.createMessagePipeline.mockReturnValue(pushPipeline)
         const networkNodeFacade = mock<NetworkNodeFacade>()
-        session = new SubscriptionSession(STREAM_PART_ID, pipelineFactory, networkNodeFacade)
+        const resends = mock<Resends>()
+        session = new SubscriptionSession(STREAM_PART_ID, pipelineFactory, networkNodeFacade, resends)
     })
 
     describe('getERC1271ContractAddress', () => {

--- a/packages/sdk/test/unit/SubscriptionSession.test.ts
+++ b/packages/sdk/test/unit/SubscriptionSession.test.ts
@@ -30,7 +30,12 @@ describe('SubscriptionSession', () => {
         pipelineFactory.createMessagePipeline.mockReturnValue(pushPipeline)
         const networkNodeFacade = mock<NetworkNodeFacade>()
         const resends = mock<Resends>()
-        session = new SubscriptionSession(STREAM_PART_ID, pipelineFactory, networkNodeFacade, resends)
+        session = new SubscriptionSession({
+            streamPartId: STREAM_PART_ID,
+            messagePipelineFactory: pipelineFactory,
+            node: networkNodeFacade,
+            resends
+        })
     })
 
     describe('getERC1271ContractAddress', () => {


### PR DESCRIPTION
## Summary

Resolve circular dependency around `Resends` and clean up dependency injection in the subscription module.

## Changes

- Move `Resends` injection from `MessagePipelineFactory` to `Subscriber`, **breaking the circular dependency**.
- Remove unnecessary `delay()` wrappers from `Subscriber` and `Resends` constructors.
- Refactor `SubscriptionSession` constructor to use options object pattern for better extensibility.