### PR TITLE
refactor(sdk): Clean-up `tsyringe` setup

### DIFF
--- a/packages/sdk/jest.config.ts
+++ b/packages/sdk/jest.config.ts
@@ -6,6 +6,7 @@ const config: Config.InitialOptions = {
     globalSetup: './jest.setup.ts',
     setupFilesAfterEnv: [
         ...defaultConfig.setupFilesAfterEnv,
+        './src/setupTsyringe.ts',
         './test/test-utils/customMatchers.ts',
         '@streamr/test-utils/setupCustomMatchers',
     ],

--- a/packages/sdk/jest.setup.ts
+++ b/packages/sdk/jest.setup.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { GitRevisionPlugin } from 'git-revision-webpack-plugin'
-import 'reflect-metadata'
 import pkg from './package.json'
 
 export default async function setup(): Promise<void> {

--- a/packages/sdk/karma-setup.js
+++ b/packages/sdk/karma-setup.js
@@ -2,7 +2,7 @@
  * This setup script is executed indirectly by Karma via the `browser-test-runner`
  * package. See karma-config.js in that package for more details.
  */
-
+import './src/setupTsyringe.ts'
 import './test/test-utils/customMatchers'
 import { customMatchers } from '@streamr/test-utils'
 

--- a/packages/sdk/karma-setup.js
+++ b/packages/sdk/karma-setup.js
@@ -2,6 +2,7 @@
  * This setup script is executed indirectly by Karma via the `browser-test-runner`
  * package. See karma-config.js in that package for more details.
  */
+
 import './src/setupTsyringe.ts'
 import './test/test-utils/customMatchers'
 import { customMatchers } from '@streamr/test-utils'

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -1,5 +1,3 @@
-import './setupTsyringe'
-
 import cloneDeep from 'lodash/cloneDeep'
 import { merge } from '@streamr/utils'
 import { generateClientId } from './utils/utils'

--- a/packages/sdk/src/Config.ts
+++ b/packages/sdk/src/Config.ts
@@ -1,4 +1,5 @@
-import 'reflect-metadata'
+import './setupTsyringe'
+
 import cloneDeep from 'lodash/cloneDeep'
 import { merge } from '@streamr/utils'
 import { generateClientId } from './utils/utils'

--- a/packages/sdk/src/ConfigTypes.ts
+++ b/packages/sdk/src/ConfigTypes.ts
@@ -1,5 +1,3 @@
-import './setupTsyringe'
-
 import type { Overrides, Eip1193Provider } from 'ethers'
 import type { DeepRequired, MarkOptional } from 'ts-essentials'
 import type { HexString, LogLevel, KeyType } from '@streamr/utils'

--- a/packages/sdk/src/ConfigTypes.ts
+++ b/packages/sdk/src/ConfigTypes.ts
@@ -1,4 +1,5 @@
-import 'reflect-metadata'
+import './setupTsyringe'
+
 import type { Overrides, Eip1193Provider } from 'ethers'
 import type { DeepRequired, MarkOptional } from 'ts-essentials'
 import type { HexString, LogLevel, KeyType } from '@streamr/utils'

--- a/packages/sdk/src/PersistenceManager.ts
+++ b/packages/sdk/src/PersistenceManager.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata'
+import './setupTsyringe'
 
 import { join } from 'path'
 import { inject, Lifecycle, scoped } from 'tsyringe'

--- a/packages/sdk/src/StreamrClient.ts
+++ b/packages/sdk/src/StreamrClient.ts
@@ -2,8 +2,8 @@
  * Importing 'timers' ensures `setImmediate` is available in browsers,
  * as it's polyfilled by `timers-browserify`. In Node.js, it's already global.
  */
-import 'reflect-metadata'
 import 'timers'
+import './setupTsyringe'
 import './utils/PatchTsyringe'
 
 import { DhtAddress } from '@streamr/dht'

--- a/packages/sdk/src/setupTsyringe.ts
+++ b/packages/sdk/src/setupTsyringe.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata'

--- a/packages/sdk/test/end-to-end/MemoryLeaks.test.ts
+++ b/packages/sdk/test/end-to-end/MemoryLeaks.test.ts
@@ -1,7 +1,6 @@
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { createTestPrivateKey, describeOnlyInNodeJs } from '@streamr/test-utils'
 import { Defer, merge, TheGraphClient, wait } from '@streamr/utils'
-import 'reflect-metadata'
 import { DependencyContainer, container as rootContainer } from 'tsyringe'
 import { writeHeapSnapshot } from 'v8'
 import { IdentityInjectionToken } from '../../src/identity/Identity'

--- a/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StorageNodeRegistry.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import { until } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/end-to-end/StreamRegistry.test.ts
+++ b/packages/sdk/test/end-to-end/StreamRegistry.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, randomEthereumAddress, randomUserId } from '@streamr/test-utils'
 import { EthereumAddress, collect, toEthereumAddress, toStreamID, until } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/end-to-end/decorated-contract.test.ts
+++ b/packages/sdk/test/end-to-end/decorated-contract.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { config as CHAIN_CONFIG } from '@streamr/config'
 import { StreamRegistryABI, StreamRegistry as StreamRegistryContract } from '@streamr/network-contracts'
 import { createTestPrivateKey, getTestProvider } from '@streamr/test-utils'

--- a/packages/sdk/test/end-to-end/sponsorship-created-event.test.ts
+++ b/packages/sdk/test/end-to-end/sponsorship-created-event.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { Wallet, parseEther } from 'ethers'
 import { StreamrClient } from '../../src/StreamrClient'

--- a/packages/sdk/test/integration/GroupKeyPersistence.test.ts
+++ b/packages/sdk/test/integration/GroupKeyPersistence.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestPrivateKey } from '@streamr/test-utils'
 import { collect, toStreamPartID, until } from '@streamr/utils'
 import { Message } from '../../src/Message'

--- a/packages/sdk/test/integration/NetworkNodeFacade.test.ts
+++ b/packages/sdk/test/integration/NetworkNodeFacade.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { NetworkNodeStub } from '../../src/NetworkNodeFacade'
 import { StreamrClient } from '../../src/StreamrClient'
 import { peerDescriptorTranslator } from '../../src/utils/utils'

--- a/packages/sdk/test/integration/PublisherKeyExchange.test.ts
+++ b/packages/sdk/test/integration/PublisherKeyExchange.test.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata'
 import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import { EthereumAddress, toUserId, UserID, wait } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/Resends.test.ts
+++ b/packages/sdk/test/integration/Resends.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestPrivateKey } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { mock } from 'jest-mock-extended'

--- a/packages/sdk/test/integration/Resends2.test.ts
+++ b/packages/sdk/test/integration/Resends2.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { StreamID, collect, toStreamPartID, until } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/Sequencing.test.ts
+++ b/packages/sdk/test/integration/Sequencing.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { collect, merge, wait, until } from '@streamr/utils'
 import { Message } from '../../src/Message'
 import { Stream } from '../../src/Stream'

--- a/packages/sdk/test/integration/Stream.test.ts
+++ b/packages/sdk/test/integration/Stream.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { StreamrClient } from '../../src/StreamrClient'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { FakeStorageNode } from '../test-utils/fake/FakeStorageNode'

--- a/packages/sdk/test/integration/StreamrClient.test.ts
+++ b/packages/sdk/test/integration/StreamrClient.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestPrivateKey, createTestWallet } from '@streamr/test-utils'
 import { Defer, StreamPartID, StreamPartIDUtils, collect, wait } from '@streamr/utils'
 import { MessageMetadata } from '../../src/Message'

--- a/packages/sdk/test/integration/Subscriber.test.ts
+++ b/packages/sdk/test/integration/Subscriber.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'

--- a/packages/sdk/test/integration/Subscriber2.test.ts
+++ b/packages/sdk/test/integration/Subscriber2.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { Defer, StreamID, collect, toUserId, until, utf8ToBinary } from '@streamr/utils'
 import sample from 'lodash/sample'

--- a/packages/sdk/test/integration/SubscriberKeyExchange.test.ts
+++ b/packages/sdk/test/integration/SubscriberKeyExchange.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import {
     StreamID,

--- a/packages/sdk/test/integration/basics.test.ts
+++ b/packages/sdk/test/integration/basics.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { collect } from '@streamr/utils'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'

--- a/packages/sdk/test/integration/bypass-validation.test.ts
+++ b/packages/sdk/test/integration/bypass-validation.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { StreamPartIDUtils } from '@streamr/utils'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 import { nextValue } from '../../src/utils/iterators'

--- a/packages/sdk/test/integration/client-destroy.test.ts
+++ b/packages/sdk/test/integration/client-destroy.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { collect } from '@streamr/utils'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'

--- a/packages/sdk/test/integration/events.test.ts
+++ b/packages/sdk/test/integration/events.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 
 describe('events', () => {

--- a/packages/sdk/test/integration/explicit-encryption-keys.test.ts
+++ b/packages/sdk/test/integration/explicit-encryption-keys.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'

--- a/packages/sdk/test/integration/gap-fill.test.ts
+++ b/packages/sdk/test/integration/gap-fill.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, testOnlyInNodeJs } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/invalid-messages.test.ts
+++ b/packages/sdk/test/integration/invalid-messages.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { StreamID, toStreamPartID, wait } from '@streamr/utils'
 import { StreamrClient } from '../../src/StreamrClient'

--- a/packages/sdk/test/integration/json-rpc-provider.test.ts
+++ b/packages/sdk/test/integration/json-rpc-provider.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { wait, until } from '@streamr/utils'
 import range from 'lodash/range'
 import sortBy from 'lodash/sortBy'

--- a/packages/sdk/test/integration/multiple-clients.test.ts
+++ b/packages/sdk/test/integration/multiple-clients.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { toUserId, UserID, until } from '@streamr/utils'
 import { Message, MessageMetadata } from '../../src/Message'
 import { StreamPermission } from '../../src/permission'

--- a/packages/sdk/test/integration/parallel-key-exchange.test.ts
+++ b/packages/sdk/test/integration/parallel-key-exchange.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { collect, wait } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/parallel-publish.test.ts
+++ b/packages/sdk/test/integration/parallel-publish.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { wait } from '@streamr/utils'
 import random from 'lodash/random'
 import uniq from 'lodash/uniq'

--- a/packages/sdk/test/integration/pre-agreed-encryption-key.test.ts
+++ b/packages/sdk/test/integration/pre-agreed-encryption-key.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { GroupKey } from '../../src/encryption/GroupKey'
 import { StreamPermission } from '../../src/permission'
 import { StreamMessageType } from '../../src/protocol/StreamMessage'

--- a/packages/sdk/test/integration/publisher-key-reuse.test.ts
+++ b/packages/sdk/test/integration/publisher-key-reuse.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/quantum-policy.test.ts
+++ b/packages/sdk/test/integration/quantum-policy.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'
 import { StreamPermission } from '../../src/permission'

--- a/packages/sdk/test/integration/resend-and-subscribe.test.ts
+++ b/packages/sdk/test/integration/resend-and-subscribe.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { Wallet } from 'ethers'
 import { Stream } from '../../src/Stream'

--- a/packages/sdk/test/integration/resend-with-existing-key.test.ts
+++ b/packages/sdk/test/integration/resend-with-existing-key.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { collect, toEthereumAddress, toStreamID, toUserId } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/revoke-permissions.test.ts
+++ b/packages/sdk/test/integration/revoke-permissions.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestPrivateKey } from '@streamr/test-utils'
 import { Defer, merge } from '@streamr/utils'
 import { Message } from '../../src/Message'

--- a/packages/sdk/test/integration/sequential-resend-subscribe.test.ts
+++ b/packages/sdk/test/integration/sequential-resend-subscribe.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { collect, until } from '@streamr/utils'
 import { Message } from '../../src/Message'
 import { StreamPermission } from '../../src/permission'

--- a/packages/sdk/test/integration/unsubscribe.test.ts
+++ b/packages/sdk/test/integration/unsubscribe.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { collect } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/integration/update-encryption-key.test.ts
+++ b/packages/sdk/test/integration/update-encryption-key.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { StreamPartID, StreamPartIDUtils, until } from '@streamr/utils'
 import { Message } from '../../src/Message'
 import { GroupKey } from '../../src/encryption/GroupKey'

--- a/packages/sdk/test/integration/waitForStorage.test.ts
+++ b/packages/sdk/test/integration/waitForStorage.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { convertStreamMessageToMessage } from '../../src/Message'
 import { Stream } from '../../src/Stream'
 import { StreamrClient } from '../../src/StreamrClient'

--- a/packages/sdk/test/test-utils/utils.ts
+++ b/packages/sdk/test/test-utils/utils.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import {
     Operator as OperatorContract,
     Sponsorship as SponsorshipContract

--- a/packages/sdk/test/unit/ChainEventPoller.test.ts
+++ b/packages/sdk/test/unit/ChainEventPoller.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { until, wait } from '@streamr/utils'
 import { AbstractProvider, Interface, Log } from 'ethers'

--- a/packages/sdk/test/unit/Decrypt.test.ts
+++ b/packages/sdk/test/unit/Decrypt.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { StreamPartIDUtils, utf8ToBinary } from '@streamr/utils'
 import { mock } from 'jest-mock-extended'

--- a/packages/sdk/test/unit/ERC1271ContractFacade.test.ts
+++ b/packages/sdk/test/unit/ERC1271ContractFacade.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestPrivateKey, randomEthereumAddress } from '@streamr/test-utils'
 import { EcdsaSecp256k1Evm, hexToBinary } from '@streamr/utils'
 import { Provider } from 'ethers'

--- a/packages/sdk/test/unit/GroupKeyManager.test.ts
+++ b/packages/sdk/test/unit/GroupKeyManager.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, randomUserId } from '@streamr/test-utils'
 import { toStreamID, toStreamPartID, toUserId } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/unit/GroupKeyQueue.test.ts
+++ b/packages/sdk/test/unit/GroupKeyQueue.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { toStreamID } from '@streamr/utils'
 import { mock, MockProxy } from 'jest-mock-extended'
 import { Identity } from '../../src/identity/Identity'

--- a/packages/sdk/test/unit/LocalGroupKeyStore.test.ts
+++ b/packages/sdk/test/unit/LocalGroupKeyStore.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { randomEthereumAddress, randomUserId } from '@streamr/test-utils'
 import { toStreamID, UserID } from '@streamr/utils'
 import range from 'lodash/range'

--- a/packages/sdk/test/unit/MessageStream.test.ts
+++ b/packages/sdk/test/unit/MessageStream.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { toStreamID, utf8ToBinary } from '@streamr/utils'
 import omit from 'lodash/omit'
 import { MessageSigner } from '../../src/signature/MessageSigner'

--- a/packages/sdk/test/unit/MetricsPublisher.test.ts
+++ b/packages/sdk/test/unit/MetricsPublisher.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { DhtAddress } from '@streamr/dht'
 import { LevelMetric, MetricsContext, wait } from '@streamr/utils'
 import type { StreamrClientConfig } from '../../src/ConfigTypes'

--- a/packages/sdk/test/unit/Operator.test.ts
+++ b/packages/sdk/test/unit/Operator.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { wait } from '@streamr/utils'
 import capitalize from 'lodash/capitalize'

--- a/packages/sdk/test/unit/ProxyNodeFinder.test.ts
+++ b/packages/sdk/test/unit/ProxyNodeFinder.test.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata'
 import { ProxyNodeFinder } from '../../src/ProxyNodeFinder'
 import { StreamIDBuilder } from '../../src/StreamIDBuilder'
 import { OperatorRegistry, FindOperatorsOnStreamResult } from '../../src/contracts/OperatorRegistry'

--- a/packages/sdk/test/unit/Publisher.test.ts
+++ b/packages/sdk/test/unit/Publisher.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { mock } from 'jest-mock-extended'
 import { Publisher } from '../../src/publish/Publisher'
 import { MessageSigner } from '../../src/signature/MessageSigner'

--- a/packages/sdk/test/unit/PushPipeline.test.ts
+++ b/packages/sdk/test/unit/PushPipeline.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { randomUserId, testOnlyInNodeJs } from '@streamr/test-utils'
 import { collect, toStreamID, utf8ToBinary, wait } from '@streamr/utils'
 import { MessageSigner } from '../../src/signature/MessageSigner'

--- a/packages/sdk/test/unit/Resends.test.ts
+++ b/packages/sdk/test/unit/Resends.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { isRunningInElectron, randomEthereumAddress, randomUserId, startTestServer } from '@streamr/test-utils'
 import { StreamPartIDUtils, collect, hexToBinary, toLengthPrefixedFrame, toStreamID } from '@streamr/utils'
 import range from 'lodash/range'

--- a/packages/sdk/test/unit/SignatureValidator.test.ts
+++ b/packages/sdk/test/unit/SignatureValidator.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { randomEthereumAddress } from '@streamr/test-utils'
 import { hexToBinary, toStreamID, toUserId, utf8ToBinary } from '@streamr/utils'
 import { MockProxy, mock } from 'jest-mock-extended'

--- a/packages/sdk/test/unit/Stream.test.ts
+++ b/packages/sdk/test/unit/Stream.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { Stream } from '../../src/Stream'
 
 describe('Stream', () => {

--- a/packages/sdk/test/unit/StreamIDBuilder.test.ts
+++ b/packages/sdk/test/unit/StreamIDBuilder.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { StreamPartIDUtils, toUserId } from '@streamr/utils'
 import { Identity } from '../../src/identity/Identity'
 import { StreamIDBuilder } from '../../src/StreamIDBuilder'

--- a/packages/sdk/test/unit/StreamrClient.test.ts
+++ b/packages/sdk/test/unit/StreamrClient.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import merge from 'lodash/merge'
 import { container } from 'tsyringe'
 import type { StreamrClientConfig } from '../../src/ConfigTypes'

--- a/packages/sdk/test/unit/WebStreamToNodeStream.test.ts
+++ b/packages/sdk/test/unit/WebStreamToNodeStream.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { promises } from 'stream'
 import { WebStreamToNodeStream } from '../../src/utils/WebStreamToNodeStream'
 import { Msg } from '../test-utils/publish'

--- a/packages/sdk/test/unit/events.test.ts
+++ b/packages/sdk/test/unit/events.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { FakeEnvironment } from '../test-utils/fake/FakeEnvironment'
 
 describe('events', () => {

--- a/packages/sdk/test/unit/messagePipeline.test.ts
+++ b/packages/sdk/test/unit/messagePipeline.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet, randomEthereumAddress } from '@streamr/test-utils'
 import { StreamPartID, StreamPartIDUtils, collect, hexToBinary, toUserId, utf8ToBinary } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/unit/validateStreamMessage.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { createTestWallet } from '@streamr/test-utils'
 import { hexToBinary, toStreamID, toStreamPartID, UserID } from '@streamr/utils'
 import { Wallet } from 'ethers'

--- a/packages/sdk/test/unit/validateStreamMessage2.test.ts
+++ b/packages/sdk/test/unit/validateStreamMessage2.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { UserID, hexToBinary, toStreamID, toUserIdRaw, utf8ToBinary } from '@streamr/utils'
 import { AsymmetricEncryptionType, ContentType, EncryptionType, GroupKeyRequest, GroupKeyResponse, SignatureType } from '@streamr/trackerless-network'
 import { mock } from 'jest-mock-extended'

--- a/packages/sdk/test/unit/waitForAssignmentsToPropagate.test.ts
+++ b/packages/sdk/test/unit/waitForAssignmentsToPropagate.test.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata'
-
 import { StreamID, toStreamID, toStreamPartID, utf8ToBinary, wait } from '@streamr/utils'
 import range from 'lodash/range'
 import shuffle from 'lodash/shuffle'


### PR DESCRIPTION
## Summary

Centralizes the `tsyringe` dependency injection setup by introducing a dedicated `setupTsyringe.ts` module that handles the `reflect-metadata` import. This eliminates the need for scattered `import 'reflect-metadata'` statements across source and test files, making the DI configuration more maintainable and ensuring consistent initialization.

## Changes

- Created `packages/sdk/src/setupTsyringe.ts` to centralize the `reflect-metadata` import
- Updated core SDK entry points (`StreamrClient.ts`, `Config.ts`, `ConfigTypes.ts`, `PersistenceManager.ts`) to import the new setup module instead of `reflect-metadata` directly
- Added `setupTsyringe.ts` to Jest's `setupFilesAfterEnv` configuration for automatic test initialization
- Added `setupTsyringe.ts` import to `karma-setup.js` to fix the browser test build
- Removed redundant `import 'reflect-metadata'` statements from 60+ test files

## Limitations and future improvements

- The setup module currently only imports `reflect-metadata`, but could be extended in the future to include other tsyringe configuration or polyfills if needed