### PR TITLE
feat(browser-test-runner): Support TypeScript karma-setup files

### DIFF
--- a/packages/browser-test-runner/src/createKarmaConfig.ts
+++ b/packages/browser-test-runner/src/createKarmaConfig.ts
@@ -9,9 +9,16 @@ export const createKarmaConfig = (
     const setupFiles = [__dirname + '/karma-setup.js']
 
     if (localDirectory !== undefined) {
-        const localSetupFile = localDirectory + '/karma-setup.js'
-        if (fs.existsSync(localSetupFile)) {
-            setupFiles.push(localSetupFile)
+        const karmaSetupCandidates = [
+            `${localDirectory}/karma-setup.js`,
+            `${localDirectory}/karma-setup.ts`
+        ]
+
+        for (const candidate of karmaSetupCandidates) {
+            if (fs.existsSync(candidate)) {
+                setupFiles.push(candidate)
+                break
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Allow packages to define their Karma setup files in either JavaScript (`karma-setup.js`) or TypeScript (`karma-setup.ts`). This provides flexibility for packages that prefer type-safe configuration.

## Changes

- Update `createKarmaConfig.ts` to check for both `karma-setup.js` and `karma-setup.ts` in the local directory
- Use the first matching file found (JS takes precedence over TS)

## Limitations and future improvements

- If Karma is not phased out first, consider migrating all packages to TypeScript configs for consistency