### PR TITLE
fix(sdk): Fix circular dependency by removing redundant `tsyringe` setup import from `PersistenceManager`

### DIFF
--- a/packages/sdk/src/PersistenceManager.ts
+++ b/packages/sdk/src/PersistenceManager.ts
@@ -1,5 +1,3 @@
-import './setupTsyringe'
-
 import { join } from 'path'
 import { inject, Lifecycle, scoped } from 'tsyringe'
 import { Identity, IdentityInjectionToken } from './identity/Identity'


### PR DESCRIPTION
## Summary

Fix a circular dependency in the SDK by removing a redundant `import './setupTsyringe'` statement from `PersistenceManager.ts`.

The circular dependency chain was:
1. `PersistenceManager.ts` imports `setupTsyringe.ts`
2. `setupTsyringe.ts` imports `Resends.ts` (to register it with tsyringe)
3. `Resends.ts` transitively depends on `PersistenceManager` through the dependency injection graph

Since `setupTsyringe.ts` is already imported at the application entry point (`StreamrClient.ts`), the import in `PersistenceManager.ts` was redundant and only served to create this circular reference.

## Changes

- Remove unnecessary `import './setupTsyringe'` from `packages/sdk/src/PersistenceManager.ts`